### PR TITLE
Standardize all condition processing

### DIFF
--- a/src/RA_Achievement.cpp
+++ b/src/RA_Achievement.cpp
@@ -137,16 +137,11 @@ BOOL Achievement::Test()
 
 	if( bResetConditions && bNotifyOnReset )
 	{
-		Reset();
+		RA_CausePause();
 
-		if ( GetPauseOnReset() )
-		{
-			RA_CausePause();
-
-			char buffer[256];
-			sprintf_s( buffer, 256, "Pause on Reset: %s", Title().c_str() );
-			MessageBox( g_RAMainWnd, NativeStr(buffer).c_str(), TEXT("Paused"), MB_OK );
-		}
+		char buffer[256];
+		sprintf_s( buffer, 256, "Pause on Reset: %s", Title().c_str() );
+		MessageBox( g_RAMainWnd, NativeStr(buffer).c_str(), TEXT("Paused"), MB_OK );
 	}
 
 	return bRetVal;

--- a/src/RA_Achievement.h
+++ b/src/RA_Achievement.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <vector>
 #include "RA_Condition.h"
 #include "RA_Defs.h"
 
@@ -84,8 +83,8 @@ public:
 	void AddConditionGroup();
 	void RemoveConditionGroup();
 
-	inline size_t NumConditionGroups() const						{ return m_vConditions.size(); }
-	inline size_t NumConditions( size_t nGroup ) const				{ return m_vConditions[ nGroup ].Count(); }
+	inline size_t NumConditionGroups() const						{ return m_vConditions.GroupCount(); }
+	inline size_t NumConditions( size_t nGroup ) const				{ return m_vConditions.GetGroup( nGroup ).Count(); }
 
 	inline HBITMAP BadgeImage() const								{ return m_hBadgeImage; }
 	inline HBITMAP BadgeImageLocked() const							{ return m_hBadgeImageLocked; }
@@ -94,23 +93,17 @@ public:
 	void SetBadgeImage( const std::string& sFilename );
 	void ClearBadgeImage();
 
-	Condition& GetCondition( size_t nCondGroup, size_t i )			{ return m_vConditions[ nCondGroup ].GetAt( i ); }
+	Condition& GetCondition( size_t nCondGroup, size_t i )			{ return m_vConditions.GetGroup( nCondGroup ).GetAt( i ); }
 	
 	std::string CreateMemString() const;
 
 	void Reset();
 
-	void UpdateProgress();
-	float ProgressGetNextStep( char* sFormat, float fLastKnownProgress );
-	float ParseProgressExpression( char* pExp );
-
 	//	Returns the new char* offset after parsing.
-	char* ParseLine( char* buffer );
+	const char* ParseLine( const char* buffer );
 	
 	//	Parse from json element
 	void Parse( const Value& element );
-	
-	char* ParseMemString( char* sMem );
 
 	//	Used for rendering updates when editing achievements. Usually always false.
 	unsigned int GetDirtyFlags() const			{ return m_nDirtyFlags; }
@@ -122,7 +115,7 @@ private:
 	/*const*/ AchievementSetType m_nSetType;
 
 	AchievementID m_nAchievementID;
-	std::vector<ConditionSet> m_vConditions;
+	ConditionSet m_vConditions;
 
 	std::string m_sTitle;
 	std::string m_sDescription;

--- a/src/RA_Condition.h
+++ b/src/RA_Condition.h
@@ -180,7 +180,7 @@ public:
 	void SerializeAppend(std::string& buffer) const;
 
 	//	Final param indicates 'or'
-	bool Test( bool& bDirtyConditions, bool& bResetRead, bool bMatchAny );
+	bool Test( bool& bDirtyConditions, bool& bResetRead );
 	size_t Count() const		{ return m_Conditions.size(); }
 
 	void Add( const Condition& newCond )				{ m_Conditions.push_back( newCond ); }

--- a/src/RA_Condition.h
+++ b/src/RA_Condition.h
@@ -75,7 +75,7 @@ public:
 
 	void ResetDelta()
 	{
-		m_nPreviousVal = 0;
+		m_nPreviousVal = m_nVal;
 	}
 
 	bool ParseVariable(const char*& sInString);	//	Parse from string

--- a/src/RA_Core.cpp
+++ b/src/RA_Core.cpp
@@ -1491,6 +1491,17 @@ char* _ReadStringTil(char nChar, char*& pOffsetInOut, BOOL bTerminate)
 	return (pStartString);
 }
 
+void _ReadStringTil(std::string& value, char nChar, const char*& pSource)
+{
+    const char* pStartString = pSource;
+
+    while (*pSource != '\0' && *pSource != nChar)
+        pSource++;
+
+    value.assign(pStartString, pSource - pStartString);
+    pSource++;
+}
+
 void _WriteBufferToFile(const std::string& sFileName, const Document& doc)
 {
 	SetCurrentDirectory(NativeStr(g_sHomeDir).c_str());

--- a/src/RA_Core.h
+++ b/src/RA_Core.h
@@ -130,6 +130,7 @@ extern BOOL _ReadTil( const char nChar, char buffer[], unsigned int nSize, DWORD
 
 //	Read a string til the end of the string, or nChar. bTerminate==TRUE replaces that char with \0.
 extern char* _ReadStringTil( char nChar, char*& pOffsetInOut, BOOL bTerminate );
+extern void  _ReadStringTil( std::string& sValue, char nChar, const char*& pOffsetInOut );
 
 //	Write out the buffer to a file
 extern void _WriteBufferToFile( const std::string& sFileName, const DataStream& rawData );

--- a/src/RA_Dlg_AchEditor.cpp
+++ b/src/RA_Dlg_AchEditor.cpp
@@ -355,7 +355,7 @@ long _stdcall EditProc(HWND hwnd, UINT nMsg, WPARAM wParam, LPARAM lParam)
 		if (lstrcmp(sEditText, TEXT("Value")))
 		{
 			//	Remove the associated 'size' entry
-			strcpy_s(g_AchievementEditorDialog.LbxDataAt(nSelItem, nSelSubItem + 1), 32, "");
+			strcpy_s(g_AchievementEditorDialog.LbxDataAt(lvDispinfo.item.iItem, lvDispinfo.item.iSubItem + 1), 32, "");
 		}
 
 		DestroyWindow(hwnd);

--- a/src/RA_Dlg_AchEditor.cpp
+++ b/src/RA_Dlg_AchEditor.cpp
@@ -1091,9 +1091,8 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
 				return FALSE;
 
 			Condition NewCondition;
-			NewCondition.SetIsBasicCondition();
-			NewCondition.CompSource().Set(EightBit, Address, 0x0000, 0);
-			NewCondition.CompTarget().Set(EightBit, ValueComparison, 0, 0);	//	Compare defaults!
+			NewCondition.CompSource().Set(EightBit, Address, 0x0000);
+			NewCondition.CompTarget().Set(EightBit, ValueComparison, 0);	//	Compare defaults!
 
 			//	Helper: guess that the currently watched memory location
 			//	 is probably what they are about to want to add a cond for.
@@ -1141,8 +1140,7 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
 					{
 						const Condition& CondToCopy = pActiveAch->GetCondition(GetSelectedConditionGroup(), static_cast<size_t>(i));
 
-						Condition NewCondition;
-						NewCondition.Set(CondToCopy);
+						Condition NewCondition(CondToCopy);
 
 						m_ConditionClipboard.Add(NewCondition);
 					}

--- a/src/RA_Dlg_AchEditor.h
+++ b/src/RA_Dlg_AchEditor.h
@@ -62,7 +62,7 @@ public:
 	size_t GetSelectedConditionGroup() const;
 	void SetSelectedConditionGroup( size_t nGrp ) const;
 
-	ConditionSet m_ConditionClipboard;
+	ConditionGroup m_ConditionClipboard;
 
 private:
 	void RepopulateGroupList( Achievement* pCheevo );

--- a/src/RA_Dlg_MemBookmark.cpp
+++ b/src/RA_Dlg_MemBookmark.cpp
@@ -674,14 +674,13 @@ unsigned int Dlg_MemBookmark::GetMemory( unsigned int nAddr, int type )
 	switch ( type )
 	{
 		case 1:
-			mem_value = g_MemManager.ActiveBankRAMByteRead( nAddr );
+			mem_value = g_MemManager.ActiveBankRAMRead(nAddr, EightBit);
 			break;
 		case 2:
-			mem_value = ( g_MemManager.ActiveBankRAMByteRead( nAddr ) | ( g_MemManager.ActiveBankRAMByteRead( nAddr + 1 ) << 8 ) );
+			mem_value = g_MemManager.ActiveBankRAMRead(nAddr, SixteenBit);
 			break;
 		case 3:
-			mem_value = ( g_MemManager.ActiveBankRAMByteRead( nAddr ) | ( g_MemManager.ActiveBankRAMByteRead( nAddr + 1 ) << 8 ) |
-				( g_MemManager.ActiveBankRAMByteRead( nAddr + 2 ) << 16 ) | ( g_MemManager.ActiveBankRAMByteRead( nAddr + 3 ) << 24 ) );
+			mem_value = g_MemManager.ActiveBankRAMRead(nAddr, ThirtyTwoBit);
 			break;
 	}
 

--- a/src/RA_Dlg_Memory.cpp
+++ b/src/RA_Dlg_Memory.cpp
@@ -1896,22 +1896,12 @@ void Dlg_Memory::UpdateSearchResult( unsigned int index, unsigned int &nMemVal, 
 
 	switch ( g_MemManager.MemoryComparisonSize())
 	{
-	case ThirtyTwoBit:
-		nMemVal = ( g_MemManager.ActiveBankRAMByteRead( nAddr ) | ( g_MemManager.ActiveBankRAMByteRead( nAddr + 1 ) << 8 ) ||
-		            g_MemManager.ActiveBankRAMByteRead( nAddr + 2 ) << 16 | ( g_MemManager.ActiveBankRAMByteRead( nAddr + 3 ) << 24 ) );
-		break;
-	case SixteenBit:
-		nMemVal = ( g_MemManager.ActiveBankRAMByteRead( nAddr ) | ( g_MemManager.ActiveBankRAMByteRead( nAddr + 1 ) << 8 ) );
-		break;
-	case EightBit:
-		nMemVal = ( g_MemManager.ActiveBankRAMByteRead( nAddr ) );
+	default:
+		nMemVal = g_MemManager.ActiveBankRAMRead(nAddr, g_MemManager.MemoryComparisonSize());
 		break;
 	case Nibble_Lower:
 	case Nibble_Upper:
-		if ( m_SearchResults[ m_nPage ].m_ResultCandidate[ element ].m_bUpperNibble )
-			nMemVal = ( ( g_MemManager.ActiveBankRAMByteRead( nAddr ) >> 4 ) & 0xf );
-		else
-			nMemVal = ( g_MemManager.ActiveBankRAMByteRead( nAddr ) & 0xf );
+		nMemVal = g_MemManager.ActiveBankRAMRead(nAddr, m_SearchResults[m_nPage].m_ResultCandidate[element].m_bUpperNibble ? Nibble_Upper : Nibble_Lower);
 		break;
 	}
 

--- a/src/RA_Dlg_Memory.h
+++ b/src/RA_Dlg_Memory.h
@@ -3,9 +3,6 @@
 #include "RA_Defs.h"
 #include "RA_CodeNotes.h"
 #include "RA_MemManager.h"
-#include "RA_Condition.h"
-
-class CodeNotes;
 
 class MemoryViewerControl
 {

--- a/src/RA_Leaderboard.h
+++ b/src/RA_Leaderboard.h
@@ -110,9 +110,9 @@ public:
 
 private:
 	const LeaderboardID		m_nID;			//	DB ID for this LB
-	ConditionGroup			m_startCond;	//	Start monitoring if this is true
-	ConditionGroup			m_cancelCond;	//	Cancel monitoring if this is true
-	ConditionGroup			m_submitCond;	//	Submit new score if this is true
+	ConditionSet			m_startCond;	//	Start monitoring if this is true
+    ConditionSet			m_cancelCond;	//	Cancel monitoring if this is true
+    ConditionSet			m_submitCond;	//	Submit new score if this is true
 
 	bool					m_bStarted;		//	False = check start condition. True = check cancel or submit conditions.
 	bool                    m_bSubmitted;   //  True if already submitted.

--- a/src/RA_Leaderboard.h
+++ b/src/RA_Leaderboard.h
@@ -14,7 +14,7 @@ public:
 		: m_nAddress( nAddr ), m_fModifier( fMod ), m_nVarSize( nSize ), m_bBCDParse( bBCDParse ), m_bParseVal( bParseVal ) {}
 	
 public:
-	char* ParseFromString( char* pBuffer );		//	Parse string into values, returns end of string
+	const char* ParseFromString( const char* pBuffer );		//	Parse string into values, returns end of string
 	double GetValue() const;					//	Get the value in-memory with modifiers
 
 public:
@@ -41,7 +41,7 @@ public:
 	};
 
 public:
-	void ParseMemString( char* sBuffer );
+	void ParseMemString( const char* sBuffer );
 	double GetValue() const;
 	double GetOperationsValue( std::vector<OperationType> ) const;
 	void AddNewValue( MemValue nVal );
@@ -83,7 +83,7 @@ public:
 public:
 	void LoadFromJSON( const Value& element );
 	void ParseLine( char* sBuffer );
-	void ParseLBData( char* sBuffer );
+	void ParseLBData( const char* sBuffer );
 
 	void Test();
 	double GetCurrentValue();
@@ -110,9 +110,9 @@ public:
 
 private:
 	const LeaderboardID		m_nID;			//	DB ID for this LB
-	ConditionSet			m_startCond;	//	Start monitoring if this is true
-	ConditionSet			m_cancelCond;	//	Cancel monitoring if this is true
-	ConditionSet			m_submitCond;	//	Submit new score if this is true
+	ConditionGroup			m_startCond;	//	Start monitoring if this is true
+	ConditionGroup			m_cancelCond;	//	Cancel monitoring if this is true
+	ConditionGroup			m_submitCond;	//	Submit new score if this is true
 
 	bool					m_bStarted;		//	False = check start condition. True = check cancel or submit conditions.
 	bool                    m_bSubmitted;   //  True if already submitted.

--- a/src/RA_MemManager.h
+++ b/src/RA_MemManager.h
@@ -83,6 +83,8 @@ public:
 	unsigned char ActiveBankRAMByteRead(ByteAddress nOffs) const;
 	void ActiveBankRAMByteWrite(ByteAddress nOffs, unsigned int nVal);
 
+	unsigned int ActiveBankRAMRead(ByteAddress nOffs, ComparisonVariableSize size) const;
+
 	void ActiveBankRAMRead(unsigned char buffer[], ByteAddress nOffs, size_t count) const;
 
 private:

--- a/src/RA_RichPresence.cpp
+++ b/src/RA_RichPresence.cpp
@@ -1,5 +1,7 @@
 #include "RA_RichPresence.h"
+
 #include "RA_Core.h"
+#include "RA_GameData.h"
 
 RA_RichPresenceInterpretter g_RichPresenceInterpretter;
 
@@ -57,6 +59,7 @@ void RA_RichPresenceInterpretter::ParseRichPresenceFile( const std::string& sFil
 	m_formats.clear();
 	m_lookups.clear();
 	m_sDisplay.clear();
+    m_conditionalDisplayStrings.clear();
 
 	const char EndLine = '\n';
 
@@ -224,6 +227,12 @@ const std::string& RA_RichPresenceInterpretter::GetRichPresenceString()
 {
 	static std::string sReturnVal;
 	sReturnVal.clear();
+
+    if (g_pCurrentGameData->GetGameID() == 0)
+    {
+        sReturnVal = "No game loaded";
+        return sReturnVal;
+    }
 
 	bool bParsingLookupName = false;
 	bool bParsingLookupContent = false;

--- a/src/RA_RichPresence.cpp
+++ b/src/RA_RichPresence.cpp
@@ -28,32 +28,10 @@ std::string RA_Formattable::Lookup( DataPos nValue ) const
 	return RA_Leaderboard::FormatScore( m_nFormatType, nValue );
 }
 
-RA_ConditionalDisplayString::RA_ConditionalDisplayString( char* pBuffer )
+RA_ConditionalDisplayString::RA_ConditionalDisplayString( const char* pBuffer )
 {
 	++pBuffer; // skip first question mark
-	do
-	{
-		ConditionSet conditionSet;
-
-		do
-		{
-			Condition nNewCond;
-			nNewCond.ParseFromString( pBuffer );
-			conditionSet.Add( nNewCond );
-
-			if( *pBuffer != '_' ) // AND
-				break;
-
-			++pBuffer;
-		} while( true );
-
-		m_conditions.push_back( conditionSet );
-
-		if (*pBuffer != 'S') // OR
-			break;
-
-		++pBuffer;
-	} while( true ); // OR
+	m_conditions.ParseFromString(pBuffer);
 
 	if( *pBuffer == '?' )
 	{
@@ -64,38 +42,14 @@ RA_ConditionalDisplayString::RA_ConditionalDisplayString( char* pBuffer )
 	else
 	{
 		// not a valid condition, ensure Test() never returns true
-		m_conditions.clear();
+		m_conditions.Clear();
 	}
 }
 
 bool RA_ConditionalDisplayString::Test()
 {
-	std::vector<ConditionSet>::iterator iter = m_conditions.begin();
-	if( iter == m_conditions.end() )
-		return false;
-
-	BOOL bDirtyConditions, bResetRead; // for HitCounts - not supported in RichPresence
-
-	// if core condition is not true, it doesnt match
-	if( !iter->Test( bDirtyConditions, bResetRead, false ) )
-		return false;
-
-	// core condition is true. if no alt conditions, it does match.
-	++iter;
-	if (iter == m_conditions.end())
-		return true;
-
-	// core condition is true. if any alt condition is true, it matches
-	do
-	{
-		if ( iter->Test( bDirtyConditions, bResetRead, false ) )
-			return true;
-
-		++iter;
-	} while( iter != m_conditions.end() );
-
-	// no alt conditions are true, not a match.
-	return false;
+	bool bDirtyConditions, bResetRead; // for HitCounts - not supported in RichPresence
+	return m_conditions.Test(bDirtyConditions, bResetRead);
 }
 
 void RA_RichPresenceInterpretter::ParseRichPresenceFile( const std::string& sFilename )

--- a/src/RA_RichPresence.h
+++ b/src/RA_RichPresence.h
@@ -26,14 +26,14 @@ private:
 class RA_ConditionalDisplayString
 {
 public:
-	RA_ConditionalDisplayString( char* pLine );
+	RA_ConditionalDisplayString( const char* pLine );
 
 	bool Test();
 	const std::string& GetDisplayString() const { return m_sDisplayString; }
 
 private:
 	std::string m_sDisplayString;
-	std::vector<ConditionSet> m_conditions;
+	ConditionSet m_conditions;
 };
 
 class RA_Formattable


### PR DESCRIPTION
This is preparatory work for supporting ANDs in leaderboard cancel conditions (#5).
* Renamed `ConditionSet` to `ConditionGroup` and added a new `ConditionSet` which is a collection of `ConditionGroup`s (foundation of an `Achievement`).
  * `ConditionSet` is a group of `ConditionGroup`s. `ConditionSet.Test` returns true if the first group evaluates true and at least one of the other groups evaluate true.
  * `ConditionGroup` is a collection of `Condition`s. `ConditionGroup.Test` returns true if all conditions in the group evaluate true.
  * `Condition` is a single condition. `Condition.Test` returns true if the condition evaluates true.
* Moved all parsing/serialization of Conditions into RA_Condition.cpp
  * Achievements, Leaderboards, and Conditional Rich Presence now fully support the entire Condition lexicon, although it seems impractical to use HitCounts/ResetIf/PauseIf in Leaderboards or Conditional Rich Presence.
* Added `ActiveBankRAMRead(addr, size)` to `MemManager` to eliminate duplicated code in Condition, Dlg_MemBookmark, Dlg_Memory, MemValue, and MemManager itself.