### PR TITLE
C Arrays to std::array

### DIFF
--- a/src/RA_Achievement.cpp
+++ b/src/RA_Achievement.cpp
@@ -102,13 +102,13 @@ char* Achievement::ParseMemString( char* sMem )
 
 char* Achievement::ParseLine( char* pBuffer )
 {
-	char* pTitle = NULL;
-	char* pDesc = NULL;
-	char* pProgress = NULL;
-	char* pProgressMax = NULL;
-	char* pProgressFmt = NULL;
-	char* pAuthor = NULL;
-	char* pBadgeFilename = NULL;
+	char* pTitle = nullptr;
+	char* pDesc = nullptr;
+	char* pProgress = nullptr;
+	char* pProgressMax = nullptr;
+	char* pProgressFmt = nullptr;
+	char* pAuthor = nullptr;
+	char* pBadgeFilename = nullptr;
 
 	unsigned int nPoints = 0;
 	time_t nDateCreatedSecs = 0;
@@ -117,12 +117,12 @@ char* Achievement::ParseLine( char* pBuffer )
 	unsigned short nDownvotes = 0;
 	
 	//	Achievement:
-	char* pNextChar = NULL;
+	char* pNextChar = nullptr;
 	unsigned int nResetCondIter = 0;
 	unsigned int nAchievementID = 0;
 	unsigned int i = 0;
 
-	if( pBuffer == NULL || pBuffer[0] == '\0' )
+	if( pBuffer == nullptr || pBuffer[0] == '\0' )
 		return pBuffer;
 
 	if( pBuffer[0] == '/' || pBuffer[0] == '\\' )
@@ -463,15 +463,15 @@ std::string Achievement::CreateMemString() const
 
 void Achievement::ClearBadgeImage()
 {
-	if( m_hBadgeImage != NULL )
+	if( m_hBadgeImage != nullptr )
 	{
 		DeleteObject( m_hBadgeImage );
-		m_hBadgeImage = NULL;
+		m_hBadgeImage = nullptr;
 	}
-	if( m_hBadgeImageLocked != NULL )
+	if( m_hBadgeImageLocked != nullptr )
 	{
 		DeleteObject( m_hBadgeImageLocked );
-		m_hBadgeImageLocked = NULL;
+		m_hBadgeImageLocked = nullptr;
 	}
 }
 
@@ -521,7 +521,7 @@ void Achievement::Set( const Achievement& rRHS )
 //
 //float Achievement::ProgressGetNextStep( char* sFormat, float fLastKnownProgress )
 //{
-//	const float fStep = ( (float)strtol( sFormat, NULL, 10 ) / 100.0f );
+//	const float fStep = ( (float)strtol( sFormat, nullptr, 10 ) / 100.0f );
 //	int nIter = 1;	//	Progress of 0% doesn't require a popup...
 //	float fStepAt = fStep * nIter;
 //	while( (fLastKnownProgress >= fStepAt) && (fStepAt < 1.0f) && (nIter < 20) )
@@ -538,7 +538,7 @@ void Achievement::Set( const Achievement& rRHS )
 //
 //float Achievement::ParseProgressExpression( char* pExp )
 //{
-//	if( pExp == NULL )
+//	if( pExp == nullptr )
 //		return 0.0f;
 // 
 //	int nOperator = 0;	//	0=add, 1=mult, 2=sub
@@ -551,7 +551,7 @@ void Achievement::Set( const Achievement& rRHS )
 // 
 //	int nIterations = 0;
 // 
-//	while( *pStrIter != NULL && nIterations < 20 )
+//	while( *pStrIter != nullptr && nIterations < 20 )
 //	{
 //		float fNextVal = 0.0f;
 // 
@@ -586,7 +586,7 @@ void Achievement::Set( const Achievement& rRHS )
 //		if( strncmp( pStrIter, "Cond:", 5 ) == 0 )
 //		{
 //			//	Get the specified condition, and the value from it.
-//			unsigned int nCondIter = strtol( pStrIter+5, NULL, 10 );
+//			unsigned int nCondIter = strtol( pStrIter+5, nullptr, 10 );
 //			
 //			if( nCondIter < NumConditions() )
 //			{
@@ -697,14 +697,14 @@ void Achievement::Set( const Achievement& rRHS )
 //		//	sprintf_s( formatSpareBuffer, 256, m_sProgressFmt ); 
 // 
 //		char* pUnused = &formatSpareBuffer[0];
-//		char* pUnused2 = NULL;
-//		char* pFirstFmt = NULL;
-//		char* pSecondFmt = NULL;
+//		char* pUnused2 = nullptr;
+//		char* pFirstFmt = nullptr;
+//		char* pSecondFmt = nullptr;
 //		strtok_s( pUnused, ",", &pFirstFmt );
 //		strtok_s( pFirstFmt, ",", &pSecondFmt );
 //		strtok_s( pSecondFmt, ",\0\n:", &pUnused2 );	//	Adds a very useful '\0' to pSecondFmt 
 //		
-//		if( pFirstFmt==NULL || pSecondFmt==NULL )
+//		if( pFirstFmt==nullptr || pSecondFmt==nullptr )
 //		{
 //			ASSERT(!"FUCK. Format string is fucked");
 //			return;

--- a/src/RA_Achievement.cpp
+++ b/src/RA_Achievement.cpp
@@ -1,30 +1,7 @@
 #include "RA_Achievement.h"
 
-#include <windows.h>
-#include <commctrl.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include <memory.h>
-#include <assert.h>
-#include <io.h>
-#include <sstream>
-
-#include "RA_Dlg_Achievement.h"
-#include "RA_Dlg_GameTitle.h"
-
-#include "md5.h"
-#include "RA_md5factory.h"
-
-#include "RA_MemManager.h"
-#include "RA_User.h"
-#include "RA_PopupWindows.h"
-#include "RA_httpthread.h"
-#include "RA_Defs.h"
-#include "RA_ImageFactory.h"
 #include "RA_Core.h"
-#include "RA_Leaderboard.h"
-#include "RA_Condition.h"
-#include "RA_RichPresence.h"
+#include "RA_ImageFactory.h"
 
 //	No game-specific code here please!
 
@@ -34,7 +11,6 @@ Achievement::Achievement( AchievementSetType nType ) :
 	m_nSetType( nType ), m_bPauseOnTrigger( FALSE ), m_bPauseOnReset( FALSE )
 {
 	Clear();
-	m_vConditions.push_back( ConditionSet() );
 }
 
 void Achievement::Parse( const Value& element )
@@ -54,172 +30,126 @@ void Achievement::Parse( const Value& element )
 
 	if( element["MemAddr"].IsString() )
 	{
-		std::string sMem = element["MemAddr"].GetString();
-		char buffer[8192];
-		sprintf_s( buffer, 8192, sMem.c_str() );
-		ParseMemString( buffer );
+		const char* sMem = element["MemAddr"].GetString();
+		if (!m_vConditions.ParseFromString(sMem) || *sMem != '\0') {
+			ASSERT(!"Invalid MemAddr");
+			m_vConditions.Clear();
+		}
 	}
 
 	SetActive( IsCoreAchievement() );	//	Activate core by default
 }
 
-char* Achievement::ParseMemString( char* sMem )
+const char* Achievement::ParseLine(const char* pBuffer)
 {
-	size_t nCondGroupID = 0;
-	char* pBuffer = sMem;
+	std::string sTemp;
 
-	do
-	{
-		std::vector<Condition> NewConditionGroup;
+	if (pBuffer == nullptr || pBuffer[0] == '\0')
+		return pBuffer;
 
-		do 
-		{
-			{
-				while( (*pBuffer) == ' ' || (*pBuffer) == '_' || (*pBuffer) == '|' || (*pBuffer) == 'S' )
-					pBuffer++; // Skip any chars up til the start of the achievement condition
-			}
-			
-			Condition nNewCond;
-			nNewCond.ParseFromString( pBuffer );
-			NewConditionGroup.push_back( nNewCond );
-		}
-		while( *pBuffer == '_' ||	// AND
-			*pBuffer == 'R' ||		// ResetIf
-			*pBuffer == 'P' ||		// PauseIf
-			*pBuffer == 'A' ||		// AddSource
-			*pBuffer == 'B' ||		// SubSource
-			*pBuffer == 'C' );		// AddHits
+	if (pBuffer[0] == '/' || pBuffer[0] == '\\')
+		return pBuffer;
 
-		for( size_t i = 0; i < NewConditionGroup.size(); ++i )
-			AddCondition( nCondGroupID, NewConditionGroup[i] );
+	//	Read ID of achievement:
+	_ReadStringTil(sTemp, ':', pBuffer);
+	SetID((unsigned int)atol(sTemp.c_str()));
 
-		nCondGroupID++;
-	}
-	while( *pBuffer == 'S' );	//	Repeat for all subconditions if they exist
+	//	parse conditions
+	m_vConditions.ParseFromString(pBuffer);
+
+	// Skip any whitespace/colons
+	while (*pBuffer == ' ' || *pBuffer == ':')
+		pBuffer++;
+
+	SetActive(false);
+
+	//	buffer now contains TITLE : DESCRIPTION : PROGRESS(unused) : PROGRESS_MAX(unused) : PROGRESS_FMT(unused) :
+	//                      AUTHOR : POINTS : CREATED : MODIFIED : UPVOTES : DOWNVOTES : BADGEFILENAME
+
+	_ReadStringTil(sTemp, ':', pBuffer);
+	SetTitle(sTemp);
+
+	_ReadStringTil(sTemp, ':', pBuffer);
+	SetDescription(sTemp);
+
+	_ReadStringTil(sTemp, ':', pBuffer);
+	SetProgressIndicator(sTemp);
+
+	_ReadStringTil(sTemp, ':', pBuffer);
+	SetProgressIndicatorMax(sTemp);
+
+	_ReadStringTil(sTemp, ':', pBuffer);
+	SetProgressIndicatorFormat(sTemp);
+
+	_ReadStringTil(sTemp, ':', pBuffer);
+	SetAuthor(sTemp);
+
+	_ReadStringTil(sTemp, ':', pBuffer);
+	SetPoints((unsigned int)atol(sTemp.c_str()));
+
+	_ReadStringTil(sTemp, ':', pBuffer);
+	SetCreatedDate((time_t)atol(sTemp.c_str()));
+
+	_ReadStringTil(sTemp, ':', pBuffer);
+	SetModifiedDate((time_t)atol(sTemp.c_str()));
+
+	_ReadStringTil(sTemp, ':', pBuffer);
+	// SetUpvotes( (unsigned short)atol( sTemp.c_str() ) );
+
+	_ReadStringTil(sTemp, ':', pBuffer);
+	// SetDownvotes( (unsigned short)atol( sTemp.c_str() ) );
+
+	_ReadStringTil(sTemp, ':', pBuffer);
+	SetBadgeImage(sTemp);
 
 	return pBuffer;
 }
 
-char* Achievement::ParseLine( char* pBuffer )
+static bool HasHitCounts(const ConditionSet& set)
 {
-	char* pTitle = nullptr;
-	char* pDesc = nullptr;
-	char* pProgress = nullptr;
-	char* pProgressMax = nullptr;
-	char* pProgressFmt = nullptr;
-	char* pAuthor = nullptr;
-	char* pBadgeFilename = nullptr;
+	for (size_t i = 0; i < set.GroupCount(); i++)
+	{
+		const ConditionGroup& group = set.GetGroup(i);
+		for (size_t j = 0; j < group.Count(); j++)
+		{
+			const Condition& condition = group.GetAt(j);
+			if (condition.CurrentHits() > 0)
+				return true;
+		}
+	}
 
-	unsigned int nPoints = 0;
-	time_t nDateCreatedSecs = 0;
-	time_t nDateModifiedSecs = 0;
-	unsigned short nUpvotes = 0;
-	unsigned short nDownvotes = 0;
-	
-	//	Achievement:
-	char* pNextChar = nullptr;
-	unsigned int nResetCondIter = 0;
-	unsigned int nAchievementID = 0;
-	unsigned int i = 0;
-
-	if( pBuffer == nullptr || pBuffer[0] == '\0' )
-		return pBuffer;
-
-	if( pBuffer[0] == '/' || pBuffer[0] == '\\' )
-		return pBuffer;
-
-	//	Read ID of achievement:
-
-	nAchievementID = strtol( pBuffer, &pNextChar, 10 );
-	pBuffer = pNextChar+1;
-
-	//	
-	pBuffer = ParseMemString( pBuffer );
-	//	
-
-	while( *pBuffer == ' ' || *pBuffer == ':' )
-		pBuffer++; // Skip any whitespace/colons
-
-	SetActive( FALSE );
-	SetID( nAchievementID );
-
-	//	buffer now contains TITLE : DESCRIPTION : $POINTS : $Author : $DateCreated : $DateModified : upvotes : downvotes : badgefilename
-	
-	pTitle				= _ReadStringTil( ':', pBuffer, TRUE );
-	pDesc				= _ReadStringTil( ':', pBuffer, TRUE );
-	pProgress			= _ReadStringTil( ':', pBuffer, TRUE );
-	pProgressMax		= _ReadStringTil( ':', pBuffer, TRUE );
-	pProgressFmt		= _ReadStringTil( ':', pBuffer, TRUE );
-	pAuthor				= _ReadStringTil( ':', pBuffer, TRUE );
-	
-	nPoints =			(unsigned int)atol(   _ReadStringTil( ':', pBuffer, TRUE ) );
-	nDateCreatedSecs =	(time_t)atol(		  _ReadStringTil( ':', pBuffer, TRUE ) );
-	nDateModifiedSecs =	(time_t)atol(		  _ReadStringTil( ':', pBuffer, TRUE ) );
-	nUpvotes =			(unsigned short)atol( _ReadStringTil( ':', pBuffer, TRUE ) );
-	nDownvotes =		(unsigned short)atol( _ReadStringTil( ':', pBuffer, TRUE ) );
-
-	pBadgeFilename		= _ReadStringTil( ':', pBuffer, TRUE );
-
-	SetPoints( nPoints );
-	SetCreatedDate( nDateCreatedSecs );
-	SetModifiedDate( nDateModifiedSecs );
-	SetTitle( pTitle );
-	SetDescription( pDesc );
-	SetAuthor( pAuthor );
-	SetProgressIndicator( pProgress );
-	SetProgressIndicatorMax( pProgressMax );
-	SetProgressIndicatorFormat( pProgressFmt );
-	//SetUpvotes( nUpvotes );
-	//SetDownvotes( nDownvotes );
-	SetBadgeImage( pBadgeFilename );
-	
-	return pBuffer;
+	return false;
 }
 
 BOOL Achievement::Test()
 {
-	BOOL bDirtyConditions = FALSE;
-	BOOL bResetConditions = FALSE;
+	bool bDirtyConditions = FALSE;
+	bool bResetConditions = FALSE;
 
-	BOOL bRetVal = FALSE;
-	BOOL bRetValSubCond = NumConditionGroups() == 1 ? TRUE : FALSE;
-	for( size_t i = 0; i < NumConditionGroups(); ++i )
-	{
-		if( i == 0 )
-			bRetVal = m_vConditions[i].Test( bDirtyConditions, bResetConditions, FALSE );
-		else	//	OR!
-			bRetValSubCond |= m_vConditions[i].Test( bDirtyConditions, bResetConditions, FALSE );
-	}
+	bool bNotifyOnReset = GetPauseOnReset() && HasHitCounts( m_vConditions );
+
+	bool bRetVal = m_vConditions.Test( bDirtyConditions, bResetConditions );
 
 	if( bDirtyConditions )
 	{
 		SetDirtyFlag( Dirty_Conditions );
 	}
 
-	if( bResetConditions )
+	if( bResetConditions && bNotifyOnReset )
 	{
-		Reset();
+		RA_CausePause();
 
-		if ( GetPauseOnReset() )
-		{
-			RA_CausePause();
-
-			char buffer[256];
-			sprintf_s( buffer, 256, "Pause on Reset: %s", Title().c_str() );
-			MessageBox( g_RAMainWnd, NativeStr(buffer).c_str(), TEXT("Paused"), MB_OK );
-		}
+		char buffer[256];
+		sprintf_s( buffer, 256, "Pause on Reset: %s", Title().c_str() );
+		MessageBox( g_RAMainWnd, NativeStr(buffer).c_str(), TEXT("Paused"), MB_OK );
 	}
 
-	return bRetVal && bRetValSubCond;
+	return bRetVal;
 }
 
 void Achievement::Clear()
 {
-	size_t i = 0;
-	for( size_t i = 0; i < m_vConditions.size(); ++i )
-		m_vConditions[i].Clear();
-
-	//m_vConditions.clear();
+	m_vConditions.Clear();
 
 	m_nAchievementID = 0;
 	
@@ -250,15 +180,15 @@ void Achievement::Clear()
 
 void Achievement::AddConditionGroup()
 {
-	m_vConditions.push_back( ConditionSet() );
+	m_vConditions.AddGroup();
 }
 
 void Achievement::RemoveConditionGroup()
 {
-	m_vConditions.pop_back();
+	m_vConditions.RemoveLastGroup();
 }
 
-void Achievement::SetID( unsigned int nID )
+void Achievement::SetID( AchievementID nID )
 { 
 	m_nAchievementID = nID;
 	SetDirtyFlag( Dirty_ID );
@@ -315,150 +245,58 @@ void Achievement::SetBadgeImage( const std::string& sBadgeURI )
 
 void Achievement::Reset()
 {
-	//	Get all conditions, set hits found=0
-	BOOL bDirty = FALSE;
-	
-	for( size_t i = 0; i < NumConditionGroups(); ++i )
-		bDirty |= m_vConditions[i].Reset( false );
-
-	if( bDirty )
+    if ( m_vConditions.Reset() )
 		SetDirtyFlag( Dirty_Conditions );
 }
 
 size_t Achievement::AddCondition( size_t nConditionGroup, const Condition& rNewCond )
 { 
 	while( NumConditionGroups() <= nConditionGroup )	//	ENSURE this is a legal op!
-		m_vConditions.push_back( ConditionSet() );
+		m_vConditions.AddGroup();
 
-	m_vConditions[nConditionGroup].Add( rNewCond );	//	NB. Copy by value	
+	ConditionGroup& group = m_vConditions.GetGroup( nConditionGroup );
+	group.Add( rNewCond );	//	NB. Copy by value	
 	SetDirtyFlag( Dirty__All );
 
-	return m_vConditions[nConditionGroup].Count();
+	return group.Count();
 }
 
 size_t Achievement::InsertCondition( size_t nConditionGroup, size_t nIndex, const Condition& rNewCond )
 { 
 	while( NumConditionGroups() <= nConditionGroup )	//	ENSURE this is a legal op!
-		m_vConditions.push_back( ConditionSet() );
+		m_vConditions.AddGroup();
 
-	m_vConditions[nConditionGroup].Insert( nIndex, rNewCond );	//	NB. Copy by value	
+	ConditionGroup& group = m_vConditions.GetGroup(nConditionGroup);
+	group.Insert( nIndex, rNewCond );	//	NB. Copy by value	
 	SetDirtyFlag( Dirty__All );
 
-	return m_vConditions[nConditionGroup].Count();
+	return group.Count();
 }
 
 BOOL Achievement::RemoveCondition( size_t nConditionGroup, unsigned int nID )
 {
-	m_vConditions[nConditionGroup].RemoveAt( nID );
-	SetDirtyFlag( Dirty__All );	//	Not Conditions: 
+	if ( nConditionGroup < m_vConditions.GroupCount() ) {
+		m_vConditions.GetGroup( nConditionGroup ).RemoveAt( nID );
+		SetDirtyFlag( Dirty__All );	//	Not Conditions: 
+		return TRUE;
+	}
 
-	return TRUE;
+	return FALSE;
 }
 
 void Achievement::RemoveAllConditions( size_t nConditionGroup )
 {
-	m_vConditions[nConditionGroup].Clear();
-
-	SetDirtyFlag( Dirty__All );	//	All - not just conditions!
+	if ( nConditionGroup < m_vConditions.GroupCount() ) {
+		m_vConditions.GetGroup( nConditionGroup ).Clear();
+		SetDirtyFlag( Dirty__All );	//	All - not just conditions
+	}
 }
 
 std::string Achievement::CreateMemString() const
 {
-	std::stringstream sstr;
-	for( size_t nGrp = 0; nGrp < NumConditionGroups(); ++nGrp )
-	{
-		if( m_vConditions[ nGrp ].Count() == 0 )	//	Ignore empty groups when saving
-			continue;
-		
-		if( nGrp > 0 )	//	Subcondition start found
-			sstr << "S";
-
-		for( size_t i = 0; i < m_vConditions[ nGrp ].Count(); ++i )
-		{
-			const Condition& NextCond = m_vConditions[ nGrp ].GetAt( i );
-			const CompVariable& Src = NextCond.CompSource();
-			const CompVariable& Target = NextCond.CompTarget();
-
-			char sNextCondition[ 256 ];
-			memset( sNextCondition, 0, 256 );
-			
-			if( NextCond.IsResetCondition() )
-				strcat_s( sNextCondition, 256, "R:" );
-			else if( NextCond.IsPauseCondition() )
-				strcat_s( sNextCondition, 256, "P:" );
-			else if ( NextCond.IsAddCondition() )
-				strcat_s( sNextCondition, 256, "A:" );
-			else if ( NextCond.IsSubCondition() )
-				strcat_s( sNextCondition, 256, "B:" );
-			else if ( NextCond.IsAddHitsCondition() )
-				strcat_s( sNextCondition, 256, "C:" );
-			
-			//	Source:
-			if( ( Src.Type() == Address ) || 
-				( Src.Type() == DeltaMem ) )
-			{
-				char buffer1[ 64 ];
-				sprintf_s( buffer1, 64, "%s0x%s%06x", ( Src.Type() == DeltaMem ) ? "d" : "", ComparisonSizeToPrefix( Src.Size() ), Src.RawValue() );
-				strcat_s( sNextCondition, 256, buffer1 );
-			}
-			else if( Src.Type() == ValueComparison )
-			{
-				//	Value: use direct!
-				char buffer2[ 64 ];
-				sprintf_s( buffer2, 64, "%d", Src.RawValue() );
-				strcat_s( sNextCondition, 256, buffer2 );
-			}
-			else
-			{
-				ASSERT( !"Unknown type? (DynMem)?" );
-			}
-			
-			//	Comparison type:
-			strcat_s( sNextCondition, 256, ComparisonTypeToStr( NextCond.CompareType() ) );
-
-			//	Target:
-			if( ( Target.Type() == Address ) || 
-				( Target.Type() == DeltaMem ) )
-			{
-				char buffer3[ 64 ];
-				sprintf_s( buffer3, 64,
-						   "%s%s%06x",
-						   ( Target.Type() == DeltaMem ) ? "d0x" : "0x",
-						   ComparisonSizeToPrefix( Target.Size() ), 
-						   Target.RawValue() );
-
-				strcat_s( sNextCondition, 256, buffer3 );
-			}
-			else if( Target.Type() == ValueComparison )
-			{
-				//	Value: use direct!
-				char buffer4[ 64 ];
-				sprintf_s( buffer4, 64, "%d", Target.RawValue() );
-				strcat_s( sNextCondition, 256, buffer4 );
-			}
-			else
-			{
-				ASSERT( !"Unknown type? (DynMem)?" );
-			}
-			
-			//	Hit count:
-			if( NextCond.RequiredHits() > 0 )
-			{
-				char buffer5[ 64 ];
-				sprintf_s( buffer5, 64, ".%d.", NextCond.RequiredHits() );
-				strcat_s( sNextCondition, 256, buffer5 );
-			}
-			
-			//	Copy in the next condition:
-			sstr << sNextCondition;
-
-			//	Are we on the last condition? THIS IS IMPORTANT: check the parsing code!
-			if( ( i + 1 ) < m_vConditions[nGrp].Count() )
-				sstr << "_";
-		}
-	}
-
-	return sstr.str();
+	std::string buffer;
+	m_vConditions.Serialize(buffer);
+	return buffer;
 }
 
 void Achievement::ClearBadgeImage()
@@ -493,14 +331,15 @@ void Achievement::Set( const Achievement& rRHS )
 
 	for( size_t i = 0; i < NumConditionGroups(); ++i )
 		RemoveAllConditions( i );
-	m_vConditions.clear();
+	m_vConditions.Clear();
 
 	for( size_t nGrp = 0; nGrp < rRHS.NumConditionGroups(); ++nGrp )
 	{
-		m_vConditions.push_back( ConditionSet() );
+		m_vConditions.AddGroup();
 
-		for( size_t i = 0; i < rRHS.m_vConditions[nGrp].Count(); ++i )
-			AddCondition( nGrp, rRHS.m_vConditions[nGrp].GetAt(i) );
+		const ConditionGroup& group = rRHS.m_vConditions.GetGroup( nGrp );
+		for( size_t i = 0; i < group.Count(); ++i )
+			AddCondition( nGrp, group.GetAt(i) );
 	}
 
 	SetDirtyFlag( Dirty__All );

--- a/src/RA_Achievement.h
+++ b/src/RA_Achievement.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <vector>
 #include "RA_Condition.h"
 #include "RA_Defs.h"
 
@@ -84,8 +83,8 @@ public:
 	void AddConditionGroup();
 	void RemoveConditionGroup();
 
-	inline size_t NumConditionGroups() const						{ return m_vConditions.size(); }
-	inline size_t NumConditions( size_t nGroup ) const				{ return m_vConditions[ nGroup ].Count(); }
+	inline size_t NumConditionGroups() const						{ return m_vConditions.GroupCount(); }
+	inline size_t NumConditions( size_t nGroup ) const				{ return m_vConditions.GetGroup( nGroup ).Count(); }
 
 	inline HBITMAP BadgeImage() const								{ return m_hBadgeImage; }
 	inline HBITMAP BadgeImageLocked() const							{ return m_hBadgeImageLocked; }
@@ -94,23 +93,17 @@ public:
 	void SetBadgeImage( const std::string& sFilename );
 	void ClearBadgeImage();
 
-	Condition& GetCondition( size_t nCondGroup, size_t i )			{ return m_vConditions[ nCondGroup ].GetAt( i ); }
+	Condition& GetCondition( size_t nCondGroup, size_t i )			{ return m_vConditions.GetGroup( nCondGroup ).GetAt( i ); }
 	
 	std::string CreateMemString() const;
 
 	void Reset();
 
-	void UpdateProgress();
-	float ProgressGetNextStep( char* sFormat, float fLastKnownProgress );
-	float ParseProgressExpression( char* pExp );
-
 	//	Returns the new char* offset after parsing.
-	char* ParseLine( char* buffer );
+	const char* ParseLine( const char* buffer );
 	
 	//	Parse from json element
 	void Parse( const Value& element );
-	
-	char* ParseMemString( char* sMem );
 
 	//	Used for rendering updates when editing achievements. Usually always false.
 	unsigned int GetDirtyFlags() const			{ return m_nDirtyFlags; }
@@ -122,7 +115,7 @@ private:
 	/*const*/ AchievementSetType m_nSetType;
 
 	AchievementID m_nAchievementID;
-	std::vector<ConditionSet> m_vConditions;
+	ConditionSet m_vConditions;
 
 	std::string m_sTitle;
 	std::string m_sDescription;

--- a/src/RA_AchievementOverlay.cpp
+++ b/src/RA_AchievementOverlay.cpp
@@ -16,12 +16,13 @@
 
 namespace
 {
-	const float PAGE_TRANSITION_IN = (-0.2f);
-	const float PAGE_TRANSITION_OUT = ( 0.2f);
-	const int NUM_MESSAGES_TO_DRAW = 4;
-	const char* FONT_TO_USE = "Tahoma";
 
-	const char* PAGE_TITLES[] = { 
+	inline constexpr auto PAGE_TRANSITION_IN   = -0.2f;
+	inline constexpr auto PAGE_TRANSITION_OUT  = 0.2f;
+	inline constexpr auto NUM_MESSAGES_TO_DRAW = 4;
+	inline constexpr auto FONT_TO_USE          = "Tahoma";
+
+	inline constexpr std::array<const char*, NumOverlayPages> PAGE_TITLES {
 		" Achievements ", 
 		" Friends ", 
 		" Messages ",
@@ -35,7 +36,6 @@ namespace
 		" Message Viewer "
 
 		};
-	static_assert( SIZEOF_ARRAY( PAGE_TITLES ) == NumOverlayPages, "Must match!" );
 
 }
 

--- a/src/RA_AchievementOverlay.cpp
+++ b/src/RA_AchievementOverlay.cpp
@@ -1777,6 +1777,11 @@ API void _RA_RenderOverlay( HDC hDC, RECT* rcSize )
 	g_AchievementOverlay.Render( hDC, rcSize );
 }
 
+API bool _RA_IsOverlayFullyVisible()
+{
+    return g_AchievementOverlay.IsFullyVisible();
+}
+
 API void _RA_InitDirectX()
 {
 	g_AchievementOverlay.InitDirectX();

--- a/src/RA_AchievementOverlay.cpp
+++ b/src/RA_AchievementOverlay.cpp
@@ -100,7 +100,7 @@ void AchievementOverlay::SelectNextTopLevelPage( BOOL bPressedRight )
 
 AchievementOverlay::AchievementOverlay()
 {
-	m_hOverlayBackground = NULL;
+	m_hOverlayBackground = nullptr;
 	m_nAchievementsSelectedItem = 0;
 	m_nFriendsSelectedItem = 0;
 	m_nMessagesSelectedItem = 0;
@@ -110,10 +110,10 @@ AchievementOverlay::AchievementOverlay()
 
 AchievementOverlay::~AchievementOverlay()
 {
-	if( m_hOverlayBackground != NULL )
+	if( m_hOverlayBackground != nullptr )
 	{
 		DeleteObject( m_hOverlayBackground );
-		m_hOverlayBackground = NULL;
+		m_hOverlayBackground = nullptr;
 	}
 }
 
@@ -140,7 +140,7 @@ void AchievementOverlay::Initialize( HINSTANCE hInst )
 	m_LatestNews.clear();
 
 	m_hOverlayBackground = LoadLocalPNG( RA_OVERLAY_BG_FILENAME, RASize( OVERLAY_WIDTH, OVERLAY_HEIGHT ) );
-	//if( m_hOverlayBackground == NULL )
+	//if( m_hOverlayBackground == nullptr )
 	//{
 	//	//	Backup
 	//	m_hOverlayBackground = LoadBitmap( hInst, MAKEINTRESOURCE(IDB_RA_BACKGROUND) );
@@ -681,13 +681,13 @@ void AchievementOverlay::DrawFriendsPage( HDC hDC, int nDX, int nDY, const RECT&
 		if( (i+nOffset) < nNumFriends )
 		{
 			RAUser* pFriend = RAUsers::LocalUser().GetFriendByIter( (i+nOffset) );
-			if( pFriend == NULL )
+			if( pFriend == nullptr )
 				continue;
 
-			if( pFriend->GetUserImage() == NULL && !pFriend->IsFetchingUserImage() )
+			if( pFriend->GetUserImage() == nullptr && !pFriend->IsFetchingUserImage() )
 				pFriend->LoadOrFetchUserImage();
 
-			if( pFriend->GetUserImage() != NULL )
+			if( pFriend->GetUserImage() != nullptr )
 				DrawImage( hDC, pFriend->GetUserImage(), nXOffs, nYOffs, 64, 64 );
 
 			if( (m_nFriendsSelectedItem - m_nFriendsScrollOffset) == i )
@@ -1370,12 +1370,12 @@ void AchievementOverlay::DrawAchievement( HDC hDC, const Achievement* pAch, int 
 
 	if( !bLocked )
 	{
-		if( pAch->BadgeImage() != NULL )
+		if( pAch->BadgeImage() != nullptr )
 			DrawImage( hDC, pAch->BadgeImage(), nX + nAchImageOffset, nY, 64, 64 );
 	}
 	else
 	{
-		if( pAch->BadgeImageLocked() != NULL )
+		if( pAch->BadgeImageLocked() != nullptr )
 			DrawImage( hDC, pAch->BadgeImageLocked(), nX + nAchImageOffset, nY, 64, 64 );
 	}
 
@@ -1509,7 +1509,7 @@ void AchievementOverlay::InitDirectX()
 	}
 
 	//LPDIRECTDRAW lpDD_Init;
-	//if (DirectDrawCreate(NULL, &lpDD_Init, NULL) != DD_OK)
+	//if (DirectDrawCreate(nullptr, &lpDD_Init, nullptr) != DD_OK)
 	//{
 	//	MessageBox( g_RAMainWnd, "DirectDrawCreate failed!", "Error!", MB_OK );
 	//	return;
@@ -1522,7 +1522,7 @@ void AchievementOverlay::InitDirectX()
 	//}
 
 	//lpDD_Init->Release();
-	//lpDD_Init = NULL;
+	//lpDD_Init = nullptr;
 
 	//m_lpDD->SetCooperativeLevel( g_RAMainWnd, DDSCL_NORMAL );
 
@@ -1531,16 +1531,16 @@ void AchievementOverlay::InitDirectX()
 
 void AchievementOverlay::ResetDirectX()
 {
-	//if( m_lpDD == NULL )
+	//if( m_lpDD == nullptr )
 	//	return;
 
 	//RECT rcTgtSize;
 	//SetRect( &rcTgtSize, 0, 0, 640, 480 );
 
-	//if( m_lpDDS_Overlay != NULL )
+	//if( m_lpDDS_Overlay != nullptr )
 	//{
 	//	m_lpDDS_Overlay->Release();
-	//	m_lpDDS_Overlay = NULL;
+	//	m_lpDDS_Overlay = nullptr;
 	//}
 
 	//DDSURFACEDESC2 ddsd;
@@ -1552,7 +1552,7 @@ void AchievementOverlay::ResetDirectX()
 	//ddsd.dwWidth = rcTgtSize.right - rcTgtSize.left;
 	//ddsd.dwHeight = rcTgtSize.bottom - rcTgtSize.top;
 
-	//HRESULT hr = m_lpDD->CreateSurface(&ddsd, &m_lpDDS_Overlay, NULL);
+	//HRESULT hr = m_lpDD->CreateSurface(&ddsd, &m_lpDDS_Overlay, nullptr);
 	//if( hr != DD_OK )
 	//{
 	//	assert(!"Cannot create overlay surface!");
@@ -1563,7 +1563,7 @@ void AchievementOverlay::ResetDirectX()
 
 void AchievementOverlay::Flip(HWND hWnd)
 {
-	//if( m_lpDDS_Overlay == NULL )
+	//if( m_lpDDS_Overlay == nullptr )
 	//	return;
 
 	//RECT rcDest;

--- a/src/RA_AchievementOverlay.h
+++ b/src/RA_AchievementOverlay.h
@@ -74,7 +74,6 @@ public:
 public:
 	void Initialize( const Achievement* pAchIn );
 	void Clear();
-	static void CB_OnReceiveData( void* pRequestObject );
 	void OnReceiveData( Document& doc );
 	
 	bool HasData() const											{ return m_bHasData; }
@@ -109,7 +108,6 @@ public:
 	~AchievementOverlay();
 
 	void Initialize( HINSTANCE hInst );
-	void InstallHINSTANCE( HINSTANCE hInst );
 
 	void Activate();
 	void Deactivate();
@@ -117,7 +115,8 @@ public:
 	void Render( HDC hDC, RECT* rcDest ) const;
 	BOOL Update( ControllerInput* input, float fDelta, BOOL bFullScreen, BOOL bPaused );
 
-	BOOL IsActive() const	{ return( m_nTransitionState!=TS_OFF ); }
+    BOOL IsActive() const { return(m_nTransitionState != TS_OFF); }
+    BOOL IsFullyVisible() const { return (m_nTransitionState == TS_HOLD); }
 
 	const int* GetActiveScrollOffset() const;
 	const int* GetActiveSelectedItem() const;
@@ -145,7 +144,6 @@ public:
 	
 	void InitDirectX();
 	void ResetDirectX();
-	void CloseDirectX();
 	void Flip(HWND hWnd);
 
 	void InstallNewsArticlesFromFile();
@@ -201,6 +199,7 @@ extern "C"
 {
 	API extern int _RA_UpdateOverlay( ControllerInput* pInput, float fDTime, bool Full_Screen, bool Paused );
 	API extern void _RA_RenderOverlay( HDC hDC, RECT* rcSize );
+    API extern bool _RA_IsOverlayFullyVisible();
 
 	API extern void _RA_InitDirectX();
 	API extern void _RA_OnPaint( HWND hWnd );

--- a/src/RA_AchievementPopup.cpp
+++ b/src/RA_AchievementPopup.cpp
@@ -7,29 +7,28 @@
 
 namespace
 {
-	const float POPUP_DIST_Y_TO_PCT = 0.856f;		//	Where on screen to end up
-	const float POPUP_DIST_Y_FROM_PCT = 0.4f;		//	Amount of screens to travel
-	const TCHAR* FONT_TO_USE = _T( "Tahoma" );
+inline constexpr auto POPUP_DIST_Y_TO_PCT   = 0.856f;		//	Where on screen to end up
+inline constexpr auto POPUP_DIST_Y_FROM_PCT = 0.4f;		//	Amount of screens to travel
+inline constexpr auto FONT_TO_USE           = _T( "Tahoma" );
 	
-	const int FONT_SIZE_TITLE = 32;
-	const int FONT_SIZE_SUBTITLE = 28;
+inline constexpr auto FONT_SIZE_TITLE    = 32;
+inline constexpr auto FONT_SIZE_SUBTITLE = 28;
 
-	const float START_AT = 0.0f;
-	const float APPEAR_AT = 0.8f;
-	const float FADEOUT_AT = 4.2f;
-	const float FINISH_AT = 5.0f;
+inline constexpr auto START_AT   = 0.0f;
+inline constexpr auto APPEAR_AT  = 0.8f;
+inline constexpr auto FADEOUT_AT = 4.2f;
+inline constexpr auto FINISH_AT  = 5.0f;
 
-	const TCHAR* MSG_SOUND[] =
-	{
-		_T( "./Overlay/login.wav" ),
-		_T( "./Overlay/info.wav" ),
-		_T( "./Overlay/unlock.wav" ),
-		_T( "./Overlay/acherror.wav" ),
-		_T( "./Overlay/lb.wav" ),
-		_T( "./Overlay/lbcancel.wav" ),
-		_T( "./Overlay/message.wav" ),
-	};
-	static_assert( SIZEOF_ARRAY( MSG_SOUND ) == NumMessageTypes, "Must match!" );
+inline constexpr std::array<LPCTSTR, NumMessageTypes> MSG_SOUND
+{
+	_T( "./Overlay/login.wav" ),
+	_T( "./Overlay/info.wav" ),
+	_T( "./Overlay/unlock.wav" ),
+	_T( "./Overlay/acherror.wav" ),
+	_T( "./Overlay/lb.wav" ),
+	_T( "./Overlay/lbcancel.wav" ),
+	_T( "./Overlay/message.wav" ),
+};
 }
 
 AchievementPopup::AchievementPopup() :

--- a/src/RA_AchievementPopup.cpp
+++ b/src/RA_AchievementPopup.cpp
@@ -40,7 +40,7 @@ AchievementPopup::AchievementPopup() :
 void AchievementPopup::PlayAudio()
 {
 	ASSERT( MessagesPresent() );	//	ActiveMessage() dereferences!
-	PlaySound( MSG_SOUND[ ActiveMessage().Type() ], NULL, SND_FILENAME|SND_ASYNC );
+	PlaySound( MSG_SOUND[ ActiveMessage().Type() ], nullptr, SND_FILENAME|SND_ASYNC );
 }
 
 void AchievementPopup::AddMessage( const MessagePopup& msg )
@@ -129,7 +129,7 @@ void AchievementPopup::Render( HDC hDC, RECT& rcDest )
 
 	if( ActiveMessage().Type() == PopupAchievementUnlocked || ActiveMessage().Type() == PopupAchievementError )
 	{
-		if (ActiveMessage().Image() != NULL)
+		if (ActiveMessage().Image() != nullptr)
 			DrawImage( hDC, ActiveMessage().Image(), nTitleX, nTitleY, 64, 64 );
 
 		nTitleX += 64 + 4 + 2;	//	Negate the 2 from earlier!
@@ -159,13 +159,13 @@ void AchievementPopup::Render( HDC hDC, RECT& rcDest )
 	HGDIOBJ hPen = CreatePen( PS_SOLID, 2, COL_POPUP_SHADOW );
 	SelectObject( hDC, hPen );
 
-	MoveToEx( hDC, nTitleX, nTitleY + szTitle.cy, NULL );
+	MoveToEx( hDC, nTitleX, nTitleY + szTitle.cy, nullptr );
 	LineTo( hDC, nTitleX + szTitle.cx, nTitleY + szTitle.cy );	//	right
 	LineTo( hDC, nTitleX + szTitle.cx, nTitleY + 1 );			//	up
 
 	if( ActiveMessage().Subtitle().length() > 0 )
 	{
-		MoveToEx( hDC, nDescX, nDescY + szAchievement.cy, NULL );
+		MoveToEx( hDC, nDescX, nDescY + szAchievement.cy, nullptr );
 		LineTo( hDC, nDescX + szAchievement.cx, nDescY + szAchievement.cy );
 		LineTo( hDC, nDescX + szAchievement.cx, nDescY + 1 );
 	}

--- a/src/RA_AchievementSet.cpp
+++ b/src/RA_AchievementSet.cpp
@@ -18,9 +18,9 @@ AchievementSet* g_pUnofficialAchievements = nullptr;
 AchievementSet* g_pLocalAchievements = nullptr;
 
 // for now
-using AchievementSets = std::array<AchievementSet*, 3>;
+using AchievementSets = std::array<AchievementSet**, 3>;
 // can't be constexpr because AchievementSet isn't a literal type
-inline const AchievementSets ACH_SETS{ g_pCoreAchievements, g_pUnofficialAchievements, g_pLocalAchievements };
+inline const AchievementSets ACH_SETS{ &g_pCoreAchievements, &g_pUnofficialAchievements, &g_pLocalAchievements };
 
 static_assert(ACH_SETS.size() == NumAchievementSetTypes, "Must match!" );
 
@@ -31,7 +31,7 @@ AchievementSet* g_pActiveAchievements = g_pCoreAchievements;
 void RASetAchievementCollection( AchievementSetType Type )
 {
 	g_nActiveAchievementSet = Type;
-	g_pActiveAchievements = ACH_SETS.at(Type);
+    g_pActiveAchievements = *ACH_SETS.at(Type);
 }
 
 std::string AchievementSet::GetAchievementSetFilename( GameID nGameID )

--- a/src/RA_AchievementSet.cpp
+++ b/src/RA_AchievementSet.cpp
@@ -245,7 +245,7 @@ void AchievementSet::Test()
 BOOL AchievementSet::SaveToFile()
 {
 	//	Takes all achievements in this group and dumps them in the filename provided.
-	FILE* pFile = NULL;
+	FILE* pFile = nullptr;
 	char sNextLine[2048];
 	char sMem[2048];
 	unsigned int i = 0;
@@ -253,7 +253,7 @@ BOOL AchievementSet::SaveToFile()
 	const std::string sFilename = GetAchievementSetFilename(g_pCurrentGameData->GetGameID());
 
 	fopen_s(&pFile, sFilename.c_str(), "w");
-	if (pFile != NULL)
+	if (pFile != nullptr)
 	{
 		sprintf_s(sNextLine, 2048, "0.030\n");						//	Min ver
 		fwrite(sNextLine, sizeof(char), strlen(sNextLine), pFile);
@@ -296,7 +296,7 @@ BOOL AchievementSet::SaveToFile()
 	
 	return FALSE;
 
-	//FILE* pf = NULL;
+	//FILE* pf = nullptr;
 	//const std::string sFilename = GetAchievementSetFilename( m_nGameID );
 	//if( fopen_s( &pf, sFilename.c_str(), "wb" ) == 0 )
 	//{
@@ -315,7 +315,7 @@ BOOL AchievementSet::Serialize( FileStream& Stream )
 	//	Why not submit each ach straight to cloud?
 	return FALSE;
 
-	//FILE* pf = NULL;
+	//FILE* pf = nullptr;
 	//const std::string sFilename = GetAchievementSetFilename( m_nGameID );
 	//if( fopen_s( &pf, sFilename.c_str(), "wb" ) == 0 )
 	//{
@@ -569,15 +569,15 @@ void AchievementSet::SaveProgress( const char* sSaveStateFilename )
 	if( !RAUsers::LocalUser().IsLoggedIn() )
 		return;
 
-	if( sSaveStateFilename == NULL )
+	if( sSaveStateFilename == nullptr )
 		return;
 	
 	SetCurrentDirectory( NativeStr( g_sHomeDir ).c_str() );
 	char buffer[ 4096 ];
 	sprintf_s( buffer, 4096, "%s.rap", sSaveStateFilename );
-	FILE* pf = NULL;
+	FILE* pf = nullptr;
 	fopen_s( &pf, buffer, "w" );
-	if( pf == NULL )
+	if( pf == nullptr )
 	{
 		ASSERT( !"Could not save progress!" );
 		return;
@@ -643,22 +643,22 @@ void AchievementSet::LoadProgress( const char* sLoadStateFilename )
 	char cheevoProgressString[4096];
 	unsigned int i = 0;
 	unsigned int j = 0;
-	char* pGivenProgressMD5 = NULL;
-	char* pGivenCheevoMD5 = NULL;
+	char* pGivenProgressMD5 = nullptr;
+	char* pGivenCheevoMD5 = nullptr;
 	char cheevoMD5TestMangled[4096];
 	int nMemStringLen = 0;
 
 	if( !RAUsers::LocalUser().IsLoggedIn() )
 		return;
 
-	if( sLoadStateFilename == NULL )
+	if( sLoadStateFilename == nullptr )
 		return;
 
 	sprintf_s( buffer, 4096, "%s%s.rap", RA_DIR_DATA, sLoadStateFilename );
 
 	char* pRawFile = _MallocAndBulkReadFileToBuffer( buffer, nFileSize );
 
-	if( pRawFile != NULL )
+	if( pRawFile != nullptr )
 	{
 		unsigned int nOffs = 0;
 		while( nOffs < (unsigned int)(nFileSize-2) && pRawFile[nOffs] != '\0' )
@@ -712,7 +712,7 @@ void AchievementSet::LoadProgress( const char* sLoadStateFilename )
 			{
 				//	Embed in achievement:
 				Achievement* pAch = Find( nID );
-				if( pAch != NULL )
+				if( pAch != nullptr )
 				{
 					std::string sMemStr = pAch->CreateMemString();
 
@@ -755,7 +755,7 @@ void AchievementSet::LoadProgress( const char* sLoadStateFilename )
 		}
 	
 		free( pRawFile );
-		pRawFile = NULL;
+		pRawFile = nullptr;
 	}
 }
 

--- a/src/RA_AchievementSet.cpp
+++ b/src/RA_AchievementSet.cpp
@@ -11,12 +11,18 @@
 #include "RA_md5factory.h"
 #include "RA_GameData.h"
 
+// Will leave it alone for now, but having these as raw pointers is a really bad idea
+
 AchievementSet* g_pCoreAchievements = nullptr;
 AchievementSet* g_pUnofficialAchievements = nullptr;
 AchievementSet* g_pLocalAchievements = nullptr;
 
-AchievementSet** ACH_SETS[] = { &g_pCoreAchievements, &g_pUnofficialAchievements, &g_pLocalAchievements };
-static_assert( SIZEOF_ARRAY( ACH_SETS ) == NumAchievementSetTypes, "Must match!" );
+// for now
+using AchievementSets = std::array<AchievementSet*, 3>;
+// can't be constexpr because AchievementSet isn't a literal type
+inline const AchievementSets ACH_SETS{ g_pCoreAchievements, g_pUnofficialAchievements, g_pLocalAchievements };
+
+static_assert(ACH_SETS.size() == NumAchievementSetTypes, "Must match!" );
 
 AchievementSetType g_nActiveAchievementSet = Core;
 AchievementSet* g_pActiveAchievements = g_pCoreAchievements;
@@ -25,7 +31,7 @@ AchievementSet* g_pActiveAchievements = g_pCoreAchievements;
 void RASetAchievementCollection( AchievementSetType Type )
 {
 	g_nActiveAchievementSet = Type;
-	g_pActiveAchievements = *ACH_SETS[ Type ];
+	g_pActiveAchievements = ACH_SETS.at(Type);
 }
 
 std::string AchievementSet::GetAchievementSetFilename( GameID nGameID )

--- a/src/RA_AchievementSet.h
+++ b/src/RA_AchievementSet.h
@@ -54,7 +54,7 @@ public:
 	//	Take a copy of the achievement at nIter, add it and return a reference to it.
 	Achievement& Clone(unsigned int nIter);
 
-	//	Find achievement with ID, or NULL if it can't be found.
+	//	Find achievement with ID, or nullptr if it can't be found.
 	Achievement* Find(AchievementID nID);
 
 	//	Find index of the given achievement in the array list (useful for LBX lookups)

--- a/src/RA_CodeNotes.cpp
+++ b/src/RA_CodeNotes.cpp
@@ -20,7 +20,7 @@ size_t CodeNotes::Load( const std::string& sFile )
 	Clear();
 	
 	SetCurrentDirectory(NativeStr( g_sHomeDir ).c_str());
-	FILE* pf = NULL;
+	FILE* pf = nullptr;
 	if( fopen_s( &pf, sFile.c_str(), "rb" ) == 0 )
 	{
 		Document doc;

--- a/src/RA_Condition.cpp
+++ b/src/RA_Condition.cpp
@@ -501,6 +501,7 @@ void ConditionGroup::RemoveAt( size_t nID )
 		iter++;
 	}
 }
+<<<<<<< HEAD
 
 void ConditionGroup::SerializeAppend(std::string& buffer) const
 {
@@ -640,3 +641,5 @@ bool ConditionSet::Reset()
 
 	return bWasReset;
 }
+=======
+>>>>>>> global_carrays_to_stdarray

--- a/src/RA_Condition.cpp
+++ b/src/RA_Condition.cpp
@@ -10,10 +10,7 @@ static_assert( SIZEOF_ARRAY( COMPARISONTYPE_STR ) == NumComparisonTypes, "Must m
 const char* CONDITIONTYPE_STR[] = { "", "Pause If", "Reset If", "Add Source", "Sub Source", "Add Hits"};
 static_assert( SIZEOF_ARRAY( CONDITIONTYPE_STR ) == Condition::NumConditionTypes, "Must match!" );
 
-int g_AddBuffer = 0;
-int g_AddHits = 0;
-
-ComparisonVariableSize PrefixToComparisonSize( char cPrefix )
+static ComparisonVariableSize PrefixToComparisonSize( char cPrefix )
 {
 	//	Careful not to use ABCDEF here, this denotes part of an actual variable!
 	switch( cPrefix )
@@ -34,7 +31,8 @@ ComparisonVariableSize PrefixToComparisonSize( char cPrefix )
 		case ' ':	return SixteenBit;
 	}
 }
-const char* ComparisonSizeToPrefix( ComparisonVariableSize nSize )
+
+static const char* ComparisonSizeToPrefix( ComparisonVariableSize nSize )
 {
 	switch( nSize )
 	{
@@ -55,7 +53,7 @@ const char* ComparisonSizeToPrefix( ComparisonVariableSize nSize )
 	}
 }
 
-const char* ComparisonTypeToStr( ComparisonType nType )
+static const char* ComparisonTypeToStr( ComparisonType nType )
 {
 	switch( nType )
 	{
@@ -69,53 +67,154 @@ const char* ComparisonTypeToStr( ComparisonType nType )
 	}
 }
 
-void Condition::ParseFromString( char*& pBuffer )
+static ComparisonType ReadOperator(const char*& pBufferInOut)
 {
-	if( pBuffer[0] == 'R' && pBuffer[1] == ':' )
+	switch (pBufferInOut[0])
 	{
-		SetIsResetCondition();
-		pBuffer+=2;
+	case '=':
+		if (pBufferInOut[1] == '=')
+			++pBufferInOut;
+		++pBufferInOut;
+		return ComparisonType::Equals;
+
+	case '!':
+		if (pBufferInOut[1] == '=')
+		{
+			pBufferInOut += 2;
+			return ComparisonType::NotEqualTo;
+		}
+		break;
+
+	case '<':
+		if (pBufferInOut[1] == '=')
+		{
+			pBufferInOut += 2;
+			return ComparisonType::LessThanOrEqual;
+		}
+
+		++pBufferInOut;
+		return ComparisonType::LessThan;
+
+	case '>':
+		if (pBufferInOut[1] == '=')
+		{
+			pBufferInOut += 2;
+			return ComparisonType::GreaterThanOrEqual;
+		}
+
+		++pBufferInOut;
+		return ComparisonType::GreaterThan;
+
+	default:
+		break;
 	}
-	else if( pBuffer[0] == 'P' && pBuffer[1] == ':' )
+
+	ASSERT(!"Could not parse?!");
+	return ComparisonType::Equals;
+}
+
+static unsigned int ReadHits(const char*& pBufferInOut)
+{
+	if (pBufferInOut[0] == '(' || pBufferInOut[0] == '.')
 	{
-		SetIsPauseCondition();
-		pBuffer+=2;
+		unsigned int nNumHits = strtol(pBufferInOut + 1, (char**)&pBufferInOut, 10);	//	dirty!
+		pBufferInOut++;
+		return nNumHits;
 	}
-	else if ( pBuffer[ 0 ] == 'A' && pBuffer[ 1 ] == ':' )
+
+	//	0 by default: disable hit-tracking!
+	return 0;
+}
+
+bool Condition::ParseFromString( const char*& pBuffer )
+{
+	if ( pBuffer[0] == 'R' && pBuffer[1] == ':' )
 	{
-		SetIsAddCondition();
+		m_nConditionType = Condition::ResetIf;
 		pBuffer += 2;
 	}
-	else if ( pBuffer[ 0 ] == 'B' && pBuffer[ 1 ] == ':' )
+	else if ( pBuffer[0] == 'P' && pBuffer[1] == ':' )
 	{
-		SetIsSubCondition();
+		m_nConditionType = Condition::PauseIf;
 		pBuffer += 2;
 	}
-	else if ( pBuffer[ 0 ] == 'C' && pBuffer[ 1 ] == ':' )
+	else if ( pBuffer[0] == 'A' && pBuffer[1] == ':' )
 	{
-		SetIsAddHitsCondition();
+		m_nConditionType = Condition::AddSource;
+		pBuffer += 2;
+	}
+	else if ( pBuffer[0] == 'B' && pBuffer[1] == ':' )
+	{
+		m_nConditionType = Condition::SubSource;
+		pBuffer += 2;
+	}
+	else if ( pBuffer[0] == 'C' && pBuffer[1] == ':' )
+	{
+		m_nConditionType = Condition::AddHits;
 		pBuffer += 2;
 	}
 	else
 	{
-		SetIsBasicCondition();
-	} 
+		m_nConditionType = Condition::Standard;
+	}
 
-	m_nCompSource.ParseVariable( pBuffer );
+	if ( !m_nCompSource.ParseVariable( pBuffer ) )
+		return false;
+
 	m_nCompareType = ReadOperator( pBuffer );
-	m_nCompTarget.ParseVariable( pBuffer );
-	ResetHits();
-	m_nRequiredHits = ReadHits( pBuffer );
 
+	if ( !m_nCompTarget.ParseVariable( pBuffer ) )
+		return false;
+
+	ResetHits();
+	m_nRequiredHits = ReadHits(pBuffer);
+
+	return true;
 }
 
-BOOL Condition::ResetHits()
-{ 
-	if( m_nCurrentHits == 0 )
-		return FALSE;
+void Condition::SerializeAppend(std::string& buffer) const
+{
+	switch (m_nConditionType)
+	{
+	case Condition::ResetIf:
+		buffer.append("R:");
+		break;
+	case Condition::PauseIf:
+		buffer.append("P:");
+		break;
+	case Condition::AddSource:
+		buffer.append("A:");
+		break;
+	case Condition::SubSource:
+		buffer.append("B:");
+		break;
+	case Condition::AddHits:
+		buffer.append("C:");
+		break;
+	default:
+		break;
+	}
+
+	m_nCompSource.SerializeAppend(buffer);
+
+	buffer.append(ComparisonTypeToStr(m_nCompareType));
+
+	m_nCompTarget.SerializeAppend(buffer);
+
+	if (m_nRequiredHits > 0) {
+		char reqHitsBuffer[24];
+		snprintf(reqHitsBuffer, sizeof(reqHitsBuffer), ".%zu.", m_nRequiredHits);
+		buffer.append(reqHitsBuffer);
+	}
+}
+
+bool Condition::ResetHits()
+{
+	if (m_nCurrentHits == 0)
+		return false;
 
 	m_nCurrentHits = 0;
-	return TRUE;
+	return true;
 }
 
 void Condition::ResetDeltas()
@@ -124,18 +223,7 @@ void Condition::ResetDeltas()
 	m_nCompTarget.ResetDelta();
 }
 
-void Condition::Clear()
-{
-	m_nConditionType = Standard;
-	m_nCurrentHits = 0;
-	m_nRequiredHits = 0;
-	m_nCompSource.SetValues( 0, 0 );
-	m_nCompareType = Equals;
-	m_nCompTarget.SetValues( 0, 0 );
-}
-
-
-void CompVariable::ParseVariable( char*& pBufferInOut )
+bool CompVariable::ParseVariable( const char*& pBufferInOut )
 {
 	char* nNextChar = nullptr;
 	unsigned int nBase = 16;	//	Assume hex address
@@ -182,163 +270,98 @@ void CompVariable::ParseVariable( char*& pBufferInOut )
 
 	m_nVal = strtol( pBufferInOut, &nNextChar, nBase );
 	pBufferInOut = nNextChar;
+
+	return true;
+}
+
+void CompVariable::SerializeAppend(std::string& buffer) const
+{
+	char valueBuffer[20];
+	switch (m_nVarType)
+	{
+	case ValueComparison:
+		sprintf_s(valueBuffer, sizeof(valueBuffer), "%zu", m_nVal);
+		buffer.append(valueBuffer);
+		break;
+
+	case DeltaMem:
+		buffer.append(1, 'd');
+		// explicit fallthrough to Address
+
+	case Address:
+		buffer.append("0x");
+
+		buffer.append(ComparisonSizeToPrefix(m_nVarSize));
+
+		if (m_nVal >= 0x10000)
+			sprintf_s(valueBuffer, sizeof(valueBuffer), "%06x", m_nVal);
+		else
+			sprintf_s(valueBuffer, sizeof(valueBuffer), "%04x", m_nVal);
+		buffer.append(valueBuffer);
+		break;
+
+	default:
+		ASSERT(!"Unknown type? (DynMem)?");
+		break;
+	}
 }
 
 //	Return the raw, live value of this variable. Advances 'deltamem'
 unsigned int CompVariable::GetValue()
 {
-	unsigned int nPreviousVal = m_nPreviousVal;
-	unsigned int nLiveVal = 0;
+	unsigned int nPreviousVal;
 
-	if( m_nVarType == ComparisonVariableType::ValueComparison )
+	switch (m_nVarType)
 	{
-		//	It's a raw value; return it.
+	case ValueComparison:
+		//	It's a raw value. Return it.
 		return m_nVal;
-	}
-	else if( ( m_nVarType == ComparisonVariableType::Address ) || ( m_nVarType == ComparisonVariableType::DeltaMem ) )
-	{
-		//	It's an address in memory: return it!
 
-		if( m_nVarSize >= ComparisonVariableSize::Bit_0 && m_nVarSize <= ComparisonVariableSize::Bit_7 )
-		{
-			const unsigned int nBitmask = ( 1 << ( m_nVarSize - ComparisonVariableSize::Bit_0 ) );
-			nLiveVal = ( g_MemManager.ActiveBankRAMByteRead( m_nVal ) & nBitmask ) != 0;
-		}
-		else if( m_nVarSize == ComparisonVariableSize::Nibble_Lower )
-		{
-			nLiveVal = g_MemManager.ActiveBankRAMByteRead( m_nVal ) & 0xf;
-		}
-		else if( m_nVarSize == ComparisonVariableSize::Nibble_Upper )
-		{
-			nLiveVal = ( g_MemManager.ActiveBankRAMByteRead( m_nVal ) >> 4 ) & 0xf;
-		}
-		else if( m_nVarSize == ComparisonVariableSize::EightBit )
-		{
-			nLiveVal = g_MemManager.ActiveBankRAMByteRead( m_nVal );
-		}
-		else if( m_nVarSize == ComparisonVariableSize::SixteenBit )
-		{
-			nLiveVal = g_MemManager.ActiveBankRAMByteRead( m_nVal );
-			nLiveVal |= ( g_MemManager.ActiveBankRAMByteRead( m_nVal + 1 ) << 8 );
-		}
-		else if( m_nVarSize == ComparisonVariableSize::ThirtyTwoBit )
-		{
-			nLiveVal = g_MemManager.ActiveBankRAMByteRead( m_nVal );
-			nLiveVal |= ( g_MemManager.ActiveBankRAMByteRead( m_nVal + 1 ) << 8 );
-			nLiveVal |= ( g_MemManager.ActiveBankRAMByteRead( m_nVal + 2 ) << 16 );
-			nLiveVal |= ( g_MemManager.ActiveBankRAMByteRead( m_nVal + 3 ) << 24 );
-		}
+	case Address:
+		//	It's an address in memory. Return it!
+		return g_MemManager.ActiveBankRAMRead(m_nVal, m_nVarSize);
 
-		if( m_nVarType == ComparisonVariableType::DeltaMem )
-		{
-			//	Return the backed up (last frame) value, but store the new one for the next frame!
-			m_nPreviousVal = nLiveVal;
-			return nPreviousVal;
-		}
-		else
-		{
-			return nLiveVal;
-		}
-	}
-	else
-	{
+	case DeltaMem:
+		//	Return the backed up (last frame) value, but store the new one for the next frame!
+		nPreviousVal = m_nPreviousVal;
+		m_nPreviousVal = g_MemManager.ActiveBankRAMRead(m_nVal, m_nVarSize);
+		return nPreviousVal;
+
+	default:
 		//	Panic!
-		ASSERT( !"Undefined mem type!" );
+		ASSERT(!"Undefined mem type!");
 		return 0;
 	}
 }
 
-ComparisonType ReadOperator( char*& pBufferInOut )
-{
-	if( pBufferInOut[ 0 ] == '=' && pBufferInOut[ 1 ] == '=' )
-	{
-		pBufferInOut += 2; 
-		return ComparisonType::Equals;
-	}
-	else if( pBufferInOut[ 0 ] == '=' )
-	{
-		pBufferInOut += 1;
-		return ComparisonType::Equals;
-	}
-	else if( pBufferInOut[ 0 ] == '!' && pBufferInOut[ 1 ] == '=' )
-	{
-		pBufferInOut += 2;
-		return ComparisonType::NotEqualTo;
-	}
-	else if( pBufferInOut[ 0 ] == '<' && pBufferInOut[ 1 ] == '=' )
-	{
-		pBufferInOut += 2;
-		return ComparisonType::LessThanOrEqual;
-	}
-	else if( pBufferInOut[ 0 ] == '<' )
-	{
-		pBufferInOut += 1;
-		return ComparisonType::LessThan;
-	}
-	else if( pBufferInOut[ 0 ] == '>' && pBufferInOut[ 1 ] == '=' )
-	{
-		pBufferInOut += 2;
-		return ComparisonType::GreaterThanOrEqual;
-	}
-	else if( pBufferInOut[ 0 ] == '>' )
-	{
-		pBufferInOut += 1;
-		return ComparisonType::GreaterThan;
-	}
-	else
-	{
-		ASSERT( !"Could not parse?!" );
-		return ComparisonType::Equals;
-	}
-}
-
-unsigned int ReadHits( char*& pBufferInOut )
-{
-	unsigned int nNumHits = 0;
-	if( pBufferInOut[0] == '(' || pBufferInOut[0] == '.' )
-	{
-		nNumHits = strtol( pBufferInOut+1, (char**)&pBufferInOut, 10 );	//	dirty!
-		pBufferInOut++;
-	}
-	else
-	{	
-		//	0 by default: disable hit-tracking!
-	}
-	
-	return nNumHits;
-}
-
-BOOL Condition::Compare()
+bool Condition::Compare( unsigned int nAddBuffer )
 {
 	switch( m_nCompareType )
 	{
 	case Equals:
-		return( m_nCompSource.GetValue() + g_AddBuffer == m_nCompTarget.GetValue() );
+		return( m_nCompSource.GetValue() + nAddBuffer == m_nCompTarget.GetValue() );
 	case LessThan:
-		return( m_nCompSource.GetValue() + g_AddBuffer < m_nCompTarget.GetValue() );
+		return( m_nCompSource.GetValue() + nAddBuffer < m_nCompTarget.GetValue() );
 	case LessThanOrEqual:
-		return( m_nCompSource.GetValue() + g_AddBuffer <= m_nCompTarget.GetValue() );
+		return( m_nCompSource.GetValue() + nAddBuffer <= m_nCompTarget.GetValue() );
 	case GreaterThan:
-		return( m_nCompSource.GetValue() + g_AddBuffer > m_nCompTarget.GetValue() );
+		return( m_nCompSource.GetValue() + nAddBuffer > m_nCompTarget.GetValue() );
 	case GreaterThanOrEqual:
-		return( m_nCompSource.GetValue() + g_AddBuffer >= m_nCompTarget.GetValue() );
+		return( m_nCompSource.GetValue() + nAddBuffer >= m_nCompTarget.GetValue() );
 	case NotEqualTo:
-		return( m_nCompSource.GetValue() + g_AddBuffer != m_nCompTarget.GetValue() );
+		return( m_nCompSource.GetValue() + nAddBuffer != m_nCompTarget.GetValue() );
 	default:
 		return true;	//?
 	}
 }
 
-BOOL ConditionSet::Test( BOOL& bDirtyConditions, BOOL& bResetRead, BOOL bMatchAny )
+bool ConditionGroup::Test( bool& bDirtyConditions, bool& bResetAll )
 {
-	g_AddBuffer = 0;
-	g_AddHits = 0;
-	BOOL bConditionValid = FALSE;
-	BOOL bSetValid = TRUE;
-	BOOL bPauseActive = FALSE;
+	unsigned int nAddBuffer = 0;
+	unsigned int nAddHits = 0;
+	bool bConditionValid = false;
+	bool bSetValid = true; // important: empty group should evaluate true
 	unsigned int i = 0;
-	unsigned int nSrc = 0;
-	unsigned int nTgt = 0;
 
 	const unsigned int nNumConditions = m_Conditions.size();
 
@@ -366,66 +389,64 @@ BOOL ConditionSet::Test( BOOL& bDirtyConditions, BOOL& bResetRead, BOOL bMatchAn
 	for( i = 0; i < nNumConditions; ++i )
 	{
 		Condition* pNextCond = &m_Conditions[ i ];
-		if( pNextCond->IsPauseCondition() || pNextCond->IsResetCondition() )
+
+		switch (pNextCond->GetConditionType())
+		{
+		case Condition::PauseIf:
+		case Condition::ResetIf:
 			continue;
 
-		if ( pNextCond->IsAddCondition() )
-		{
-			g_AddBuffer += pNextCond->CompSource().GetValue();
-			bSetValid &= TRUE;
+		case Condition::AddSource:
+			nAddBuffer += pNextCond->CompSource().GetValue();
 			continue;
-		}
 
-		if ( pNextCond->IsSubCondition() )
-		{
-			g_AddBuffer -= pNextCond->CompSource().GetValue();
-			bSetValid &= TRUE;
+		case Condition::SubSource:
+			nAddBuffer -= pNextCond->CompSource().GetValue();
 			continue;
-		}
 
-		if ( pNextCond->IsAddHitsCondition() )
-		{
-			if ( pNextCond->Compare() )
-			{
-				pNextCond->IncrHits();
-				bDirtyConditions = TRUE;
+		case Condition::AddHits:
+			if (pNextCond->Compare()) {
+				if (pNextCond->RequiredHits() == 0 || pNextCond->CurrentHits() < pNextCond->RequiredHits()) {
+					pNextCond->IncrHits();
+					bDirtyConditions = true;
+				}
 			}
 
-			g_AddHits += pNextCond->CurrentHits();
+			nAddHits += pNextCond->CurrentHits();
 			continue;
+
+		default:
+			break;
 		}
 
-		if ( pNextCond->RequiredHits() != 0 && ( pNextCond->CurrentHits() + g_AddHits >= pNextCond->RequiredHits() ) )
+		// if the condition has a target hit count that has already been met, ignore it.
+		if ( pNextCond->RequiredHits() != 0 && ( pNextCond->CurrentHits() + nAddHits >= pNextCond->RequiredHits() ) ) 
 		{
-			g_AddBuffer = 0;
-			g_AddHits = 0;
+			nAddBuffer = 0;
+			nAddHits = 0;
 			continue;
 		}
 
-		bConditionValid = pNextCond->Compare();
+		bConditionValid = pNextCond->Compare( nAddBuffer );
 		if( bConditionValid )
 		{
 			pNextCond->IncrHits();
-			bDirtyConditions = TRUE;
+			bDirtyConditions = true;
 
 			//	Process this logic, if this condition is true:
-
 			if( pNextCond->RequiredHits() == 0 )
 			{
 				//	Not a hit-based requirement: ignore any additional logic!
 			}
-			else if( pNextCond->CurrentHits() + g_AddHits < pNextCond->RequiredHits() )
+			else if( pNextCond->CurrentHits() + nAddHits < pNextCond->RequiredHits() )
 			{
 				//	Not entirely valid yet!
-				bConditionValid = FALSE;
+				bConditionValid = false;
 			}
-
-			if( bMatchAny )	//	'or'
-				break;
 		}
 
-		g_AddBuffer = 0;
-		g_AddHits = 0;
+		nAddBuffer = 0;
+		nAddHits = 0;
 
 		//	Sequential or non-sequential?
 		bSetValid &= bConditionValid;
@@ -440,8 +461,8 @@ BOOL ConditionSet::Test( BOOL& bDirtyConditions, BOOL& bResetRead, BOOL bMatchAn
 			bConditionValid = pNextCond->Compare();
 			if( bConditionValid )
 			{
-				bResetRead = TRUE;			//	Resets all hits found so far
-				bSetValid = FALSE;			//	Cannot be valid if we've hit a reset condition.
+				bResetAll = true;			//	Resets all hits found so far
+				bSetValid = false;			//	Cannot be valid if we've hit a reset condition.
 				break;						//	No point processing any further reset conditions.
 			}
 		}
@@ -450,20 +471,21 @@ BOOL ConditionSet::Test( BOOL& bDirtyConditions, BOOL& bResetRead, BOOL bMatchAn
 	return bSetValid;
 }
 
-BOOL ConditionSet::Reset( BOOL bIncludingDeltas )
+bool ConditionGroup::Reset(bool bIncludingDeltas)
 {
-	BOOL bDirty = FALSE;
-	for( size_t i = 0; i < m_Conditions.size(); ++i )
+	bool bWasReset = false;
+	for( size_t i = 0; i < m_Conditions.size(); ++i ) 
 	{
-		bDirty |= m_Conditions[i].ResetHits();
+		bWasReset |= m_Conditions[i].ResetHits();
+
 		if( bIncludingDeltas )
 			m_Conditions[i].ResetDeltas();
 	}
 
-	return bDirty;
+	return bWasReset;
 }
 
-void ConditionSet::RemoveAt( size_t nID )
+void ConditionGroup::RemoveAt( size_t nID )
 {
 	size_t nCount = 0;
 	std::vector<Condition>::iterator iter = m_Conditions.begin();
@@ -478,4 +500,143 @@ void ConditionSet::RemoveAt( size_t nID )
 		nCount++;
 		iter++;
 	}
+}
+
+void ConditionGroup::SerializeAppend(std::string& buffer) const
+{
+	if (m_Conditions.empty())
+		return;
+
+	m_Conditions[0].SerializeAppend(buffer);
+	for (size_t i = 1; i < m_Conditions.size(); ++i) 
+	{
+		buffer.append(1, '_');
+		m_Conditions[i].SerializeAppend(buffer);
+	}
+}
+
+bool ConditionSet::ParseFromString(const char*& sSerialized)
+{
+	ConditionGroup* group = nullptr;
+	m_vConditionGroups.clear();
+
+	// if string starts with 'S', there's no Core group. generate an empty one and leave 'group' as null
+	// so the alt group will get created by the first condition.
+	if (*sSerialized == 'S')
+	{
+		++sSerialized;
+		m_vConditionGroups.emplace_back();
+	}
+
+	do
+	{
+		Condition condition;
+		if (!condition.ParseFromString(sSerialized))
+			return false;
+
+		if (!group) 
+		{
+			m_vConditionGroups.emplace_back();
+			group = &m_vConditionGroups.back();
+		}
+
+		group->Add(condition);
+
+		if (*sSerialized == '_') 
+		{
+			// AND
+			++sSerialized;
+		}
+		else if (*sSerialized == 'S') 
+		{
+			// OR
+			++sSerialized;
+			group = nullptr;
+		}
+		else 
+		{
+			// EOF or invalid character
+			break;
+		}
+
+	} while (true);
+
+	return true;
+}
+
+void ConditionSet::Serialize(std::string& buffer) const
+{
+	buffer.clear();
+	if (m_vConditionGroups.empty())
+		return;
+
+	int conditions = 0;
+	for (const ConditionGroup& group : m_vConditionGroups)
+		conditions += group.Count();
+
+	// estimate 16 bytes per condition: "R:0xH0001=12" is only 12, so we give ourselves a little leeway
+	buffer.reserve(conditions * 16);
+
+	m_vConditionGroups[0].SerializeAppend(buffer);
+	for (size_t i = 1; i < m_vConditionGroups.size(); ++i)
+	{
+		// ignore empty groups when serializing
+		if (m_vConditionGroups[i].Count() == 0)
+			continue;
+
+		buffer.append(1, 'S');
+		m_vConditionGroups[i].SerializeAppend(buffer);
+	}
+}
+
+bool ConditionSet::Test(bool& bDirtyConditions, bool& bResetConditions)
+{
+	// bDirtyConditions is set if any condition's HitCount changes
+	bDirtyConditions = false;
+
+	// bResetConditions is set if any condition's ResetIf triggers
+	bResetConditions = false;
+
+	if (m_vConditionGroups.empty())
+		return false;
+
+	// use local variable for tracking need to reset in case caller passes the same address for 
+	// both variables when they don't care about the result
+	bool bNeedsReset = false;
+
+	// for a set to be true, the first group (core) must be true. if any additional groups (alt)
+	// exist, at least one of them must also be true.
+	bool bResult = m_vConditionGroups[0].Test(bDirtyConditions, bNeedsReset);
+	if (m_vConditionGroups.size() > 1) 
+	{
+		bool bAltResult = false;
+		for (size_t i = 1; i < m_vConditionGroups.size(); ++i) 
+		{
+			if (m_vConditionGroups[i].Test(bDirtyConditions, bNeedsReset))
+				bAltResult = true;
+		}
+
+		if (!bAltResult || bNeedsReset)
+			bResult = false;
+	}
+
+	if (bNeedsReset)
+	{
+		bResetConditions = true;
+		bDirtyConditions = Reset();
+	}
+
+	return bResult;
+}
+
+bool ConditionSet::Reset()
+{
+	bool bWasReset = false;
+	for (ConditionGroup& group : m_vConditionGroups)
+	{
+		if (group.Reset(false))
+			bWasReset = true;
+	}
+
+	return bWasReset;
 }

--- a/src/RA_Condition.cpp
+++ b/src/RA_Condition.cpp
@@ -1,14 +1,6 @@
 #include "RA_Condition.h"
 #include "RA_MemManager.h"
 
-const char* COMPARISONVARIABLESIZE_STR[] = { "Bit0", "Bit1", "Bit2", "Bit3", "Bit4", "Bit5", "Bit6", "Bit7", "Lower4", "Upper4", "8-bit", "16-bit", "32-bit" };
-static_assert( SIZEOF_ARRAY( COMPARISONVARIABLESIZE_STR ) == NumComparisonVariableSizeTypes, "Must match!" );
-const char* COMPARISONVARIABLETYPE_STR[] = { "Memory", "Value", "Delta", "DynVar" };
-static_assert( SIZEOF_ARRAY( COMPARISONVARIABLETYPE_STR ) == NumComparisonVariableTypes, "Must match!" );
-const char* COMPARISONTYPE_STR[] = { "=", "<", "<=", ">", ">=", "!=" };
-static_assert( SIZEOF_ARRAY( COMPARISONTYPE_STR ) == NumComparisonTypes, "Must match!" );
-const char* CONDITIONTYPE_STR[] = { "", "Pause If", "Reset If", "Add Source", "Sub Source", "Add Hits"};
-static_assert( SIZEOF_ARRAY( CONDITIONTYPE_STR ) == Condition::NumConditionTypes, "Must match!" );
 
 static ComparisonVariableSize PrefixToComparisonSize( char cPrefix )
 {
@@ -501,7 +493,6 @@ void ConditionGroup::RemoveAt( size_t nID )
 		iter++;
 	}
 }
-<<<<<<< HEAD
 
 void ConditionGroup::SerializeAppend(std::string& buffer) const
 {
@@ -641,5 +632,4 @@ bool ConditionSet::Reset()
 
 	return bWasReset;
 }
-=======
->>>>>>> global_carrays_to_stdarray
+

--- a/src/RA_Condition.cpp
+++ b/src/RA_Condition.cpp
@@ -137,7 +137,7 @@ void Condition::Clear()
 
 void CompVariable::ParseVariable( char*& pBufferInOut )
 {
-	char* nNextChar = NULL;
+	char* nNextChar = nullptr;
 	unsigned int nBase = 16;	//	Assume hex address
 
 	if( toupper( pBufferInOut[0] ) == 'D' && pBufferInOut[1] == '0' && toupper( pBufferInOut[2] ) == 'X' )

--- a/src/RA_Condition.h
+++ b/src/RA_Condition.h
@@ -20,7 +20,10 @@ enum ComparisonVariableSize
 
 	NumComparisonVariableSizeTypes
 };
-extern const char* COMPARISONVARIABLESIZE_STR[];
+inline constexpr std::array<const char*, NumComparisonVariableSizeTypes> COMPARISONVARIABLESIZE_STR{
+	"Bit0", "Bit1", "Bit2", "Bit3", "Bit4", "Bit5", "Bit6", "Bit7", "Lower4", "Upper4", "8-bit", "16-bit",
+	"32-bit"
+};
 
 enum ComparisonVariableType
 {
@@ -31,7 +34,9 @@ enum ComparisonVariableType
 
 	NumComparisonVariableTypes
 };
-extern const char* COMPARISONVARIABLETYPE_STR[];
+inline constexpr std::array<const char*, NumComparisonVariableTypes> COMPARISONVARIABLETYPE_STR{
+	"Memory", "Value", "Delta", "DynVar"
+};
 
 enum ComparisonType
 {
@@ -44,9 +49,11 @@ enum ComparisonType
 
 	NumComparisonTypes
 };
-extern const char* COMPARISONTYPE_STR[];
+inline constexpr std::array<const char*, NumComparisonTypes> COMPARISONTYPE_STR{
+	"=", "<", "<=", ">", ">=", "!="
+};
 
-extern const char* CONDITIONTYPE_STR[];
+
 
 class CompVariable
 {
@@ -174,7 +181,16 @@ private:
 	unsigned int	m_nCurrentHits;
 };
 
+<<<<<<< HEAD
 class ConditionGroup
+=======
+inline constexpr std::array<const char*, Condition::NumConditionTypes> CONDITIONTYPE_STR{
+	"", "Pause If", "Reset If", "Add Source", "Sub Source", "Add Hits"
+};
+
+
+class ConditionSet
+>>>>>>> global_carrays_to_stdarray
 {
 public:
 	void SerializeAppend(std::string& buffer) const;
@@ -214,3 +230,6 @@ public:
 protected:
 	std::vector<ConditionGroup> m_vConditionGroups;
 };
+//extern BOOL CompareConditionValues( unsigned int nLHS, const enum CompType nCmpType, unsigned int nRHS );
+extern ComparisonType ReadOperator( char*& pBufferInOut );
+extern unsigned int ReadHits( char*& pBufferInOut );

--- a/src/RA_Condition.h
+++ b/src/RA_Condition.h
@@ -55,18 +55,16 @@ public:
 	 :	m_nVal( 0 ),
 		m_nPreviousVal( 0 ),
 		m_nVarSize( ComparisonVariableSize::EightBit ),
-		m_nVarType( ComparisonVariableType::Address ),
-		m_nBankID( 0 )
+		m_nVarType( ComparisonVariableType::Address )
 	{
 	}
 
 public:
-	void Set( ComparisonVariableSize nSize, ComparisonVariableType nType, unsigned int nInitialValue, unsigned short nBankID )
+	void Set( ComparisonVariableSize nSize, ComparisonVariableType nType, unsigned int nInitialValue )
 	{
 		m_nVarSize = nSize;
 		m_nVarType = nType;
 		m_nVal = nInitialValue;
-		m_nBankID = nBankID;
 	}
 
 	void SetValues( unsigned int nVal, unsigned int nPrevVal )
@@ -79,16 +77,10 @@ public:
 	{
 		m_nPreviousVal = m_nVal;
 	}
-	
-	//void Clear()
-	//{
-	//	m_nVal = 0;
-	//	m_nPreviousVal = 0;
-	//	m_nVarSize = COMPVAR_8BIT;
-	//	m_nVarType = COMPVARTYPE_ADDRESS;
-	//}
 
-	void ParseVariable( char*& sInString );	//	Parse from string
+	bool ParseVariable(const char*& sInString);	//	Parse from string
+	void SerializeAppend(std::string& buffer) const;
+
 	unsigned int GetValue();				//	Returns the live value
 	
 	inline void SetSize( ComparisonVariableSize nSize )		{ m_nVarSize = nSize; }
@@ -99,12 +91,10 @@ public:
 	
 	inline unsigned int RawValue() const					{ return m_nVal; }
 	inline unsigned int RawPreviousValue() const			{ return m_nPreviousVal; }
-	inline unsigned short BankID() const					{ return m_nBankID; }
 
 private:
 	ComparisonVariableSize m_nVarSize;
 	ComparisonVariableType m_nVarType;
-	unsigned short m_nBankID;
 	unsigned int m_nVal;
 	unsigned int m_nPreviousVal;
 };
@@ -135,53 +125,43 @@ public:
 
 public:
 	//	Parse a Condition from a string of characters
-	void ParseFromString( char*& sBuffer );
+	bool ParseFromString(const char*& sBuffer);
+	void SerializeAppend(std::string& buffer) const;
 
 	//	Returns a logical comparison between m_CompSource and m_CompTarget, depending on m_nComparison
-	BOOL Compare();
+	bool Compare(unsigned int nAddBuffer = 0);
 
 	//	Returns whether a change was made
-	BOOL ResetHits();
+	bool ResetHits();
 
 	//	Resets 'last known' values
 	void ResetDeltas();
-	void Clear();
 	
 	inline CompVariable& CompSource()				{ return m_nCompSource; }	//	NB both required!!
 	inline const CompVariable& CompSource() const	{ return m_nCompSource; }
 	inline CompVariable& CompTarget()				{ return m_nCompTarget; }
 	inline const CompVariable& CompTarget() const	{ return m_nCompTarget; }
-
 	void SetCompareType( ComparisonType nType )		{ m_nCompareType = nType; }
-
 	inline ComparisonType CompareType() const		{ return m_nCompareType; }
 
 	inline unsigned int RequiredHits() const		{ return m_nRequiredHits; }
 	inline unsigned int CurrentHits() const			{ return m_nCurrentHits; }
 
-	inline BOOL IsResetCondition() const			{ return( m_nConditionType == ResetIf ); }
-	inline BOOL IsPauseCondition() const			{ return( m_nConditionType == PauseIf ); }
-	inline BOOL IsAddCondition() const				{ return( m_nConditionType == AddSource ); }
-	inline BOOL IsSubCondition() const				{ return( m_nConditionType == SubSource ); }
-	inline BOOL IsAddHitsCondition() const			{ return( m_nConditionType == AddHits ); }
+	inline bool IsResetCondition() const			{ return( m_nConditionType == ResetIf ); }
+	inline bool IsPauseCondition() const			{ return( m_nConditionType == PauseIf ); }
+	inline bool IsAddCondition() const				{ return( m_nConditionType == AddSource ); }
+	inline bool IsSubCondition() const				{ return( m_nConditionType == SubSource ); }
+	inline bool IsAddHitsCondition() const			{ return( m_nConditionType == AddHits ); }
 
 	inline ConditionType GetConditionType() const	{ return m_nConditionType; }
 	void SetConditionType( ConditionType nNewType )	{ m_nConditionType = nNewType; }
 	
 	void SetRequiredHits( unsigned int nHits )		{ m_nRequiredHits = nHits; }
 	void IncrHits()									{ m_nCurrentHits++; }
-	BOOL IsComplete() const							{ return( m_nCurrentHits >= m_nRequiredHits ); }
+	bool IsComplete() const							{ return( m_nCurrentHits >= m_nRequiredHits ); }
 
 	void OverrideCurrentHits( unsigned int nHits )	{ m_nCurrentHits = nHits; }
 
-	void SetIsBasicCondition()						{ m_nConditionType = Standard; }
-	void SetIsPauseCondition()						{ m_nConditionType = PauseIf; }
-	void SetIsResetCondition()						{ m_nConditionType = ResetIf; }
-	void SetIsAddCondition()						{ m_nConditionType = AddSource; }
-	void SetIsSubCondition()						{ m_nConditionType = SubSource; }
-	void SetIsAddHitsCondition()					{ m_nConditionType = AddHits; }
-
-	void Set( const Condition& rRHS )				{ (*this) = rRHS; }
 
 private:
 	ConditionType	m_nConditionType;
@@ -189,16 +169,18 @@ private:
 	CompVariable	m_nCompSource;
 	ComparisonType	m_nCompareType;
 	CompVariable	m_nCompTarget;
-	
+
 	unsigned int	m_nRequiredHits;
 	unsigned int	m_nCurrentHits;
 };
 
-class ConditionSet
+class ConditionGroup
 {
 public:
+	void SerializeAppend(std::string& buffer) const;
+
 	//	Final param indicates 'or'
-	BOOL Test( BOOL& bDirtyConditions, BOOL& bResetRead, BOOL bMatchAny );
+	bool Test( bool& bDirtyConditions, bool& bResetRead );
 	size_t Count() const		{ return m_Conditions.size(); }
 
 	void Add( const Condition& newCond )				{ m_Conditions.push_back( newCond ); }
@@ -207,16 +189,28 @@ public:
 	const Condition& GetAt( size_t i ) const			{ return m_Conditions[i]; }
 	void Clear()										{ m_Conditions.clear(); }
 	void RemoveAt( size_t i );
-	BOOL Reset( BOOL bIncludingDeltas );	//	Returns dirty
+	bool Reset( bool bIncludingDeltas );	//	Returns dirty
 
 protected:
 	std::vector<Condition> m_Conditions;
 };
 
-extern ComparisonVariableSize PrefixToComparisonSize( char cPrefix );
-extern const char* ComparisonSizeToPrefix( ComparisonVariableSize nSize );
-extern const char* ComparisonTypeToStr( ComparisonType nType );
+class ConditionSet
+{
+public:
+	bool ParseFromString(const char*& sSerialized);
+	void Serialize(std::string& buffer) const;
 
-//extern BOOL CompareConditionValues( unsigned int nLHS, const enum CompType nCmpType, unsigned int nRHS );
-extern ComparisonType ReadOperator( char*& pBufferInOut );
-extern unsigned int ReadHits( char*& pBufferInOut );
+	bool Test(bool& bDirtyConditions, bool& bWasReset);
+	bool Reset();
+
+	void Clear()                                        { m_vConditionGroups.clear(); }
+	size_t GroupCount() const                           { return m_vConditionGroups.size(); }
+	void AddGroup()                                     { m_vConditionGroups.emplace_back(); }
+	void RemoveLastGroup()                              { m_vConditionGroups.pop_back(); }
+	ConditionGroup& GetGroup(size_t i)                  { return m_vConditionGroups[i]; }
+	const ConditionGroup& GetGroup(size_t i) const      { return m_vConditionGroups[i]; }
+
+protected:
+	std::vector<ConditionGroup> m_vConditionGroups;
+};

--- a/src/RA_Condition.h
+++ b/src/RA_Condition.h
@@ -181,16 +181,11 @@ private:
 	unsigned int	m_nCurrentHits;
 };
 
-<<<<<<< HEAD
-class ConditionGroup
-=======
 inline constexpr std::array<const char*, Condition::NumConditionTypes> CONDITIONTYPE_STR{
 	"", "Pause If", "Reset If", "Add Source", "Sub Source", "Add Hits"
 };
 
-
-class ConditionSet
->>>>>>> global_carrays_to_stdarray
+class ConditionGroup
 {
 public:
 	void SerializeAppend(std::string& buffer) const;

--- a/src/RA_Core.cpp
+++ b/src/RA_Core.cpp
@@ -478,7 +478,7 @@ API void CCONV _RA_ClearMemoryBanks()
 //	const unsigned int nBufferSize = (3*1024*1024);	//	3mb enough?
 //
 //	char* buffer = new char[nBufferSize];	
-//	if( buffer != NULL )
+//	if( buffer != nullptr )
 //	{
 //		char sAddr[1024];
 //		sprintf_s( sAddr, 1024, "/files/%s", sFilename );
@@ -490,7 +490,7 @@ API void CCONV _RA_ClearMemoryBanks()
 //			_WriteBufferToFile( sOutput, buffer, nBytesRead );
 //
 //		delete[] ( buffer );
-//		buffer = NULL;
+//		buffer = nullptr;
 //	}
 //}
 
@@ -532,18 +532,18 @@ API BOOL CCONV _RA_OfferNewRAUpdate(const char* sNewVer)
 
 		//_WriteBufferToFile( "BatchUpdater.bat", sBatchUpdater, strlen( sBatchUpdater ) );
 
-		//ShellExecute( NULL,
+		//ShellExecute( nullptr,
 		//	"open",
 		//	"BatchUpdater.bat",
-		//	NULL,
-		//	NULL,
+		//	nullptr,
+		//	nullptr,
 		//	SW_SHOWNORMAL ); 
 
-		ShellExecute(NULL,
+		ShellExecute(nullptr,
 			TEXT("open"),
 			TEXT("http://www.retroachievements.org/download.php"),
-			NULL,
-			NULL,
+			nullptr,
+			nullptr,
 			SW_SHOWNORMAL);
 
 		return TRUE;
@@ -645,9 +645,9 @@ API int CCONV _RA_HandleHTTPResults()
 					const std::string& sReply = doc["LatestVersion"].GetString();
 					if (sReply.substr(0, 2).compare("0.") == 0)
 					{
-						long nValServer = std::strtol(sReply.c_str() + 2, NULL, 10);
-						long nValKnown = std::strtol(g_sKnownRAVersion.c_str() + 2, NULL, 10);
-						long nValCurrent = std::strtol(g_sClientVersion + 2, NULL, 10);
+						long nValServer = std::strtol(sReply.c_str() + 2, nullptr, 10);
+						long nValKnown = std::strtol(g_sKnownRAVersion.c_str() + 2, nullptr, 10);
+						long nValCurrent = std::strtol(g_sClientVersion + 2, nullptr, 10);
 
 						if (nValKnown < nValServer && nValCurrent < nValServer)
 						{
@@ -759,32 +759,35 @@ API HMENU CCONV _RA_CreatePopupMenu()
 	HMENU hRA_LB = CreatePopupMenu();
 	if (RAUsers::LocalUser().IsLoggedIn())
 	{
+		// TODO: Use the literals once PR 23 is accepted
 		AppendMenu(hRA, MF_STRING, IDM_RA_FILES_LOGOUT, TEXT("Log&out"));
-		AppendMenu(hRA, MF_SEPARATOR, NULL, NULL);
+		AppendMenu(hRA, MF_SEPARATOR, UINT_PTR{}, nullptr);
 		AppendMenu(hRA, MF_STRING, IDM_RA_OPENUSERPAGE, TEXT("Open my &User Page"));
 
 		UINT nGameFlags = MF_STRING;
 		//if( g_pActiveAchievements->GameID() == 0 )	//	Disabled til I can get this right: Snes9x doesn't call this?
 		//	nGameFlags |= (MF_GRAYED|MF_DISABLED);
 
+
+        // TODO: Replace UINT_PTR{} with the _z literal after PR #23 gets accepted
 		AppendMenu(hRA, nGameFlags, IDM_RA_OPENGAMEPAGE, TEXT("Open this &Game's Page"));
-		AppendMenu(hRA, MF_SEPARATOR, NULL, NULL);
+		AppendMenu(hRA, MF_SEPARATOR, UINT_PTR{}, nullptr);
 		AppendMenu(hRA, g_bHardcoreModeActive ? MF_CHECKED : MF_UNCHECKED, IDM_RA_HARDCORE_MODE, TEXT("&Hardcore Mode"));
-		AppendMenu(hRA, MF_SEPARATOR, NULL, NULL);
+		AppendMenu(hRA, MF_SEPARATOR, UINT_PTR{}, nullptr);
 
 		AppendMenu( hRA, MF_POPUP, (UINT_PTR)hRA_LB, "Leaderboards" );
 		AppendMenu( hRA_LB, g_bLeaderboardsActive ? MF_CHECKED : MF_UNCHECKED, IDM_RA_TOGGLELEADERBOARDS, TEXT("Enable &Leaderboards"));
-		AppendMenu( hRA_LB, MF_SEPARATOR, NULL, NULL );
+		AppendMenu( hRA_LB, MF_SEPARATOR, UINT_PTR{}, nullptr );
 		AppendMenu( hRA_LB, g_bLBDisplayNotification ? MF_CHECKED : MF_UNCHECKED, IDM_RA_TOGGLE_LB_NOTIFICATIONS, TEXT( "Display Challenge Notification" ) );
 		AppendMenu( hRA_LB, g_bLBDisplayCounter ? MF_CHECKED : MF_UNCHECKED, IDM_RA_TOGGLE_LB_COUNTER, TEXT( "Display Time/Score Counter" ) );
 		AppendMenu( hRA_LB, g_bLBDisplayScoreboard ? MF_CHECKED : MF_UNCHECKED, IDM_RA_TOGGLE_LB_SCOREBOARD, TEXT( "Display Rank Scoreboard" ) );
 
-		AppendMenu(hRA, MF_SEPARATOR, NULL, NULL);
+		AppendMenu(hRA, MF_SEPARATOR, UINT_PTR{}, nullptr);
 		AppendMenu(hRA, MF_STRING, IDM_RA_FILES_ACHIEVEMENTS, TEXT("Achievement &Sets"));
 		AppendMenu(hRA, MF_STRING, IDM_RA_FILES_ACHIEVEMENTEDITOR, TEXT("Achievement &Editor"));
 		AppendMenu(hRA, MF_STRING, IDM_RA_FILES_MEMORYFINDER, TEXT("&Memory Inspector"));
 		AppendMenu(hRA, MF_STRING, IDM_RA_PARSERICHPRESENCE, TEXT("Rich &Presence Monitor"));
-		AppendMenu(hRA, MF_SEPARATOR, NULL, NULL);
+		AppendMenu(hRA, MF_SEPARATOR, UINT_PTR{}, nullptr);
 		AppendMenu(hRA, MF_STRING, IDM_RA_REPORTBROKENACHIEVEMENTS, TEXT("&Report Broken Achievements"));
 		AppendMenu(hRA, MF_STRING, IDM_RA_GETROMCHECKSUM, TEXT("Get ROM &Checksum"));
 		AppendMenu(hRA, MF_STRING, IDM_RA_SCANFORGAMES, TEXT("Scan &for games"));
@@ -794,7 +797,7 @@ API HMENU CCONV _RA_CreatePopupMenu()
 		AppendMenu(hRA, MF_STRING, IDM_RA_FILES_LOGIN, TEXT("&Login to RA"));
 	}
 
-	AppendMenu(hRA, MF_SEPARATOR, NULL, NULL);
+	AppendMenu(hRA, MF_SEPARATOR, UINT_PTR{}, nullptr);
 	AppendMenu(hRA, MF_STRING, IDM_RA_FILES_CHECKFORUPDATE, TEXT("&Check for Emulator Update"));
 
 	return hRA;
@@ -988,9 +991,9 @@ API void CCONV _RA_SavePreferences()
 	}
 
 	SetCurrentDirectory(NativeStr(g_sHomeDir).c_str());
-	FILE* pf = NULL;
+	FILE* pf = nullptr;
 	fopen_s(&pf, std::string(std::string(RA_PREFERENCES_FILENAME_PREFIX) + g_sClientName + ".cfg").c_str(), "wb");
-	if (pf != NULL)
+	if (pf != nullptr)
 	{
 		FileStream fs(pf);
 		Writer<FileStream> writer(fs);
@@ -1125,7 +1128,7 @@ void RestoreWindowPosition(HWND hDlg, const char* sDlgKey, bool bToRight, bool b
 		}
 	}
 
-	SetWindowPos(hDlg, NULL, rc.left, rc.top, rc.right - rc.left, rc.bottom - rc.top, 0);
+	SetWindowPos(hDlg, nullptr, rc.left, rc.top, rc.right - rc.left, rc.bottom - rc.top, 0);
 
 	pos->bLoaded = true;
 
@@ -1173,23 +1176,23 @@ API void CCONV _RA_InvokeDialog(LPARAM nID)
 	switch (nID)
 	{
 	case IDM_RA_FILES_ACHIEVEMENTS:
-		if (g_AchievementsDialog.GetHWND() == NULL)
+		if (g_AchievementsDialog.GetHWND() == nullptr)
 			g_AchievementsDialog.InstallHWND(CreateDialog(g_hThisDLLInst, MAKEINTRESOURCE(IDD_RA_ACHIEVEMENTS), g_RAMainWnd, g_AchievementsDialog.s_AchievementsProc));
-		if (g_AchievementsDialog.GetHWND() != NULL)
+		if (g_AchievementsDialog.GetHWND() != nullptr)
 			ShowWindow(g_AchievementsDialog.GetHWND(), SW_SHOW);
 		break;
 
 	case IDM_RA_FILES_ACHIEVEMENTEDITOR:
-		if (g_AchievementEditorDialog.GetHWND() == NULL)
+		if (g_AchievementEditorDialog.GetHWND() == nullptr)
 			g_AchievementEditorDialog.InstallHWND(CreateDialog(g_hThisDLLInst, MAKEINTRESOURCE(IDD_RA_ACHIEVEMENTEDITOR), g_RAMainWnd, g_AchievementEditorDialog.s_AchievementEditorProc));
-		if (g_AchievementEditorDialog.GetHWND() != NULL)
+		if (g_AchievementEditorDialog.GetHWND() != nullptr)
 			ShowWindow(g_AchievementEditorDialog.GetHWND(), SW_SHOW);
 		break;
 
 	case IDM_RA_FILES_MEMORYFINDER:
-		if (g_MemoryDialog.GetHWND() == NULL)
+		if (g_MemoryDialog.GetHWND() == nullptr)
 			g_MemoryDialog.InstallHWND(CreateDialog(g_hThisDLLInst, MAKEINTRESOURCE(IDD_RA_MEMORY), g_RAMainWnd, g_MemoryDialog.s_MemoryProc));
-		if (g_MemoryDialog.GetHWND() != NULL)
+		if (g_MemoryDialog.GetHWND() != nullptr)
 			ShowWindow(g_MemoryDialog.GetHWND(), SW_SHOW);
 		break;
 
@@ -1263,11 +1266,11 @@ API void CCONV _RA_InvokeDialog(LPARAM nID)
 		if (RAUsers::LocalUser().IsLoggedIn())
 		{
 			std::string sTarget = "http://" RA_HOST_URL + std::string("/User/") + RAUsers::LocalUser().Username();
-			ShellExecute(NULL,
+			ShellExecute(nullptr,
 				TEXT("open"),
 				NativeStr(sTarget).c_str(),
-				NULL,
-				NULL,
+				nullptr,
+				nullptr,
 				SW_SHOWNORMAL);
 		}
 		break;
@@ -1276,11 +1279,11 @@ API void CCONV _RA_InvokeDialog(LPARAM nID)
 		if (g_pCurrentGameData->GetGameID() != 0)
 		{
 			std::string sTarget = "http://" RA_HOST_URL + std::string("/Game/") + std::to_string(g_pCurrentGameData->GetGameID());
-			ShellExecute(NULL,
+			ShellExecute(nullptr,
 				TEXT("open"),
 				NativeStr(sTarget).c_str(),
-				NULL,
-				NULL,
+				nullptr,
+				nullptr,
 				SW_SHOWNORMAL);
 		}
 		else
@@ -1298,7 +1301,7 @@ API void CCONV _RA_InvokeDialog(LPARAM nID)
 
 		if (g_sROMDirLocation.length() > 0)
 		{
-			if (g_GameLibrary.GetHWND() == NULL)
+			if (g_GameLibrary.GetHWND() == nullptr)
 			{
 				_FetchGameHashLibraryFromWeb();		//	##BLOCKING##
 				_FetchGameTitlesFromWeb();			//	##BLOCKING##
@@ -1307,7 +1310,7 @@ API void CCONV _RA_InvokeDialog(LPARAM nID)
 				g_GameLibrary.InstallHWND(CreateDialog(g_hThisDLLInst, MAKEINTRESOURCE(IDD_RA_GAMELIBRARY), g_RAMainWnd, &Dlg_GameLibrary::s_GameLibraryProc));
 			}
 
-			if (g_GameLibrary.GetHWND() != NULL)
+			if (g_GameLibrary.GetHWND() != nullptr)
 				ShowWindow(g_GameLibrary.GetHWND(), SW_SHOW);
 		}
 		break;
@@ -1321,9 +1324,9 @@ API void CCONV _RA_InvokeDialog(LPARAM nID)
 			//	Then install it
 			g_RichPresenceInterpretter.ParseRichPresenceFile(sRichPresenceFile);
 
-			if (g_RichPresenceDialog.GetHWND() == NULL)
+			if (g_RichPresenceDialog.GetHWND() == nullptr)
 				g_RichPresenceDialog.InstallHWND(CreateDialog(g_hThisDLLInst, MAKEINTRESOURCE(IDD_RA_RICHPRESENCE), g_RAMainWnd, &Dlg_RichPresence::s_RichPresenceDialogProc));
-			if (g_RichPresenceDialog.GetHWND() != NULL)
+			if (g_RichPresenceDialog.GetHWND() != nullptr)
 				ShowWindow(g_RichPresenceDialog.GetHWND(), SW_SHOW);
 
 			g_RichPresenceDialog.StartMonitoring();
@@ -1447,7 +1450,7 @@ API void CCONV _RA_DoAchievementsFrame()
 
 void CCONV _RA_InstallSharedFunctions(bool(*fpIsActive)(void), void(*fpCauseUnpause)(void), void(*fpRebuildMenu)(void), void(*fpEstimateTitle)(char*), void(*fpResetEmulation)(void), void(*fpLoadROM)(const char*))
 {
-	void(*fpCausePause)(void) = NULL;
+	void(*fpCausePause)(void) = nullptr;
 	_RA_InstallSharedFunctionsExt(fpIsActive, fpCauseUnpause, fpCausePause, fpRebuildMenu, fpEstimateTitle, fpResetEmulation, fpLoadROM);
 }
 
@@ -1556,8 +1559,8 @@ char* _MallocAndBulkReadFileToBuffer(const char* sFilename, long& nFileSizeOut)
 	SetCurrentDirectory(NativeStr(g_sHomeDir).c_str());
 	FILE* pf = nullptr;
 	fopen_s(&pf, sFilename, "r");
-	if (pf == NULL)
-		return NULL;
+	if (pf == nullptr)
+		return nullptr;
 
 	//	Calculate filesize
 	fseek(pf, 0L, SEEK_END);
@@ -1568,7 +1571,7 @@ char* _MallocAndBulkReadFileToBuffer(const char* sFilename, long& nFileSizeOut)
 	{
 		//	No good content in this file.
 		fclose(pf);
-		return NULL;
+		return nullptr;
 	}
 
 	//	malloc() must be managed!
@@ -1591,9 +1594,9 @@ std::string _TimeStampToString(time_t nTime)
 
 BOOL _FileExists(const std::string& sFileName)
 {
-	FILE* pf = NULL;
+	FILE* pf = nullptr;
 	fopen_s(&pf, sFileName.c_str(), "rb");
-	if (pf != NULL)
+	if (pf != nullptr)
 	{
 		fclose(pf);
 		return TRUE;
@@ -1607,9 +1610,9 @@ BOOL _FileExists(const std::string& sFileName)
 std::string GetFolderFromDialog()
 {
 	std::string sRetVal;
-	//HRESULT hr = CoInitializeEx( NULL, COINIT_APARTMENTTHREADED|COINIT_DISABLE_OLE1DDE );
+	//HRESULT hr = CoInitializeEx( nullptr, COINIT_APARTMENTTHREADED|COINIT_DISABLE_OLE1DDE );
 	IFileOpenDialog* pDlg = nullptr;
-	HRESULT hr = CoCreateInstance(CLSID_FileOpenDialog, NULL, CLSCTX_ALL, IID_IFileOpenDialog, reinterpret_cast<void**>(&pDlg));
+	HRESULT hr = CoCreateInstance(CLSID_FileOpenDialog, nullptr, CLSCTX_ALL, IID_IFileOpenDialog, reinterpret_cast<void**>(&pDlg));
 	if (hr == S_OK)
 	{
 		pDlg->SetOptions(FOS_PICKFOLDERS);

--- a/src/RA_Core.cpp
+++ b/src/RA_Core.cpp
@@ -1508,6 +1508,17 @@ char* _ReadStringTil(char nChar, char*& pOffsetInOut, BOOL bTerminate)
 	return (pStartString);
 }
 
+void _ReadStringTil(std::string& value, char nChar, const char*& pSource)
+{
+    const char* pStartString = pSource;
+
+    while (*pSource != '\0' && *pSource != nChar)
+        pSource++;
+
+    value.assign(pStartString, pSource - pStartString);
+    pSource++;
+}
+
 void _WriteBufferToFile(const std::string& sFileName, const Document& doc)
 {
 	SetCurrentDirectory(NativeStr(g_sHomeDir).c_str());

--- a/src/RA_Core.cpp
+++ b/src/RA_Core.cpp
@@ -71,6 +71,11 @@ typedef struct WindowPosition {
 typedef std::map<std::string, WindowPosition> WindowPositionMap;
 WindowPositionMap g_mWindowPositions;
 
+namespace
+{
+	const unsigned int PROCESS_WAIT_TIME = 100;
+	unsigned int g_nProcessTimer = 0;
+}
 
 BOOL APIENTRY DllMain(HMODULE hModule, DWORD dwReason, LPVOID lpReserved)
 {
@@ -451,6 +456,8 @@ API int CCONV _RA_OnLoadNewRom(const BYTE* pROM, unsigned int nROMSize)
 	g_MemoryDialog.OnLoad_NewRom();
 	g_AchievementOverlay.OnLoad_NewRom();
 	g_MemBookmarkDialog.OnLoad_NewRom();
+
+	g_nProcessTimer = 0;
 
 	return 0;
 }
@@ -1418,6 +1425,7 @@ API void CCONV _RA_OnLoadState(const char* sFilename)
 		g_LeaderboardManager.Reset();
 		g_PopupWindows.LeaderboardPopups().Reset();
 		g_MemoryDialog.Invalidate();
+		g_nProcessTimer = PROCESS_WAIT_TIME;
 	}
 }
 
@@ -1425,8 +1433,14 @@ API void CCONV _RA_DoAchievementsFrame()
 {
 	if (RAUsers::LocalUser().IsLoggedIn())
 	{
-		g_pActiveAchievements->Test();
-		g_LeaderboardManager.Test();
+		if (g_nProcessTimer >= PROCESS_WAIT_TIME)
+		{
+			g_pActiveAchievements->Test();
+			g_LeaderboardManager.Test();
+		}
+		else
+			g_nProcessTimer++;
+
 		g_MemoryDialog.Invalidate();
 	}
 }

--- a/src/RA_Core.h
+++ b/src/RA_Core.h
@@ -130,6 +130,7 @@ extern BOOL _ReadTil( const char nChar, char buffer[], unsigned int nSize, DWORD
 
 //	Read a string til the end of the string, or nChar. bTerminate==TRUE replaces that char with \0.
 extern char* _ReadStringTil( char nChar, char*& pOffsetInOut, BOOL bTerminate );
+extern void  _ReadStringTil( std::string& sValue, char nChar, const char*& pOffsetInOut );
 
 //	Write out the buffer to a file
 extern void _WriteBufferToFile( const std::string& sFileName, const DataStream& rawData );

--- a/src/RA_Core.h
+++ b/src/RA_Core.h
@@ -122,7 +122,7 @@ extern bool g_bLBDisplayCounter;
 extern bool g_bLBDisplayScoreboard;
 extern unsigned int g_nNumHTTPThreads;
 
-//	Read a file to a malloc'd buffer. Returns NULL on error. Owner MUST free() buffer if not NULL.
+//	Read a file to a malloc'd buffer. Returns nullptr on error. Owner MUST free() buffer if not nullptr.
 extern char* _MallocAndBulkReadFileToBuffer( const char* sFilename, long& nFileSizeOut );
 
 //	Read file until reaching the end of the file, or the specified char.

--- a/src/RA_Defs.cpp
+++ b/src/RA_Defs.cpp
@@ -62,7 +62,7 @@ void RADebugLogNoFormat(const char* data)
 	OutputDebugString(NativeStr(data).c_str());
 
 	//SetCurrentDirectory( g_sHomeDir.c_str() );//?
-	FILE* pf = NULL;
+	FILE* pf = nullptr;
 	if (fopen_s(&pf, RA_LOG_FILENAME, "a") == 0)
 	{
 		fwrite(data, sizeof(char), strlen(data), pf);
@@ -92,7 +92,7 @@ void RADebugLog(const char* format, ...)
 	OutputDebugString(NativeStr(buf).c_str());
 
 	//SetCurrentDirectory( g_sHomeDir.c_str() );//?
-	FILE* pf = NULL;
+	FILE* pf = nullptr;
 	if (fopen_s(&pf, RA_LOG_FILENAME, "a") == 0)
 	{
 		fwrite(buf, sizeof(char), strlen(buf), pf);

--- a/src/RA_Defs.h
+++ b/src/RA_Defs.h
@@ -12,6 +12,7 @@
 #include <deque>
 #include <map>
 
+
 #ifndef RA_EXPORTS
 
 //	Version Information is integrated into tags
@@ -184,9 +185,9 @@ typedef DWORD			ARGB;
 			}
 
 			if ( !bResize )
-				SetWindowPos( hwnd, NULL, xPos, yPos, NULL, NULL, SWP_NOSIZE | SWP_NOZORDER );
+				SetWindowPos( hwnd, nullptr, xPos, yPos, 0, 0, SWP_NOSIZE | SWP_NOZORDER );
 			else
-				SetWindowPos( hwnd, NULL, 0, 0, xPos, yPos, SWP_NOMOVE | SWP_NOZORDER );
+				SetWindowPos( hwnd, nullptr, 0, 0, xPos, yPos, SWP_NOMOVE | SWP_NOZORDER );
 		}
 	};
 

--- a/src/RA_Defs.h
+++ b/src/RA_Defs.h
@@ -44,14 +44,14 @@
 //NB. These must NOT be accessible from the emulator!
 //#define RA_INTEGRATION_VERSION	"0.053"
 
-#pragma warning(push, 1)
-
-#define _SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING
 //	RA-Only
 #define RAPIDJSON_HAS_STDSTRING 1
 #pragma warning(push, 1)
+
+#define _SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING
+
+
 // This is not needed the most recent version
-#define _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS
 //	RA-Only
 #include "rapidjson/include/rapidjson/document.h"
 #include "rapidjson/include/rapidjson/reader.h"
@@ -59,10 +59,7 @@
 #include "rapidjson/include/rapidjson/filestream.h"
 #include "rapidjson/include/rapidjson/stringbuffer.h"
 #include "rapidjson/include/rapidjson/error/en.h"
-<<<<<<< HEAD
-=======
 
->>>>>>> global_carrays_to_stdarray
 #pragma warning(pop)
 using namespace rapidjson;
 extern GetParseErrorFunc GetJSONParseErrorStr;

--- a/src/RA_Defs.h
+++ b/src/RA_Defs.h
@@ -13,6 +13,7 @@
 #include <queue>
 #include <deque>
 #include <map>
+#include <array>
 
 
 #ifndef RA_EXPORTS
@@ -43,6 +44,9 @@
 //NB. These must NOT be accessible from the emulator!
 //#define RA_INTEGRATION_VERSION	"0.053"
 
+#pragma warning(push, 1)
+
+#define _SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING
 //	RA-Only
 #define RAPIDJSON_HAS_STDSTRING 1
 #pragma warning(push, 1)
@@ -55,6 +59,10 @@
 #include "rapidjson/include/rapidjson/filestream.h"
 #include "rapidjson/include/rapidjson/stringbuffer.h"
 #include "rapidjson/include/rapidjson/error/en.h"
+<<<<<<< HEAD
+=======
+
+>>>>>>> global_carrays_to_stdarray
 #pragma warning(pop)
 using namespace rapidjson;
 extern GetParseErrorFunc GetJSONParseErrorStr;

--- a/src/RA_Defs.h
+++ b/src/RA_Defs.h
@@ -1,3 +1,5 @@
+#ifndef RA_DEFS_H
+#define RA_DEFS_H
 #pragma once
 
 #include <Windows.h>
@@ -19,9 +21,33 @@
 
 #else
 
+
+// Maybe an extra check just in-case
+
+#if _HAS_CXX17
+#define _DEPRECATED          [[deprecated]]
+#define _DEPRECATEDR(reason) [[deprecated(reason)]]
+#define _FALLTHROUGH         [[fallthrough]]//; you need ';' at the end
+#define _NODISCARD           [[nodiscard]]
+#define _NORETURN            [[noreturn]]
+#define _UNUSED              [[maybe_unused]]
+
+// Disables the use of const_casts, if you get an error, it's not a literal
+// type. You could use it on functions but they will need a deduction guide
+// That would probably be better with a forwarding function
+
+
+
+
+#endif // _HAS_CXX17
 //NB. These must NOT be accessible from the emulator!
 //#define RA_INTEGRATION_VERSION	"0.053"
 
+//	RA-Only
+#define RAPIDJSON_HAS_STDSTRING 1
+#pragma warning(push, 1)
+// This is not needed the most recent version
+#define _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS
 //	RA-Only
 #include "rapidjson/include/rapidjson/document.h"
 #include "rapidjson/include/rapidjson/reader.h"
@@ -29,11 +55,20 @@
 #include "rapidjson/include/rapidjson/filestream.h"
 #include "rapidjson/include/rapidjson/stringbuffer.h"
 #include "rapidjson/include/rapidjson/error/en.h"
+#pragma warning(pop)
 using namespace rapidjson;
 extern GetParseErrorFunc GetJSONParseErrorStr;
 
-#endif	//RA_EXPORTS
 
+
+using namespace std::string_literals;
+//using namespace std::chrono_literals; we could use this later
+namespace ra {}
+using namespace ra;
+
+#endif	//RA_EXPORTS
+#define _CONSTANT_VAR inline constexpr auto
+#define _CONSTANT     inline constexpr
 
 #define RA_KEYS_DLL						"RA_Keys.dll"
 #define RA_PREFERENCES_FILENAME_PREFIX	"RAPrefs_"
@@ -63,160 +98,153 @@ extern GetParseErrorFunc GetJSONParseErrorStr;
 #define SIZEOF_ARRAY( ar )	( sizeof( ar ) / sizeof( ar[ 0 ] ) )
 #define SAFE_DELETE( x )	{ if( x != nullptr ) { delete x; x = nullptr; } }
 
-typedef unsigned char	BYTE;
-typedef unsigned long	DWORD;
-typedef int				BOOL;
-typedef DWORD			ARGB;
+using ARGB = DWORD;
 
 //namespace RA
 //{
-	template<typename T>
-	static inline const T& RAClamp( const T& val, const T& lower, const T& upper )
-	{
-		return( val < lower ) ? lower : ( ( val > upper ) ? upper : val );
-	}
-	
-	class RARect : public RECT
-	{
-	public:
-		RARect() {}
-		RARect( LONG nX, LONG nY, LONG nW, LONG nH )
-		{
-			left = nX;
-			right = nX + nW;
-			top = nY;
-			bottom = nY + nH;
-		}
+template<typename T>
+static inline const T& RAClamp(const T& val, const T& lower, const T& upper)
+{
+    return(val < lower) ? lower : ((val > upper) ? upper : val);
+}
 
-	public:
-		inline int Width() const		{ return( right - left ); }
-		inline int Height() const		{ return( bottom - top ); }
-	};
+class RARect : public RECT
+{
+public:
+    RARect() {}
+    RARect(LONG nX, LONG nY, LONG nW, LONG nH)
+    {
+        left = nX;
+        right = nX + nW;
+        top = nY;
+        bottom = nY + nH;
+    }
 
-	class RASize
-	{
-	public:
-		RASize() : m_nWidth( 0 ), m_nHeight( 0 ) {}
-		RASize( const RASize& rhs ) : m_nWidth( rhs.m_nWidth ), m_nHeight( rhs.m_nHeight ) {}
-		RASize( int nW, int nH ) : m_nWidth( nW ), m_nHeight( nH ) {}
+public:
+    inline int Width() const { return(right - left); }
+    inline int Height() const { return(bottom - top); }
+};
 
-	public:
-		inline int Width() const		{ return m_nWidth; }
-		inline int Height() const		{ return m_nHeight; }
-		inline void SetWidth( int nW )	{ m_nWidth = nW; }
-		inline void SetHeight( int nH )	{ m_nHeight = nH; }
+class RASize
+{
+public:
+    RASize() : m_nWidth(0), m_nHeight(0) {}
+    RASize(const RASize& rhs) : m_nWidth(rhs.m_nWidth), m_nHeight(rhs.m_nHeight) {}
+    RASize(int nW, int nH) : m_nWidth(nW), m_nHeight(nH) {}
 
-	private:
-		int m_nWidth;
-		int m_nHeight;
-	};
+public:
+    inline int Width() const { return m_nWidth; }
+    inline int Height() const { return m_nHeight; }
+    inline void SetWidth(int nW) { m_nWidth = nW; }
+    inline void SetHeight(int nH) { m_nHeight = nH; }
 
-	const RASize RA_BADGE_PX( 64, 64 );
-	const RASize RA_USERPIC_PX( 64, 64 );
+private:
+    int m_nWidth;
+    int m_nHeight;
+};
 
-	class ResizeContent
-	{
-	public:
-		enum AlignType
-		{
-			NO_ALIGN,
-			ALIGN_RIGHT,
-			ALIGN_BOTTOM,
-			ALIGN_BOTTOM_RIGHT
-		};
+const RASize RA_BADGE_PX(64, 64);
+const RASize RA_USERPIC_PX(64, 64);
 
-	public:
-		HWND hwnd;
-		POINT pLT;
-		POINT pRB;
-		AlignType nAlignType;
-		int nDistanceX;
-		int nDistanceY;
-		bool bResize;
+class ResizeContent
+{
+public:
+    enum AlignType
+    {
+        NO_ALIGN,
+        ALIGN_RIGHT,
+        ALIGN_BOTTOM,
+        ALIGN_BOTTOM_RIGHT
+    };
 
-		ResizeContent( HWND parentHwnd, HWND contentHwnd, AlignType newAlignType, bool isResize )
-		{
-			hwnd = contentHwnd;
-			nAlignType = newAlignType;
-			bResize = isResize;
-			
-			RARect rect;
-			GetWindowRect( hwnd, &rect );
+public:
+    HWND hwnd;
+    POINT pLT;
+    POINT pRB;
+    AlignType nAlignType;
+    int nDistanceX;
+    int nDistanceY;
+    bool bResize;
 
-			pLT.x = rect.left;	pLT.y = rect.top;
-			pRB.x = rect.right; pRB.y = rect.bottom;
+    ResizeContent(HWND parentHwnd, HWND contentHwnd, AlignType newAlignType, bool isResize)
+    {
+        hwnd = contentHwnd;
+        nAlignType = newAlignType;
+        bResize = isResize;
 
-			ScreenToClient( parentHwnd, &pLT );
-			ScreenToClient( parentHwnd, &pRB );
+        RARect rect;
+        GetWindowRect(hwnd, &rect);
 
-			GetWindowRect ( parentHwnd, &rect );
-			nDistanceX = rect.Width() - pLT.x;
-			nDistanceY = rect.Height() - pLT.y;
-			
-			if ( bResize )
-			{
-				nDistanceX -= (pRB.x - pLT.x);
-				nDistanceY -= (pRB.y - pLT.y);
-			}
-		}
+        pLT.x = rect.left;	pLT.y = rect.top;
+        pRB.x = rect.right; pRB.y = rect.bottom;
 
-		void Resize(int width, int height)
-		{
-			int xPos, yPos;
+        ScreenToClient(parentHwnd, &pLT);
+        ScreenToClient(parentHwnd, &pRB);
 
-			switch ( nAlignType )
-			{
-				case ResizeContent::ALIGN_RIGHT:
-					xPos = width - nDistanceX - ( bResize ? pLT.x : 0 );
-					yPos = bResize ? ( pRB.y - pLT.x ) : pLT.y;
-					break;
-				case ResizeContent::ALIGN_BOTTOM:
-					xPos = bResize ? ( pRB.x - pLT.x ) : pLT.x;
-					yPos = height - nDistanceY - ( bResize ? pLT.y : 0 );
-					break;
-				case ResizeContent::ALIGN_BOTTOM_RIGHT:
-					xPos = width - nDistanceX - ( bResize ? pLT.x : 0 );
-					yPos = height - nDistanceY - ( bResize ? pLT.y : 0 );
-					break;
-				default:
-					xPos = bResize ? ( pRB.x - pLT.x ) : pLT.x;
-					yPos = bResize ? ( pRB.y - pLT.x ) : pLT.y;
-					break;
-			}
+        GetWindowRect(parentHwnd, &rect);
+        nDistanceX = rect.Width() - pLT.x;
+        nDistanceY = rect.Height() - pLT.y;
 
-			if ( !bResize )
-				SetWindowPos( hwnd, nullptr, xPos, yPos, 0, 0, SWP_NOSIZE | SWP_NOZORDER );
-			else
-				SetWindowPos( hwnd, nullptr, 0, 0, xPos, yPos, SWP_NOMOVE | SWP_NOZORDER );
-		}
-	};
+        if (bResize)
+        {
+            nDistanceX -= (pRB.x - pLT.x);
+            nDistanceY -= (pRB.y - pLT.y);
+        }
+    }
 
-	enum AchievementSetType
-	{
-		Core,
-		Unofficial,
-		Local,
+    void Resize(int width, int height)
+    {
+        int xPos, yPos;
 
-		NumAchievementSetTypes
-	};
-	
-	typedef std::vector<BYTE> DataStream;
-	typedef unsigned long ByteAddress;
+        switch (nAlignType)
+        {
+        case ResizeContent::ALIGN_RIGHT:
+            xPos = width - nDistanceX - (bResize ? pLT.x : 0);
+            yPos = bResize ? (pRB.y - pLT.x) : pLT.y;
+            break;
+        case ResizeContent::ALIGN_BOTTOM:
+            xPos = bResize ? (pRB.x - pLT.x) : pLT.x;
+            yPos = height - nDistanceY - (bResize ? pLT.y : 0);
+            break;
+        case ResizeContent::ALIGN_BOTTOM_RIGHT:
+            xPos = width - nDistanceX - (bResize ? pLT.x : 0);
+            yPos = height - nDistanceY - (bResize ? pLT.y : 0);
+            break;
+        default:
+            xPos = bResize ? (pRB.x - pLT.x) : pLT.x;
+            yPos = bResize ? (pRB.y - pLT.x) : pLT.y;
+            break;
+        }
 
-	typedef unsigned int AchievementID;
-	typedef unsigned int LeaderboardID;
-	typedef unsigned int GameID;
+        if (!bResize)
+            SetWindowPos(hwnd, NULL, xPos, yPos, NULL, NULL, SWP_NOSIZE | SWP_NOZORDER);
+        else
+            SetWindowPos(hwnd, NULL, 0, 0, xPos, yPos, SWP_NOMOVE | SWP_NOZORDER);
+    }
+};
 
-	char* DataStreamAsString( DataStream& stream );
+enum AchievementSetType
+{
+    Core,
+    Unofficial,
+    Local,
 
-	extern void RADebugLogNoFormat( const char* data );
-	extern void RADebugLog( const char* sFormat, ... );
-	extern BOOL DirectoryExists( const char* sPath );
+    NumAchievementSetTypes
+};
 
-	const int SERVER_PING_DURATION = 2*60;
+
+
+
+
+
+extern void RADebugLogNoFormat(const char* data);
+extern void RADebugLog(const char* sFormat, ...);
+extern BOOL DirectoryExists(const char* sPath);
+
+const int SERVER_PING_DURATION = 2 * 60;
 //};
 //using namespace RA;
-	
+
 #define RA_LOG RADebugLog
 
 #ifdef _DEBUG
@@ -226,30 +254,362 @@ typedef DWORD			ARGB;
 #undef ASSERT
 #define ASSERT( x ) {}
 #endif
-	
+
 #ifndef UNUSED
 #define UNUSED( x ) ( x );
 #endif
 
-extern std::string Narrow(const wchar_t* wstr);
-extern std::string Narrow(const std::wstring& wstr);
-extern std::wstring Widen(const char* str);
-extern std::wstring Widen(const std::string& str);
+
+
+
+
+
+
+
+namespace ra {
+
+using tstring       = std::basic_string<TCHAR>;
+using DataStream    = std::basic_string<BYTE>;
+
+using ByteAddress   = std::size_t;
+using DataPos       = std::size_t;
+using AchievementID = std::size_t;
+using LeaderboardID = std::size_t;
+using GameID        = std::size_t;
+
+// forgot to add this
+// if you are already in ra or type "using namespace ra" that's good enough
+// This must be an inline namespace
+inline namespace int_literals
+{
+
+// Don't feel like casting non-stop
+// There's also standard literals for strings and clock types
+
+// N.B.: The parameter can only be either "unsigned long long", char16_t, or char32_t
+
+/// <summary>
+///   <para>
+///     Use it if you need an unsigned integer without the need for explicit
+///     narrowing conversions.
+///   </para>
+///   <para>
+///     usage: <c>auto some_int{21_z};</c> where <c>21</c> is
+///            <paramref name="n" />.
+///   </para>
+/// </summary>
+/// <param name="n">The integer.</param>
+/// <returns>The integer as <c>std::size_t</c>.</returns>
+_CONSTANT_VAR operator""_z(unsigned long long n) noexcept {
+    return static_cast<std::size_t>(n);
+} // end operator""_z
+
+
+/// <summary>
+///   <para>
+///     Use it if you need an integer without the need for explicit narrowing
+///     conversions.
+///   </para>
+///   <para>
+///     usage: <c>auto some_int{1_i};</c> where <c>1</c> is
+///            <paramref name="n" />.
+///   </para>
+/// </summary>
+/// <param name="n">The integer.</param>
+/// <returns>The integer as <c>std::intptr_t</c>.</returns>
+_CONSTANT_VAR operator""_i(unsigned long long n) noexcept {
+    return static_cast<std::intptr_t>(n);
+} // end operator""_i
+
+  // We need one for DWORD, because it doesn't match LPDWORD for some stuff
+_CONSTANT_VAR operator""_dw(unsigned long long n) noexcept {
+    return static_cast<_CSTD DWORD>(n);
+} // end operator""_dw
+
+// streamsize varies as well
+/// <summary>
+/// A literal
+/// </summary>
+/// <param name="n">The n.</param>
+/// <returns></returns>
+_CONSTANT_VAR operator""_ss(unsigned long long n) noexcept {
+    return static_cast<std::streamsize>(n);
+} // end operator""_ss
+
+// Literal for unsigned short
+_CONSTANT_VAR operator""_hu(unsigned long long n) noexcept {
+    return static_cast<std::uint16_t>(n);
+} // end operator""_hu
+
+
+_CONSTANT_VAR operator""_dp(unsigned long long n) noexcept {
+    return static_cast<DataPos>(n);
+} // end operator""_dp
+
+// If you follow the standard every alias is considered mutually exclusive, if not don't worry about it
+// These are here if you follow the standards (starts with ISO C++11/C11) rvalue conversions
+
+
+_CONSTANT_VAR operator""_ba(unsigned long long n) noexcept
+{
+    return static_cast<ByteAddress>(n);
+} // end operator""_ba
+
+
+_CONSTANT_VAR operator""_achid(unsigned long long n) noexcept {
+    return static_cast<AchievementID>(n);
+} // end operator""_achid
+
+
+_CONSTANT_VAR operator""_lbid(unsigned long long n) noexcept {
+    return static_cast<LeaderboardID>(n);
+} // end operator""_lbid
+
+
+_CONSTANT_VAR operator""_gameid(unsigned long long n) noexcept {
+    return static_cast<GameID>(n);
+} // end operator""_gameid
+
+} // inline namespace int_literals
+
+
+
+std::string DataStreamAsString(const DataStream& stream);
+std::string Narrow(const std::wstring& wstr);
+std::string Narrow(const wchar_t* wstr);
+std::wstring Widen(const std::string& str);
+std::wstring Widen(const char* str);
+
+
+
+
 
 //	No-ops to help convert:
-//	No-ops to help convert:
-extern std::wstring Widen(const wchar_t* wstr);
-extern std::wstring Widen(const std::wstring& wstr);
-extern std::string Narrow(const char* str);
-extern std::string Narrow(const std::string& wstr);
+std::wstring Widen(const wchar_t* wstr);
+std::wstring Widen(const std::wstring& wstr);
+std::string Narrow(const char* str);
+std::string Narrow(const std::string& wstr);
+std::string ByteAddressToString(ByteAddress nAddr);
 
-typedef std::basic_string<TCHAR> tstring;
 
+template<typename Enum, typename = std::enable_if_t<std::is_enum_v<Enum>>>
+_CONSTANT_VAR etoi(Enum e) -> std::underlying_type_t<Enum>
+{
+    return static_cast<std::underlying_type_t<Enum>>(e);
+}
+
+// function alias template
+template<typename Enum>
+_CONSTANT_VAR to_integral = etoi<Enum>;
+
+/// <summary>
+///   Converts a standard string with a signed character type to a
+///   <c>DataStream</c>.
+/// </summary>
+/// <param name="str">The string.</param>
+/// <typeparam name="CharT">
+///   The character type, must be signed or you will get an intellisense error.
+/// </typeparam>
+/// <returns><paramref name="str" /> as a <c>DataStream</c>.</returns>
+/// <remarks>
+///   <c>DataStream</c> is just an alias for an unsigned standard string.
+/// </remarks>
+template<
+    typename CharT,
+    class = std::enable_if_t<is_char_v<CharT> && std::is_signed_v<CharT>>
+>
+DataStream stodata_stream(const std::basic_string<CharT>& str) noexcept
+{
+    return convert_string<DataStream>(str);
+} // end function stodata_stream
+
+
+  // This should save some pain...
+template<typename SignedType, class = std::enable_if_t<std::is_signed_v<SignedType>>>
+_CONSTANT_VAR to_unsigned(SignedType st) noexcept -> std::make_unsigned_t<SignedType>
+{
+    using unsigned_t = std::make_unsigned_t<SignedType>;
+    return static_cast<unsigned_t>(st);
+}
+
+template<typename UnsignedType, class = std::enable_if_t<std::is_unsigned_v<UnsignedType>>>
+_CONSTANT_VAR to_signed(UnsignedType ust) noexcept -> std::make_signed_t<UnsignedType>
+{
+    using signed_t = std::make_signed_t<UnsignedType>;
+    return static_cast<signed_t>(ust);
+}
+
+
+// Stuff in the detail namespace are things people using the RA_Integration API
+// shouldn't use
+namespace detail {
+
+// There helper variable templates that are much easier to use, using these
+// explicitly is not recommended because it can lead to user errors.
+
+// A lot of these are just extra compile-time validation to ensure types are used correctly
+// Like you will get an intellisense error instead of a runtime error
+
+/// <summary>
+///   A check to tell whether a type is a known character type. If this
+///   function was reached, <typeparamref name="CharT" /> is a known character
+///   type.
+/// </summary>
+/// <typeparam name="CharT">A type to be evalualted</typeparam>
+template<typename CharT>
+struct is_char :
+    std::bool_constant<std::is_integral_v<CharT> &&
+    (std::is_same_v<CharT, char> || std::is_same_v<CharT, wchar_t> ||
+        std::is_same_v<CharT, char16_t> || std::is_same_v<CharT, char32_t> ||
+        std::is_same_v<CharT, unsigned char>)> {};
+
+// for the hell of it
+template<
+    typename StringType,
+    class = std::void_t<>
+>
+struct is_string : std::false_type {};
+
+// TODO: Have implementations of concepts that are required for std::basic_string
+
+// There really should be a buttload of checks but that'll take too long for now
+template<typename StringType>
+struct is_string<StringType, std::enable_if_t<
+    is_char<typename std::char_traits<typename StringType::value_type>::char_type>::value>>
+    : std::true_type {};
+
+template<
+    typename EqualityComparable,
+    class = std::void_t<>
+>
+struct is_equality_comparable : std::false_type {};
+
+
+template<typename EqualityComparable>
+struct is_equality_comparable<EqualityComparable,
+    std::enable_if_t<std::is_convertible_v<
+    decltype(std::declval<EqualityComparable>() == std::declval<EqualityComparable>()), bool>
+    >> : std::true_type {};
+
+template<
+    typename LessThanComparable,
+    class = std::void_t<>
+>
+struct is_lessthan_comparable : std::false_type {};
+
+
+template<typename LessThanComparable>
+struct is_lessthan_comparable<LessThanComparable,
+    std::enable_if_t<std::is_convertible_v<
+    decltype(std::declval<LessThanComparable>() < std::declval<LessThanComparable>()), bool>
+    >> : std::true_type{};
+
+// nothrows: for each one of these the operator has to be marked with noexcept to pass
+template<typename EqualityComparable>
+struct is_nothrow_equality_comparable :
+    std::bool_constant<noexcept(is_equality_comparable<EqualityComparable>::value)> {};
+
+template<typename LessThanComparable>
+struct is_nothrow_lessthan_comparable :
+    std::bool_constant<noexcept(is_lessthan_comparable<LessThanComparable>::value)> {};
+
+} // namespace detail
+
+
+// is_char helper variable template
+template<typename CharT>
+_CONSTANT_VAR is_char_v = detail::is_char<CharT>::value;
+
+
+// is_string helper variable template
+template<typename StringType>
+_CONSTANT_VAR is_string_v = detail::is_string<StringType>::value;
+
+// is_equality_comparable helper variable template
+template<typename EqualityComparable>
+_CONSTANT_VAR is_equality_comparable_v = detail::is_equality_comparable<EqualityComparable>::value;
+
+// is_lessthan_comparable helper variable template
+template<typename LessThanComparable>
+_CONSTANT_VAR is_lessthan_comparable_v = detail::is_lessthan_comparable<LessThanComparable>::value;
+
+// is_nothrow_equality_comparable helper variable template
+template<typename EqualityComparable>
+_CONSTANT_VAR is_nothrow_equality_comparable_v = detail::is_nothrow_equality_comparable<EqualityComparable>::value;
+
+template<typename LessThanComparable>
+_CONSTANT_VAR is_nothrow_lessthan_comparable_v = detail::is_nothrow_lessthan_comparable<LessThanComparable>::value;
+
+// We probably don't need this now but it'll be useful later when using STL filestreams instead of C filestreams
+/// <summary>Calculates the size of any standard fstream.</summary>
+/// <param name="filename">The filename.</param>
+/// <typeparam name="CharT">
+///   The character type, it should be auto deduced if valid. Otherwise you'll
+///   get an intellisense error.
+/// </typeparam>
+/// <typeparam name="Traits">
+///   The character traits of <typeparamref name="CharT" />.
+/// </typeparam>
+/// <returns>The size of the file stream.</returns>
+template<
+    typename CharT,
+    typename Traits = std::char_traits<CharT>,
+    class = std::enable_if_t<is_char_v<CharT>>
+>
+typename Traits::pos_type filesize(std::basic_string<CharT>& filename) noexcept {
+    // It's always the little things...
+    using file_type = std::basic_fstream<CharT>;
+    file_type file{ filename, std::ios::in | std::ios::ate | std::ios::binary };
+    return file.tellg();
+} // end function filesize
+
+  // All puporse string converter
+  /// <summary>
+  ///   Converts <paramref name="in" /> into an
+  ///   <typeparamref name="OutputString" />. To use this you have to at least
+  ///   specfiy <typeparamref name="OutputString" />. It won't work between
+  ///   Mutli-Byte to UTF-16, Use Widen() instead.
+  /// </summary>
+  /// <typeparam name="InputString">
+  ///   The type of string to be converted.
+  /// </typeparam>
+  /// <typeparam name="OutputString">
+  ///   The type of string to be converted to.
+  /// </typeparam>
+  /// <param name="in">The string to be converted.</param>
+  /// <returns>An <typeparamref name="OutputString" />.</returns>
+  /// <exception cref="std::ios_base::failure">
+  ///   If this was not thrown explicitly, there are no side effects. The runtime
+  ///   throws this exception if any bit in the stream is not
+  ///   <see cref="std::ios_base::good_bit" />.
+  /// </exception>
+template<
+    typename OutputString,
+    typename InputString,
+    class = std::enable_if_t<(is_string_v<InputString> && is_string_v<OutputString>) &&
+    (!std::is_same_v<InputString, OutputString>) && (!std::is_same_v<OutputString, std::wstring>)>
+>
+OutputString convert_string(_In_ const InputString& in) noexcept {
+    using out_char_t       = typename OutputString::value_type;
+    using out_stringstream = std::basic_ostringstream<out_char_t>;
+
+    out_stringstream oss;
+
+    for (auto& i : in) {
+        oss << i;
+    }
+
+    return oss.str();
+} // end function convert_string
+
+} // namespace ra
 
 #ifdef UNICODE
-#define NativeStr(x) Widen(x)
+#define NativeStr(x) ra::Widen(x)
 #define NativeStrType std::wstring
 #else
-#define NativeStr(x) Narrow(x)
+#define NativeStr(x) ra::Narrow(x)
 #define NativeStrType std::string
 #endif
+
+#endif // !RA_DEFS_H

--- a/src/RA_Dlg_AchEditor.cpp
+++ b/src/RA_Dlg_AchEditor.cpp
@@ -14,12 +14,7 @@
 
 #pragma comment(lib, "comctl32.lib")
 
-namespace
-{
-	const char* COLUMN_TITLE[] = { "ID", "Flag", "Type", "Size", "Memory", "Cmp", "Type", "Size", "Mem/Val", "Hits" };
-	const int COLUMN_WIDTH[] = { 30, 75, 42, 50, 72, 35, 42, 50, 72, 72 };
-	static_assert(SIZEOF_ARRAY(COLUMN_TITLE) == SIZEOF_ARRAY(COLUMN_WIDTH), "Must match!");
-}
+
 
 enum CondSubItems
 {
@@ -36,6 +31,16 @@ enum CondSubItems
 
 	NumColumns
 };
+
+namespace
+{
+inline constexpr std::array<const char*, CondSubItems::NumColumns> COLUMN_TITLE{
+	"ID", "Flag", "Type", "Size", "Memory", "Cmp", "Type", "Size", "Mem/Val", "Hits"
+};
+inline constexpr std::array<int, CondSubItems::NumColumns> COLUMN_WIDTH{
+	30, 75, 42, 50, 72, 35, 42, 50, 72, 72
+};
+}
 
 BOOL g_bPreferDecimalVal = TRUE;
 Dlg_AchievementEditor g_AchievementEditorDialog;

--- a/src/RA_Dlg_AchEditor.cpp
+++ b/src/RA_Dlg_AchEditor.cpp
@@ -355,7 +355,7 @@ long _stdcall EditProc(HWND hwnd, UINT nMsg, WPARAM wParam, LPARAM lParam)
 		if (lstrcmp(sEditText, TEXT("Value")))
 		{
 			//	Remove the associated 'size' entry
-			strcpy_s(g_AchievementEditorDialog.LbxDataAt(nSelItem, nSelSubItem + 1), 32, "");
+			strcpy_s(g_AchievementEditorDialog.LbxDataAt(lvDispinfo.item.iItem, lvDispinfo.item.iSubItem + 1), 32, "");
 		}
 
 		DestroyWindow(hwnd);
@@ -1092,9 +1092,8 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
 				return FALSE;
 
 			Condition NewCondition;
-			NewCondition.SetIsBasicCondition();
-			NewCondition.CompSource().Set(EightBit, Address, 0x0000, 0);
-			NewCondition.CompTarget().Set(EightBit, ValueComparison, 0, 0);	//	Compare defaults!
+			NewCondition.CompSource().Set(EightBit, Address, 0x0000);
+			NewCondition.CompTarget().Set(EightBit, ValueComparison, 0);	//	Compare defaults!
 
 			//	Helper: guess that the currently watched memory location
 			//	 is probably what they are about to want to add a cond for.
@@ -1142,8 +1141,7 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
 					{
 						const Condition& CondToCopy = pActiveAch->GetCondition(GetSelectedConditionGroup(), static_cast<size_t>(i));
 
-						Condition NewCondition;
-						NewCondition.Set(CondToCopy);
+						Condition NewCondition(CondToCopy);
 
 						m_ConditionClipboard.Add(NewCondition);
 					}

--- a/src/RA_Dlg_AchEditor.cpp
+++ b/src/RA_Dlg_AchEditor.cpp
@@ -100,10 +100,10 @@ Dlg_AchievementEditor::Dlg_AchievementEditor()
 
 Dlg_AchievementEditor::~Dlg_AchievementEditor()
 {
-	if (m_hAchievementBadge != NULL)
+	if (m_hAchievementBadge != nullptr)
 	{
 		DeleteObject(m_hAchievementBadge);
-		m_hAchievementBadge = NULL;
+		m_hAchievementBadge = nullptr;
 	}
 }
 
@@ -150,7 +150,7 @@ void Dlg_AchievementEditor::SetupColumns(HWND hList)
 
 BOOL Dlg_AchievementEditor::IsActive() const
 {
-	return(g_AchievementEditorDialog.GetHWND() != NULL) && (IsWindowVisible(g_AchievementEditorDialog.GetHWND()));
+	return(g_AchievementEditorDialog.GetHWND() != nullptr) && (IsWindowVisible(g_AchievementEditorDialog.GetHWND()));
 }
 
 const int Dlg_AchievementEditor::AddCondition(HWND hList, const Condition& Cond)
@@ -261,15 +261,15 @@ void Dlg_AchievementEditor::UpdateCondition(HWND hList, LV_ITEM& item, const Con
 // 			//BringWindowToTop( hDlg );
 // 
 // 			//EndDialog( hDlg, FALSE );
-// 			//AchievementEditorDialog.SetICEControl( NULL );
-// 			//m_hICEControl = NULL;	//	end of life
+// 			//AchievementEditorDialog.SetICEControl( nullptr );
+// 			//m_hICEControl = nullptr;	//	end of life
 // 			bFullyHandled = FALSE;
 // 			break;
 // 		}
 // 	case WM_KILLFOCUS:
 // 		{
 // 			//EndDialog( hDlg, FALSE );
-// 			//g_AchievementEditorDialog.SetICEControl( NULL );
+// 			//g_AchievementEditorDialog.SetICEControl( nullptr );
 // // 
 // // 			{
 // // 				HWND hDlg = g_AchievementEditorDialog.GetHWND();
@@ -298,7 +298,7 @@ void Dlg_AchievementEditor::UpdateCondition(HWND hList, LV_ITEM& item, const Con
 // 			break;
 // 		}
 // 			//EndDialog( hDlg, FALSE );
-// 			//g_AchievementEditorDialog.SetICEControl( NULL );
+// 			//g_AchievementEditorDialog.SetICEControl( nullptr );
 // 			// 
 // 			// 			{
 // 			// 				HWND hDlg = g_AchievementEditorDialog.GetHWND();
@@ -395,7 +395,7 @@ long _stdcall DropDownProc(HWND hwnd, UINT nMsg, WPARAM wParam, LPARAM lParam)
 			lvDispinfo.item.mask = LVIF_TEXT;
 			lvDispinfo.item.iItem = nSelItem;
 			lvDispinfo.item.iSubItem = nSelSubItem;
-			lvDispinfo.item.pszText = NULL;
+			lvDispinfo.item.pszText = nullptr;
 
 			TCHAR sEditText[32];
 			GetWindowText(hwnd, sEditText, 32);
@@ -454,7 +454,7 @@ long _stdcall DropDownProc(HWND hwnd, UINT nMsg, WPARAM wParam, LPARAM lParam)
 			// 				lvDispinfo.item.mask = LVIF_TEXT;
 			// 				lvDispinfo.item.iItem = nSelItem;
 			// 				lvDispinfo.item.iSubItem = nSelSubItem;
-			// 				lvDispinfo.item.pszText = NULL;
+			// 				lvDispinfo.item.pszText = nullptr;
 			// 
 			// 				char szEditText[12];
 			// 				GetWindowText( hwnd, szEditText, 12 );
@@ -531,7 +531,7 @@ BOOL CreateIPE(int nItem, int nSubItem)
 	case CSI_GROUP:
 	{
 		//	Condition: dropdown
-		ASSERT( g_hIPEEdit == NULL );
+		ASSERT( g_hIPEEdit == nullptr );
 		if ( g_hIPEEdit )
 			break;
 
@@ -543,10 +543,10 @@ BOOL CreateIPE(int nItem, int nSubItem)
 			rcSubItem.left, rcSubItem.top, nWidth, (int)( 1.6f * nHeight * Condition::NumConditionTypes ),
 			g_AchievementEditorDialog.GetHWND(),
 			0,
-			GetModuleHandle( NULL ),
-			NULL );
+			GetModuleHandle( nullptr ),
+			nullptr );
 
-		if ( g_hIPEEdit == NULL )
+		if ( g_hIPEEdit == nullptr )
 		{
 			ASSERT( !"Could not create combo box!" );
 			MessageBox( nullptr, TEXT( "Could not create combo box." ), TEXT( "Error" ), MB_OK | MB_ICONERROR );
@@ -595,10 +595,10 @@ BOOL CreateIPE(int nItem, int nSubItem)
 			rcSubItem.left, rcSubItem.top, nWidth, static_cast<int>(1.6f * nHeight * nNumItems),
 			g_AchievementEditorDialog.GetHWND(),
 			0,
-			GetModuleHandle(NULL),
-			NULL);
+			GetModuleHandle(nullptr),
+			nullptr);
 
-		if (g_hIPEEdit == NULL)
+		if (g_hIPEEdit == nullptr)
 		{
 			ASSERT(!"Could not create edit box!");
 			MessageBox(nullptr, TEXT("Could not create edit box."), TEXT("Error"), MB_OK | MB_ICONERROR);
@@ -638,7 +638,7 @@ BOOL CreateIPE(int nItem, int nSubItem)
 	case CSI_SIZE_TGT:
 	{
 		//	Size: dropdown
-		ASSERT(g_hIPEEdit == NULL);
+		ASSERT(g_hIPEEdit == nullptr);
 		if (g_hIPEEdit)
 			break;
 
@@ -666,10 +666,10 @@ BOOL CreateIPE(int nItem, int nSubItem)
 			rcSubItem.left, rcSubItem.top, nWidth, (int)(1.6f * nHeight * NumComparisonVariableSizeTypes),
 			g_AchievementEditorDialog.GetHWND(),
 			0,
-			GetModuleHandle(NULL),
-			NULL);
+			GetModuleHandle(nullptr),
+			nullptr);
 
-		if (g_hIPEEdit == NULL)
+		if (g_hIPEEdit == nullptr)
 		{
 			ASSERT(!"Could not create combo box!");
 			MessageBox(nullptr, TEXT("Could not create combo box."), TEXT("Error"), MB_OK | MB_ICONERROR);
@@ -693,7 +693,7 @@ BOOL CreateIPE(int nItem, int nSubItem)
 	case CSI_COMPARISON:
 	{
 		//	Compare: dropdown
-		ASSERT(g_hIPEEdit == NULL);
+		ASSERT(g_hIPEEdit == nullptr);
 		if (g_hIPEEdit)
 			break;
 
@@ -710,10 +710,10 @@ BOOL CreateIPE(int nItem, int nSubItem)
 			rcSubItem.left, rcSubItem.top, nWidth, (int)(1.6f * nHeight * NumComparisonTypes),
 			g_AchievementEditorDialog.GetHWND(),
 			0,
-			GetModuleHandle(NULL),
-			NULL);
+			GetModuleHandle(nullptr),
+			nullptr);
 
-		if (g_hIPEEdit == NULL)
+		if (g_hIPEEdit == nullptr)
 		{
 			ASSERT(!"Could not create combo box...");
 			MessageBox(nullptr, TEXT("Could not create combo box."), TEXT("Error"), MB_OK | MB_ICONERROR);
@@ -738,7 +738,7 @@ BOOL CreateIPE(int nItem, int nSubItem)
 	case CSI_VALUE_SRC:	//	Mem/Val: edit
 	case CSI_VALUE_TGT: //	Mem/Val: edit
 	{
-		ASSERT(g_hIPEEdit == NULL);
+		ASSERT(g_hIPEEdit == nullptr);
 		if (g_hIPEEdit)
 			break;
 
@@ -759,10 +759,10 @@ BOOL CreateIPE(int nItem, int nSubItem)
 			rcSubItem.left, rcSubItem.top, nWidth, (int)(1.5f*nHeight),
 			g_AchievementEditorDialog.GetHWND(),
 			0,
-			GetModuleHandle(NULL),
-			NULL);
+			GetModuleHandle(nullptr),
+			nullptr);
 
-		if (g_hIPEEdit == NULL)
+		if (g_hIPEEdit == nullptr)
 		{
 			ASSERT(!"Could not create edit box!");
 			MessageBox(nullptr, TEXT("Could not create edit box."), TEXT("Error"), MB_OK | MB_ICONERROR);
@@ -777,7 +777,7 @@ BOOL CreateIPE(int nItem, int nSubItem)
 		//	Special case, hitcounts
 		if (nSubItem == CSI_HITCOUNT)
 		{
-			if (g_AchievementEditorDialog.ActiveAchievement() != NULL)
+			if (g_AchievementEditorDialog.ActiveAchievement() != nullptr)
 			{
 				const size_t nGrp = g_AchievementEditorDialog.GetSelectedConditionGroup();
 				const Condition& Cond = g_AchievementEditorDialog.ActiveAchievement()->GetCondition(nGrp, nItem);
@@ -818,11 +818,11 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
 	case WM_TIMER:
 	{
 		//	Ignore if we are currently editing a box!
-		if (g_hIPEEdit != NULL)
+		if (g_hIPEEdit != nullptr)
 			break;
 
 		Achievement* pActiveAch = ActiveAchievement();
-		if (pActiveAch == NULL)
+		if (pActiveAch == nullptr)
 			break;
 
 		if (pActiveAch->IsDirty())
@@ -848,7 +848,7 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
 		m_BadgeNames.InstallAchEditorCombo(GetDlgItem(m_hAchievementEditorDlg, IDC_RA_BADGENAME));
 		m_BadgeNames.FetchNewBadgeNamesThreaded();
 
-		if (m_pSelectedAchievement != NULL)
+		if (m_pSelectedAchievement != nullptr)
   		    RepopulateGroupList(m_pSelectedAchievement);
 
 		if (!CanCausePause())
@@ -876,7 +876,7 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
 		for ( ResizeContent content : vDlgAchEditorResize )
 			content.Resize( winRect.Width(), winRect.Height() );
 
-		InvalidateRect( hDlg, NULL, TRUE );
+		InvalidateRect( hDlg, nullptr, TRUE );
 
 		RememberWindowSize(hDlg, "Achievement Editor");
 	}
@@ -897,7 +897,7 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
 		case IDC_RA_CHK_SHOW_DECIMALS:
 		{
 			g_bPreferDecimalVal = !g_bPreferDecimalVal;
-			if (ActiveAchievement() != NULL)
+			if (ActiveAchievement() != nullptr)
 			{
 				ActiveAchievement()->SetDirtyFlag(Dirty__All);
 				LoadAchievement(ActiveAchievement(), TRUE);
@@ -908,9 +908,10 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
 		}
 
 		case IDC_RA_CHK_ACH_ACTIVE:
-			if (ActiveAchievement() != NULL)
+			if (ActiveAchievement() != nullptr)
 			{
-				SendMessage(g_AchievementsDialog.GetHWND(), WM_COMMAND, IDC_RA_RESET_ACH, NULL);
+				// TODO: Use the literals once PR 23 is accepted
+				SendMessage(g_AchievementsDialog.GetHWND(), WM_COMMAND, IDC_RA_RESET_ACH, LPARAM{});
 				CheckDlgButton(hDlg, IDC_RA_CHK_ACH_ACTIVE, ActiveAchievement()->Active());
 			}
 			bHandled = TRUE;
@@ -918,7 +919,7 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
 
 		case IDC_RA_CHK_ACH_PAUSE_ON_TRIGGER:
 			{
-				if (ActiveAchievement() != NULL)
+				if (ActiveAchievement() != nullptr)
 					ActiveAchievement()->SetPauseOnTrigger(!ActiveAchievement()->GetPauseOnTrigger());
 
 				bHandled = TRUE;
@@ -927,7 +928,7 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
 
 		case IDC_RA_CHK_ACH_PAUSE_ON_RESET:
 			{
-				if (ActiveAchievement() != NULL)
+				if (ActiveAchievement() != nullptr)
 					ActiveAchievement()->SetPauseOnReset(!ActiveAchievement()->GetPauseOnReset());
 
 				bHandled = TRUE;
@@ -945,7 +946,7 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
 
 		case IDC_RA_BADGENAME:
 		{
-			// 				if( m_pSelectedAchievement == NULL )
+			// 				if( m_pSelectedAchievement == nullptr )
 			// 				{
 			// 					bHandled = TRUE;
 			// 					break;
@@ -973,7 +974,7 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
 
 		case IDC_RA_PROGRESSINDICATORS:
 		{
-			DialogBox((HINSTANCE)(GetModuleHandle(NULL)), MAKEINTRESOURCE(IDD_RA_ACHIEVEMENTPROGRESS), hDlg, AchProgressProc);
+			DialogBox((HINSTANCE)(GetModuleHandle(nullptr)), MAKEINTRESOURCE(IDD_RA_ACHIEVEMENTPROGRESS), hDlg, AchProgressProc);
 			//DialogBox( ghInstance, MAKEINTRESOURCE(IDD_RA_ACHIEVEMENTPROGRESS), hDlg, AchProgressProc );
 			bHandled = TRUE;
 		}
@@ -989,7 +990,7 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
 					return TRUE;
 
 				Achievement* pActiveAch = ActiveAchievement();
-				if (pActiveAch == NULL)
+				if (pActiveAch == nullptr)
 					return FALSE;
 
 				//	Disable all achievement tracking
@@ -1028,7 +1029,7 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
 					return TRUE;
 
 				Achievement* pActiveAch = ActiveAchievement();
-				if (pActiveAch == NULL)
+				if (pActiveAch == nullptr)
 					return FALSE;
 
 				//	Disable all achievement tracking:
@@ -1129,7 +1130,7 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
 		{
 			HWND hList = GetDlgItem(hDlg, IDC_RA_LBX_CONDITIONS);
 			Achievement* pActiveAch = ActiveAchievement();
-			if (pActiveAch != NULL)
+			if (pActiveAch != nullptr)
 			{
 				unsigned int uSelectedCount = ListView_GetSelectedCount(hList);
 
@@ -1160,7 +1161,7 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
 			HWND hList = GetDlgItem(hDlg, IDC_RA_LBX_CONDITIONS);
 			Achievement* pActiveAch = ActiveAchievement();
 
-			if (pActiveAch != NULL)
+			if (pActiveAch != nullptr)
 			{
 				if (m_ConditionClipboard.Count() > 0)
 				{
@@ -1192,7 +1193,7 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
 			if (nSel != -1)
 			{
 				Achievement* pActiveAch = ActiveAchievement();
-				if (pActiveAch != NULL)
+				if (pActiveAch != nullptr)
 				{
 					unsigned int uSelectedCount = ListView_GetSelectedCount(hList);
 
@@ -1231,7 +1232,7 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
 		{
 			HWND hList = GetDlgItem(hDlg, IDC_RA_LBX_CONDITIONS);
 			Achievement* pActiveAch = ActiveAchievement();
-			if (pActiveAch != NULL)
+			if (pActiveAch != nullptr)
 			{
 				int nSelectedIndex = ListView_GetNextItem(hList, -1, LVNI_SELECTED);
 				if (nSelectedIndex >= 0)
@@ -1285,7 +1286,7 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
 		{
 			HWND hList = GetDlgItem(hDlg, IDC_RA_LBX_CONDITIONS);
 			Achievement* pActiveAch = ActiveAchievement();
-			if (pActiveAch != NULL)
+			if (pActiveAch != nullptr)
 			{
 				int nSelectedIndex = ListView_GetNextItem(hList, -1, LVNI_SELECTED);
 				if (nSelectedIndex >= 0)
@@ -1366,7 +1367,7 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
 			if (GetOpenFileName(&ofn) == 0)	//	0 == cancelled
 				return FALSE;
 
-			if (ofn.lpstrFile != NULL)
+			if (ofn.lpstrFile != nullptr)
 			{
 				Document Response;
 				if (RAWeb::DoBlockingImageUpload(RequestUploadBadgeImage, Narrow(ofn.lpstrFile), Response))
@@ -1409,7 +1410,7 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
 
 		case IDC_RA_ACH_ADDGROUP:
 		{
-			if (ActiveAchievement() == NULL)
+			if (ActiveAchievement() == nullptr)
 				break;
 
 			if (ActiveAchievement()->NumConditionGroups() == 1)
@@ -1431,7 +1432,7 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
 		break;
 		case IDC_RA_ACH_DELGROUP:
 		{
-			if (ActiveAchievement() == NULL)
+			if (ActiveAchievement() == nullptr)
 				break;
 
 			if (ActiveAchievement()->NumConditionGroups() == 3)
@@ -1473,7 +1474,7 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
 		{
 			//	Only post this if the edit control is not empty:
 			//	 if it's empty, we're not dealing with THIS edit control!
-			if (g_hIPEEdit != NULL)
+			if (g_hIPEEdit != nullptr)
 			{
 				LV_DISPINFO lvDispinfo;
 				ZeroMemory(&lvDispinfo, sizeof(LV_DISPINFO));
@@ -1483,7 +1484,7 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
 				lvDispinfo.item.mask = LVIF_TEXT;
 				lvDispinfo.item.iItem = nSelItem;
 				lvDispinfo.item.iSubItem = nSelSubItem;
-				lvDispinfo.item.pszText = NULL;
+				lvDispinfo.item.pszText = nullptr;
 
 				TCHAR sEditText[32];
 				GetWindowText(g_hIPEEdit, sEditText, 32);
@@ -1513,7 +1514,7 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
 			//	http://cboard.cprogramming.com/windows-programming/122733-%5Bc%5D-editing-subitems-listview-win32-api.html
 
 			HWND hList = GetDlgItem(m_hAchievementEditorDlg, IDC_RA_LBX_CONDITIONS);
-			ASSERT(hList != NULL);
+			ASSERT(hList != nullptr);
 
 			//	Note: first item should be an ID!
 			if (pOnClick->iItem != -1 && pOnClick->iSubItem != 0)
@@ -1589,7 +1590,7 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
 			NMLVDISPINFO* pDispInfo = (NMLVDISPINFO*)(lParam);
 
 			Achievement* pActiveAch = ActiveAchievement();
-			if (pActiveAch == NULL)
+			if (pActiveAch == nullptr)
 				return FALSE;
 
 			if (pDispInfo->item.iItem < 0 || pDispInfo->item.iItem >= (int)pActiveAch->NumConditions(GetSelectedConditionGroup()))
@@ -1701,7 +1702,7 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
 				if (rCond.CompSource().Type() == ComparisonVariableType::ValueComparison && g_bPreferDecimalVal)
 					nBase = 10;
 
-				unsigned int nVal = strtol(sData, NULL, nBase);
+				unsigned int nVal = strtol(sData, nullptr, nBase);
 				rCond.CompSource().SetValues(nVal, nVal);
 				break;
 			}
@@ -1711,14 +1712,14 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
 				if (rCond.CompTarget().Type() == ComparisonVariableType::ValueComparison && g_bPreferDecimalVal)
 					nBase = 10;
 
-				unsigned int nVal = strtol(sData, NULL, nBase);
+				unsigned int nVal = strtol(sData, nullptr, nBase);
 				rCond.CompTarget().SetValues(nVal, nVal);
 				break;
 			}
 			case CSI_HITCOUNT:
 			{
 				//	Always decimal
-				rCond.SetRequiredHits(strtol(sData, NULL, 10));
+				rCond.SetRequiredHits(strtol(sData, nullptr, 10));
 				break;
 			}
 			default:
@@ -1769,7 +1770,7 @@ void Dlg_AchievementEditor::UpdateSelectedBadgeImage(const std::string& sBackupB
 
 	HWND hCheevoPic = GetDlgItem(m_hAchievementEditorDlg, IDC_RA_CHEEVOPIC);
 	SendMessage(hCheevoPic, STM_SETIMAGE, (WPARAM)IMAGE_BITMAP, (LPARAM)m_hAchievementBadge);
-	InvalidateRect(hCheevoPic, NULL, TRUE);
+	InvalidateRect(hCheevoPic, nullptr, TRUE);
 
 	//	Find buffer in the dropdown list
 	int nSel = ComboBox_FindStringExact(GetDlgItem(m_hAchievementEditorDlg, IDC_RA_BADGENAME), 0, sAchievementBadgeURI.c_str());
@@ -1780,7 +1781,7 @@ void Dlg_AchievementEditor::UpdateSelectedBadgeImage(const std::string& sBackupB
 void Dlg_AchievementEditor::UpdateBadge(const std::string& sNewName)
 {
 	//	If a change is detected: change it!
-	if (m_pSelectedAchievement != NULL)
+	if (m_pSelectedAchievement != nullptr)
 	{
 		if (m_pSelectedAchievement->BadgeImageURI().compare(sNewName) != 0)
 		{
@@ -1804,14 +1805,14 @@ void Dlg_AchievementEditor::UpdateBadge(const std::string& sNewName)
 void Dlg_AchievementEditor::RepopulateGroupList(Achievement* pCheevo)
 {
 	HWND hGroupList = GetDlgItem(m_hAchievementEditorDlg, IDC_RA_ACH_GROUP);
-	if (hGroupList == NULL)
+	if (hGroupList == nullptr)
 		return;
 
 	int nSel = ListBox_GetCurSel(hGroupList);
 
 	while (ListBox_DeleteString(hGroupList, 0) >= 0) {}
 
-	if (pCheevo != NULL)
+	if (pCheevo != nullptr)
 	{
 		for (size_t i = 0; i < pCheevo->NumConditionGroups(); ++i)
 		{
@@ -1829,13 +1830,13 @@ void Dlg_AchievementEditor::RepopulateGroupList(Achievement* pCheevo)
 void Dlg_AchievementEditor::PopulateConditions(Achievement* pCheevo)
 {
 	HWND hCondList = GetDlgItem(m_hAchievementEditorDlg, IDC_RA_LBX_CONDITIONS);
-	if (hCondList == NULL)
+	if (hCondList == nullptr)
 		return;
 
 	ListView_DeleteAllItems(hCondList);
 	m_nNumOccupiedRows = 0;
 
-	if (pCheevo != NULL)
+	if (pCheevo != nullptr)
 	{
 		unsigned int nGrp = GetSelectedConditionGroup();
 		for (size_t i = 0; i < m_pSelectedAchievement->NumConditions(nGrp); ++i)
@@ -1847,7 +1848,7 @@ void Dlg_AchievementEditor::LoadAchievement(Achievement* pCheevo, BOOL bAttemptK
 {
 	char buffer[1024];
 
-	if (pCheevo == NULL)
+	if (pCheevo == nullptr)
 	{
 		m_pSelectedAchievement = pCheevo;
 
@@ -1875,7 +1876,7 @@ void Dlg_AchievementEditor::LoadAchievement(Achievement* pCheevo, BOOL bAttemptK
 		EnableWindow(GetDlgItem(m_hAchievementEditorDlg, IDC_RA_PROGRESSINDICATORS), FALSE);
 
 		UpdateBadge("00000");
-		PopulateConditions(NULL);
+		PopulateConditions(nullptr);
 
 		m_bPopulatingAchievementEditorData = FALSE;
 	}
@@ -1959,7 +1960,7 @@ void Dlg_AchievementEditor::LoadAchievement(Achievement* pCheevo, BOOL bAttemptK
 		if (pCheevo->GetDirtyFlags() & Dirty_Conditions)
 		{
 			HWND hCondList = GetDlgItem(m_hAchievementEditorDlg, IDC_RA_LBX_CONDITIONS);
-			if (hCondList != NULL)
+			if (hCondList != nullptr)
 			{
 				unsigned int nGrp = GetSelectedConditionGroup();
 
@@ -1999,9 +2000,9 @@ void Dlg_AchievementEditor::LoadAchievement(Achievement* pCheevo, BOOL bAttemptK
 		m_bPopulatingAchievementEditorData = FALSE;
 	}
 
-	//InvalidateRect( hList, NULL, TRUE );
+	//InvalidateRect( hList, nullptr, TRUE );
 	//UpdateWindow( hList );
-	//RedrawWindow( hList, NULL, NULL, RDW_INVALIDATE );
+	//RedrawWindow( hList, nullptr, nullptr, RDW_INVALIDATE );
 }
 
 void Dlg_AchievementEditor::OnLoad_NewRom()
@@ -2055,7 +2056,7 @@ void BadgeNames::OnNewBadgeNames(const Document& data)
 	unsigned int nLowerLimit = data["FirstBadge"].GetUint();
 	unsigned int nUpperLimit = data["NextBadge"].GetUint();
 
-	SendMessage( m_hDestComboBox, WM_SETREDRAW, FALSE, NULL );
+	SendMessage( m_hDestComboBox, WM_SETREDRAW, FALSE, LPARAM{});
 
 	//	Clean out cbo
 	while (ComboBox_DeleteString(m_hDestComboBox, 0) > 0)
@@ -2069,11 +2070,11 @@ void BadgeNames::OnNewBadgeNames(const Document& data)
 		ComboBox_AddString(m_hDestComboBox, buffer);
 	}
 
-	SendMessage( m_hDestComboBox, WM_SETREDRAW, TRUE, NULL );
-	RedrawWindow( m_hDestComboBox, NULL, NULL, RDW_ERASE | RDW_FRAME | RDW_INVALIDATE | RDW_ALLCHILDREN );
+	SendMessage( m_hDestComboBox, WM_SETREDRAW, TRUE, LPARAM{});
+	RedrawWindow( m_hDestComboBox, nullptr, nullptr, RDW_ERASE | RDW_FRAME | RDW_INVALIDATE | RDW_ALLCHILDREN );
 
 	//	Find buffer in the dropdown list
-	if ( g_AchievementEditorDialog.ActiveAchievement() != NULL )
+	if ( g_AchievementEditorDialog.ActiveAchievement() != nullptr )
 	{
 		int nSel = ComboBox_FindStringExact( m_hDestComboBox, 0, g_AchievementEditorDialog.ActiveAchievement()->BadgeImageURI().c_str() );
 		if ( nSel != -1 )

--- a/src/RA_Dlg_AchEditor.h
+++ b/src/RA_Dlg_AchEditor.h
@@ -8,8 +8,8 @@
 
 namespace
 {
-	const size_t MAX_CONDITIONS = 200;
-	const size_t MEM_STRING_TEXT_LEN = 80;
+inline constexpr auto MAX_CONDITIONS      = std::size_t{ 200 };
+inline constexpr auto MEM_STRING_TEXT_LEN = std::size_t{ 80 };
 }
 
 class BadgeNames

--- a/src/RA_Dlg_AchEditor.h
+++ b/src/RA_Dlg_AchEditor.h
@@ -62,7 +62,7 @@ public:
 	size_t GetSelectedConditionGroup() const;
 	void SetSelectedConditionGroup( size_t nGrp ) const;
 
-	ConditionSet m_ConditionClipboard;
+	ConditionGroup m_ConditionClipboard;
 
 private:
 	void RepopulateGroupList( Achievement* pCheevo );

--- a/src/RA_Dlg_Achievement.cpp
+++ b/src/RA_Dlg_Achievement.cpp
@@ -1,5 +1,6 @@
 #include "RA_Dlg_Achievement.h"
 
+#include "RA_Resource.h" // was this included twice?, when it was lower there were errors
 #include "RA_Achievement.h"
 #include "RA_AchievementSet.h"
 #include "RA_Core.h"
@@ -9,21 +10,28 @@
 #include "RA_GameData.h"
 #include "RA_httpthread.h"
 #include "RA_md5factory.h"
-#include "RA_Resource.h"
+
 #include "RA_User.h"
 #include "RA_GameData.h"
 
 
 namespace
 {
-	const char* COLUMN_TITLES_CORE[] = { "ID", "Title", "Points", "Author", "Achieved?", "Modified?" };
-	const char* COLUMN_TITLES_UNOFFICIAL[] = { "ID", "Title", "Points", "Author", "Active",	"Votes" };
-	const char* COLUMN_TITLES_LOCAL[] = { "ID", "Title", "Points", "Author", "Active",	"Votes" };
-	const int COLUMN_SIZE[] = { 45, 200, 45, 80, 65, 65 };
+inline constexpr auto NUM_COLS = 6;
+inline constexpr std::array<const char*, NUM_COLS> COLUMN_TITLES_CORE{
+	"ID", "Title", "Points", "Author", "Achieved?", "Modified?"
+};
+inline constexpr std::array<const char*, NUM_COLS> COLUMN_TITLES_UNOFFICIAL{
+	"ID", "Title", "Points", "Author", "Active", "Votes"
+};
+inline constexpr std::array<const char*, NUM_COLS> COLUMN_TITLES_LOCAL{
+	"ID", "Title", "Points", "Author", "Active", "Votes"
+};
+inline constexpr std::array<int, NUM_COLS> COLUMN_SIZE{ 45, 200, 45, 80, 65, 65 };
 
-	const int NUM_COLS = SIZEOF_ARRAY(COLUMN_SIZE);
+	
 
-	int iSelect = -1;
+int iSelect = -1;
 }
 
 Dlg_Achievements g_AchievementsDialog;

--- a/src/RA_Dlg_Achievement.cpp
+++ b/src/RA_Dlg_Achievement.cpp
@@ -142,9 +142,9 @@ void Dlg_Achievements::RemoveAchievement(HWND hList, int nIter)
 	SetDlgItemText(m_hAchievementsDlg, IDC_RA_NUMACH, NativeStr(buffer).c_str());
 	SetDlgItemText( m_hAchievementsDlg, IDC_RA_POINT_TOTAL, NativeStr( std::to_string( g_pActiveAchievements->PointTotal() ) ).c_str() );
 
-	UpdateSelectedAchievementButtons(NULL);
+	UpdateSelectedAchievementButtons(nullptr);
 
-	g_AchievementEditorDialog.LoadAchievement(NULL, FALSE);
+	g_AchievementEditorDialog.LoadAchievement(nullptr, FALSE);
 }
 
 size_t Dlg_Achievements::AddAchievement(HWND hList, const Achievement& Ach)
@@ -680,7 +680,7 @@ INT_PTR Dlg_Achievements::AchievementsProc(HWND hDlg, UINT nMsg, WPARAM wParam, 
 					for ( unsigned int i = 0; i < g_pActiveAchievements->NumAchievements(); i++ )
 						g_pActiveAchievements->GetAchievement( i ).SetModified( FALSE );
 
-					InvalidateRect( hDlg, NULL, FALSE );
+					InvalidateRect( hDlg, nullptr, FALSE );
 				}
 				else
 				{
@@ -725,7 +725,7 @@ INT_PTR Dlg_Achievements::AchievementsProc(HWND hDlg, UINT nMsg, WPARAM wParam, 
 					if (TempSet.LoadFromFile(g_pCurrentGameData->GetGameID()))
 					{
 						Achievement* pAchBackup = TempSet.Find(nID);
-						if (pAchBackup != NULL)
+						if (pAchBackup != nullptr)
 						{
 							Cheevo.Set(*pAchBackup);
 
@@ -886,7 +886,7 @@ INT_PTR Dlg_Achievements::AchievementsProc(HWND hDlg, UINT nMsg, WPARAM wParam, 
 			}
 			else
 			{
-				UpdateSelectedAchievementButtons(NULL);
+				UpdateSelectedAchievementButtons(nullptr);
 			}
 		}
 		break;
@@ -1059,7 +1059,7 @@ INT_PTR Dlg_Achievements::CommitAchievements(HWND hDlg)
 
 void Dlg_Achievements::UpdateSelectedAchievementButtons(const Achievement* Cheevo)
 {
-	if (Cheevo == NULL)
+	if (Cheevo == nullptr)
 	{
 		EnableWindow(GetDlgItem(m_hAchievementsDlg, IDC_RA_RESET_ACH), FALSE);
 		EnableWindow(GetDlgItem(m_hAchievementsDlg, IDC_RA_REVERTSELECTED), FALSE);
@@ -1105,7 +1105,7 @@ void Dlg_Achievements::OnLoad_NewRom(GameID nGameID)
 	EnableWindow(GetDlgItem(m_hAchievementsDlg, IDC_RA_PROMOTE_ACH), FALSE);
 
 	HWND hList = GetDlgItem(m_hAchievementsDlg, IDC_RA_LISTACHIEVEMENTS);
-	if (hList != NULL)
+	if (hList != nullptr)
 	{
 		//SetupColumns( hList );
 		LoadAchievements(hList);
@@ -1127,7 +1127,7 @@ void Dlg_Achievements::OnLoad_NewRom(GameID nGameID)
 		SetDlgItemText( m_hAchievementsDlg, IDC_RA_POINT_TOTAL, NativeStr( std::to_string( g_pActiveAchievements->PointTotal() ) ).c_str() );
 	}
 
-	UpdateSelectedAchievementButtons(NULL);
+	UpdateSelectedAchievementButtons(nullptr);
 }
 
 void Dlg_Achievements::OnGet_Achievement(const Achievement& ach)
@@ -1199,7 +1199,7 @@ void Dlg_Achievements::OnEditData(size_t nItem, Column nColumn, const std::strin
 	m_lbxData[nItem][nColumn] = sNewData;
 
 	HWND hList = GetDlgItem(m_hAchievementsDlg, IDC_RA_LISTACHIEVEMENTS);
-	if (hList != NULL)
+	if (hList != nullptr)
 	{
 		LV_ITEM item;
 		ZeroMemory(&item, sizeof(item));

--- a/src/RA_Dlg_Achievement.h
+++ b/src/RA_Dlg_Achievement.h
@@ -5,7 +5,7 @@
 #include <wtypes.h>
 #include <assert.h>
 
-const int MAX_TEXT_ITEM_SIZE = 80;
+constexpr auto MAX_TEXT_ITEM_SIZE = 80;
 
 //extern const char* g_sColTitles[];
 //extern const int g_nColSizes[];

--- a/src/RA_Dlg_AchievementsReporter.cpp
+++ b/src/RA_Dlg_AchievementsReporter.cpp
@@ -12,14 +12,19 @@
 
 namespace
 {
-	const char* COL_TITLE[] = { "", "Title", "Description", "Author", "Achieved?" };
-	const int COL_SIZE[] = { 19, 105, 205, 75, 62 };
-	static_assert(SIZEOF_ARRAY(COL_TITLE) == SIZEOF_ARRAY(COL_SIZE), "Must match!");
-
-	const char* PROBLEM_STR[] = { "Unknown", "Triggers at wrong time", "Didn't trigger at all" };
+inline constexpr auto max_cols{ 6 };
+inline constexpr std::array<const char*, max_cols> COL_TITLE{ "", "Title", "Description", "Author", "Achieved?" };
+inline constexpr std::array<int, max_cols> COL_SIZE{ 19, 105, 205, 75, 62 };
+inline constexpr std::array<const char*, 3> PROBLEM_STR{ 
+	"Unknown", "Triggers at wrong time", "Didn't trigger at all" 
+};
 }
 
 int Dlg_AchievementsReporter::ms_nNumOccupiedRows = 0;
+
+
+// Doing this as a 2d std::array is possible, you just need to make the capacity of the string MAX_TEXT_LEN - 16
+// -16 because the capacity is always 16 more than the size in standard C++
 char Dlg_AchievementsReporter::ms_lbxData[MAX_ACHIEVEMENTS][NumReporterColumns][MAX_TEXT_LEN];
 
 Dlg_AchievementsReporter g_AchievementsReporterDialog;

--- a/src/RA_Dlg_AchievementsReporter.h
+++ b/src/RA_Dlg_AchievementsReporter.h
@@ -3,11 +3,14 @@
 
 class Achievement;
 
+
+inline constexpr auto MAX_ACHIEVEMENTS = 200;
+inline constexpr auto MAX_TEXT_LEN     = 250;
+
 class Dlg_AchievementsReporter
 {
 public:
-	static const int MAX_ACHIEVEMENTS = 200;
-	static const int MAX_TEXT_LEN = 250;
+
 
 public:
 	enum ReporterColumns

--- a/src/RA_Dlg_GameLibrary.cpp
+++ b/src/RA_Dlg_GameLibrary.cpp
@@ -85,7 +85,7 @@ bool ListFiles(std::string path, std::string mask, std::deque<std::string>& rFil
 	return true;
 }
 
-//HWND Dlg_GameLibrary::m_hDialogBox = NULL;
+//HWND Dlg_GameLibrary::m_hDialogBox = nullptr;
 //std::vector<GameEntry> Dlg_GameLibrary::m_vGameEntries;
 //std::map<std::string, unsigned int> Dlg_GameLibrary::m_GameHashLibrary;
 //std::map<unsigned int, std::string> Dlg_GameLibrary::m_GameTitlesLibrary;
@@ -102,9 +102,9 @@ Dlg_GameLibrary::~Dlg_GameLibrary()
 void ParseGameHashLibraryFromFile(std::map<std::string, GameID>& GameHashLibraryOut)
 {
 	SetCurrentDirectory(NativeStr(g_sHomeDir).c_str());
-	FILE* pf = NULL;
+	FILE* pf = nullptr;
 	fopen_s(&pf, RA_GAME_HASH_FILENAME, "rb");
-	if (pf != NULL)
+	if (pf != nullptr)
 	{
 		Document doc;
 		doc.ParseStream(FileStream(pf));
@@ -118,7 +118,7 @@ void ParseGameHashLibraryFromFile(std::map<std::string, GameID>& GameHashLibrary
 					continue;
 
 				const std::string sMD5 = iter->name.GetString();
-				//GameID nID = static_cast<GameID>( std::strtoul( iter->value.GetString(), NULL, 10 ) );	//	MUST BE STRING, then converted to uint. Keys are strings ONLY
+				//GameID nID = static_cast<GameID>( std::strtoul( iter->value.GetString(), nullptr, 10 ) );	//	MUST BE STRING, then converted to uint. Keys are strings ONLY
 				GameID nID = static_cast<GameID>(iter->value.GetUint());
 				GameHashLibraryOut[sMD5] = nID;
 			}
@@ -300,7 +300,8 @@ void Dlg_GameLibrary::ThreadedScanProc()
 				fread(pBuf, sizeof(BYTE), nSize, pf);	//Check
 				Results[FilesToScan.front()] = RAGenerateMD5(pBuf, nSize);
 
-				SendMessage(g_GameLibrary.GetHWND(), WM_TIMER, NULL, NULL);
+				// TODO: Use the the appropriate literals when PR 23 is accepted
+				SendMessage(g_GameLibrary.GetHWND(), WM_TIMER, WPARAM{}, LPARAM{});
 			}
 
 			fclose(pf);
@@ -365,7 +366,7 @@ void Dlg_GameLibrary::ScanAndAddRomsRecursive(const std::string& sBaseDir)
 					sprintf_s(sAbsFileDir, 2048, "%s\\%s", sBaseDir.c_str(), sFilename.c_str());
 
 					HANDLE hROMReader = CreateFile(NativeStr(sAbsFileDir).c_str(), GENERIC_READ, FILE_SHARE_READ,
-						NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+						nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
 
 					if (hROMReader != INVALID_HANDLE_VALUE)
 					{
@@ -375,7 +376,7 @@ void Dlg_GameLibrary::ScanAndAddRomsRecursive(const std::string& sBaseDir)
 							nSize = (File_Inf.nFileSizeHigh << 16) + File_Inf.nFileSizeLow;
 
 						DWORD nBytes = 0;
-						BOOL bResult = ReadFile(hROMReader, sROMRawData, nSize, &nBytes, NULL);
+						BOOL bResult = ReadFile(hROMReader, sROMRawData, nSize, &nBytes, nullptr);
 						const std::string sHashOut = RAGenerateMD5(sROMRawData, nSize);
 
 						if (m_GameHashLibrary.find(sHashOut) != m_GameHashLibrary.end())
@@ -396,7 +397,7 @@ void Dlg_GameLibrary::ScanAndAddRomsRecursive(const std::string& sBaseDir)
 		} while (FindNextFile(hFind, &ffd) != 0);
 
 		delete[](sROMRawData);
-		sROMRawData = NULL;
+		sROMRawData = nullptr;
 
 		FindClose(hFind);
 	}
@@ -478,9 +479,9 @@ BOOL Dlg_GameLibrary::LaunchSelected()
 void Dlg_GameLibrary::LoadAll()
 {
 	mtx.lock();
-	FILE* pLoadIn = NULL;
+	FILE* pLoadIn = nullptr;
 	fopen_s(&pLoadIn, RA_MY_GAME_LIBRARY_FILENAME, "rb");
-	if (pLoadIn != NULL)
+	if (pLoadIn != nullptr)
 	{
 		DWORD nCharsRead1 = 0;
 		DWORD nCharsRead2 = 0;
@@ -520,9 +521,9 @@ void Dlg_GameLibrary::LoadAll()
 void Dlg_GameLibrary::SaveAll()
 {
 	mtx.lock();
-	FILE* pf = NULL;
+	FILE* pf = nullptr;
 	fopen_s(&pf, RA_MY_GAME_LIBRARY_FILENAME, "wb");
-	if (pf != NULL)
+	if (pf != nullptr)
 	{
 		std::map<std::string, std::string>::iterator iter = Results.begin();
 		while (iter != Results.end())
@@ -578,7 +579,7 @@ INT_PTR CALLBACK Dlg_GameLibrary::GameLibraryProc(HWND hDlg, UINT uMsg, WPARAM w
 	}
 
 	case WM_TIMER:
-		if ((g_GameLibrary.GetHWND() != NULL) && (IsWindowVisible(g_GameLibrary.GetHWND())))
+		if ((g_GameLibrary.GetHWND() != nullptr) && (IsWindowVisible(g_GameLibrary.GetHWND())))
 			RefreshList();
 		//ReloadGameListData();
 		return FALSE;

--- a/src/RA_Dlg_GameLibrary.cpp
+++ b/src/RA_Dlg_GameLibrary.cpp
@@ -25,12 +25,12 @@
 
 namespace
 {
-	const char* COL_TITLE[] = { "ID", "Game Title", "Completion", "File Path" };
-	const int COL_SIZE[] = { 30, 230, 110, 170 };
-	static_assert(SIZEOF_ARRAY(COL_TITLE) == SIZEOF_ARRAY(COL_SIZE), "Must match!");
-	const bool bCancelScan = false;
+inline constexpr auto col_max{ 4 };
+inline constexpr std::array<const char*, col_max> COL_TITLE{ "ID", "Game Title", "Completion", "File Path" };
+inline constexpr std::array<int, col_max> COL_SIZE{ 30, 230, 110, 170 };
+inline constexpr auto bCancelScan{ false };
 
-	std::mutex mtx;
+std::mutex mtx;
 }
 
 //static 

--- a/src/RA_Dlg_GameTitle.cpp
+++ b/src/RA_Dlg_GameTitle.cpp
@@ -113,7 +113,7 @@ INT_PTR Dlg_GameTitle::GameTitleProc( HWND hDlg, UINT uMsg, WPARAM wParam, LPARA
 			{
 				//	Existing title
 				ASSERT( m_aGameTitles.find( std::string( sSelectedTitle ) ) != m_aGameTitles.end() );
-				nGameID = m_aGameTitles[ std::string( Narrow(sSelectedTitle) ) ];
+				nGameID = m_aGameTitles[ std::string(ra::Narrow(sSelectedTitle) ) ];
 			}
 
 			PostArgs args;

--- a/src/RA_Dlg_Login.cpp
+++ b/src/RA_Dlg_Login.cpp
@@ -50,8 +50,8 @@ INT_PTR CALLBACK RA_Dlg_Login::RA_Dlg_LoginProc( HWND hDlg, UINT uMsg, WPARAM wP
 				}
 
 				PostArgs args;
-				args[ 'u' ] = Narrow( sUserEntry );
-				args[ 'p' ] = Narrow( sPassEntry );		//	Plaintext password(!)
+				args[ 'u' ] = ra::Narrow( sUserEntry );
+				args[ 'p' ] = ra::Narrow( sPassEntry );		//	Plaintext password(!)
 				
 				Document doc;
 				if( RAWeb::DoBlockingRequest( RequestLogin, args, doc ) )

--- a/src/RA_Dlg_MemBookmark.cpp
+++ b/src/RA_Dlg_MemBookmark.cpp
@@ -832,13 +832,9 @@ std::string Dlg_MemBookmark::ImportDialog()
 	}
 
 	IFileOpenDialog* pDlg = nullptr;
-<<<<<<< HEAD
+
 	HRESULT hr = CoCreateInstance( CLSID_FileOpenDialog, nullptr, CLSCTX_ALL, IID_IFileOpenDialog, reinterpret_cast<void**>( &pDlg ) );
 	if ( hr == S_OK )
-=======
-	HRESULT hr = CoCreateInstance(CLSID_FileOpenDialog, NULL, CLSCTX_ALL, IID_IFileOpenDialog, reinterpret_cast<void**>(&pDlg));
-	if (hr == S_OK)
->>>>>>> global_carrays_to_stdarray
 	{
 		hr = pDlg->SetFileTypes(c_rgFileTypes.size(), &c_rgFileTypes.front());
 		if (hr == S_OK)
@@ -854,11 +850,7 @@ std::string Dlg_MemBookmark::ImportDialog()
 					hr = pItem->GetDisplayName(SIGDN_FILESYSPATH, &pStr);
 					if (hr == S_OK)
 					{
-<<<<<<< HEAD
 						str = ra::Narrow( pStr );
-=======
-						str = Narrow(pStr);
->>>>>>> global_carrays_to_stdarray
 					}
 
 					pItem->Release();

--- a/src/RA_Dlg_MemBookmark.cpp
+++ b/src/RA_Dlg_MemBookmark.cpp
@@ -144,7 +144,7 @@ INT_PTR Dlg_MemBookmark::MemBookmarkDialogProc( HWND hDlg, UINT uMsg, WPARAM wPa
 			for ( ResizeContent content : vDlgMemBookmarkResize )
 				content.Resize( winRect.Width(), winRect.Height() );
 
-			//InvalidateRect( hDlg, NULL, TRUE );
+			//InvalidateRect( hDlg, nullptr, TRUE );
 			RememberWindowSize(hDlg, "Memory Bookmarks");
 		}
 		break;
@@ -380,7 +380,7 @@ INT_PTR Dlg_MemBookmark::MemBookmarkDialogProc( HWND hDlg, UINT uMsg, WPARAM wPa
 							nSel = ListView_GetNextItem( hList, -1, LVNI_SELECTED );
 						}
 
-						InvalidateRect( hList, NULL, FALSE );
+						InvalidateRect( hList, nullptr, FALSE );
 					}
 
 					return TRUE;
@@ -414,7 +414,7 @@ INT_PTR Dlg_MemBookmark::MemBookmarkDialogProc( HWND hDlg, UINT uMsg, WPARAM wPa
 							bookmark->ResetCount();
 						}
 						
-						InvalidateRect( hList, NULL, FALSE );
+						InvalidateRect( hList, nullptr, FALSE );
 					}
 
 					return TRUE;
@@ -460,7 +460,7 @@ INT_PTR Dlg_MemBookmark::MemBookmarkDialogProc( HWND hDlg, UINT uMsg, WPARAM wPa
 
 BOOL Dlg_MemBookmark::IsActive() const
 {
-	return(g_MemBookmarkDialog.GetHWND() != NULL) && (IsWindowVisible(g_MemBookmarkDialog.GetHWND()));
+	return(g_MemBookmarkDialog.GetHWND() != nullptr) && (IsWindowVisible(g_MemBookmarkDialog.GetHWND()));
 }
 
 void Dlg_MemBookmark::UpdateBookmarks( bool bForceWrite )
@@ -506,7 +506,7 @@ void Dlg_MemBookmark::PopulateList()
 		return;
 
 	HWND hList = GetDlgItem( m_hMemBookmarkDialog, IDC_RA_LBX_ADDRESSES );
-	if ( hList == NULL )
+	if ( hList == nullptr )
 		return;
 
 	int topIndex = ListView_GetTopIndex( hList );
@@ -707,7 +707,7 @@ void Dlg_MemBookmark::ExportJSON()
 	defaultDir = g_sHomeDir + defaultDir;
 
 	IFileSaveDialog* pDlg = nullptr;
-	HRESULT hr = CoCreateInstance( CLSID_FileSaveDialog, NULL, CLSCTX_ALL, IID_IFileSaveDialog, reinterpret_cast<void**>( &pDlg ) );
+	HRESULT hr = CoCreateInstance( CLSID_FileSaveDialog, nullptr, CLSCTX_ALL, IID_IFileSaveDialog, reinterpret_cast<void**>( &pDlg ) );
 	if ( hr == S_OK )
 	{
 		hr = pDlg->SetFileTypes( ARRAYSIZE( c_rgFileTypes ), c_rgFileTypes );
@@ -719,11 +719,11 @@ void Dlg_MemBookmark::ExportJSON()
 			if ( hr == S_OK )
 			{
 				PIDLIST_ABSOLUTE pidl;
-				hr = SHParseDisplayName( Widen( defaultDir ).c_str(), NULL, &pidl, SFGAO_FOLDER, 0 );
+				hr = SHParseDisplayName( Widen( defaultDir ).c_str(), nullptr, &pidl, SFGAO_FOLDER, 0 );
 				if ( hr == S_OK )
 				{
 					IShellItem* pItem = nullptr;
-					SHCreateShellItem( NULL, NULL, pidl, &pItem );
+					SHCreateShellItem( nullptr, nullptr, pidl, &pItem );
 					hr = pDlg->SetDefaultFolder( pItem );
 					if ( hr == S_OK )
 					{
@@ -834,7 +834,7 @@ std::string Dlg_MemBookmark::ImportDialog()
 	}
 
 	IFileOpenDialog* pDlg = nullptr;
-	HRESULT hr = CoCreateInstance( CLSID_FileOpenDialog, NULL, CLSCTX_ALL, IID_IFileOpenDialog, reinterpret_cast<void**>( &pDlg ) );
+	HRESULT hr = CoCreateInstance( CLSID_FileOpenDialog, nullptr, CLSCTX_ALL, IID_IFileOpenDialog, reinterpret_cast<void**>( &pDlg ) );
 	if ( hr == S_OK )
 	{
 		hr = pDlg->SetFileTypes( ARRAYSIZE( c_rgFileTypes ), c_rgFileTypes );
@@ -930,10 +930,10 @@ BOOL Dlg_MemBookmark::EditLabel ( int nItem, int nSubItem )
 		rcSubItem.left, rcSubItem.top, nWidth, (int)( 1.5f*nHeight ),
 		g_MemBookmarkDialog.GetHWND(),
 		0,
-		GetModuleHandle( NULL ),
-		NULL );
+		GetModuleHandle( nullptr ),
+		nullptr );
 
-	if ( g_hIPEEditBM == NULL )
+	if ( g_hIPEEditBM == nullptr )
 	{
 		ASSERT( !"Could not create edit box!" );
 		MessageBox( nullptr, _T("Could not create edit box."), _T("Error"), MB_OK | MB_ICONERROR );

--- a/src/RA_Dlg_MemBookmark.cpp
+++ b/src/RA_Dlg_MemBookmark.cpp
@@ -576,7 +576,7 @@ void Dlg_MemBookmark::AddAddress()
 	// Fetch Memory Address from Memory Inspector
 	TCHAR buffer[ 256 ];
 	GetDlgItemText( g_MemoryDialog.GetHWND(), IDC_RA_WATCHING, buffer, 256 );
-	unsigned int nAddr = strtol( Narrow( buffer ).c_str(), nullptr, 16 );
+	unsigned int nAddr = strtol(ra::Narrow( buffer ).c_str(), nullptr, 16 );
 	NewBookmark->SetAddress( nAddr );
 
 	// Check Data Type
@@ -747,7 +747,7 @@ void Dlg_MemBookmark::ExportJSON()
 									{
 										Value item( kObjectType );
 										char buffer[ 256 ];
-										sprintf_s( buffer, Narrow( bookmark->Description() ).c_str(), sizeof( buffer ) );
+										sprintf_s( buffer, ra::Narrow( bookmark->Description() ).c_str(), sizeof( buffer ) );
 										Value s( buffer, allocator );
 
 										item.AddMember( "Description", s, allocator );
@@ -758,7 +758,7 @@ void Dlg_MemBookmark::ExportJSON()
 									}
 									doc.AddMember( "Bookmarks", bookmarks, allocator );
 
-									_WriteBufferToFile( Narrow( pStr ), doc );
+									_WriteBufferToFile(ra::Narrow( pStr ), doc );
 								}
 
 								pItem->Release();
@@ -850,7 +850,7 @@ std::string Dlg_MemBookmark::ImportDialog()
 					hr = pItem->GetDisplayName( SIGDN_FILESYSPATH, &pStr );
 					if ( hr == S_OK )
 					{
-						str = Narrow( pStr );
+						str = ra::Narrow( pStr );
 					}
 
 					pItem->Release();

--- a/src/RA_Dlg_MemBookmark.cpp
+++ b/src/RA_Dlg_MemBookmark.cpp
@@ -674,14 +674,13 @@ unsigned int Dlg_MemBookmark::GetMemory( unsigned int nAddr, int type )
 	switch ( type )
 	{
 		case 1:
-			mem_value = g_MemManager.ActiveBankRAMByteRead( nAddr );
+			mem_value = g_MemManager.ActiveBankRAMRead(nAddr, EightBit);
 			break;
 		case 2:
-			mem_value = ( g_MemManager.ActiveBankRAMByteRead( nAddr ) | ( g_MemManager.ActiveBankRAMByteRead( nAddr + 1 ) << 8 ) );
+			mem_value = g_MemManager.ActiveBankRAMRead(nAddr, SixteenBit);
 			break;
 		case 3:
-			mem_value = ( g_MemManager.ActiveBankRAMByteRead( nAddr ) | ( g_MemManager.ActiveBankRAMByteRead( nAddr + 1 ) << 8 ) |
-				( g_MemManager.ActiveBankRAMByteRead( nAddr + 2 ) << 16 ) | ( g_MemManager.ActiveBankRAMByteRead( nAddr + 3 ) << 24 ) );
+			mem_value = g_MemManager.ActiveBankRAMRead(nAddr, ThirtyTwoBit);
 			break;
 	}
 

--- a/src/RA_Dlg_MemBookmark.cpp
+++ b/src/RA_Dlg_MemBookmark.cpp
@@ -7,6 +7,7 @@
 #include "RA_MemManager.h"
 
 #include <strsafe.h>
+#include <atlbase.h>
 
 Dlg_MemBookmark g_MemBookmarkDialog;
 std::vector<ResizeContent> vDlgMemBookmarkResize;
@@ -19,15 +20,13 @@ int nSelSubItemBM;
 
 namespace
 {
-	const char* COLUMN_TITLE[] = { "Description", "Address", "Value", "Prev.", "Changes" };
-	const int COLUMN_WIDTH[] = { 112, 64, 64, 64, 54 };
-	static_assert( SIZEOF_ARRAY( COLUMN_TITLE ) == SIZEOF_ARRAY( COLUMN_WIDTH ), "Must match!" );
+inline constexpr std::array<const char*, 5> COLUMN_TITLE{ "Description", "Address", "Value", "Prev.", "Changes" };
+inline constexpr std::array<int, 5> COLUMN_WIDTH{ 112, 64, 64, 64, 54 };
 }
 
-const COMDLG_FILTERSPEC c_rgFileTypes[] =
-{
-	{ L"Text Document (*.txt)",       L"*.txt" }
-};
+
+inline constexpr std::array<COMDLG_FILTERSPEC, 1> c_rgFileTypes{ {L"Text Document (*.txt)", L"*.txt"} };
+
 
 enum BookmarkSubItems
 {
@@ -709,7 +708,7 @@ void Dlg_MemBookmark::ExportJSON()
 	HRESULT hr = CoCreateInstance( CLSID_FileSaveDialog, nullptr, CLSCTX_ALL, IID_IFileSaveDialog, reinterpret_cast<void**>( &pDlg ) );
 	if ( hr == S_OK )
 	{
-		hr = pDlg->SetFileTypes( ARRAYSIZE( c_rgFileTypes ), c_rgFileTypes );
+		hr = pDlg->SetFileTypes( c_rgFileTypes.size(), &c_rgFileTypes.front() );
 		if ( hr == S_OK )
 		{
 			char defaultFileName[ 512 ];
@@ -826,31 +825,40 @@ std::string Dlg_MemBookmark::ImportDialog()
 {
 	std::string str;
 
-	if ( g_pCurrentGameData->GetGameID() == 0 )
+	if (g_pCurrentGameData->GetGameID() == 0)
 	{
-		MessageBox( nullptr, _T("ROM not loaded: please load a ROM first!"), _T("Error!"), MB_OK );
+		MessageBox(nullptr, _T("ROM not loaded: please load a ROM first!"), _T("Error!"), MB_OK);
 		return str;
 	}
 
 	IFileOpenDialog* pDlg = nullptr;
+<<<<<<< HEAD
 	HRESULT hr = CoCreateInstance( CLSID_FileOpenDialog, nullptr, CLSCTX_ALL, IID_IFileOpenDialog, reinterpret_cast<void**>( &pDlg ) );
 	if ( hr == S_OK )
+=======
+	HRESULT hr = CoCreateInstance(CLSID_FileOpenDialog, NULL, CLSCTX_ALL, IID_IFileOpenDialog, reinterpret_cast<void**>(&pDlg));
+	if (hr == S_OK)
+>>>>>>> global_carrays_to_stdarray
 	{
-		hr = pDlg->SetFileTypes( ARRAYSIZE( c_rgFileTypes ), c_rgFileTypes );
-		if ( hr == S_OK )
+		hr = pDlg->SetFileTypes(c_rgFileTypes.size(), &c_rgFileTypes.front());
+		if (hr == S_OK)
 		{
-			hr = pDlg->Show( nullptr );
-			if ( hr == S_OK )
+			hr = pDlg->Show(nullptr);
+			if (hr == S_OK)
 			{
 				IShellItem* pItem = nullptr;
-				hr = pDlg->GetResult( &pItem );
-				if ( hr == S_OK )
+				hr = pDlg->GetResult(&pItem);
+				if (hr == S_OK)
 				{
 					LPWSTR pStr = nullptr;
-					hr = pItem->GetDisplayName( SIGDN_FILESYSPATH, &pStr );
-					if ( hr == S_OK )
+					hr = pItem->GetDisplayName(SIGDN_FILESYSPATH, &pStr);
+					if (hr == S_OK)
 					{
+<<<<<<< HEAD
 						str = ra::Narrow( pStr );
+=======
+						str = Narrow(pStr);
+>>>>>>> global_carrays_to_stdarray
 					}
 
 					pItem->Release();

--- a/src/RA_Dlg_Memory.cpp
+++ b/src/RA_Dlg_Memory.cpp
@@ -61,12 +61,7 @@ int nDlgMemoryMinX;
 int nDlgMemoryMinY;
 int nDlgMemViewerGapY;
 
-std::string ByteAddressToString(ByteAddress nAddr)
-{
-	static char buffer[16];
-	sprintf_s(buffer, "0x%06x", nAddr);
-	return std::string(buffer);
-}
+
 
 INT_PTR CALLBACK MemoryViewerControl::s_MemoryDrawProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {

--- a/src/RA_Dlg_Memory.cpp
+++ b/src/RA_Dlg_Memory.cpp
@@ -20,16 +20,11 @@
 
 namespace
 {
-	const size_t MIN_RESULTS_TO_DUMP = 500000;
-	const size_t MIN_SEARCH_PAGE_SIZE = 50;
-
-	const char* COMP_STR[] = {
-		{ "EQUAL" },
-		{ "LESS THAN" },
-		{ "LESS THAN/EQUAL" },
-		{ "GREATER THAN" },
-		{ "GREATER THAN/EQUAL" },
-		{ "NOT EQUAL" } };
+inline constexpr auto MIN_RESULTS_TO_DUMP = std::size_t{ 500000 };
+inline constexpr auto MIN_SEARCH_PAGE_SIZE = std::size_t{ 50 };
+inline constexpr std::array<const char*, 6> COMP_STR {
+ "EQUAL", "LESS THAN", "LESS THAN/EQUAL", "GREATER THAN", "GREATER THAN/EQUAL", "NOT EQUAL" 
+};
 }
 
 Dlg_Memory g_MemoryDialog;

--- a/src/RA_Dlg_Memory.cpp
+++ b/src/RA_Dlg_Memory.cpp
@@ -266,9 +266,9 @@ void MemoryViewerControl::setWatchedAddress(unsigned int address)
 void MemoryViewerControl::Invalidate()
 {
 	HWND hOurDlg = GetDlgItem(g_MemoryDialog.GetHWND(), IDC_RA_MEMTEXTVIEWER);
-	if (hOurDlg != NULL)
+	if (hOurDlg != nullptr)
 	{
-		InvalidateRect(hOurDlg, NULL, FALSE);
+		InvalidateRect(hOurDlg, nullptr, FALSE);
 
 		// In RALibRetro, s_MemoryDrawProc doesn't seem to be getting trigger by the InvalidateRect, so explicitly force the render by calling UpdateWindow
 		// TODO: figure out why this is necessary and remove it. There's a similar check in Dlg_Memory::Invalidate for the search results
@@ -343,7 +343,7 @@ bool MemoryViewerControl::OnEditInput(UINT c)
 		if (g_MemBookmarkDialog.GetHWND() != nullptr)
 		{
 			const MemBookmark* Bookmark = g_MemBookmarkDialog.FindBookmark(nByteAddress);
-			if (Bookmark != NULL)
+			if (Bookmark != nullptr)
 				g_MemBookmarkDialog.WriteFrozenValue(*Bookmark);
 		}
 
@@ -554,7 +554,7 @@ void MemoryViewerControl::RenderMemViewer(HWND hTarget)
 	int h = rect.bottom - rect.top - 6;
 
 	//	Pick font
-	if (m_hViewerFont == NULL)
+	if (m_hViewerFont == nullptr)
 		m_hViewerFont = (HFONT)GetStockObject(SYSTEM_FIXED_FONT);
 	HGDIOBJ hOldFont = SelectObject(hMemDC, m_hViewerFont);
 
@@ -619,12 +619,12 @@ void MemoryViewerControl::RenderMemViewer(HWND hTarget)
 				freeze = 0;
 				for (int j = 0; j < 16; ++j)
 				{
-					notes |= (g_MemoryDialog.Notes().FindCodeNote(addr + j) != NULL) ? (1 << j) : 0;
+					notes |= (g_MemoryDialog.Notes().FindCodeNote(addr + j) != nullptr) ? (1 << j) : 0;
 					const MemBookmark* bm = g_MemBookmarkDialog.FindBookmark(addr + j);
-					bookmarks |= (bm != NULL) ? (1 << j) : 0;
-					freeze |= ( bm != NULL && bm->Frozen() ) ? ( 1 << j ) : 0;
+					bookmarks |= (bm != nullptr) ? (1 << j) : 0;
+					freeze |= ( bm != nullptr && bm->Frozen() ) ? ( 1 << j ) : 0;
 
-					if ( bm != NULL && bm->Frozen() )
+					if ( bm != nullptr && bm->Frozen() )
 					{
 						if ( g_MemBookmarkDialog.GetHWND() != nullptr )
 							g_MemBookmarkDialog.WriteFrozenValue( *bm );
@@ -748,7 +748,7 @@ void MemoryViewerControl::RenderMemViewer(HWND hTarget)
 		HPEN hPen = CreatePen(PS_SOLID, 1, RGB(0, 0, 0));
 		HGDIOBJ hOldPen = SelectObject(hMemDC, hPen);
 
-		MoveToEx(hMemDC, 3 + m_szFontSize.cx * 9, 3 + m_szFontSize.cy, NULL);
+		MoveToEx(hMemDC, 3 + m_szFontSize.cx * 9, 3 + m_szFontSize.cy, nullptr);
 		LineTo(hMemDC, 3 + m_szFontSize.cx * 9, 3 + ((m_nDisplayedLines + 1) * m_szFontSize.cy));
 
 		SelectObject(hMemDC, hOldPen);
@@ -773,9 +773,9 @@ void Dlg_Memory::Init()
 	wc.style = CS_PARENTDC | CS_HREDRAW | CS_VREDRAW | CS_GLOBALCLASS;
 	wc.lpfnWndProc = (WNDPROC)MemoryViewerControl::s_MemoryDrawProc;
 	wc.hInstance = g_hThisDLLInst;
-	wc.hCursor = LoadCursor(NULL, IDC_ARROW);
+	wc.hCursor = LoadCursor(nullptr, IDC_ARROW);
 	wc.hbrBackground = (HBRUSH)GetStockObject(WHITE_BRUSH);
-	wc.lpszMenuName = NULL;
+	wc.lpszMenuName = nullptr;
 	wc.lpszClassName = TEXT("MemoryViewerControl");
 
 	RegisterClass(&wc);
@@ -908,7 +908,7 @@ INT_PTR Dlg_Memory::MemoryProc( HWND hDlg, UINT nMsg, WPARAM wParam, LPARAM lPar
 						UpdateSearchResult( pDIS->itemID, nVal, buffer );
 
 						const CodeNotes::CodeNoteObj* pSavedNote = m_CodeNotes.FindCodeNote( currentResult.m_nAddr );
-						if ( ( pSavedNote != NULL ) && ( pSavedNote->Note().length() > 0 ) )
+						if ( ( pSavedNote != nullptr ) && ( pSavedNote->Note().length() > 0 ) )
 							_tcscat_s( buffer, tstring( "   (" + pSavedNote->Note() + ")" ).c_str() );
 
 						COLORREF color;
@@ -926,9 +926,9 @@ INT_PTR Dlg_Memory::MemoryProc( HWND hDlg, UINT nMsg, WPARAM wParam, LPARAM lPar
 								color = RGB( 255, 215, 215 ); // Red if search result doesn't match comparison.
 								currentResult.m_bHasChanged = true;
 							}
-							else if ( g_MemBookmarkDialog.FindBookmark( currentResult.m_nAddr ) != NULL )
+							else if ( g_MemBookmarkDialog.FindBookmark( currentResult.m_nAddr ) != nullptr )
 								color = RGB( 220, 255, 220 ); // Green if Bookmark is found.
-							else if ( g_MemoryDialog.Notes().FindCodeNote( currentResult.m_nAddr ) != NULL )
+							else if ( g_MemoryDialog.Notes().FindCodeNote( currentResult.m_nAddr ) != nullptr )
 								color = RGB( 220, 240, 255 ); // Blue if Code Note is found.
 							else if ( currentResult.m_bHasChanged )
 								color = RGB( 240, 240, 240 ); // Grey if still valid, but has changed
@@ -1050,9 +1050,9 @@ INT_PTR Dlg_Memory::MemoryProc( HWND hDlg, UINT nMsg, WPARAM wParam, LPARAM lPar
 							tstring buffer = nativeBuffer;
 							//	Read hex or dec
 							if ( buffer[ 0 ] == '0' && buffer[ 1 ] == 'x' )
-								nValueQuery = static_cast<unsigned int>( std::strtoul( buffer.c_str() + 2, NULL, 16 ) );
+								nValueQuery = static_cast<unsigned int>( std::strtoul( buffer.c_str() + 2, nullptr, 16 ) );
 							else
-								nValueQuery = static_cast<unsigned int>( std::strtoul( buffer.c_str(), NULL, 10 ) );
+								nValueQuery = static_cast<unsigned int>( std::strtoul( buffer.c_str(), nullptr, 10 ) );
 						}
 					}
 
@@ -1265,11 +1265,11 @@ INT_PTR Dlg_Memory::MemoryProc( HWND hDlg, UINT nMsg, WPARAM wParam, LPARAM lPar
 					if ( g_pCurrentGameData->GetGameID() != 0 )
 					{
 						tstring sTarget = "http://" RA_HOST_URL + tstring( "/codenotes.php?g=" ) + std::to_string( g_pCurrentGameData->GetGameID() );
-						ShellExecute( NULL,
+						ShellExecute( nullptr,
 							_T( "open" ),
 							NativeStr( sTarget ).c_str(),
-							NULL,
-							NULL,
+							nullptr,
+							nullptr,
 							SW_SHOWNORMAL );
 					}
 					else
@@ -1282,9 +1282,9 @@ INT_PTR Dlg_Memory::MemoryProc( HWND hDlg, UINT nMsg, WPARAM wParam, LPARAM lPar
 
 				case IDC_RA_OPENBOOKMARKS:
 				{
-					if ( g_MemBookmarkDialog.GetHWND() == NULL )
+					if ( g_MemBookmarkDialog.GetHWND() == nullptr )
 						g_MemBookmarkDialog.InstallHWND( CreateDialog( g_hThisDLLInst, MAKEINTRESOURCE( IDD_RA_MEMBOOKMARK ), hDlg, g_MemBookmarkDialog.s_MemBookmarkDialogProc ) );
-					if ( g_MemBookmarkDialog.GetHWND() != NULL )
+					if ( g_MemBookmarkDialog.GetHWND() != nullptr )
 						ShowWindow( g_MemBookmarkDialog.GetHWND(), SW_SHOW );
 
 					return FALSE;
@@ -1410,7 +1410,7 @@ INT_PTR Dlg_Memory::MemoryProc( HWND hDlg, UINT nMsg, WPARAM wParam, LPARAM lPar
 								{
 									ByteAddress nAddr = static_cast<ByteAddress>( std::strtoul( Narrow( sAddr ).c_str(), nullptr, 16 ) );
 									const CodeNotes::CodeNoteObj* pSavedNote = m_CodeNotes.FindCodeNote( nAddr );
-									if ( pSavedNote != NULL && pSavedNote->Note().length() > 0 )
+									if ( pSavedNote != nullptr && pSavedNote->Note().length() > 0 )
 										SetDlgItemText( hDlg, IDC_RA_MEMSAVENOTE, NativeStr( pSavedNote->Note() ).c_str() );
 
 									MemoryViewerControl::setAddress( ( nAddr & ~( 0xf ) ) - ( (int)( MemoryViewerControl::m_nDisplayedLines / 2 ) << 4 ) + ( 0x50 ) );
@@ -1452,7 +1452,7 @@ INT_PTR Dlg_Memory::MemoryProc( HWND hDlg, UINT nMsg, WPARAM wParam, LPARAM lPar
 							MemoryViewerControl::m_nActiveMemBank = nBankID;
 							g_MemManager.ChangeActiveMemBank( nBankID );
 
-							InvalidateRect( m_hWnd, NULL, FALSE );	//	Force redraw on mem viewer
+							InvalidateRect( m_hWnd, nullptr, FALSE );	//	Force redraw on mem viewer
 							break;
 						}
 					}
@@ -1493,7 +1493,7 @@ void Dlg_Memory::OnWatchingMemChange()
 void Dlg_Memory::RepopulateMemNotesFromFile()
 {
 	HWND hMemWatch = GetDlgItem(g_MemoryDialog.m_hWnd, IDC_RA_WATCHING);
-	if (hMemWatch != NULL)
+	if (hMemWatch != nullptr)
 	{
 		SetDlgItemText(hMemWatch, IDC_RA_WATCHING, TEXT(""));
 		SetDlgItemText(hMemWatch, IDC_RA_MEMSAVENOTE, TEXT(""));
@@ -1610,9 +1610,9 @@ void Dlg_Memory::Invalidate()
 
 	// Update Search Results
 	HWND hList = GetDlgItem(m_hWnd, IDC_RA_MEM_LIST);
-	if (hList != NULL)
+	if (hList != nullptr)
 	{
-		InvalidateRect(hList, NULL, FALSE);
+		InvalidateRect(hList, nullptr, FALSE);
 		if (g_EmulatorID == RA_Libretro)
 			UpdateWindow(hList);
 	}
@@ -1661,7 +1661,7 @@ void Dlg_Memory::SetWatchingAddress(unsigned int nAddr)
 
 BOOL Dlg_Memory::IsActive() const
 {
-	return(g_MemoryDialog.GetHWND() != NULL) && (IsWindowVisible(g_MemoryDialog.GetHWND()));
+	return(g_MemoryDialog.GetHWND() != nullptr) && (IsWindowVisible(g_MemoryDialog.GetHWND()));
 }
 
 void Dlg_Memory::ClearBanks()

--- a/src/RA_Dlg_Memory.cpp
+++ b/src/RA_Dlg_Memory.cpp
@@ -1899,22 +1899,12 @@ void Dlg_Memory::UpdateSearchResult( unsigned int index, unsigned int &nMemVal, 
 
 	switch ( g_MemManager.MemoryComparisonSize())
 	{
-	case ThirtyTwoBit:
-		nMemVal = ( g_MemManager.ActiveBankRAMByteRead( nAddr ) | ( g_MemManager.ActiveBankRAMByteRead( nAddr + 1 ) << 8 ) ||
-		            g_MemManager.ActiveBankRAMByteRead( nAddr + 2 ) << 16 | ( g_MemManager.ActiveBankRAMByteRead( nAddr + 3 ) << 24 ) );
-		break;
-	case SixteenBit:
-		nMemVal = ( g_MemManager.ActiveBankRAMByteRead( nAddr ) | ( g_MemManager.ActiveBankRAMByteRead( nAddr + 1 ) << 8 ) );
-		break;
-	case EightBit:
-		nMemVal = ( g_MemManager.ActiveBankRAMByteRead( nAddr ) );
+	default:
+		nMemVal = g_MemManager.ActiveBankRAMRead(nAddr, g_MemManager.MemoryComparisonSize());
 		break;
 	case Nibble_Lower:
 	case Nibble_Upper:
-		if ( m_SearchResults[ m_nPage ].m_ResultCandidate[ element ].m_bUpperNibble )
-			nMemVal = ( ( g_MemManager.ActiveBankRAMByteRead( nAddr ) >> 4 ) & 0xf );
-		else
-			nMemVal = ( g_MemManager.ActiveBankRAMByteRead( nAddr ) & 0xf );
+		nMemVal = g_MemManager.ActiveBankRAMRead(nAddr, m_SearchResults[m_nPage].m_ResultCandidate[element].m_bUpperNibble ? Nibble_Upper : Nibble_Lower);
 		break;
 	}
 

--- a/src/RA_Dlg_Memory.h
+++ b/src/RA_Dlg_Memory.h
@@ -24,7 +24,8 @@ public:
 	static bool OnEditInput( UINT c );
 
 	static void setAddress( unsigned int nAddr );
-	static void moveAddress( int offset, int nibbleOff );
+    static void setWatchedAddress( unsigned int nAddr );
+    static void moveAddress( int offset, int nibbleOff );
 	static void editData( unsigned int nByteAddress, bool bLowerNibble, unsigned int value );
 	static void Invalidate();
 
@@ -37,6 +38,7 @@ private:
 	static SIZE m_szFontSize;
 	static unsigned int m_nDataStartXOffset;
 	static unsigned int m_nAddressOffset;
+    static unsigned int m_nWatchedAddress;
 	static unsigned int m_nDataSize;
 	static unsigned int m_nEditAddress;
 	static unsigned int m_nEditNibble;

--- a/src/RA_Dlg_Memory.h
+++ b/src/RA_Dlg_Memory.h
@@ -3,9 +3,6 @@
 #include "RA_Defs.h"
 #include "RA_CodeNotes.h"
 #include "RA_MemManager.h"
-#include "RA_Condition.h"
-
-class CodeNotes;
 
 class MemoryViewerControl
 {

--- a/src/RA_Dlg_RichPresence.cpp
+++ b/src/RA_Dlg_RichPresence.cpp
@@ -12,7 +12,7 @@ INT_PTR CALLBACK Dlg_RichPresence::RichPresenceDialogProc(HWND hDlg, UINT nMsg, 
 	{
 	case WM_INITDIALOG:
 	{
-		SendMessage( GetDlgItem( hDlg, IDC_RA_RICHPRESENCERESULTTEXT ), WM_SETFONT, (WPARAM)m_hFont, NULL );
+		SendMessage( GetDlgItem( hDlg, IDC_RA_RICHPRESENCERESULTTEXT ), WM_SETFONT, (WPARAM)m_hFont, LPARAM{});
 
 		RestoreWindowPosition( hDlg, "Rich Presence Monitor", true, true );
 		return TRUE;
@@ -68,7 +68,7 @@ Dlg_RichPresence::Dlg_RichPresence()
 	: m_hRichPresenceDialog( nullptr ),
 	  m_bTimerActive( false )
 {
-	m_hFont = CreateFont( 15, 0, 0, 0, FW_NORMAL, FALSE, FALSE, FALSE, DEFAULT_CHARSET, OUT_DEFAULT_PRECIS, CLIP_DEFAULT_PRECIS, CLEARTYPE_QUALITY, VARIABLE_PITCH, NULL );
+	m_hFont = CreateFont( 15, 0, 0, 0, FW_NORMAL, FALSE, FALSE, FALSE, DEFAULT_CHARSET, OUT_DEFAULT_PRECIS, CLIP_DEFAULT_PRECIS, CLEARTYPE_QUALITY, VARIABLE_PITCH, nullptr );
 }
 
 Dlg_RichPresence::~Dlg_RichPresence()
@@ -92,7 +92,7 @@ void Dlg_RichPresence::StartTimer()
 {
 	if ( !m_bTimerActive )
 	{
-		SetTimer( m_hRichPresenceDialog, 1, 1000, NULL );
+		SetTimer( m_hRichPresenceDialog, 1, 1000, nullptr );
 		m_bTimerActive = true;
 	}
 }

--- a/src/RA_GameData.cpp
+++ b/src/RA_GameData.cpp
@@ -1,5 +1,7 @@
 #include "RA_GameData.h"
 
+
+// TODO: Does this really need to be a pointer? If so it needs to be owned.
 GameData* g_pCurrentGameData = new GameData();
 
 void GameData::ParseData(const Document& doc)

--- a/src/RA_ImageFactory.cpp
+++ b/src/RA_ImageFactory.cpp
@@ -28,10 +28,10 @@ HRESULT UserImageFactory_CreateDIBSectionFromBitmapSource( IWICBitmapSource *pTo
 	UINT nWidth = 0;
 	UINT nHeight = 0;
 
-	void *pvImageBits = NULL;
+	void *pvImageBits = nullptr;
 	BITMAPINFO bminfo;
-	HWND hWindow = NULL;
-	HDC hdcScreen = NULL;
+	HWND hWindow = nullptr;
+	HDC hdcScreen = nullptr;
 
 	WICPixelFormatGUID pixelFormat;
 
@@ -63,7 +63,7 @@ HRESULT UserImageFactory_CreateDIBSectionFromBitmapSource( IWICBitmapSource *pTo
 		bminfo.bmiHeader.biCompression = BI_RGB;
 
 		hWindow = GetActiveWindow();
-		while( GetParent( hWindow ) != NULL )
+		while( GetParent( hWindow ) != nullptr )
 			hWindow = GetParent( hWindow );
 
 		// Get a DC for the full screen
@@ -79,9 +79,9 @@ HRESULT UserImageFactory_CreateDIBSectionFromBitmapSource( IWICBitmapSource *pTo
 			}
 
 			//	TBD: check this. As a handle this should just be as-is, right?
-			hBitmapInOut = CreateDIBSection( hdcScreen, &bminfo, DIB_RGB_COLORS, &pvImageBits, NULL, 0 );
+			hBitmapInOut = CreateDIBSection( hdcScreen, &bminfo, DIB_RGB_COLORS, &pvImageBits, nullptr, 0 );
 
-			ReleaseDC( NULL, hdcScreen );
+			ReleaseDC( nullptr, hdcScreen );
 
 			hr = hBitmapInOut ? S_OK : E_FAIL;
 		}
@@ -104,7 +104,7 @@ HRESULT UserImageFactory_CreateDIBSectionFromBitmapSource( IWICBitmapSource *pTo
 	{
 		hr = pToRenderBitmapSource->CopyPixels(
 			//hr = IWICBitmapSource_CopyPixels( pToRenderBitmapSource,
-			NULL,
+			nullptr,
 			cbStride,
 			cbImage,
 			(BYTE*)pvImageBits );
@@ -114,7 +114,7 @@ HRESULT UserImageFactory_CreateDIBSectionFromBitmapSource( IWICBitmapSource *pTo
 	if( FAILED( hr ) )
 	{
 		DeleteObject( hBitmapInOut );
-		hBitmapInOut = NULL;
+		hBitmapInOut = nullptr;
 	}
 
 	return hr;
@@ -124,12 +124,12 @@ BOOL InitializeUserImageFactory( HINSTANCE hInst )
 {
 	HRESULT hr = S_OK;;
 
-	g_UserImageFactoryInst.m_pIWICFactory = NULL;
-	g_UserImageFactoryInst.m_pOriginalBitmapSource = NULL;
+	g_UserImageFactoryInst.m_pIWICFactory = nullptr;
+	g_UserImageFactoryInst.m_pOriginalBitmapSource = nullptr;
 
-	HeapSetInformation( NULL, HeapEnableTerminationOnCorruption, NULL, 0 );
+	HeapSetInformation( nullptr, HeapEnableTerminationOnCorruption, nullptr, 0 );
 
-	hr = CoInitializeEx( NULL, COINIT_MULTITHREADED | COINIT_DISABLE_OLE1DDE );
+	hr = CoInitializeEx( nullptr, COINIT_MULTITHREADED | COINIT_DISABLE_OLE1DDE );
 
 	// Create WIC factory
 	//#define IID_PPV_ARGS(ppType) ((LPVOID*)(ppType))
@@ -141,7 +141,7 @@ BOOL InitializeUserImageFactory( HINSTANCE hInst )
 		&CLSID_WICImagingFactory,
 #endif
 
-		NULL,
+		nullptr,
 		CLSCTX_INPROC_SERVER,
 
 #if defined (__cplusplus)
@@ -201,7 +201,7 @@ HRESULT ConvertBitmapSource( RECT rcDest, IWICBitmapSource*& pToRenderBitmapSour
 				hr = pConverter->Initialize( static_cast<IWICBitmapSource*>( pScaler ),	// Input bitmap to convert
 											 GUID_WICPixelFormat32bppBGR,				//	&GUID_WICPixelFormat32bppBGR,
 											 WICBitmapDitherTypeNone,					// Specified dither patterm
-											 NULL,										// Specify a particular palette 
+											 nullptr,										// Specify a particular palette 
 											 0.f,										// Alpha threshold
 											 WICBitmapPaletteTypeCustom );				// Palette translation type
 
@@ -230,7 +230,7 @@ HBITMAP LoadOrFetchBadge( const std::string& sBadgeURI, const RASize& sz )
 		if( !RAWeb::HTTPRequestExists( RequestBadge, sBadgeURI ) && !RAWeb::HTTPResponseExists( RequestBadge, sBadgeURI ) )
 			RAWeb::CreateThreadedHTTPRequest( RequestBadge, args, sBadgeURI );
 
-		return NULL;
+		return nullptr;
 	}
 	else
 	{
@@ -250,7 +250,7 @@ HBITMAP LoadOrFetchUserPic( const std::string& sUserName, const RASize& sz )
 		if( !RAWeb::HTTPRequestExists( RequestUserPic, sUserName ) && !RAWeb::HTTPResponseExists( RequestUserPic, sUserName ) )
 			RAWeb::CreateThreadedHTTPRequest( RequestUserPic, args, sUserName );
 
-		return NULL;
+		return nullptr;
 	}
 	else
 	{

--- a/src/RA_ImageFactory.h
+++ b/src/RA_ImageFactory.h
@@ -14,7 +14,7 @@ struct IWICImagingFactory;
 class UserImageFactoryVars
 {
 public:
-	UserImageFactoryVars() :m_pOriginalBitmapSource( NULL ), m_pIWICFactory( NULL ) {}
+	UserImageFactoryVars() :m_pOriginalBitmapSource( nullptr ), m_pIWICFactory( nullptr ) {}
 
 public:
 	IWICBitmapSource* m_pOriginalBitmapSource;

--- a/src/RA_Integration.vcxproj
+++ b/src/RA_Integration.vcxproj
@@ -124,23 +124,25 @@
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="base.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseUnicode|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="base.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="base.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='DebugUnicode|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="base.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>11.0.50727.1</_ProjectFileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <OutDir>..\bin\$(Configuration)\</OutDir>
-    <IntDir>..\obj\$(Configuration)\</IntDir>
     <TargetName>RA_Integration</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugUnicode|Win32'">
@@ -167,12 +169,11 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(RA_IncludePath);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_DEBUG;RA_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DisableSpecificWarnings>4091</DisableSpecificWarnings>
     </ClCompile>
@@ -189,6 +190,9 @@
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ResourceCompile>
+    <PostBuildEvent>
+      <Command>copy /y $(TargetPath) $(LocalDebuggerWorkingDirectory)\RA_Integration.dll</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='DebugUnicode|Win32'">
     <ClCompile>

--- a/src/RA_Integration.vcxproj
+++ b/src/RA_Integration.vcxproj
@@ -176,6 +176,7 @@
       <WarningLevel>Level3</WarningLevel>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DisableSpecificWarnings>4091</DisableSpecificWarnings>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <AdditionalDependencies>windowscodecs.lib;winmm.lib;Winhttp.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/src/RA_Interface.cpp
+++ b/src/RA_Interface.cpp
@@ -107,7 +107,7 @@ int		(CCONV *_RA_UpdateOverlay) (ControllerInput* pInput, float fDeltaTime, bool
 int		(CCONV *_RA_UpdatePopups) (ControllerInput* pInput, float fDeltaTime, bool Full_Screen, bool Paused) = nullptr;
 void	(CCONV *_RA_RenderOverlay) (HDC hDC, RECT* prcSize) = nullptr;
 void	(CCONV *_RA_RenderPopups) (HDC hDC, RECT* prcSize) = nullptr;
-
+bool    (CCONV *_RA_IsOverlayFullyVisible) () = nullptr;
 
 //	Helpers:
 bool RA_UserLoggedIn()
@@ -143,6 +143,14 @@ void RA_UpdateRenderOverlay( HDC hDC, ControllerInput* pInput, float fDeltaTime,
 
 	if( _RA_RenderOverlay != nullptr )
 		_RA_RenderOverlay( hDC, prcSize );
+}
+
+bool RA_IsOverlayFullyVisible()
+{
+    if (_RA_IsOverlayFullyVisible != nullptr)
+        return _RA_IsOverlayFullyVisible();
+
+    return false;
 }
 
 void RA_OnLoadNewRom( BYTE* pROMData, unsigned int nROMSize )
@@ -419,6 +427,7 @@ const char* CCONV _RA_InstallIntegration()
 	_RA_UpdateOverlay		= (int(CCONV *)(ControllerInput*, float, bool, bool))	GetProcAddress( g_hRADLL, "_RA_UpdateOverlay" );
 	_RA_UpdatePopups		= (int(CCONV *)(ControllerInput*, float, bool, bool))	GetProcAddress( g_hRADLL, "_RA_UpdatePopups" );
 	_RA_RenderOverlay		= (void(CCONV *)(HDC, RECT*))							GetProcAddress( g_hRADLL, "_RA_RenderOverlay" );
+    _RA_IsOverlayFullyVisible=(bool(CCONV *)())                                     GetProcAddress( g_hRADLL, "_RA_IsOverlayFullyVisible" );
 	_RA_RenderPopups		= (void(CCONV *)(HDC, RECT*))							GetProcAddress( g_hRADLL, "_RA_RenderPopups" );
 	_RA_OnLoadNewRom		= (int(CCONV *)(const BYTE*, unsigned int))				GetProcAddress( g_hRADLL, "_RA_OnLoadNewRom" );
 	_RA_InstallMemoryBank	= (void(CCONV *)(int, void*, void*, int))				GetProcAddress( g_hRADLL, "_RA_InstallMemoryBank" );

--- a/src/RA_Interface.cpp
+++ b/src/RA_Interface.cpp
@@ -4,55 +4,55 @@
 
 //	Exposed, shared
 //	App-level:
-bool	(CCONV *_RA_GameIsActive) (void) = NULL;
-void	(CCONV *_RA_CauseUnpause) (void) = NULL;
-void	(CCONV *_RA_CausePause) (void) = NULL;
-void	(CCONV *_RA_RebuildMenu) (void) = NULL;
-void	(CCONV *_RA_ResetEmulation) (void) = NULL;
-void	(CCONV *_RA_GetEstimatedGameTitle) (char* sNameOut) = NULL;
-void	(CCONV *_RA_LoadROM) (const char* sNameOut) = NULL;
+bool	(CCONV *_RA_GameIsActive) (void) = nullptr;
+void	(CCONV *_RA_CauseUnpause) (void) = nullptr;
+void	(CCONV *_RA_CausePause) (void) = nullptr;
+void	(CCONV *_RA_RebuildMenu) (void) = nullptr;
+void	(CCONV *_RA_ResetEmulation) (void) = nullptr;
+void	(CCONV *_RA_GetEstimatedGameTitle) (char* sNameOut) = nullptr;
+void	(CCONV *_RA_LoadROM) (const char* sNameOut) = nullptr;
 
 
 bool RA_GameIsActive()
 {
-	if( _RA_GameIsActive != NULL )
+	if( _RA_GameIsActive != nullptr )
 		return _RA_GameIsActive();
 	return false;
 }
 
 void RA_CauseUnpause()
 {
-	if( _RA_CauseUnpause != NULL )
+	if( _RA_CauseUnpause != nullptr )
 		_RA_CauseUnpause();
 }
 
 void RA_CausePause()
 {
-	if (_RA_CausePause != NULL)
+	if (_RA_CausePause != nullptr)
 		_RA_CausePause();
 }
 
 void RA_RebuildMenu()
 {
-	if( _RA_RebuildMenu != NULL )
+	if( _RA_RebuildMenu != nullptr )
 		_RA_RebuildMenu();
 }
 
 void RA_ResetEmulation()
 {
-	if( _RA_ResetEmulation != NULL )
+	if( _RA_ResetEmulation != nullptr )
 		_RA_ResetEmulation();
 }
 
 void RA_LoadROM( const char* sFullPath )
 {
-	if( _RA_LoadROM != NULL )
+	if( _RA_LoadROM != nullptr )
 		_RA_LoadROM( sFullPath );
 }
 
 void RA_GetEstimatedGameTitle( char* sNameOut )
 {
-	if( _RA_GetEstimatedGameTitle != NULL )
+	if( _RA_GetEstimatedGameTitle != nullptr )
 		_RA_GetEstimatedGameTitle( sNameOut );
 }
 
@@ -287,7 +287,7 @@ BOOL DoBlockingHttpGet( const char* sRequestedPage, char* pBufferOut, const unsi
 			hRequest = WinHttpOpenRequest( hConnect, 
 				L"GET", 
 				wBuffer, 
-				NULL, 
+				nullptr, 
 				WINHTTP_NO_REFERER, 
 				WINHTTP_DEFAULT_ACCEPT_TYPES,
 				0);
@@ -303,7 +303,7 @@ BOOL DoBlockingHttpGet( const char* sRequestedPage, char* pBufferOut, const unsi
 					0,
 					0);
 
-				if( WinHttpReceiveResponse( hRequest, NULL ) )
+				if( WinHttpReceiveResponse( hRequest, nullptr ) )
 				{
 					nBytesToRead = 0;
 					(*pBytesRead) = 0;
@@ -388,7 +388,7 @@ std::string GetLastErrorAsString()
 
     LPSTR messageBuffer = nullptr;
     size_t size = FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-                                 NULL, errorMessageID, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&messageBuffer, 0, NULL);
+                                 nullptr, errorMessageID, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&messageBuffer, 0, nullptr);
 
     std::string message(messageBuffer, size);
 
@@ -407,7 +407,7 @@ const char* CCONV _RA_InstallIntegration()
         return "0.000";
 
     g_hRADLL = LoadLibrary( TEXT( "RA_Integration.dll" ) );
-    if ( g_hRADLL == NULL )
+    if ( g_hRADLL == nullptr )
     {
         char buffer[1024];
         sprintf_s( buffer, 1024, "LoadLibrary failed: %d : %s\n", ::GetLastError(), GetLastErrorAsString().c_str() );
@@ -460,18 +460,18 @@ void RA_Init( HWND hMainHWND, int nConsoleID, const char* sClientVersion )
 	ZeroMemory( buffer, 1024 );
 	if( DoBlockingHttpGet( "LatestIntegration.html", buffer, 1024, &nBytesRead ) == FALSE )
 	{
-		MessageBoxA( NULL, "Cannot access www.retroachievements.org - working offline.", "Warning", MB_OK|MB_ICONEXCLAMATION );
+		MessageBoxA( nullptr, "Cannot access www.retroachievements.org - working offline.", "Warning", MB_OK|MB_ICONEXCLAMATION );
 		return;
 	}
 
-	const unsigned int nLatestDLLVer = strtol( buffer+2, NULL, 10 );
+	const unsigned int nLatestDLLVer = strtol( buffer+2, nullptr, 10 );
 
 	BOOL bInstalled = FALSE;
 	int nMBReply = IDNO;
 	do
 	{
 		const char* sVerInstalled = _RA_InstallIntegration();
-		const unsigned int nVerInstalled = strtol( sVerInstalled+2, NULL, 10 );
+		const unsigned int nVerInstalled = strtol( sVerInstalled+2, nullptr, 10 );
 		if( nVerInstalled < nLatestDLLVer )
 		{
 			RA_Shutdown();	//	Unhook the DLL, it's out of date. We may need to overwrite the DLL, so unhook it.%
@@ -484,7 +484,7 @@ void RA_Init( HWND hMainHWND, int nConsoleID, const char* sClientVersion )
 				nLatestDLLVer,
 				"Automatically update your RetroAchievements Toolset file?" );
 
-			nMBReply = MessageBoxA( NULL, sErrorMsg, "Warning", MB_YESNO );
+			nMBReply = MessageBoxA( nullptr, sErrorMsg, "Warning", MB_YESNO );
 
 			if( nMBReply == IDYES )
 			{
@@ -517,14 +517,14 @@ void RA_InstallSharedFunctions( bool(*fpIsActive)(void), void(*fpCauseUnpause)(v
 	_RA_LoadROM					= fpLoadROM;
 
 	//	Also install *within* DLL! FFS
-	if( _RA_InstallSharedFunctions != NULL )
+	if( _RA_InstallSharedFunctions != nullptr )
 		_RA_InstallSharedFunctions( fpIsActive, fpCauseUnpause, fpCausePause, fpRebuildMenu, fpEstimateTitle, fpResetEmulation, fpLoadROM );
 }
 
 void RA_Shutdown()
 {
 	//	Call shutdown on toolchain
-	if( _RA_Shutdown != NULL )
+	if( _RA_Shutdown != nullptr )
 		_RA_Shutdown();
 
 	//	Clear func ptrs

--- a/src/RA_Interface.h
+++ b/src/RA_Interface.h
@@ -147,6 +147,9 @@ extern void RA_DoAchievementsFrame();
 //	Updates and renders all on-screen overlays.
 extern void RA_UpdateRenderOverlay( HDC hDC, ControllerInput* pInput, float fDeltaTime, RECT* prcSize, bool Full_Screen, bool Paused );
 
+//  Determines if the overlay is completely covering the screen.
+extern bool RA_IsOverlayFullyVisible();
+
 //	Returns true if the user has successfully logged in.
 extern bool RA_UserLoggedIn();
 

--- a/src/RA_Leaderboard.cpp
+++ b/src/RA_Leaderboard.cpp
@@ -10,7 +10,7 @@ RA_LeaderboardManager g_LeaderboardManager;
 
 namespace
 {
-	const char* FormatTypeToString[] =
+	inline constexpr std::array<const char*, RA_Leaderboard::Format__MAX> FormatTypeToString
 	{
 		"TIME",			//	TimeFrames
 		"TIMESECS",		//	TimeSecs
@@ -19,7 +19,6 @@ namespace
 		"VALUE",		//	Value
 		"OTHER",		//	Other
 	};
-	static_assert( SIZEOF_ARRAY( FormatTypeToString ) == RA_Leaderboard::Format__MAX, "These must match!" );
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/src/RA_Leaderboard.h
+++ b/src/RA_Leaderboard.h
@@ -14,7 +14,7 @@ public:
 		: m_nAddress( nAddr ), m_fModifier( fMod ), m_nVarSize( nSize ), m_bBCDParse( bBCDParse ), m_bParseVal( bParseVal ) {}
 	
 public:
-	char* ParseFromString( char* pBuffer );		//	Parse string into values, returns end of string
+	const char* ParseFromString( const char* pBuffer );		//	Parse string into values, returns end of string
 	double GetValue() const;					//	Get the value in-memory with modifiers
 
 public:
@@ -41,7 +41,7 @@ public:
 	};
 
 public:
-	void ParseMemString( char* sBuffer );
+	void ParseMemString( const char* sBuffer );
 	double GetValue() const;
 	double GetOperationsValue( std::vector<OperationType> ) const;
 	void AddNewValue( MemValue nVal );
@@ -83,7 +83,7 @@ public:
 public:
 	void LoadFromJSON( const Value& element );
 	void ParseLine( char* sBuffer );
-	void ParseLBData( char* sBuffer );
+	void ParseLBData( const char* sBuffer );
 
 	void Test();
 	double GetCurrentValue();
@@ -111,8 +111,8 @@ public:
 private:
 	const LeaderboardID		m_nID;			//	DB ID for this LB
 	ConditionSet			m_startCond;	//	Start monitoring if this is true
-	ConditionSet			m_cancelCond;	//	Cancel monitoring if this is true
-	ConditionSet			m_submitCond;	//	Submit new score if this is true
+    ConditionSet			m_cancelCond;	//	Cancel monitoring if this is true
+    ConditionSet			m_submitCond;	//	Submit new score if this is true
 
 	bool					m_bStarted;		//	False = check start condition. True = check cancel or submit conditions.
 	bool                    m_bSubmitted;   //  True if already submitted.

--- a/src/RA_LeaderboardPopup.cpp
+++ b/src/RA_LeaderboardPopup.cpp
@@ -12,17 +12,17 @@
 
 namespace
 {
-	const float SCOREBOARD_APPEAR_AT = 0.8f;
-	const float SCOREBOARD_FADEOUT_AT = 6.2f;
-	const float SCOREBOARD_FINISH_AT = 7.0f;
+	inline constexpr auto SCOREBOARD_APPEAR_AT  = 0.8f;
+	inline constexpr auto SCOREBOARD_FADEOUT_AT = 6.2f;
+	inline constexpr auto SCOREBOARD_FINISH_AT  = 7.0f;
 
-	const char* FONT_TO_USE = "Tahoma";
+	inline constexpr auto FONT_TO_USE = "Tahoma";
 
-	const COLORREF g_ColBG = RGB( 32, 32, 32 );
+	inline constexpr auto g_ColBG = RGB( 32, 32, 32 );
 	
-	const int FONT_SIZE_TITLE = 28;
-	const int FONT_SIZE_SUBTITLE = 22;
-	const int FONT_SIZE_TEXT = 16;
+	inline constexpr auto FONT_SIZE_TITLE    = 28;
+	inline constexpr auto FONT_SIZE_SUBTITLE = 22;
+	inline constexpr auto FONT_SIZE_TEXT     = 16;
 }
 
 

--- a/src/RA_MemManager.h
+++ b/src/RA_MemManager.h
@@ -83,6 +83,8 @@ public:
 	unsigned char ActiveBankRAMByteRead(ByteAddress nOffs) const;
 	void ActiveBankRAMByteWrite(ByteAddress nOffs, unsigned int nVal);
 
+	unsigned int ActiveBankRAMRead(ByteAddress nOffs, ComparisonVariableSize size) const;
+
 	void ActiveBankRAMRead(unsigned char buffer[], ByteAddress nOffs, size_t count) const;
 
 private:

--- a/src/RA_MemManager.h
+++ b/src/RA_MemManager.h
@@ -19,6 +19,8 @@ public:
 	bool m_bHasChanged;
 };
 
+// TODO: We should try to make these function objects, or a function type, not sure the intention here
+
 typedef unsigned char (_RAMByteReadFn)( unsigned int nOffs );
 typedef void (_RAMByteWriteFn)( unsigned int nOffs, unsigned int nVal );
 
@@ -37,6 +39,8 @@ private:
 		{}
 		
 	private:
+        // TODO: If you really want to disable it, mark it with delete and implement move semantics unless
+        // you don't want them moved either (which would make the type useless)
 		//	Copying disabled
 		BankData( const BankData& );
 		BankData& operator=( BankData& );

--- a/src/RA_PopupWindows.cpp
+++ b/src/RA_PopupWindows.cpp
@@ -16,6 +16,8 @@ API int _RA_UpdatePopups( ControllerInput* input, float fDTime, bool Full_Screen
 
 API int _RA_RenderPopups( HDC hDC, RECT* rcSize )
 {
-	PopupWindows::Render( hDC, rcSize );
+	if (!g_AchievementOverlay.IsFullyVisible())
+		PopupWindows::Render( hDC, rcSize );
+
 	return 0;
 }

--- a/src/RA_ProgressPopup.cpp
+++ b/src/RA_ProgressPopup.cpp
@@ -31,7 +31,7 @@ ProgressPopup::ProgressPopup()
 		memset( m_sMessageTitleQueue[ i ], '\0', 1024 );
 		memset( m_sMessageDescQueue[ i ], '\0', 1024 );
 		m_nMessageType[ i ] = 0;
-		m_hMessageImage[ i ] = NULL;
+		m_hMessageImage[ i ] = nullptr;
 	}
 }
 
@@ -44,7 +44,7 @@ void ProgressPopup::AddMessage( const char* sTitle, const char* sDesc, int nMess
 		{
 			sprintf_s( m_sMessageTitleQueue[ i ], 1024, "%s", sTitle );
 
-			if( sDesc != NULL )
+			if( sDesc != nullptr )
 				sprintf_s( m_sMessageDescQueue[ i ], 1024, "%s", sDesc );
 			else
 				sprintf_s( m_sMessageDescQueue[ i ], 1024, "%s", "" );
@@ -72,7 +72,7 @@ void ProgressPopup::NextMessage()
 	memset( m_sMessageTitleQueue[ OVERLAY_MESSAGE_QUEUE_SIZE - 1 ], 0, 1024 );
 	memset( m_sMessageDescQueue[ OVERLAY_MESSAGE_QUEUE_SIZE - 1 ], 0, 1024 );
 	m_nMessageType[ OVERLAY_MESSAGE_QUEUE_SIZE - 1 ] = 0;
-	m_hMessageImage[ OVERLAY_MESSAGE_QUEUE_SIZE - 1 ] = NULL;
+	m_hMessageImage[ OVERLAY_MESSAGE_QUEUE_SIZE - 1 ] = nullptr;
 }
 
 void ProgressPopup::Update( ControllerInput input, float fDelta, BOOL bFullScreen, BOOL bPaused )
@@ -185,13 +185,13 @@ void ProgressPopup::Render( HDC hDC, RECT& rcDest )
 	HGDIOBJ hPen = CreatePen( PS_SOLID, 2, RGB( 0, 0, 0 ) );
 	SelectObject( hDC, hPen );
 
-	MoveToEx( hDC, nTitleX, nTitleY + szTitle.cy, NULL );
+	MoveToEx( hDC, nTitleX, nTitleY + szTitle.cy, nullptr );
 	LineTo( hDC, nTitleX + szTitle.cx, nTitleY + szTitle.cy );	//	right
 	LineTo( hDC, nTitleX + szTitle.cx, nTitleY + 1 );			//	up
 
 	if( GetDesc()[ 0 ] != '\0' )
 	{
-		MoveToEx( hDC, nDescX, nDescY + szAchievement.cy, NULL );
+		MoveToEx( hDC, nDescX, nDescY + szAchievement.cy, nullptr );
 		LineTo( hDC, nDescX + szAchievement.cx, nDescY + szAchievement.cy );
 		LineTo( hDC, nDescX + szAchievement.cx, nDescY + 1 );
 	}

--- a/src/RA_ProgressPopup.cpp
+++ b/src/RA_ProgressPopup.cpp
@@ -8,16 +8,16 @@
 
 namespace
 {
-	const int FONT_SIZE_MAIN = 32;
-	const int FONT_SIZE_SUBTITLE = 28;
+inline constexpr auto FONT_SIZE_MAIN     = 32;
+inline constexpr auto FONT_SIZE_SUBTITLE = 28;
 
-	const float APPEAR_AT = 0.8f;
-	const float FADEOUT_AT = 4.2f;
-	const float FINISH_AT = 5.0f;
+inline constexpr auto APPEAR_AT  = 0.8f;
+inline constexpr auto FADEOUT_AT = 4.2f;
+inline constexpr auto FINISH_AT  = 5.0f;
 
-	const float POPUP_DIST_Y_TO_PCT = 0.856f;	//	Where on screen to end up
-	const float POPUP_DIST_Y_FROM_PCT = 0.4f;	//	Amount of screens to travel
-	const char* FONT_TO_USE = "Tahoma";
+inline constexpr auto POPUP_DIST_Y_TO_PCT   = 0.856f;	//	Where on screen to end up
+inline constexpr auto POPUP_DIST_Y_FROM_PCT = 0.4f;	    //	Amount of screens to travel
+inline constexpr auto FONT_TO_USE           = "Tahoma";
 }
 
 //ProgressPopup g_ProgressPopup;

--- a/src/RA_ProgressPopup.h
+++ b/src/RA_ProgressPopup.h
@@ -7,7 +7,7 @@
 //	Graphic to display an progress towards an achievement
 
 
-#define OVERLAY_MESSAGE_QUEUE_SIZE (5)
+inline constexpr auto OVERLAY_MESSAGE_QUEUE_SIZE = 5;
 
 class ProgressPopup
 {

--- a/src/RA_ProgressPopup.h
+++ b/src/RA_ProgressPopup.h
@@ -17,7 +17,7 @@ public:
 	void Update( ControllerInput input, float fDelta, BOOL bFullScreen, BOOL bPaused );
 	void Render( HDC hDC, RECT& rcDest );
 
-	void AddMessage( const char* sTitle, const char* sMessage, int nMessageType=0, HBITMAP hImage=NULL );
+	void AddMessage( const char* sTitle, const char* sMessage, int nMessageType=0, HBITMAP hImage=nullptr );
 	float GetYOffsetPct() const;
 
 	BOOL IsActive() const				{ return m_sMessageTitleQueue[0][0] != '\0'; }

--- a/src/RA_RichPresence.cpp
+++ b/src/RA_RichPresence.cpp
@@ -111,9 +111,9 @@ void RA_RichPresenceInterpretter::ParseRichPresenceFile( const std::string& sFil
 	const char* FormatTypeStr = "FormatType=";
 	const char* DisplayableStr = "Display:";
 
-	FILE* pFile = NULL;
+	FILE* pFile = nullptr;
 	fopen_s( &pFile, sFilename.c_str(), "r" );
-	if( pFile != NULL )
+	if( pFile != nullptr )
 	{
 		DWORD nCharsRead = 0;
 		char buffer[4096];
@@ -139,7 +139,7 @@ void RA_RichPresenceInterpretter::ParseRichPresenceFile( const std::string& sFil
 						if( pValue[0] == '0' && pValue[1] == 'x' )
 							nBase = 16;
 
-						DataPos nVal = static_cast<DataPos>( strtol( pValue, NULL, nBase ) );
+						DataPos nVal = static_cast<DataPos>( strtol( pValue, nullptr, nBase ) );
 
 						newLookup.AddLookupData( nVal, pName );
 					}

--- a/src/RA_RichPresence.cpp
+++ b/src/RA_RichPresence.cpp
@@ -1,5 +1,7 @@
 #include "RA_RichPresence.h"
+
 #include "RA_Core.h"
+#include "RA_GameData.h"
 
 RA_RichPresenceInterpretter g_RichPresenceInterpretter;
 
@@ -28,32 +30,10 @@ std::string RA_Formattable::Lookup( DataPos nValue ) const
 	return RA_Leaderboard::FormatScore( m_nFormatType, nValue );
 }
 
-RA_ConditionalDisplayString::RA_ConditionalDisplayString( char* pBuffer )
+RA_ConditionalDisplayString::RA_ConditionalDisplayString( const char* pBuffer )
 {
 	++pBuffer; // skip first question mark
-	do
-	{
-		ConditionSet conditionSet;
-
-		do
-		{
-			Condition nNewCond;
-			nNewCond.ParseFromString( pBuffer );
-			conditionSet.Add( nNewCond );
-
-			if( *pBuffer != '_' ) // AND
-				break;
-
-			++pBuffer;
-		} while( true );
-
-		m_conditions.push_back( conditionSet );
-
-		if (*pBuffer != 'S') // OR
-			break;
-
-		++pBuffer;
-	} while( true ); // OR
+	m_conditions.ParseFromString(pBuffer);
 
 	if( *pBuffer == '?' )
 	{
@@ -64,38 +44,14 @@ RA_ConditionalDisplayString::RA_ConditionalDisplayString( char* pBuffer )
 	else
 	{
 		// not a valid condition, ensure Test() never returns true
-		m_conditions.clear();
+		m_conditions.Clear();
 	}
 }
 
 bool RA_ConditionalDisplayString::Test()
 {
-	std::vector<ConditionSet>::iterator iter = m_conditions.begin();
-	if( iter == m_conditions.end() )
-		return false;
-
-	BOOL bDirtyConditions, bResetRead; // for HitCounts - not supported in RichPresence
-
-	// if core condition is not true, it doesnt match
-	if( !iter->Test( bDirtyConditions, bResetRead, false ) )
-		return false;
-
-	// core condition is true. if no alt conditions, it does match.
-	++iter;
-	if (iter == m_conditions.end())
-		return true;
-
-	// core condition is true. if any alt condition is true, it matches
-	do
-	{
-		if ( iter->Test( bDirtyConditions, bResetRead, false ) )
-			return true;
-
-		++iter;
-	} while( iter != m_conditions.end() );
-
-	// no alt conditions are true, not a match.
-	return false;
+	bool bDirtyConditions, bResetRead; // for HitCounts - not supported in RichPresence
+	return m_conditions.Test(bDirtyConditions, bResetRead);
 }
 
 void RA_RichPresenceInterpretter::ParseRichPresenceFile( const std::string& sFilename )
@@ -103,6 +59,7 @@ void RA_RichPresenceInterpretter::ParseRichPresenceFile( const std::string& sFil
 	m_formats.clear();
 	m_lookups.clear();
 	m_sDisplay.clear();
+    m_conditionalDisplayStrings.clear();
 
 	const char EndLine = '\n';
 
@@ -270,6 +227,12 @@ const std::string& RA_RichPresenceInterpretter::GetRichPresenceString()
 {
 	static std::string sReturnVal;
 	sReturnVal.clear();
+
+    if (g_pCurrentGameData->GetGameID() == 0)
+    {
+        sReturnVal = "No game loaded";
+        return sReturnVal;
+    }
 
 	bool bParsingLookupName = false;
 	bool bParsingLookupContent = false;

--- a/src/RA_RichPresence.h
+++ b/src/RA_RichPresence.h
@@ -26,14 +26,14 @@ private:
 class RA_ConditionalDisplayString
 {
 public:
-	RA_ConditionalDisplayString( char* pLine );
+	RA_ConditionalDisplayString( const char* pLine );
 
 	bool Test();
 	const std::string& GetDisplayString() const { return m_sDisplayString; }
 
 private:
 	std::string m_sDisplayString;
-	std::vector<ConditionSet> m_conditions;
+	ConditionSet m_conditions;
 };
 
 class RA_Formattable

--- a/src/RA_User.cpp
+++ b/src/RA_User.cpp
@@ -53,7 +53,7 @@ RAUser* RAUsers::GetUser( const std::string& sUser )
 RAUser::RAUser( const std::string& sUsername ) :
 	m_sUsername( sUsername ),
 	m_nScore( 0 ),
-	m_hUserImage( NULL ),
+	m_hUserImage( nullptr ),
 	m_bFetchingUserImage( false )
 {
 	//	Register
@@ -71,9 +71,9 @@ RAUser::~RAUser()
 
 void RAUser::FlushBitmap()
 {
-	if( m_hUserImage != NULL )
+	if( m_hUserImage != nullptr )
 		DeleteObject( m_hUserImage );
-	m_hUserImage = NULL;
+	m_hUserImage = nullptr;
 }
 
 

--- a/src/RA_User.h
+++ b/src/RA_User.h
@@ -80,7 +80,7 @@ public:
 	RAUser* AddFriend( const std::string& sFriend, unsigned int nScore );
 	RAUser* FindFriend( const std::string& sName );
 
-	RAUser* GetFriendByIter( size_t nOffs )				{ return nOffs < m_aFriends.size() ? m_aFriends[ nOffs ] : NULL; }
+	RAUser* GetFriendByIter( size_t nOffs )				{ return nOffs < m_aFriends.size() ? m_aFriends[ nOffs ] : nullptr; }
 	const size_t NumFriends() const						{ return m_aFriends.size(); }
 
 	void SetStoreToken( BOOL bStoreToken )				{ bStoreToken = bStoreToken; }

--- a/src/RA_Version.rc
+++ b/src/RA_Version.rc
@@ -72,12 +72,8 @@ BEGIN
             VALUE "FileVersion", RA_INTEGRATION_VERSION_MAJOR, RA_INTEGRATION_VERSION_MINOR, RA_INTEGRATION_VERSION_REVISION, RA_INTEGRATION_VERSION_MODIFIED
             VALUE "InternalName", "RA_Integration"
             VALUE "LegalCopyright", "Copyright (C) 2018 retroachievements.org"
-#ifdef _DEBUG
-			VALUE "OriginalFilename", "RA_Integration_d.dll"
-#else
-			VALUE "OriginalFilename", "RA_Integration.dll"
-#endif
-			VALUE "ProductName", "RetroAchievements Integration Toolkit"
+            VALUE "OriginalFilename", "RA_Integration.dll"
+            VALUE "ProductName", "RetroAchievements Integration Toolkit"
             VALUE "ProductVersion", RA_INTEGRATION_VERSION_PRODUCT
         END
     END

--- a/src/RA_httpthread.cpp
+++ b/src/RA_httpthread.cpp
@@ -105,7 +105,7 @@ static_assert( SIZEOF_ARRAY( UploadTypeToPost ) == NumUploadTypes, "Must match u
 std::vector<HANDLE> g_vhHTTPThread;
 HttpResults HttpRequestQueue;
 
-HANDLE RAWeb::ms_hHTTPMutex = NULL;
+HANDLE RAWeb::ms_hHTTPMutex = nullptr;
 HttpResults RAWeb::ms_LastHttpResults;
 
 PostArgs PrevArgs;
@@ -126,7 +126,7 @@ BOOL RequestObject::ParseResponseToJSON( Document& rDocOut )
 //	RA_LOG( __FUNCTION__ ": (%08x) GET from %s...\n", GetCurrentThreadId(), sRequestedPage );
 //
 //	BOOL bResults = FALSE, bSuccess = FALSE;
-//	HINTERNET hSession = NULL, hConnect = NULL, hRequest = NULL;
+//	HINTERNET hSession = nullptr, hConnect = nullptr, hRequest = nullptr;
 //
 //	WCHAR wBuffer[1024];
 //	size_t nTemp;
@@ -146,7 +146,7 @@ BOOL RequestObject::ParseResponseToJSON( Document& rDocOut )
 //		WINHTTP_NO_PROXY_BYPASS, 0);
 //
 //	// Specify an HTTP server.
-//	if( hSession != NULL )
+//	if( hSession != nullptr )
 //	{
 //		if( strncmp( sRequestedPage, "Badge", 5 ) == 0 )
 //			hConnect = WinHttpConnect( hSession, RA_IMG_HOST_W, INTERNET_DEFAULT_HTTP_PORT, 0 );
@@ -154,20 +154,20 @@ BOOL RequestObject::ParseResponseToJSON( Document& rDocOut )
 //			hConnect = WinHttpConnect( hSession, RA_HOST_W, INTERNET_DEFAULT_HTTP_PORT, 0 );
 //
 //		// Create an HTTP Request handle.
-//		if( hConnect != NULL )
+//		if( hConnect != nullptr )
 //		{
 //			mbstowcs_s( &nTemp, wBuffer, 1024, sRequestedPage, strlen(sRequestedPage)+1 );
 //
 //			hRequest = WinHttpOpenRequest( hConnect, 
 //				L"GET", 
 //				wBuffer, 
-//				NULL, 
+//				nullptr, 
 //				WINHTTP_NO_REFERER, 
 //				WINHTTP_DEFAULT_ACCEPT_TYPES,
 //				0);
 //
 //			// Send a Request.
-//			if( hRequest != NULL )
+//			if( hRequest != nullptr )
 //			{
 //				bResults = WinHttpSendRequest( hRequest, 
 //					L"Content-Type: application/x-www-form-urlencoded",
@@ -177,7 +177,7 @@ BOOL RequestObject::ParseResponseToJSON( Document& rDocOut )
 //					0,
 //					0 );
 //
-//				if( WinHttpReceiveResponse( hRequest, NULL ) )
+//				if( WinHttpReceiveResponse( hRequest, nullptr ) )
 //				{
 //					nBytesToRead = 0;
 //					nBytesRead = 0;
@@ -219,11 +219,11 @@ BOOL RequestObject::ParseResponseToJSON( Document& rDocOut )
 //	}
 //
 //	// Close open handles.
-//	if( hRequest != NULL )
+//	if( hRequest != nullptr )
 //		WinHttpCloseHandle( hRequest );
-//	if( hConnect != NULL )
+//	if( hConnect != nullptr )
 //		WinHttpCloseHandle( hConnect );
-//	if( hSession != NULL )
+//	if( hSession != nullptr )
 //		WinHttpCloseHandle( hSession );
 //
 //	return bSuccess;
@@ -299,12 +299,12 @@ BOOL RAWeb::DoBlockingHttpGet( const std::string& sRequestedPage, DataStream& Re
  		WINHTTP_NO_PROXY_BYPASS, 0);
  
  	// Specify an HTTP server.
-	if( hSession != NULL )
+	if( hSession != nullptr )
 	{
  		HINTERNET hConnect = WinHttpConnect( hSession, Widen( bIsImageRequest ? RA_HOST_IMG_URL : RA_HOST_URL ).c_str(), INTERNET_DEFAULT_HTTP_PORT, 0 );
  
  		// Create an HTTP Request handle.
- 		if( hConnect != NULL )
+ 		if( hConnect != nullptr )
 		{
 			WCHAR wBuffer[1024];
 			mbstowcs_s( &nTemp, wBuffer, 1024, sRequestedPage.c_str(), strlen( sRequestedPage.c_str() )+1 );
@@ -312,13 +312,13 @@ BOOL RAWeb::DoBlockingHttpGet( const std::string& sRequestedPage, DataStream& Re
  			HINTERNET hRequest = WinHttpOpenRequest( hConnect, 
  				L"GET", 
  				wBuffer, 
- 				NULL, 
+ 				nullptr, 
  				WINHTTP_NO_REFERER, 
  				WINHTTP_DEFAULT_ACCEPT_TYPES,
  				0);
  
  			// Send a Request.
- 			if( hRequest != NULL )
+ 			if( hRequest != nullptr )
  			{
  				BOOL bResults = WinHttpSendRequest( hRequest, 
  					L"Content-Type: application/x-www-form-urlencoded",
@@ -328,7 +328,7 @@ BOOL RAWeb::DoBlockingHttpGet( const std::string& sRequestedPage, DataStream& Re
  					0,
  					0);
 
-				if( WinHttpReceiveResponse( hRequest, NULL ) )
+				if( WinHttpReceiveResponse( hRequest, nullptr ) )
 				{
 					DWORD nBytesToRead = 0;
 					WinHttpQueryDataAvailable( hRequest, &nBytesToRead );
@@ -368,15 +368,15 @@ BOOL RAWeb::DoBlockingHttpGet( const std::string& sRequestedPage, DataStream& Re
 
 			}
 
-			if( hRequest != NULL )
+			if( hRequest != nullptr )
 				WinHttpCloseHandle( hRequest );
 		}
 
-		if( hConnect != NULL )
+		if( hConnect != nullptr )
 			WinHttpCloseHandle( hConnect );
 	}
 
-	if( hSession != NULL )
+	if( hSession != nullptr )
 		WinHttpCloseHandle( hSession );
 	
 	return bSuccess;
@@ -409,7 +409,7 @@ BOOL RAWeb::DoBlockingHttpPost( const std::string& sRequestedPage, const std::st
 			HINTERNET hRequest = WinHttpOpenRequest( hConnect,
 													 L"POST",
 													 Widen( sRequestedPage ).c_str(),
-													 NULL,
+													 nullptr,
 													 WINHTTP_NO_REFERER,
 													 WINHTTP_DEFAULT_ACCEPT_TYPES,
 													 0 );
@@ -510,7 +510,7 @@ BOOL DoBlockingImageUpload( UploadType nType, const std::string& sFilename, Data
 	RA_LOG( __FUNCTION__ ": (%04x) uploading \"%s\" to %s...\n", GetCurrentThreadId(), sFilename.c_str(), sRequestedPage.c_str() );
 
 	BOOL bSuccess = FALSE;
-	HINTERNET hConnect = NULL, hRequest = NULL;
+	HINTERNET hConnect = nullptr, hRequest = nullptr;
 
 	char sClientName[1024];
 	sprintf_s( sClientName, 1024, "Retro Achievements Client %s %s", g_sClientName, g_sClientVersion );
@@ -526,12 +526,12 @@ BOOL DoBlockingImageUpload( UploadType nType, const std::string& sFilename, Data
 		WINHTTP_NO_PROXY_BYPASS, 0);
 
 	// Specify an HTTP server.
-	if (hSession != NULL)
+	if (hSession != nullptr)
 	{
 		hConnect = WinHttpConnect(hSession, Widen(RA_HOST_URL).c_str(), INTERNET_DEFAULT_HTTP_PORT, 0);
 	}
 
-	if( hConnect != NULL )
+	if( hConnect != nullptr )
 	{
 		WCHAR wBuffer[1024];
 		mbstowcs_s( &nTemp, wBuffer, 1024, sRequestedPage.c_str(), strlen( sRequestedPage.c_str() )+1 );
@@ -539,13 +539,13 @@ BOOL DoBlockingImageUpload( UploadType nType, const std::string& sFilename, Data
 		hRequest = WinHttpOpenRequest( hConnect, 
 			L"POST", 
 			wBuffer, 
-			NULL, 
+			nullptr, 
 			WINHTTP_NO_REFERER, 
 			WINHTTP_DEFAULT_ACCEPT_TYPES,
 			0);
 	}
 
-	if( hRequest != NULL )
+	if( hRequest != nullptr )
 	{
 		//---------------------------41184676334
 		const char* mimeBoundary = "---------------------------41184676334";
@@ -589,7 +589,7 @@ BOOL DoBlockingImageUpload( UploadType nType, const std::string& sFilename, Data
 				0);
 		}
 
-		if( WinHttpReceiveResponse( hRequest, NULL ) )
+		if( WinHttpReceiveResponse( hRequest, nullptr ) )
 		{
 			//BYTE* sDataDestOffset = &pBufferOut[0];
 
@@ -682,13 +682,13 @@ void RAWeb::RA_InitializeHTTPThreads()
 {
 	RA_LOG( __FUNCTION__ " called\n" );
 
-	RAWeb::ms_hHTTPMutex = CreateMutex( NULL, FALSE, NULL );
+	RAWeb::ms_hHTTPMutex = CreateMutex( nullptr, FALSE, nullptr );
 	for( size_t i = 0; i < g_nNumHTTPThreads; ++i )
 	{
 		DWORD dwThread;
-		HANDLE hThread = CreateThread( NULL, 0, RAWeb::HTTPWorkerThread, (void*)i, 0 , &dwThread );
-		ASSERT( hThread != NULL );
-		if( hThread != NULL )
+		HANDLE hThread = CreateThread( nullptr, 0, RAWeb::HTTPWorkerThread, (void*)i, 0 , &dwThread );
+		ASSERT( hThread != nullptr );
+		if( hThread != nullptr )
 		{
 			g_vhHTTPThread.push_back( hThread );
 			RA_LOG( __FUNCTION__ " Adding HTTP thread %d (%08x, %08x)\n", i, dwThread, hThread );
@@ -709,7 +709,7 @@ DWORD RAWeb::HTTPWorkerThread( LPVOID lpParameter )
 		WaitForSingleObject(RAWeb::Mutex(), INFINITE);
 		RequestObject* pObj = HttpRequestQueue.PopNextItem();
 		ReleaseMutex(RAWeb::Mutex());
-		if( pObj != NULL )
+		if( pObj != nullptr )
 		{
 			DataStream Response;
 			switch( pObj->GetRequestType() )
@@ -742,7 +742,7 @@ DWORD RAWeb::HTTPWorkerThread( LPVOID lpParameter )
 		if( bDoPingKeepAlive )
 		{
 			//	Post a pingback once every few minutes to keep the server aware of our presence
-			if( time( NULL ) > nSendNextKeepAliveAt )
+			if( time( nullptr ) > nSendNextKeepAliveAt )
 			{
 				nSendNextKeepAliveAt += SERVER_PING_DURATION;
 
@@ -832,7 +832,7 @@ void RAWeb::RA_KillHTTPThreads()
 
 RequestObject* HttpResults::PopNextItem()
 {
-	RequestObject* pRetVal = NULL;
+	RequestObject* pRetVal = nullptr;
 	WaitForSingleObject( RAWeb::Mutex(), INFINITE );
 	{
 		if( m_aRequests.size() > 0 )
@@ -848,7 +848,7 @@ RequestObject* HttpResults::PopNextItem()
 
 const RequestObject* HttpResults::PeekNextItem() const
 {
-	RequestObject* pRetVal = NULL;
+	RequestObject* pRetVal = nullptr;
 	WaitForSingleObject( RAWeb::Mutex(), INFINITE );
 	{
 		pRetVal = m_aRequests.front();

--- a/src/RA_httpthread.cpp
+++ b/src/RA_httpthread.cpp
@@ -113,7 +113,7 @@ PostArgs PrevArgs;
 
 BOOL RequestObject::ParseResponseToJSON( Document& rDocOut )
 {
-	rDocOut.Parse( DataStreamAsString( GetResponse() ) );
+	rDocOut.Parse(ra::DataStreamAsString( GetResponse() ).c_str() );
 
 	if( rDocOut.HasParseError() )
 		RA_LOG( "Possible parse issue on response, %s (%s)\n", GetJSONParseErrorStr( rDocOut.GetParseError() ), RequestTypeToString[ m_nType ] );
@@ -247,7 +247,7 @@ BOOL RAWeb::DoBlockingRequest( RequestType nType, const PostArgs& PostData, Docu
 	{
 		if( response.size() > 0 )
 		{
-			JSONResponseOut.Parse( DataStreamAsString( response ) );
+			JSONResponseOut.Parse( DataStreamAsString( response ).c_str());
 			//LogJSON( JSONResponseOut );	//	Already logged during DoBlockingRequest()?
 
 			if( JSONResponseOut.HasParseError() )
@@ -479,12 +479,12 @@ BOOL RAWeb::DoBlockingHttpPost( const std::string& sRequestedPage, const std::st
 	if( ResponseOut.size() > 0 )
 	{
 		Document doc;
-		doc.Parse( DataStreamAsString( ResponseOut ) );
+		doc.Parse(ra::DataStreamAsString(ResponseOut).c_str());
 
 		if( doc.HasParseError() )
 		{
 			RA_LOG( "Cannot parse JSON!\n" );
-			RA_LOG( DataStreamAsString( ResponseOut ) );
+			RA_LOG(ra::DataStreamAsString( ResponseOut ).c_str() );
 			RA_LOG( "\n" );
 		}
 		else
@@ -636,7 +636,7 @@ BOOL RAWeb::DoBlockingImageUpload( UploadType nType, const std::string& sFilenam
 	DataStream response;
 	if( ::DoBlockingImageUpload( nType, sFilename, response ) )
 	{
-		ResponseOut.Parse(DataStreamAsString(response));
+		ResponseOut.Parse(ra::DataStreamAsString(response).c_str());
 		if( !ResponseOut.HasParseError() )
 		{
 			return TRUE;

--- a/src/RA_httpthread.cpp
+++ b/src/RA_httpthread.cpp
@@ -17,43 +17,12 @@
 #include <algorithm>	//	std::replace
 
 
-const char* RequestTypeToString[] = 
-{
-	"RequestLogin",
 
-	"RequestScore",
-	"RequestNews",
-	"RequestPatch",
-	"RequestLatestClientPage",
-	"RequestRichPresence",
-	"RequestAchievementInfo",
-	"RequestLeaderboardInfo",
-	"RequestCodeNotes",
-	"RequestFriendList",
-	"RequestBadgeIter",
-	"RequestUnlocks",
-	"RequestHashLibrary",
-	"RequestGamesList",
-	"RequestAllProgress",
-	"RequestGameID",
 
-	"RequestPing",
-	"RequestPostActivity",
-	"RequestSubmitAwardAchievement",
-	"RequestSubmitCodeNote",
-	"RequestSubmitLeaderboardEntry",
-	"RequestSubmitAchievementData",
-	"RequestSubmitTicket",
-	"RequestSubmitNewTitleEntry",
-	
-	"RequestUserPic",
-	"RequestBadge",
 
-	"STOP_THREAD",
-};
-static_assert( SIZEOF_ARRAY( RequestTypeToString ) == NumRequestTypes, "Must match up!" );
 
-const char* RequestTypeToPost[] =
+
+inline constexpr RequestTypes RequestTypeToPost
 {
 	"login",
 	"score",
@@ -86,19 +55,19 @@ const char* RequestTypeToPost[] =
 
 	"_stopthread_",			//	STOP_THREAD
 };
-static_assert( SIZEOF_ARRAY( RequestTypeToPost ) == NumRequestTypes, "Must match up!" );
 
-const char* UploadTypeToString[] = 
+
+inline constexpr UploadTypes UploadTypeToString
 {
 	"RequestUploadBadgeImage",
 };
-static_assert( SIZEOF_ARRAY( UploadTypeToString ) == NumUploadTypes, "Must match up!" );
 
-const char* UploadTypeToPost[] =
+
+inline constexpr UploadTypes UploadTypeToPost
 {
 	"uploadbadgeimage",
 };
-static_assert( SIZEOF_ARRAY( UploadTypeToPost ) == NumUploadTypes, "Must match up!" );
+
 
 //	No game-specific code here please!
 

--- a/src/RA_httpthread.cpp
+++ b/src/RA_httpthread.cpp
@@ -758,7 +758,9 @@ DWORD RAWeb::HTTPWorkerThread( LPVOID lpParameter )
 					{
 						if( g_MemoryDialog.IsActive() || g_AchievementEditorDialog.IsActive() || g_MemBookmarkDialog.IsActive() )
 						{
-							if( g_bHardcoreModeActive )
+							if( !g_pActiveAchievements || g_pActiveAchievements->NumAchievements() == 0 )
+								args['m'] = "Developing Achievements";
+							else if( g_bHardcoreModeActive )
 								args['m'] = "Inspecting Memory in Hardcore mode";
 							else if( g_nActiveAchievementSet == Core )
 								args['m'] = "Fixing Achievements";

--- a/src/RA_httpthread.h
+++ b/src/RA_httpthread.h
@@ -64,7 +64,43 @@ enum UploadType
 	NumUploadTypes
 };
 
-extern const char* RequestTypeToString[];
+using RequestTypes = std::array<const char*, NumRequestTypes>;
+using UploadTypes  = std::array<const char*, NumUploadTypes>;
+
+inline constexpr RequestTypes RequestTypeToString
+{
+	"RequestLogin",
+
+	"RequestScore",
+	"RequestNews",
+	"RequestPatch",
+	"RequestLatestClientPage",
+	"RequestRichPresence",
+	"RequestAchievementInfo",
+	"RequestLeaderboardInfo",
+	"RequestCodeNotes",
+	"RequestFriendList",
+	"RequestBadgeIter",
+	"RequestUnlocks",
+	"RequestHashLibrary",
+	"RequestGamesList",
+	"RequestAllProgress",
+	"RequestGameID",
+
+	"RequestPing",
+	"RequestPostActivity",
+	"RequestSubmitAwardAchievement",
+	"RequestSubmitCodeNote",
+	"RequestSubmitLeaderboardEntry",
+	"RequestSubmitAchievementData",
+	"RequestSubmitTicket",
+	"RequestSubmitNewTitleEntry",
+
+	"RequestUserPic",
+	"RequestBadge",
+
+	"STOP_THREAD",
+};
 
 typedef std::map<char, std::string> PostArgs;
 

--- a/src/RA_md5factory.cpp
+++ b/src/RA_md5factory.cpp
@@ -19,8 +19,8 @@ std::string RAGenerateMD5( const std::string& sStringToMD5 )
 	md5_byte_t digest[16];
 
 	md5_byte_t* pDataBuffer = new md5_byte_t[ sStringToMD5.length() ];
-	ASSERT( pDataBuffer != NULL );
-	if( pDataBuffer == NULL )
+	ASSERT( pDataBuffer != nullptr );
+	if( pDataBuffer == nullptr )
 		return "";
 
 	memcpy( pDataBuffer, sStringToMD5.c_str(), sStringToMD5.length() );
@@ -37,7 +37,7 @@ std::string RAGenerateMD5( const std::string& sStringToMD5 )
 			  digest[8],digest[9],digest[10],digest[11],digest[12],digest[13],digest[14],digest[15] );
 
 	delete[] pDataBuffer;
-	pDataBuffer = NULL;
+	pDataBuffer = nullptr;
 
 	return buffer;
 }

--- a/src/base.props
+++ b/src/base.props
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros">
+    <RA_DIR>$(SolutionDir)</RA_DIR>
+    <RapidJSON_IncludeDir>$(RA_DIR)rapidjson/include/</RapidJSON_IncludeDir>
+    <RA_IncludePath>$(RA_DIR);$(RapidJSON_IncludeDir)</RA_IncludePath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <OutDir>$(SolutionDir)bin\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)obj\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <FloatingPointExceptions>true</FloatingPointExceptions>
+      <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <PostBuildEvent>
+      <Command>copy /y $(TargetPath) $(LocalDebuggerWorkingDirectory)$(TargetFileName)</Command>
+    </PostBuildEvent>
+    <PostBuildEvent>
+      <Message>Copies the compiled binary from the output directory to the working directory in "Debugging". Same command applies to release mode.</Message>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <BuildMacro Include="RA_DIR">
+      <Value>$(RA_DIR)</Value>
+      <EnvironmentVariable>true</EnvironmentVariable>
+    </BuildMacro>
+    <BuildMacro Include="RapidJSON_IncludeDir">
+      <Value>$(RapidJSON_IncludeDir)</Value>
+      <EnvironmentVariable>true</EnvironmentVariable>
+    </BuildMacro>
+    <BuildMacro Include="RA_IncludePath">
+      <Value>$(RA_IncludePath)</Value>
+      <EnvironmentVariable>true</EnvironmentVariable>
+    </BuildMacro>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Converted all the "global" C arrays (skimmed the top of each file) with std::array. No risk of memory leak (as far as what was changed). Also missed a few COM stuff and changed those.

You can use the methods std::array has to offer, with the same, if not faster speed. A few globals were turned in to constant expressions to disable accidental const_cast on them.