### PR TITLE
display "Developing Achievements" if no achievements in current set

### DIFF
--- a/src/RA_httpthread.cpp
+++ b/src/RA_httpthread.cpp
@@ -758,7 +758,9 @@ DWORD RAWeb::HTTPWorkerThread( LPVOID lpParameter )
 					{
 						if( g_MemoryDialog.IsActive() || g_AchievementEditorDialog.IsActive() || g_MemBookmarkDialog.IsActive() )
 						{
-							if( g_bHardcoreModeActive )
+							if( !g_pActiveAchievements || g_pActiveAchievements->NumAchievements() == 0 )
+								args['m'] = "Developing Achievements";
+							else if( g_bHardcoreModeActive )
 								args['m'] = "Inspecting Memory in Hardcore mode";
 							else if( g_nActiveAchievementSet == Core )
 								args['m'] = "Fixing Achievements";


### PR DESCRIPTION
display "Developing Achievements" if no achievements in current set and memory windows are open, regardless of which set is selected or whether or not hardcode mode is enabled