### PR TITLE
Additional changes to support rendering in RALibRetro

### DIFF
--- a/src/RA_AchievementOverlay.cpp
+++ b/src/RA_AchievementOverlay.cpp
@@ -1777,6 +1777,11 @@ API void _RA_RenderOverlay( HDC hDC, RECT* rcSize )
 	g_AchievementOverlay.Render( hDC, rcSize );
 }
 
+API bool _RA_IsOverlayFullyVisible()
+{
+    return g_AchievementOverlay.IsFullyVisible();
+}
+
 API void _RA_InitDirectX()
 {
 	g_AchievementOverlay.InitDirectX();

--- a/src/RA_AchievementOverlay.h
+++ b/src/RA_AchievementOverlay.h
@@ -74,7 +74,6 @@ public:
 public:
 	void Initialize( const Achievement* pAchIn );
 	void Clear();
-	static void CB_OnReceiveData( void* pRequestObject );
 	void OnReceiveData( Document& doc );
 	
 	bool HasData() const											{ return m_bHasData; }
@@ -109,7 +108,6 @@ public:
 	~AchievementOverlay();
 
 	void Initialize( HINSTANCE hInst );
-	void InstallHINSTANCE( HINSTANCE hInst );
 
 	void Activate();
 	void Deactivate();
@@ -117,7 +115,8 @@ public:
 	void Render( HDC hDC, RECT* rcDest ) const;
 	BOOL Update( ControllerInput* input, float fDelta, BOOL bFullScreen, BOOL bPaused );
 
-	BOOL IsActive() const	{ return( m_nTransitionState!=TS_OFF ); }
+    BOOL IsActive() const { return(m_nTransitionState != TS_OFF); }
+    BOOL IsFullyVisible() const { return (m_nTransitionState == TS_HOLD); }
 
 	const int* GetActiveScrollOffset() const;
 	const int* GetActiveSelectedItem() const;
@@ -145,7 +144,6 @@ public:
 	
 	void InitDirectX();
 	void ResetDirectX();
-	void CloseDirectX();
 	void Flip(HWND hWnd);
 
 	void InstallNewsArticlesFromFile();
@@ -201,6 +199,7 @@ extern "C"
 {
 	API extern int _RA_UpdateOverlay( ControllerInput* pInput, float fDTime, bool Full_Screen, bool Paused );
 	API extern void _RA_RenderOverlay( HDC hDC, RECT* rcSize );
+    API extern bool _RA_IsOverlayFullyVisible();
 
 	API extern void _RA_InitDirectX();
 	API extern void _RA_OnPaint( HWND hWnd );

--- a/src/RA_Dlg_Memory.h
+++ b/src/RA_Dlg_Memory.h
@@ -24,7 +24,8 @@ public:
 	static bool OnEditInput( UINT c );
 
 	static void setAddress( unsigned int nAddr );
-	static void moveAddress( int offset, int nibbleOff );
+    static void setWatchedAddress( unsigned int nAddr );
+    static void moveAddress( int offset, int nibbleOff );
 	static void editData( unsigned int nByteAddress, bool bLowerNibble, unsigned int value );
 	static void Invalidate();
 
@@ -37,6 +38,7 @@ private:
 	static SIZE m_szFontSize;
 	static unsigned int m_nDataStartXOffset;
 	static unsigned int m_nAddressOffset;
+    static unsigned int m_nWatchedAddress;
 	static unsigned int m_nDataSize;
 	static unsigned int m_nEditAddress;
 	static unsigned int m_nEditNibble;

--- a/src/RA_Interface.cpp
+++ b/src/RA_Interface.cpp
@@ -107,7 +107,7 @@ int		(CCONV *_RA_UpdateOverlay) (ControllerInput* pInput, float fDeltaTime, bool
 int		(CCONV *_RA_UpdatePopups) (ControllerInput* pInput, float fDeltaTime, bool Full_Screen, bool Paused) = nullptr;
 void	(CCONV *_RA_RenderOverlay) (HDC hDC, RECT* prcSize) = nullptr;
 void	(CCONV *_RA_RenderPopups) (HDC hDC, RECT* prcSize) = nullptr;
-
+bool    (CCONV *_RA_IsOverlayFullyVisible) () = nullptr;
 
 //	Helpers:
 bool RA_UserLoggedIn()
@@ -143,6 +143,14 @@ void RA_UpdateRenderOverlay( HDC hDC, ControllerInput* pInput, float fDeltaTime,
 
 	if( _RA_RenderOverlay != nullptr )
 		_RA_RenderOverlay( hDC, prcSize );
+}
+
+bool RA_IsOverlayFullyVisible()
+{
+    if (_RA_IsOverlayFullyVisible != nullptr)
+        return _RA_IsOverlayFullyVisible();
+
+    return false;
 }
 
 void RA_OnLoadNewRom( BYTE* pROMData, unsigned int nROMSize )
@@ -419,6 +427,7 @@ const char* CCONV _RA_InstallIntegration()
 	_RA_UpdateOverlay		= (int(CCONV *)(ControllerInput*, float, bool, bool))	GetProcAddress( g_hRADLL, "_RA_UpdateOverlay" );
 	_RA_UpdatePopups		= (int(CCONV *)(ControllerInput*, float, bool, bool))	GetProcAddress( g_hRADLL, "_RA_UpdatePopups" );
 	_RA_RenderOverlay		= (void(CCONV *)(HDC, RECT*))							GetProcAddress( g_hRADLL, "_RA_RenderOverlay" );
+    _RA_IsOverlayFullyVisible=(bool(CCONV *)())                                     GetProcAddress( g_hRADLL, "_RA_IsOverlayFullyVisible" );
 	_RA_RenderPopups		= (void(CCONV *)(HDC, RECT*))							GetProcAddress( g_hRADLL, "_RA_RenderPopups" );
 	_RA_OnLoadNewRom		= (int(CCONV *)(const BYTE*, unsigned int))				GetProcAddress( g_hRADLL, "_RA_OnLoadNewRom" );
 	_RA_InstallMemoryBank	= (void(CCONV *)(int, void*, void*, int))				GetProcAddress( g_hRADLL, "_RA_InstallMemoryBank" );

--- a/src/RA_Interface.h
+++ b/src/RA_Interface.h
@@ -147,6 +147,9 @@ extern void RA_DoAchievementsFrame();
 //	Updates and renders all on-screen overlays.
 extern void RA_UpdateRenderOverlay( HDC hDC, ControllerInput* pInput, float fDeltaTime, RECT* prcSize, bool Full_Screen, bool Paused );
 
+//  Determines if the overlay is completely covering the screen.
+extern bool RA_IsOverlayFullyVisible();
+
 //	Returns true if the user has successfully logged in.
 extern bool RA_UserLoggedIn();
 

--- a/src/RA_PopupWindows.cpp
+++ b/src/RA_PopupWindows.cpp
@@ -16,6 +16,8 @@ API int _RA_UpdatePopups( ControllerInput* input, float fDTime, bool Full_Screen
 
 API int _RA_RenderPopups( HDC hDC, RECT* rcSize )
 {
-	PopupWindows::Render( hDC, rcSize );
+	if (!g_AchievementOverlay.IsFullyVisible())
+		PopupWindows::Render( hDC, rcSize );
+
 	return 0;
 }

--- a/src/RA_Version.rc
+++ b/src/RA_Version.rc
@@ -72,12 +72,8 @@ BEGIN
             VALUE "FileVersion", RA_INTEGRATION_VERSION_MAJOR, RA_INTEGRATION_VERSION_MINOR, RA_INTEGRATION_VERSION_REVISION, RA_INTEGRATION_VERSION_MODIFIED
             VALUE "InternalName", "RA_Integration"
             VALUE "LegalCopyright", "Copyright (C) 2018 retroachievements.org"
-#ifdef _DEBUG
-			VALUE "OriginalFilename", "RA_Integration_d.dll"
-#else
-			VALUE "OriginalFilename", "RA_Integration.dll"
-#endif
-			VALUE "ProductName", "RetroAchievements Integration Toolkit"
+            VALUE "OriginalFilename", "RA_Integration.dll"
+            VALUE "ProductName", "RetroAchievements Integration Toolkit"
             VALUE "ProductVersion", RA_INTEGRATION_VERSION_PRODUCT
         END
     END


### PR DESCRIPTION
Changes for https://github.com/RetroAchievements/RALibretro/issues/3

* exposed RA_IsOverlayFullyVisible so RALibRetro can not render the screen when the overlay is visible
* disabled rendering popups while overlay is visible
* fix updating highlighted address in Memory Inspector when RALibRetro is paused.

