### PR TITLE
Precompiled header (Probably should be accepted last)

### DIFF
--- a/src/RA_Achievement.cpp
+++ b/src/RA_Achievement.cpp
@@ -1,29 +1,19 @@
 #include "RA_Achievement.h"
 
-#include <windows.h>
-#include <commctrl.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include <memory.h>
-#include <assert.h>
-#include <io.h>
-#include <sstream>
-
 #include "RA_Dlg_Achievement.h"
 #include "RA_Dlg_GameTitle.h"
 
-#include "md5.h"
+
 #include "RA_md5factory.h"
 
 #include "RA_MemManager.h"
 #include "RA_User.h"
 #include "RA_PopupWindows.h"
 #include "RA_httpthread.h"
-#include "RA_Defs.h"
+
 #include "RA_ImageFactory.h"
 #include "RA_Core.h"
-#include "RA_Leaderboard.h"
-#include "RA_Condition.h"
+
 #include "RA_RichPresence.h"
 
 //	No game-specific code here please!

--- a/src/RA_Achievement.h
+++ b/src/RA_Achievement.h
@@ -1,8 +1,10 @@
+#ifndef RA_ACHIEVEMENT_H
+#define RA_ACHIEVEMENT_H
 #pragma once
 
-#include <vector>
+
 #include "RA_Condition.h"
-#include "RA_Defs.h"
+
 
 
 //////////////////////////////////////////////////////////////////////////
@@ -10,15 +12,15 @@
 //////////////////////////////////////////////////////////////////////////
 enum Achievement_DirtyFlags
 {
-	Dirty_Title			= 1<<0,
-	Dirty_Desc			= 1<<1,
-	Dirty_Points		= 1<<2,
-	Dirty_Author		= 1<<3,
-	Dirty_ID			= 1<<4,
-	Dirty_Badge			= 1<<5,
-	Dirty_Conditions	= 1<<6,
-	Dirty_Votes			= 1<<7,
-	Dirty_Description	= 1<<8,
+	Dirty_Title			= 1 << 0,
+	Dirty_Desc			= 1 << 1,
+	Dirty_Points		= 1 << 2,
+	Dirty_Author		= 1 << 3,
+	Dirty_ID			= 1 << 4,
+	Dirty_Badge			= 1 << 5,
+	Dirty_Conditions	= 1 << 6,
+	Dirty_Votes			= 1 << 7,
+	Dirty_Description	= 1 << 8,
 
 	Dirty__All			= (unsigned int)(-1)
 };
@@ -26,97 +28,97 @@ enum Achievement_DirtyFlags
 class Achievement
 {
 public:
-	Achievement( AchievementSetType nType );
+	Achievement(AchievementSetType nType);
 
 public:
 	void Clear();
 	BOOL Test();
 
-	size_t AddCondition( size_t nConditionGroup, const Condition& pNewCond );
-	size_t InsertCondition( size_t nConditionGroup, size_t nIndex, const Condition& pNewCond );
-	BOOL RemoveCondition( size_t nConditionGroup, unsigned int nConditionID );
-	void RemoveAllConditions( size_t nConditionGroup );
-	
-	void Set( const Achievement& rRHS );
+	size_t AddCondition(size_t nConditionGroup, const Condition& pNewCond);
+	size_t InsertCondition(size_t nConditionGroup, size_t nIndex, const Condition& pNewCond);
+	BOOL RemoveCondition(size_t nConditionGroup, unsigned int nConditionID);
+	void RemoveAllConditions(size_t nConditionGroup);
 
-	inline BOOL Active() const											{ return m_bActive; }
-	void SetActive( BOOL bActive );
+	void Set(const Achievement& rRHS);
 
-	inline BOOL Modified() const										{ return m_bModified; }
-	void SetModified( BOOL bModified );
+	inline BOOL Active() const { return m_bActive; }
+	void SetActive(BOOL bActive);
 
-	inline BOOL GetPauseOnTrigger() const                               { return m_bPauseOnTrigger; }
-	void SetPauseOnTrigger(BOOL bPause)                                 { m_bPauseOnTrigger = bPause; }
+	inline BOOL Modified() const { return m_bModified; }
+	void SetModified(BOOL bModified);
 
-	inline BOOL GetPauseOnReset() const                                 { return m_bPauseOnReset; }
-	void SetPauseOnReset(BOOL bPause)                                   { m_bPauseOnReset = bPause; }
+	inline BOOL GetPauseOnTrigger() const { return m_bPauseOnTrigger; }
+	void SetPauseOnTrigger(BOOL bPause) { m_bPauseOnTrigger = bPause; }
 
-	BOOL IsCoreAchievement() const										{ return m_nSetType == Core; }
+	inline BOOL GetPauseOnReset() const { return m_bPauseOnReset; }
+	void SetPauseOnReset(BOOL bPause) { m_bPauseOnReset = bPause; }
 
-	void SetID( AchievementID nID );
-	inline AchievementID ID() const										{ return m_nAchievementID; }
+	BOOL IsCoreAchievement() const { return m_nSetType == Core; }
 
-	inline const std::string& Title() const								{ return m_sTitle; }
-	void SetTitle( const std::string& sTitle )							{ m_sTitle = sTitle; }
-	inline const std::string& Description() const						{ return m_sDescription; }
-	void SetDescription( const std::string& sDescription )				{ m_sDescription = sDescription; }
-	inline const std::string& Author() const							{ return m_sAuthor; }
-	void SetAuthor( const std::string& sAuthor )						{ m_sAuthor = sAuthor; }
-	inline unsigned int Points() const									{ return m_nPointValue; }
-	void SetPoints( unsigned int nPoints )								{ m_nPointValue = nPoints; }
+	void SetID(AchievementID nID);
+	inline AchievementID ID() const { return m_nAchievementID; }
 
-	inline time_t CreatedDate() const									{ return m_nTimestampCreated; }
-	void SetCreatedDate( time_t nTimeCreated )							{ m_nTimestampCreated = nTimeCreated; }
-	inline time_t ModifiedDate() const									{ return m_nTimestampModified; }
-	void SetModifiedDate( time_t nTimeModified )						{ m_nTimestampModified = nTimeModified; }
-	
+	inline const std::string& Title() const { return m_sTitle; }
+	void SetTitle(const std::string& sTitle) { m_sTitle = sTitle; }
+	inline const std::string& Description() const { return m_sDescription; }
+	void SetDescription(const std::string& sDescription) { m_sDescription = sDescription; }
+	inline const std::string& Author() const { return m_sAuthor; }
+	void SetAuthor(const std::string& sAuthor) { m_sAuthor = sAuthor; }
+	inline unsigned int Points() const { return m_nPointValue; }
+	void SetPoints(unsigned int nPoints) { m_nPointValue = nPoints; }
+
+	inline time_t CreatedDate() const { return m_nTimestampCreated; }
+	void SetCreatedDate(time_t nTimeCreated) { m_nTimestampCreated = nTimeCreated; }
+	inline time_t ModifiedDate() const { return m_nTimestampModified; }
+	void SetModifiedDate(time_t nTimeModified) { m_nTimestampModified = nTimeModified; }
+
 	inline unsigned short Upvotes() const { return m_nUpvotes; }
 	inline unsigned short Downvotes() const { return m_nDownvotes; }
 
-	inline const std::string& Progress() const							{ return m_sProgress; }
-	void SetProgressIndicator( const std::string& sProgress )			{ m_sProgress = sProgress; }
-	inline const std::string& ProgressMax() const						{ return m_sProgressMax; }
-	void SetProgressIndicatorMax( const std::string& sProgressMax )		{ m_sProgressMax = sProgressMax; }
-	inline const std::string& ProgressFmt() const						{ return m_sProgressFmt; }
-	void SetProgressIndicatorFormat( const std::string& sProgressFmt )	{ m_sProgressFmt = sProgressFmt; }
-	
+	inline const std::string& Progress() const { return m_sProgress; }
+	void SetProgressIndicator(const std::string& sProgress) { m_sProgress = sProgress; }
+	inline const std::string& ProgressMax() const { return m_sProgressMax; }
+	void SetProgressIndicatorMax(const std::string& sProgressMax) { m_sProgressMax = sProgressMax; }
+	inline const std::string& ProgressFmt() const { return m_sProgressFmt; }
+	void SetProgressIndicatorFormat(const std::string& sProgressFmt) { m_sProgressFmt = sProgressFmt; }
+
 
 	void AddConditionGroup();
 	void RemoveConditionGroup();
 
-	inline size_t NumConditionGroups() const						{ return m_vConditions.size(); }
-	inline size_t NumConditions( size_t nGroup ) const				{ return m_vConditions[ nGroup ].Count(); }
+	inline size_t NumConditionGroups() const { return m_vConditions.size(); }
+	inline size_t NumConditions(size_t nGroup) const { return m_vConditions[nGroup].Count(); }
 
-	inline HBITMAP BadgeImage() const								{ return m_hBadgeImage; }
-	inline HBITMAP BadgeImageLocked() const							{ return m_hBadgeImageLocked; }
-	inline const std::string& BadgeImageURI() const					{ return m_sBadgeImageURI; }
-	
-	void SetBadgeImage( const std::string& sFilename );
+	inline HBITMAP BadgeImage() const { return m_hBadgeImage; }
+	inline HBITMAP BadgeImageLocked() const { return m_hBadgeImageLocked; }
+	inline const std::string& BadgeImageURI() const { return m_sBadgeImageURI; }
+
+	void SetBadgeImage(const std::string& sFilename);
 	void ClearBadgeImage();
 
-	Condition& GetCondition( size_t nCondGroup, size_t i )			{ return m_vConditions[ nCondGroup ].GetAt( i ); }
-	
+	Condition& GetCondition(size_t nCondGroup, size_t i) { return m_vConditions[nCondGroup].GetAt(i); }
+
 	std::string CreateMemString() const;
 
 	void Reset();
 
 	void UpdateProgress();
-	float ProgressGetNextStep( char* sFormat, float fLastKnownProgress );
-	float ParseProgressExpression( char* pExp );
+	float ProgressGetNextStep(char* sFormat, float fLastKnownProgress);
+	float ParseProgressExpression(char* pExp);
 
 	//	Returns the new char* offset after parsing.
-	char* ParseLine( char* buffer );
-	
+	char* ParseLine(char* buffer);
+
 	//	Parse from json element
-	void Parse( const Value& element );
-	
-	char* ParseMemString( char* sMem );
+	void Parse(const Value& element);
+
+	char* ParseMemString(char* sMem);
 
 	//	Used for rendering updates when editing achievements. Usually always false.
-	unsigned int GetDirtyFlags() const			{ return m_nDirtyFlags; }
-	BOOL IsDirty() const						{ return (m_nDirtyFlags!=0); }
-	void SetDirtyFlag( unsigned int nFlags )	{ m_nDirtyFlags |= nFlags; }
-	void ClearDirtyFlag()						{ m_nDirtyFlags = 0; }
+	unsigned int GetDirtyFlags() const { return m_nDirtyFlags; }
+	BOOL IsDirty() const { return (m_nDirtyFlags != 0); }
+	void SetDirtyFlag(unsigned int nFlags) { m_nDirtyFlags |= nFlags; }
+	void ClearDirtyFlag() { m_nDirtyFlags = 0; }
 
 private:
 	/*const*/ AchievementSetType m_nSetType;
@@ -156,3 +158,6 @@ private:
 	HBITMAP m_hBadgeImageLocked;
 };
 
+
+
+#endif // !RA_ACHIEVEMENT_H

--- a/src/RA_AchievementOverlay.cpp
+++ b/src/RA_AchievementOverlay.cpp
@@ -1,18 +1,17 @@
 #include "RA_AchievementOverlay.h"
 
-#include "RA_Interface.h"
-#include "RA_Achievement.h"
+#include "RA_Core.h"
 #include "RA_AchievementSet.h"
 #include "RA_User.h"
 #include "RA_httpthread.h"
-#include "RA_Resource.h"
+
 #include "RA_ImageFactory.h"
 #include "RA_PopupWindows.h"
-#include "RA_Core.h"
+
 #include "RA_Leaderboard.h"
 #include "RA_GameData.h"
 
-#include <time.h>
+
 
 namespace
 {

--- a/src/RA_AchievementOverlay.h
+++ b/src/RA_AchievementOverlay.h
@@ -1,12 +1,14 @@
+#ifndef RA_ACHIEVEMENTOVERLAY_H
+#define RA_ACHIEVEMENTOVERLAY_H
 #pragma once
 
-#include <WTypes.h>
+
 #include "RA_Achievement.h"
 #include "RA_User.h"
 #include "RA_Core.h"
-#include "RA_Interface.h"
 
-#include <ddraw.h>
+
+
 
 enum OverlayPage
 {
@@ -39,10 +41,10 @@ enum TransitionState
 class LeaderboardExamine
 {
 public:
-	void Initialize( const unsigned int nLBIDIn );
+	void Initialize(const unsigned int nLBIDIn);
 	//static void CB_OnReceiveData( void* pRequestObject );
-	void OnReceiveData( const Document& doc );
-	
+	void OnReceiveData(const Document& doc);
+
 public:
 	unsigned int m_nLBID;
 	//	Refer to RA_Leaderboard entry rank info via g_LeaderboardManager.FindLB(m_nLBID)
@@ -57,11 +59,11 @@ public:
 	class RecentWinnerData
 	{
 	public:
-		RecentWinnerData( const std::string& sUser, const std::string& sWonAt ) :
-			m_sUser( sUser ), m_sWonAt( sWonAt )
+		RecentWinnerData(const std::string& sUser, const std::string& sWonAt) :
+			m_sUser(sUser), m_sWonAt(sWonAt)
 		{}
-		const std::string& User() const		{ return m_sUser; }
-		const std::string& WonAt() const	{ return m_sWonAt; }
+		const std::string& User() const { return m_sUser; }
+		const std::string& WonAt() const { return m_sWonAt; }
 
 	private:
 		const std::string m_sUser;
@@ -72,25 +74,25 @@ public:
 	AchievementExamine();
 
 public:
-	void Initialize( const Achievement* pAchIn );
+	void Initialize(const Achievement* pAchIn);
 	void Clear();
-	static void CB_OnReceiveData( void* pRequestObject );
-	void OnReceiveData( Document& doc );
-	
-	bool HasData() const											{ return m_bHasData; }
-	const std::string& CreatedDate() const							{ return m_CreatedDate; }
-	const std::string& ModifiedDate() const							{ return m_LastModifiedDate; }
-	size_t NumRecentWinners() const									{ return RecentWinners.size(); }
-	const RecentWinnerData& GetRecentWinner( size_t nOffs ) const	{ return RecentWinners.at( nOffs ); }
-	
-	unsigned int TotalWinners() const								{ return m_nTotalWinners; }
-	unsigned int PossibleWinners() const							{ return m_nPossibleWinners; }
+	static void CB_OnReceiveData(void* pRequestObject);
+	void OnReceiveData(Document& doc);
+
+	bool HasData() const { return m_bHasData; }
+	const std::string& CreatedDate() const { return m_CreatedDate; }
+	const std::string& ModifiedDate() const { return m_LastModifiedDate; }
+	size_t NumRecentWinners() const { return RecentWinners.size(); }
+	const RecentWinnerData& GetRecentWinner(size_t nOffs) const { return RecentWinners.at(nOffs); }
+
+	unsigned int TotalWinners() const { return m_nTotalWinners; }
+	unsigned int PossibleWinners() const { return m_nPossibleWinners; }
 
 private:
 	const Achievement* m_pSelectedAchievement;
 	std::string m_CreatedDate;
 	std::string m_LastModifiedDate;
-	
+
 	bool m_bHasData;
 
 	//	Data found:
@@ -108,41 +110,41 @@ public:
 	AchievementOverlay();
 	~AchievementOverlay();
 
-	void Initialize( HINSTANCE hInst );
-	void InstallHINSTANCE( HINSTANCE hInst );
+	void Initialize(HINSTANCE hInst);
+	void InstallHINSTANCE(HINSTANCE hInst);
 
 	void Activate();
 	void Deactivate();
 
-	void Render( HDC hDC, RECT* rcDest ) const;
-	BOOL Update( ControllerInput* input, float fDelta, BOOL bFullScreen, BOOL bPaused );
+	void Render(HDC hDC, RECT* rcDest) const;
+	BOOL Update(ControllerInput* input, float fDelta, BOOL bFullScreen, BOOL bPaused);
 
-	BOOL IsActive() const	{ return( m_nTransitionState!=TS_OFF ); }
+	BOOL IsActive() const { return(m_nTransitionState != TS_OFF); }
 
 	const int* GetActiveScrollOffset() const;
 	const int* GetActiveSelectedItem() const;
 
 	void OnLoad_NewRom();
-	void OnUserPicDownloaded( const char* sUsername );
+	void OnUserPicDownloaded(const char* sUsername);
 
-	void DrawAchievementsPage( HDC hDC, int nDX, int nDY, const RECT& rcTarget ) const;
-	void DrawAchievementExaminePage( HDC hDC, int nDX, int nDY, const RECT& rcTarget ) const;
-	void DrawMessagesPage( HDC hDC, int nDX, int nDY, const RECT& rcTarget ) const;
-	void DrawFriendsPage( HDC hDC, int nDX, int nDY, const RECT& rcTarget ) const;
-	void DrawNewsPage( HDC hDC, int nDX, int nDY, const RECT& rcTarget ) const;
-	void DrawLeaderboardPage( HDC hDC, int nDX, int nDY, const RECT& rcTarget ) const;
-	void DrawLeaderboardExaminePage( HDC hDC, int nDX, int nDY, const RECT& rcTarget ) const;
+	void DrawAchievementsPage(HDC hDC, int nDX, int nDY, const RECT& rcTarget) const;
+	void DrawAchievementExaminePage(HDC hDC, int nDX, int nDY, const RECT& rcTarget) const;
+	void DrawMessagesPage(HDC hDC, int nDX, int nDY, const RECT& rcTarget) const;
+	void DrawFriendsPage(HDC hDC, int nDX, int nDY, const RECT& rcTarget) const;
+	void DrawNewsPage(HDC hDC, int nDX, int nDY, const RECT& rcTarget) const;
+	void DrawLeaderboardPage(HDC hDC, int nDX, int nDY, const RECT& rcTarget) const;
+	void DrawLeaderboardExaminePage(HDC hDC, int nDX, int nDY, const RECT& rcTarget) const;
 
-	void DrawBar( HDC hDC, int nX, int nY, int nW, int nH, int nMax, int nSel ) const;
-	void DrawUserFrame( HDC hDC, RAUser* pUser, int nX, int nY, int nW, int nH ) const;
-	void DrawAchievement( HDC hDC, const Achievement* Ach, int nX, int nY, BOOL bSelected, BOOL bCanLock ) const;
+	void DrawBar(HDC hDC, int nX, int nY, int nW, int nH, int nMax, int nSel) const;
+	void DrawUserFrame(HDC hDC, RAUser* pUser, int nX, int nY, int nW, int nH) const;
+	void DrawAchievement(HDC hDC, const Achievement* Ach, int nX, int nY, BOOL bSelected, BOOL bCanLock) const;
 
-	OverlayPage CurrentPage()		{ return m_Pages[ m_nPageStackPointer ]; }
-	void AddPage( OverlayPage NewPage );
+	OverlayPage CurrentPage() { return m_Pages[m_nPageStackPointer]; }
+	void AddPage(OverlayPage NewPage);
 	BOOL GoBack();
 
-	void SelectNextTopLevelPage( BOOL bPressedRight );
-	
+	void SelectNextTopLevelPage(BOOL bPressedRight);
+
 	void InitDirectX();
 	void ResetDirectX();
 	void CloseDirectX();
@@ -185,7 +187,7 @@ private:
 	TransitionState			m_nTransitionState;
 	float					m_fTransitionTimer;
 
-	OverlayPage				m_Pages[ 5 ];
+	OverlayPage				m_Pages[5];
 	unsigned int			m_nPageStackPointer;
 
 	//HBITMAP m_hLockedBitmap;	//	Cached	
@@ -199,11 +201,11 @@ extern AchievementOverlay g_AchievementOverlay;
 //	Exposed to DLL
 extern "C"
 {
-	API extern int _RA_UpdateOverlay( ControllerInput* pInput, float fDTime, bool Full_Screen, bool Paused );
-	API extern void _RA_RenderOverlay( HDC hDC, RECT* rcSize );
+	API extern int _RA_UpdateOverlay(ControllerInput* pInput, float fDTime, bool Full_Screen, bool Paused);
+	API extern void _RA_RenderOverlay(HDC hDC, RECT* rcSize);
 
 	API extern void _RA_InitDirectX();
-	API extern void _RA_OnPaint( HWND hWnd );
+	API extern void _RA_OnPaint(HWND hWnd);
 }
 
 extern const COLORREF COL_TEXT;
@@ -214,3 +216,6 @@ extern const COLORREF COL_BLACK;
 extern const COLORREF COL_POPUP;
 extern const COLORREF COL_POPUP_BG;
 extern const COLORREF COL_POPUP_SHADOW;
+
+
+#endif // !RA_ACHIEVEMENTOVERLAY_H

--- a/src/RA_AchievementPopup.cpp
+++ b/src/RA_AchievementPopup.cpp
@@ -1,7 +1,5 @@
 #include "RA_AchievementPopup.h"
 
-#include "RA_Achievement.h"
-#include "RA_Defs.h"
 #include "RA_AchievementOverlay.h"
 #include "RA_ImageFactory.h"
 

--- a/src/RA_AchievementPopup.h
+++ b/src/RA_AchievementPopup.h
@@ -1,3 +1,5 @@
+#ifndef RA_ACHIEVEMENTPOPUP_H
+#define RA_ACHIEVEMENTPOPUP_H
 #pragma once
 
 #include "RA_Defs.h"
@@ -20,17 +22,17 @@ enum PopupMessageType
 class MessagePopup
 {
 public:
-	MessagePopup( const std::string& sTitle, const std::string& sSubtitle, PopupMessageType nMsgType = PopupInfo, HBITMAP hImg = nullptr ) :
-		m_sMessageTitle( sTitle ),
-		m_sMessageSubtitle( sSubtitle ),
-		m_nMessageType( nMsgType ),
-		m_hMessageImage( hImg )
+	MessagePopup(const std::string& sTitle, const std::string& sSubtitle, PopupMessageType nMsgType = PopupInfo, HBITMAP hImg = nullptr) :
+		m_sMessageTitle(sTitle),
+		m_sMessageSubtitle(sSubtitle),
+		m_nMessageType(nMsgType),
+		m_hMessageImage(hImg)
 	{}
 public:
-	const std::string& Title() const	{ return m_sMessageTitle; }
-	const std::string& Subtitle() const	{ return m_sMessageSubtitle; }
-	PopupMessageType Type() const		{ return m_nMessageType; }
-	HBITMAP Image() const				{ return m_hMessageImage; }
+	const std::string& Title() const { return m_sMessageTitle; }
+	const std::string& Subtitle() const { return m_sMessageSubtitle; }
+	PopupMessageType Type() const { return m_nMessageType; }
+	HBITMAP Image() const { return m_hMessageImage; }
 
 private:
 	const std::string m_sMessageTitle;
@@ -46,15 +48,15 @@ public:
 public:
 	AchievementPopup();
 
-	void Update( ControllerInput input, float fDelta, bool bFullScreen, bool bPaused );
-	void Render( HDC hDC, RECT& rcDest );
+	void Update(ControllerInput input, float fDelta, bool bFullScreen, bool bPaused);
+	void Render(HDC hDC, RECT& rcDest);
 
-	void AddMessage( const MessagePopup& msg );
+	void AddMessage(const MessagePopup& msg);
 	float GetYOffsetPct() const;
 
 	//bool IsActive() const						{ return( m_vMessages.size() > 0 ); }
-	bool MessagesPresent() const				{ return( m_vMessages.size() > 0 ); }
-	const MessagePopup& ActiveMessage() const	{ return m_vMessages.front(); }
+	bool MessagesPresent() const { return(m_vMessages.size() > 0); }
+	const MessagePopup& ActiveMessage() const { return m_vMessages.front(); }
 
 	void Clear();
 	void PlayAudio();
@@ -65,3 +67,6 @@ private:
 };
 
 //extern AchievementPopup g_PopupWindow;
+
+
+#endif // !RA_ACHIEVEMENTPOPUP_H

--- a/src/RA_AchievementSet.cpp
+++ b/src/RA_AchievementSet.cpp
@@ -1,4 +1,4 @@
-#pragma once
+// #pragma once: Why is this here in a source file?
 
 #include "RA_AchievementSet.h"
 #include "RA_Core.h"
@@ -6,7 +6,6 @@
 #include "RA_Dlg_AchEditor.h"
 #include "RA_User.h"
 #include "RA_PopupWindows.h"
-#include "RA_httpthread.h"
 #include "RA_RichPresence.h"
 #include "RA_md5factory.h"
 #include "RA_GameData.h"

--- a/src/RA_AchievementSet.h
+++ b/src/RA_AchievementSet.h
@@ -1,8 +1,7 @@
+#ifndef RA_ACHIEVEMENTSET_H
+#define RA_ACHIEVEMENTSET_H
 #pragma once
 
-#include <vector>
-#include "RA_Condition.h"
-#include "RA_Defs.h"
 #include "RA_Achievement.h"
 
 
@@ -37,14 +36,14 @@ public:
 	std::string GetAchievementSetFilename(GameID nGameID);
 
 	//	Get Achievement at offset
-	Achievement& GetAchievement(size_t nIter)	{ return m_Achievements[nIter]; }
-	inline size_t NumAchievements() const		{ return m_Achievements.size(); }
+	Achievement& GetAchievement(size_t nIter) { return m_Achievements[nIter]; }
+	inline size_t NumAchievements() const { return m_Achievements.size(); }
 
 	// Get Points Total
 	inline unsigned int PointTotal()
 	{
 		unsigned int total = 0;
-		for ( Achievement ach : m_Achievements ) total += ach.Points();
+		for (Achievement ach : m_Achievements) total += ach.Points();
 		return total;
 	}
 
@@ -89,5 +88,8 @@ extern AchievementSet* g_pLocalAchievements;
 
 extern AchievementSet* g_pActiveAchievements;
 extern AchievementSetType g_nActiveAchievementSet;
-	
-extern void RASetAchievementCollection( enum AchievementSetType Type );
+
+extern void RASetAchievementCollection(enum AchievementSetType Type);
+
+
+#endif // !RA_ACHIEVEMENTSET_H

--- a/src/RA_CodeNotes.cpp
+++ b/src/RA_CodeNotes.cpp
@@ -1,12 +1,10 @@
 #include "RA_CodeNotes.h"
 
-#include <Windows.h>
 
 #include "RA_Core.h"
 #include "RA_httpthread.h"
 #include "RA_Dlg_Memory.h"
 #include "RA_User.h"
-#include "RA_Achievement.h"
 #include "RA_AchievementSet.h"
 #include "RA_GameData.h"
 

--- a/src/RA_CodeNotes.h
+++ b/src/RA_CodeNotes.h
@@ -1,3 +1,5 @@
+#ifndef RA_CODENOTES_H
+#define RA_CODENOTES_H
 #pragma once
 
 #include "RA_Defs.h"
@@ -8,41 +10,43 @@ public:
 	class CodeNoteObj
 	{
 	public:
-		CodeNoteObj( const std::string& sAuthor, std::string sNote ) : 
-		  m_sAuthor( sAuthor ), m_sNote( sNote ) {}
+		CodeNoteObj(const std::string& sAuthor, std::string sNote) :
+			m_sAuthor(sAuthor), m_sNote(sNote) {}
 
 	public:
-		const std::string& Author() const			{ return m_sAuthor; }
-		const std::string& Note() const				{ return m_sNote; }
+		const std::string& Author() const { return m_sAuthor; }
+		const std::string& Note() const { return m_sNote; }
 
-		void SetNote( const std::string& sNote )	{ m_sNote = sNote; }
+		void SetNote(const std::string& sNote) { m_sNote = sNote; }
 
 	private:
 		const std::string m_sAuthor;
 		std::string m_sNote;
 	};
-	
+
 public:
 	void Clear();
 
-	BOOL Save( const std::string& sFile );
-	size_t Load( const std::string& sFile );
+	BOOL Save(const std::string& sFile);
+	size_t Load(const std::string& sFile);
 
-	BOOL ReloadFromWeb( GameID nID );
-	static void OnCodeNotesResponse( Document& doc );
+	BOOL ReloadFromWeb(GameID nID);
+	static void OnCodeNotesResponse(Document& doc);
 
-	void Add( const ByteAddress& nAddr, const std::string& sAuthor, const std::string& sNote );
-	BOOL Remove( const ByteAddress& nAddr );
-	
-	const CodeNoteObj* FindCodeNote( const ByteAddress& nAddr ) const		
+	void Add(const ByteAddress& nAddr, const std::string& sAuthor, const std::string& sNote);
+	BOOL Remove(const ByteAddress& nAddr);
+
+	const CodeNoteObj* FindCodeNote(const ByteAddress& nAddr) const
 	{
-		std::map<ByteAddress, CodeNoteObj>::const_iterator iter = m_CodeNotes.find( nAddr );
-		return( iter != m_CodeNotes.end() ) ? &iter->second : nullptr; 
+		std::map<ByteAddress, CodeNoteObj>::const_iterator iter = m_CodeNotes.find(nAddr);
+		return(iter != m_CodeNotes.end()) ? &iter->second : nullptr;
 	}
 
-	std::map<ByteAddress, CodeNoteObj>::const_iterator FirstNote() const	{ return m_CodeNotes.begin(); }
-	std::map<ByteAddress, CodeNoteObj>::const_iterator EndOfNotes() const	{ return m_CodeNotes.end(); }
+	std::map<ByteAddress, CodeNoteObj>::const_iterator FirstNote() const { return m_CodeNotes.begin(); }
+	std::map<ByteAddress, CodeNoteObj>::const_iterator EndOfNotes() const { return m_CodeNotes.end(); }
 
 private:
 	std::map<ByteAddress, CodeNoteObj> m_CodeNotes;
 };
+
+#endif // !RA_CODENOTES_H

--- a/src/RA_Condition.h
+++ b/src/RA_Condition.h
@@ -1,4 +1,7 @@
+#ifndef RA_CONDITION_H
+#define RA_CONDITION_H
 #pragma once
+
 #include "RA_Defs.h"
 
 enum ComparisonVariableSize
@@ -52,16 +55,16 @@ class CompVariable
 {
 public:
 	CompVariable()
-	 :	m_nVal( 0 ),
-		m_nPreviousVal( 0 ),
-		m_nVarSize( ComparisonVariableSize::EightBit ),
-		m_nVarType( ComparisonVariableType::Address ),
-		m_nBankID( 0 )
+		: m_nVal(0),
+		m_nPreviousVal(0),
+		m_nVarSize(ComparisonVariableSize::EightBit),
+		m_nVarType(ComparisonVariableType::Address),
+		m_nBankID(0)
 	{
 	}
 
 public:
-	void Set( ComparisonVariableSize nSize, ComparisonVariableType nType, unsigned int nInitialValue, unsigned short nBankID )
+	void Set(ComparisonVariableSize nSize, ComparisonVariableType nType, unsigned int nInitialValue, unsigned short nBankID)
 	{
 		m_nVarSize = nSize;
 		m_nVarType = nType;
@@ -69,7 +72,7 @@ public:
 		m_nBankID = nBankID;
 	}
 
-	void SetValues( unsigned int nVal, unsigned int nPrevVal )
+	void SetValues(unsigned int nVal, unsigned int nPrevVal)
 	{
 		m_nVal = nVal;
 		m_nPreviousVal = nPrevVal;
@@ -79,7 +82,7 @@ public:
 	{
 		m_nPreviousVal = m_nVal;
 	}
-	
+
 	//void Clear()
 	//{
 	//	m_nVal = 0;
@@ -88,18 +91,18 @@ public:
 	//	m_nVarType = COMPVARTYPE_ADDRESS;
 	//}
 
-	void ParseVariable( char*& sInString );	//	Parse from string
+	void ParseVariable(char*& sInString);	//	Parse from string
 	unsigned int GetValue();				//	Returns the live value
-	
-	inline void SetSize( ComparisonVariableSize nSize )		{ m_nVarSize = nSize; }
-	inline ComparisonVariableSize Size() const				{ return m_nVarSize; }
 
-	inline void SetType( ComparisonVariableType nType )		{ m_nVarType = nType; }
-	inline ComparisonVariableType Type() const				{ return m_nVarType; }
-	
-	inline unsigned int RawValue() const					{ return m_nVal; }
-	inline unsigned int RawPreviousValue() const			{ return m_nPreviousVal; }
-	inline unsigned short BankID() const					{ return m_nBankID; }
+	inline void SetSize(ComparisonVariableSize nSize) { m_nVarSize = nSize; }
+	inline ComparisonVariableSize Size() const { return m_nVarSize; }
+
+	inline void SetType(ComparisonVariableType nType) { m_nVarType = nType; }
+	inline ComparisonVariableType Type() const { return m_nVarType; }
+
+	inline unsigned int RawValue() const { return m_nVal; }
+	inline unsigned int RawPreviousValue() const { return m_nPreviousVal; }
+	inline unsigned short BankID() const { return m_nBankID; }
 
 private:
 	ComparisonVariableSize m_nVarSize;
@@ -127,15 +130,15 @@ public:
 
 public:
 	Condition()
-	 :	m_nConditionType( Standard ),
-		m_nCompareType( Equals ),
-		m_nRequiredHits( 0 ),
-		m_nCurrentHits( 0 )
+		: m_nConditionType(Standard),
+		m_nCompareType(Equals),
+		m_nRequiredHits(0),
+		m_nCurrentHits(0)
 	{}
 
 public:
 	//	Parse a Condition from a string of characters
-	void ParseFromString( char*& sBuffer );
+	void ParseFromString(char*& sBuffer);
 
 	//	Returns a logical comparison between m_CompSource and m_CompTarget, depending on m_nComparison
 	BOOL Compare();
@@ -146,42 +149,42 @@ public:
 	//	Resets 'last known' values
 	void ResetDeltas();
 	void Clear();
-	
-	inline CompVariable& CompSource()				{ return m_nCompSource; }	//	NB both required!!
-	inline const CompVariable& CompSource() const	{ return m_nCompSource; }
-	inline CompVariable& CompTarget()				{ return m_nCompTarget; }
-	inline const CompVariable& CompTarget() const	{ return m_nCompTarget; }
 
-	void SetCompareType( ComparisonType nType )		{ m_nCompareType = nType; }
+	inline CompVariable& CompSource() { return m_nCompSource; }	//	NB both required!!
+	inline const CompVariable& CompSource() const { return m_nCompSource; }
+	inline CompVariable& CompTarget() { return m_nCompTarget; }
+	inline const CompVariable& CompTarget() const { return m_nCompTarget; }
 
-	inline ComparisonType CompareType() const		{ return m_nCompareType; }
+	void SetCompareType(ComparisonType nType) { m_nCompareType = nType; }
 
-	inline unsigned int RequiredHits() const		{ return m_nRequiredHits; }
-	inline unsigned int CurrentHits() const			{ return m_nCurrentHits; }
+	inline ComparisonType CompareType() const { return m_nCompareType; }
 
-	inline BOOL IsResetCondition() const			{ return( m_nConditionType == ResetIf ); }
-	inline BOOL IsPauseCondition() const			{ return( m_nConditionType == PauseIf ); }
-	inline BOOL IsAddCondition() const				{ return( m_nConditionType == AddSource ); }
-	inline BOOL IsSubCondition() const				{ return( m_nConditionType == SubSource ); }
-	inline BOOL IsAddHitsCondition() const			{ return( m_nConditionType == AddHits ); }
+	inline unsigned int RequiredHits() const { return m_nRequiredHits; }
+	inline unsigned int CurrentHits() const { return m_nCurrentHits; }
 
-	inline ConditionType GetConditionType() const	{ return m_nConditionType; }
-	void SetConditionType( ConditionType nNewType )	{ m_nConditionType = nNewType; }
-	
-	void SetRequiredHits( unsigned int nHits )		{ m_nRequiredHits = nHits; }
-	void IncrHits()									{ m_nCurrentHits++; }
-	BOOL IsComplete() const							{ return( m_nCurrentHits >= m_nRequiredHits ); }
+	inline BOOL IsResetCondition() const { return(m_nConditionType == ResetIf); }
+	inline BOOL IsPauseCondition() const { return(m_nConditionType == PauseIf); }
+	inline BOOL IsAddCondition() const { return(m_nConditionType == AddSource); }
+	inline BOOL IsSubCondition() const { return(m_nConditionType == SubSource); }
+	inline BOOL IsAddHitsCondition() const { return(m_nConditionType == AddHits); }
 
-	void OverrideCurrentHits( unsigned int nHits )	{ m_nCurrentHits = nHits; }
+	inline ConditionType GetConditionType() const { return m_nConditionType; }
+	void SetConditionType(ConditionType nNewType) { m_nConditionType = nNewType; }
 
-	void SetIsBasicCondition()						{ m_nConditionType = Standard; }
-	void SetIsPauseCondition()						{ m_nConditionType = PauseIf; }
-	void SetIsResetCondition()						{ m_nConditionType = ResetIf; }
-	void SetIsAddCondition()						{ m_nConditionType = AddSource; }
-	void SetIsSubCondition()						{ m_nConditionType = SubSource; }
-	void SetIsAddHitsCondition()					{ m_nConditionType = AddHits; }
+	void SetRequiredHits(unsigned int nHits) { m_nRequiredHits = nHits; }
+	void IncrHits() { m_nCurrentHits++; }
+	BOOL IsComplete() const { return(m_nCurrentHits >= m_nRequiredHits); }
 
-	void Set( const Condition& rRHS )				{ (*this) = rRHS; }
+	void OverrideCurrentHits(unsigned int nHits) { m_nCurrentHits = nHits; }
+
+	void SetIsBasicCondition() { m_nConditionType = Standard; }
+	void SetIsPauseCondition() { m_nConditionType = PauseIf; }
+	void SetIsResetCondition() { m_nConditionType = ResetIf; }
+	void SetIsAddCondition() { m_nConditionType = AddSource; }
+	void SetIsSubCondition() { m_nConditionType = SubSource; }
+	void SetIsAddHitsCondition() { m_nConditionType = AddHits; }
+
+	void Set(const Condition& rRHS) { (*this) = rRHS; }
 
 private:
 	ConditionType	m_nConditionType;
@@ -189,7 +192,7 @@ private:
 	CompVariable	m_nCompSource;
 	ComparisonType	m_nCompareType;
 	CompVariable	m_nCompTarget;
-	
+
 	unsigned int	m_nRequiredHits;
 	unsigned int	m_nCurrentHits;
 };
@@ -198,25 +201,27 @@ class ConditionSet
 {
 public:
 	//	Final param indicates 'or'
-	BOOL Test( BOOL& bDirtyConditions, BOOL& bResetRead, BOOL bMatchAny );
-	size_t Count() const		{ return m_Conditions.size(); }
+	BOOL Test(BOOL& bDirtyConditions, BOOL& bResetRead, BOOL bMatchAny);
+	size_t Count() const { return m_Conditions.size(); }
 
-	void Add( const Condition& newCond )				{ m_Conditions.push_back( newCond ); }
-	void Insert( size_t i, const Condition& newCond )	{ m_Conditions.insert( m_Conditions.begin() + i, newCond ); }
-	Condition& GetAt( size_t i )						{ return m_Conditions[i]; }
-	const Condition& GetAt( size_t i ) const			{ return m_Conditions[i]; }
-	void Clear()										{ m_Conditions.clear(); }
-	void RemoveAt( size_t i );
-	BOOL Reset( BOOL bIncludingDeltas );	//	Returns dirty
+	void Add(const Condition& newCond) { m_Conditions.push_back(newCond); }
+	void Insert(size_t i, const Condition& newCond) { m_Conditions.insert(m_Conditions.begin() + i, newCond); }
+	Condition& GetAt(size_t i) { return m_Conditions[i]; }
+	const Condition& GetAt(size_t i) const { return m_Conditions[i]; }
+	void Clear() { m_Conditions.clear(); }
+	void RemoveAt(size_t i);
+	BOOL Reset(BOOL bIncludingDeltas);	//	Returns dirty
 
 protected:
 	std::vector<Condition> m_Conditions;
 };
 
-extern ComparisonVariableSize PrefixToComparisonSize( char cPrefix );
-extern const char* ComparisonSizeToPrefix( ComparisonVariableSize nSize );
-extern const char* ComparisonTypeToStr( ComparisonType nType );
+extern ComparisonVariableSize PrefixToComparisonSize(char cPrefix);
+extern const char* ComparisonSizeToPrefix(ComparisonVariableSize nSize);
+extern const char* ComparisonTypeToStr(ComparisonType nType);
 
 //extern BOOL CompareConditionValues( unsigned int nLHS, const enum CompType nCmpType, unsigned int nRHS );
-extern ComparisonType ReadOperator( char*& pBufferInOut );
-extern unsigned int ReadHits( char*& pBufferInOut );
+extern ComparisonType ReadOperator(char*& pBufferInOut);
+extern unsigned int ReadHits(char*& pBufferInOut);
+
+#endif // !RA_CONDITION_H

--- a/src/RA_Core.cpp
+++ b/src/RA_Core.cpp
@@ -1,22 +1,13 @@
 #include "RA_Core.h"
 
-#include "RA_Achievement.h"
 #include "RA_AchievementSet.h"
 #include "RA_AchievementOverlay.h"
 #include "RA_BuildVer.h"
-#include "RA_CodeNotes.h"
-#include "RA_Defs.h"
 #include "RA_GameData.h"
-#include "RA_httpthread.h"
 #include "RA_ImageFactory.h"
-#include "RA_Interface.h"
-#include "RA_Leaderboard.h"
 #include "RA_md5factory.h"
-#include "RA_MemManager.h"
 #include "RA_PopupWindows.h"
-#include "RA_Resource.h"
 #include "RA_RichPresence.h"
-#include "RA_User.h"
 
 #include "RA_Dlg_AchEditor.h"
 #include "RA_Dlg_Achievement.h"
@@ -29,10 +20,9 @@
 #include "RA_Dlg_RomChecksum.h"
 #include "RA_Dlg_MemBookmark.h"
 
-#include <locale>
+// TODO: Remove this later after PR #23 is accepted
 #include <codecvt>
-#include <direct.h>
-#include <io.h>		//	_access()
+
 
 
 std::string g_sKnownRAVersion;

--- a/src/RA_Core.h
+++ b/src/RA_Core.h
@@ -1,8 +1,10 @@
+#ifndef RA_CORE_H
+#define RA_CORE_H
 #pragma once
 
 #include "RA_Defs.h"
 #include "RA_Interface.h"
-#include <stdio.h>
+
 
 #if defined RA_EXPORTS
 #define API __declspec(dllexport)
@@ -14,86 +16,86 @@
 extern "C" {
 #endif
 
-//	Fetch the version number of this integration version.
-API const char* CCONV _RA_IntegrationVersion();
+	//	Fetch the version number of this integration version.
+	API const char* CCONV _RA_IntegrationVersion();
 
-//	Initialize all data related to RA Engine. Call as early as possible.
-API int CCONV _RA_InitI( HWND hMainHWND, /*enum EmulatorID*/int nConsoleID, const char* sClientVersion );
+	//	Initialize all data related to RA Engine. Call as early as possible.
+	API int CCONV _RA_InitI(HWND hMainHWND, /*enum EmulatorID*/int nConsoleID, const char* sClientVersion);
 
-//	Call for a tidy exit at end of app.
-API int CCONV _RA_Shutdown();
+	//	Call for a tidy exit at end of app.
+	API int CCONV _RA_Shutdown();
 
-//	Allocates and configures a popup menu, to be called, embedded and managed by the app.
-API HMENU CCONV _RA_CreatePopupMenu();
+	//	Allocates and configures a popup menu, to be called, embedded and managed by the app.
+	API HMENU CCONV _RA_CreatePopupMenu();
 
-//	Check all achievement sets for changes, and displays a dlg box to warn lost changes.
-API bool CCONV _RA_ConfirmLoadNewRom( bool bQuittingApp );
+	//	Check all achievement sets for changes, and displays a dlg box to warn lost changes.
+	API bool CCONV _RA_ConfirmLoadNewRom(bool bQuittingApp);
 
-//	On or immediately after a new ROM is loaded, including if the ROM is reset.
-API int CCONV _RA_OnLoadNewRom( const BYTE* pROM, unsigned int nROMSize );
+	//	On or immediately after a new ROM is loaded, including if the ROM is reset.
+	API int CCONV _RA_OnLoadNewRom(const BYTE* pROM, unsigned int nROMSize);
 
-//	On or immediately after a new ROM is loaded, for each memory bank found
-//	NB:
-//pReader is typedef unsigned char (_RAMByteReadFn)( size_t nOffset );
-//pWriter is typedef void (_RAMByteWriteFn)( unsigned int nOffs, unsigned int nVal );
-API void CCONV _RA_InstallMemoryBank( int nBankID, void* pReader, void* pWriter, int nBankSize );
+	//	On or immediately after a new ROM is loaded, for each memory bank found
+	//	NB:
+	//pReader is typedef unsigned char (_RAMByteReadFn)( size_t nOffset );
+	//pWriter is typedef void (_RAMByteWriteFn)( unsigned int nOffs, unsigned int nVal );
+	API void CCONV _RA_InstallMemoryBank(int nBankID, void* pReader, void* pWriter, int nBankSize);
 
-//	Call before installing any memory banks
-API void CCONV _RA_ClearMemoryBanks();
+	//	Call before installing any memory banks
+	API void CCONV _RA_ClearMemoryBanks();
 
-//	Immediately after loading a new state.
-API void CCONV _RA_OnLoadState( const char* sFileName );
+	//	Immediately after loading a new state.
+	API void CCONV _RA_OnLoadState(const char* sFileName);
 
-//	Immediately after saving a new state.
-API void CCONV _RA_OnSaveState( const char* sFileName );
-
-
-//	Perform one test for all achievements in the current set. Call this once per frame/cycle.
-API void CCONV _RA_DoAchievementsFrame();
+	//	Immediately after saving a new state.
+	API void CCONV _RA_OnSaveState(const char* sFileName);
 
 
-//	Use in special cases where the emulator contains more than one console ID.
-API void CCONV _RA_SetConsoleID( unsigned int nConsoleID );
+	//	Perform one test for all achievements in the current set. Call this once per frame/cycle.
+	API void CCONV _RA_DoAchievementsFrame();
 
-//	Display a dialog helping the user get the latest RA client version
-API BOOL CCONV _RA_OfferNewRAUpdate( const char* sNewVer );
 
-//	Deal with any HTTP results that come along. Call per-cycle from main thread.
-API int CCONV _RA_HandleHTTPResults();
+	//	Use in special cases where the emulator contains more than one console ID.
+	API void CCONV _RA_SetConsoleID(unsigned int nConsoleID);
 
-//	Execute a blocking check to see if this client is out of date.
-API void CCONV _RA_CheckForUpdate();
+	//	Display a dialog helping the user get the latest RA client version
+	API BOOL CCONV _RA_OfferNewRAUpdate(const char* sNewVer);
 
-//	Update the title of the app
-API void CCONV _RA_UpdateAppTitle( const char* sMessage = nullptr );
+	//	Deal with any HTTP results that come along. Call per-cycle from main thread.
+	API int CCONV _RA_HandleHTTPResults();
 
-//	Load preferences from ra_prefs.cfg
-API void CCONV _RA_LoadPreferences();
+	//	Execute a blocking check to see if this client is out of date.
+	API void CCONV _RA_CheckForUpdate();
 
-//	Save preferences to ra_prefs.cfg
-API void CCONV _RA_SavePreferences();
+	//	Update the title of the app
+	API void CCONV _RA_UpdateAppTitle(const char* sMessage = nullptr);
 
-//	Display or unhide an RA dialog.
-API void CCONV _RA_InvokeDialog( LPARAM nID );
+	//	Load preferences from ra_prefs.cfg
+	API void CCONV _RA_LoadPreferences();
 
-//	Call this when the pause state changes, to update RA with the new state.
-API void CCONV _RA_SetPaused( bool bIsPaused );
+	//	Save preferences to ra_prefs.cfg
+	API void CCONV _RA_SavePreferences();
 
-//	Returns the currently active user
-API const char* CCONV _RA_Username();
+	//	Display or unhide an RA dialog.
+	API void CCONV _RA_InvokeDialog(LPARAM nID);
 
-//	Attempt to login, or present login dialog.
-API void CCONV _RA_AttemptLogin( bool bBlocking );
+	//	Call this when the pause state changes, to update RA with the new state.
+	API void CCONV _RA_SetPaused(bool bIsPaused);
 
-//	Return whether or not the hardcore mode is active.
-API int CCONV _RA_HardcoreModeIsActive();
+	//	Returns the currently active user
+	API const char* CCONV _RA_Username();
 
-//	Return whether a HTTPGetRequest already exists
-API int CCONV _RA_HTTPGetRequestExists( const char* sPageName );
+	//	Attempt to login, or present login dialog.
+	API void CCONV _RA_AttemptLogin(bool bBlocking);
 
-//	Install user-side functions that can be called from the DLL
-API void CCONV _RA_InstallSharedFunctions(bool(*fpIsActive)(void), void(*fpCauseUnpause)(void), void(*fpRebuildMenu)(void), void(*fpEstimateTitle)(char*), void(*fpResetEmulation)(void), void(*fpLoadROM)(const char*));
-API void CCONV _RA_InstallSharedFunctionsExt( bool(*fpIsActive)(void), void(*fpCauseUnpause)(void), void(*fpCausePause)(void), void(*fpRebuildMenu)(void), void(*fpEstimateTitle)(char*), void(*fpResetEmulation)(void), void(*fpLoadROM)(const char*) );
+	//	Return whether or not the hardcore mode is active.
+	API int CCONV _RA_HardcoreModeIsActive();
+
+	//	Return whether a HTTPGetRequest already exists
+	API int CCONV _RA_HTTPGetRequestExists(const char* sPageName);
+
+	//	Install user-side functions that can be called from the DLL
+	API void CCONV _RA_InstallSharedFunctions(bool(*fpIsActive)(void), void(*fpCauseUnpause)(void), void(*fpRebuildMenu)(void), void(*fpEstimateTitle)(char*), void(*fpResetEmulation)(void), void(*fpLoadROM)(const char*));
+	API void CCONV _RA_InstallSharedFunctionsExt(bool(*fpIsActive)(void), void(*fpCauseUnpause)(void), void(*fpCausePause)(void), void(*fpRebuildMenu)(void), void(*fpEstimateTitle)(char*), void(*fpResetEmulation)(void), void(*fpLoadROM)(const char*));
 
 #ifdef __cplusplus
 }
@@ -123,28 +125,28 @@ extern bool g_bLBDisplayScoreboard;
 extern unsigned int g_nNumHTTPThreads;
 
 //	Read a file to a malloc'd buffer. Returns NULL on error. Owner MUST free() buffer if not NULL.
-extern char* _MallocAndBulkReadFileToBuffer( const char* sFilename, long& nFileSizeOut );
+extern char* _MallocAndBulkReadFileToBuffer(const char* sFilename, long& nFileSizeOut);
 
 //	Read file until reaching the end of the file, or the specified char.
-extern BOOL _ReadTil( const char nChar, char buffer[], unsigned int nSize, DWORD* pCharsRead, FILE* pFile );
+extern BOOL _ReadTil(const char nChar, char buffer[], unsigned int nSize, DWORD* pCharsRead, FILE* pFile);
 
 //	Read a string til the end of the string, or nChar. bTerminate==TRUE replaces that char with \0.
-extern char* _ReadStringTil( char nChar, char*& pOffsetInOut, BOOL bTerminate );
+extern char* _ReadStringTil(char nChar, char*& pOffsetInOut, BOOL bTerminate);
 
 //	Write out the buffer to a file
-extern void _WriteBufferToFile( const std::string& sFileName, const DataStream& rawData );
-extern void _WriteBufferToFile( const std::string& sFileName, const Document& doc );
-extern void _WriteBufferToFile( const std::string& sFileName, const std::string& sString );
-extern void _WriteBufferToFile( const char* sFile, const BYTE* sBuffer, int nBytes );
+extern void _WriteBufferToFile(const std::string& sFileName, const DataStream& rawData);
+extern void _WriteBufferToFile(const std::string& sFileName, const Document& doc);
+extern void _WriteBufferToFile(const std::string& sFileName, const std::string& sString);
+extern void _WriteBufferToFile(const char* sFile, const BYTE* sBuffer, int nBytes);
 
 //	Fetch various interim txt/data files
 extern void _FetchGameHashLibraryFromWeb();
 extern void _FetchGameTitlesFromWeb();
 extern void _FetchMyProgressFromWeb();
 
-extern BOOL _FileExists( const std::string& sFileName );
+extern BOOL _FileExists(const std::string& sFileName);
 
-extern std::string _TimeStampToString( time_t nTime );
+extern std::string _TimeStampToString(time_t nTime);
 
 extern std::string GetFolderFromDialog();
 
@@ -155,3 +157,6 @@ BOOL CanCausePause();
 void RestoreWindowPosition(HWND hDlg, const char* sDlgKey, bool bToRight, bool bToBottom);
 void RememberWindowPosition(HWND hDlg, const char* sDlgKey);
 void RememberWindowSize(HWND hDlg, const char* sDlgKey);
+
+
+#endif // !RA_CORE_H

--- a/src/RA_Defs.cpp
+++ b/src/RA_Defs.cpp
@@ -1,8 +1,6 @@
 #include "RA_Defs.h"
 
-#include <stdio.h>
-#include <Windows.h>
-#include <locale>
+// TODO: remove these later, it's needed here for now
 #include <codecvt>
 
 GetParseErrorFunc GetJSONParseErrorStr = GetParseError_En;
@@ -13,6 +11,9 @@ char* DataStreamAsString(DataStream& stream)
 	return reinterpret_cast<char*>(stream.data());
 }
 
+
+// TODO: Remove "_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING" from the project defines
+// once PR #23 has been accepted
 std::string Narrow(const wchar_t* wstr)
 {
 	static std::wstring_convert< std::codecvt_utf8_utf16< wchar_t >, wchar_t > converter;

--- a/src/RA_Dlg_AchEditor.cpp
+++ b/src/RA_Dlg_AchEditor.cpp
@@ -1,15 +1,10 @@
 #include "RA_Dlg_AchEditor.h"
 
-#include "RA_Achievement.h"
 #include "RA_AchievementSet.h"
-#include "RA_Resource.h"
-#include "RA_Defs.h"
 #include "RA_Core.h"
 #include "RA_Dlg_Achievement.h"
 #include "RA_Dlg_Memory.h"
-#include "RA_httpthread.h"
 #include "RA_ImageFactory.h"
-#include "RA_MemManager.h"
 #include "RA_User.h"
 
 #pragma comment(lib, "comctl32.lib")

--- a/src/RA_Dlg_AchEditor.h
+++ b/src/RA_Dlg_AchEditor.h
@@ -1,27 +1,26 @@
+#ifndef RA_DLG_ACHEDITOR_H
+#define RA_DLG_ACHEDITOR_H
 #pragma once
-
-#include <wtypes.h>
-#include <vector>
 
 #include "RA_httpthread.h"
 #include "RA_Achievement.h"
 
 namespace
 {
-	const size_t MAX_CONDITIONS = 200;
-	const size_t MEM_STRING_TEXT_LEN = 80;
+const size_t MAX_CONDITIONS = 200;
+const size_t MEM_STRING_TEXT_LEN = 80;
 }
 
 class BadgeNames
 {
 public:
 	BadgeNames()
-	 :	m_hDestComboBox( nullptr ) {}
-	void InstallAchEditorCombo( HWND hCombo )	{ m_hDestComboBox = hCombo; }
-	
+		: m_hDestComboBox(nullptr) {}
+	void InstallAchEditorCombo(HWND hCombo) { m_hDestComboBox = hCombo; }
+
 	void FetchNewBadgeNamesThreaded();
-	void AddNewBadgeName( const char* pStr, bool bAndSelect );
-	void OnNewBadgeNames( const Document& data );
+	void AddNewBadgeName(const char* pStr, bool bAndSelect);
+	void OnNewBadgeNames(const Document& data);
 
 private:
 	HWND m_hDestComboBox;
@@ -39,38 +38,38 @@ public:
 	INT_PTR AchievementEditorProc(HWND, UINT, WPARAM, LPARAM);
 public:
 	void OnLoad_NewRom();
-	void LoadAchievement( Achievement* pCheevo, BOOL bAttemptKeepScrollbar );
+	void LoadAchievement(Achievement* pCheevo, BOOL bAttemptKeepScrollbar);
 
-	inline void SetICEControl( HWND hIce )							{ m_hICEControl = hIce; }
-	inline char* LbxDataAt( unsigned int nRow, unsigned int nCol )	{ return m_lbxData[nRow][nCol]; }
+	inline void SetICEControl(HWND hIce) { m_hICEControl = hIce; }
+	inline char* LbxDataAt(unsigned int nRow, unsigned int nCol) { return m_lbxData[nRow][nCol]; }
 
-	HWND GetICEControl() const										{ return m_hICEControl; }
+	HWND GetICEControl() const { return m_hICEControl; }
 
-	void InstallHWND( HWND hWnd )									{ m_hAchievementEditorDlg = hWnd; }
-	HWND GetHWND() const											{ return m_hAchievementEditorDlg; }
+	void InstallHWND(HWND hWnd) { m_hAchievementEditorDlg = hWnd; }
+	HWND GetHWND() const { return m_hAchievementEditorDlg; }
 	BOOL IsActive() const;
 
-	Achievement* ActiveAchievement() const							{ return m_pSelectedAchievement; }
-	BOOL IsPopulatingAchievementEditorData() const					{ return m_bPopulatingAchievementEditorData; }
-	void SetIgnoreEdits( BOOL bIgnore )								{ m_bPopulatingAchievementEditorData = bIgnore; }
+	Achievement* ActiveAchievement() const { return m_pSelectedAchievement; }
+	BOOL IsPopulatingAchievementEditorData() const { return m_bPopulatingAchievementEditorData; }
+	void SetIgnoreEdits(BOOL bIgnore) { m_bPopulatingAchievementEditorData = bIgnore; }
 
-	void UpdateBadge( const std::string& sNewName );							//	Call to set/update data
-	void UpdateSelectedBadgeImage( const std::string& sBackupBadgeToUse = "" );	//	Call to just update the badge image/bitmap
+	void UpdateBadge(const std::string& sNewName);							//	Call to set/update data
+	void UpdateSelectedBadgeImage(const std::string& sBackupBadgeToUse = "");	//	Call to just update the badge image/bitmap
 
-	BadgeNames& GetBadgeNames()										{ return m_BadgeNames; }
+	BadgeNames& GetBadgeNames() { return m_BadgeNames; }
 
 	size_t GetSelectedConditionGroup() const;
-	void SetSelectedConditionGroup( size_t nGrp ) const;
+	void SetSelectedConditionGroup(size_t nGrp) const;
 
 	ConditionSet m_ConditionClipboard;
 
 private:
-	void RepopulateGroupList( Achievement* pCheevo );
-	void PopulateConditions( Achievement* pCheevo );
-	void SetupColumns( HWND hList );
+	void RepopulateGroupList(Achievement* pCheevo);
+	void PopulateConditions(Achievement* pCheevo);
+	void SetupColumns(HWND hList);
 
-	const int AddCondition( HWND hList, const Condition& Cond );
-	void UpdateCondition( HWND hList, LV_ITEM& item, const Condition& Cond );
+	const int AddCondition(HWND hList, const Condition& Cond);
+	void UpdateCondition(HWND hList, LV_ITEM& item, const Condition& Cond);
 
 private:
 	static const int m_nNumCols = 10;//;sizeof( g_sColTitles ) / sizeof( g_sColTitles[0] );
@@ -78,8 +77,8 @@ private:
 	HWND m_hAchievementEditorDlg;
 	HWND m_hICEControl;
 
-	char m_lbxData[ MAX_CONDITIONS ][ m_nNumCols ][ MEM_STRING_TEXT_LEN ];
-	TCHAR m_lbxGroupNames[ MAX_CONDITIONS ][ MEM_STRING_TEXT_LEN ];
+	char m_lbxData[MAX_CONDITIONS][m_nNumCols][MEM_STRING_TEXT_LEN];
+	TCHAR m_lbxGroupNames[MAX_CONDITIONS][MEM_STRING_TEXT_LEN];
 	int m_nNumOccupiedRows;
 
 	Achievement* m_pSelectedAchievement;
@@ -92,3 +91,6 @@ private:
 void GenerateResizes(HWND hDlg);
 
 extern Dlg_AchievementEditor g_AchievementEditorDialog;
+
+
+#endif // !RA_DLG_ACHEDITOR_H

--- a/src/RA_Dlg_Achievement.cpp
+++ b/src/RA_Dlg_Achievement.cpp
@@ -1,15 +1,11 @@
 #include "RA_Dlg_Achievement.h"
 
-#include "RA_Achievement.h"
 #include "RA_AchievementSet.h"
 #include "RA_Core.h"
-#include "RA_Defs.h"
 #include "RA_Dlg_AchEditor.h"
 #include "RA_Dlg_GameTitle.h"
 #include "RA_GameData.h"
-#include "RA_httpthread.h"
 #include "RA_md5factory.h"
-#include "RA_Resource.h"
 #include "RA_User.h"
 #include "RA_GameData.h"
 

--- a/src/RA_Dlg_Achievement.h
+++ b/src/RA_Dlg_Achievement.h
@@ -1,9 +1,10 @@
+#ifndef RA_DLG_ACHIEVEMENT_H
+#define RA_DLG_ACHIEVEMENT_H
 #pragma once
 
 #include "RA_Achievement.h"
 
-#include <wtypes.h>
-#include <assert.h>
+
 
 const int MAX_TEXT_ITEM_SIZE = 80;
 
@@ -19,7 +20,7 @@ public:
 	{
 		ID,
 		Title,
-    Points,
+		Points,
 		Author,
 		Achieved,
 		Active=Achieved,
@@ -38,26 +39,26 @@ public:
 
 public:
 	int GetSelectedAchievementIndex();
-	void OnLoad_NewRom( GameID nGameID );
-	void OnGet_Achievement( const Achievement& ach );
-	void ReloadLBXData( int nOffset );
-	void OnEditData( size_t nItem, Column nColumn, const std::string& sNewData );
-	void OnEditAchievement( const Achievement& ach );
-	void OnClickAchievementSet( AchievementSetType nAchievementSet );
+	void OnLoad_NewRom(GameID nGameID);
+	void OnGet_Achievement(const Achievement& ach);
+	void ReloadLBXData(int nOffset);
+	void OnEditData(size_t nItem, Column nColumn, const std::string& sNewData);
+	void OnEditAchievement(const Achievement& ach);
+	void OnClickAchievementSet(AchievementSetType nAchievementSet);
 
-	inline std::string& LbxDataAt( size_t nRow, Column nCol )	{ return( m_lbxData[ nRow ] )[ nCol ]; }
+	inline std::string& LbxDataAt(size_t nRow, Column nCol) { return(m_lbxData[nRow])[nCol]; }
 
-	inline HWND GetHWND() const		{ return m_hAchievementsDlg; }
-	void InstallHWND( HWND hWnd )	{ m_hAchievementsDlg = hWnd; }
+	inline HWND GetHWND() const { return m_hAchievementsDlg; }
+	void InstallHWND(HWND hWnd) { m_hAchievementsDlg = hWnd; }
 
 private:
-	void SetupColumns( HWND hList );
-	void LoadAchievements( HWND hList );
+	void SetupColumns(HWND hList);
+	void LoadAchievements(HWND hList);
 
-	void RemoveAchievement( HWND hList, int nIter );
-	size_t AddAchievement( HWND hList, const Achievement& Ach );
+	void RemoveAchievement(HWND hList, int nIter);
+	size_t AddAchievement(HWND hList, const Achievement& Ach);
 
-	INT_PTR Dlg_Achievements::CommitAchievements( HWND hDlg );
+	INT_PTR Dlg_Achievements::CommitAchievements(HWND hDlg);
 
 	void UpdateSelectedAchievementButtons(const Achievement* Cheevo);
 
@@ -68,3 +69,6 @@ private:
 };
 
 extern Dlg_Achievements g_AchievementsDialog;
+
+
+#endif // !RA_DLG_ACHIEVEMENT_H

--- a/src/RA_Dlg_AchievementsReporter.cpp
+++ b/src/RA_Dlg_AchievementsReporter.cpp
@@ -1,12 +1,9 @@
 #include "RA_Dlg_AchievementsReporter.h"
 
-#include "RA_Achievement.h"
 #include "RA_AchievementSet.h"
 #include "RA_Core.h"
-#include "RA_Defs.h"
 #include "RA_GameData.h"
 #include "RA_httpthread.h"
-#include "RA_Resource.h"
 #include "RA_User.h"
 
 

--- a/src/RA_Dlg_AchievementsReporter.h
+++ b/src/RA_Dlg_AchievementsReporter.h
@@ -1,4 +1,7 @@
+#ifndef RA_DLG_ACHIEVEMENTSREPORTER_H
+#define RA_DLG_ACHIEVEMENTSREPORTER_H
 #pragma once
+
 #include "RA_Defs.h"
 
 class Achievement;
@@ -23,16 +26,16 @@ public:
 	};
 
 public:
-	static void DoModalDialog( HINSTANCE hInst, HWND hParent );
-	static INT_PTR CALLBACK AchievementsReporterProc( HWND, UINT, WPARAM, LPARAM );
+	static void DoModalDialog(HINSTANCE hInst, HWND hParent);
+	static INT_PTR CALLBACK AchievementsReporterProc(HWND, UINT, WPARAM, LPARAM);
 
 public:
-	static void SetupColumns( HWND hList );
-	static int AddAchievementToListBox( HWND hList, const Achievement* pAch );
+	static void SetupColumns(HWND hList);
+	static int AddAchievementToListBox(HWND hList, const Achievement* pAch);
 
 public:
 	static int ms_nNumOccupiedRows;
-	static char ms_lbxData[ MAX_ACHIEVEMENTS ][ NumReporterColumns ][ MAX_TEXT_LEN ];
+	static char ms_lbxData[MAX_ACHIEVEMENTS][NumReporterColumns][MAX_TEXT_LEN];
 };
 
 extern Dlg_AchievementsReporter g_AchievementsReporterDialog;
@@ -40,3 +43,6 @@ extern Dlg_AchievementsReporter g_AchievementsReporterDialog;
 
 
 
+
+
+#endif // !RA_DLG_ACHIEVEMENTSREPORTER_H

--- a/src/RA_Dlg_GameLibrary.cpp
+++ b/src/RA_Dlg_GameLibrary.cpp
@@ -1,21 +1,6 @@
 #include "RA_Dlg_GameLibrary.h"
 
-#include <windowsx.h>
-#include <stdio.h>
-#include <commctrl.h>
-#include <string>
-#include <sstream>
-#include <mutex>
-#include <vector>
-#include <queue>
-#include <deque>
-#include <stack>
-#include <thread>
-#include <shlobj.h>
-
-#include "RA_Defs.h"
 #include "RA_Core.h"
-#include "RA_Resource.h"
 #include "RA_User.h"
 #include "RA_Achievement.h"
 #include "RA_httpthread.h"

--- a/src/RA_Dlg_GameLibrary.h
+++ b/src/RA_Dlg_GameLibrary.h
@@ -1,22 +1,19 @@
+#ifndef RA_DLG_GAMELIBRARY_H
+#define RA_DLG_GAMELIBRARY_H
 #pragma once
 
-#include <wtypes.h>
-#include <vector>
-#include <deque>
-#include <map>
-//#include <string>
 #include "RA_Defs.h"
 
 class GameEntry
 {
 public:
-	GameEntry( const std::string& sTitle, const std::string& sFile, unsigned int nGameID ) :
-		m_sTitle( sTitle ), m_sFilename( sFile ), m_nGameID( nGameID ) {}
+	GameEntry(const std::string& sTitle, const std::string& sFile, unsigned int nGameID) :
+		m_sTitle(sTitle), m_sFilename(sFile), m_nGameID(nGameID) {}
 
-	const std::string& Title() const	{ return m_sTitle; }
-	const std::string& Filename() const	{ return m_sFilename; }
-	unsigned int GameID() const			{ return m_nGameID; }
-	
+	const std::string& Title() const { return m_sTitle; }
+	const std::string& Filename() const { return m_sFilename; }
+	unsigned int GameID() const { return m_nGameID; }
+
 	const std::string m_sTitle;
 	const std::string m_sFilename;
 	const unsigned int m_nGameID;
@@ -30,25 +27,25 @@ public:
 
 public:
 	//void DoModalDialog( HINSTANCE hInst, HWND hParent );
-	static INT_PTR CALLBACK s_GameLibraryProc( HWND, UINT, WPARAM, LPARAM );
-	INT_PTR CALLBACK GameLibraryProc( HWND, UINT, WPARAM, LPARAM );
+	static INT_PTR CALLBACK s_GameLibraryProc(HWND, UINT, WPARAM, LPARAM);
+	INT_PTR CALLBACK GameLibraryProc(HWND, UINT, WPARAM, LPARAM);
 
 public:
-	void InstallHWND( HWND hWnd )		{ m_hDialogBox = hWnd; }
-	HWND GetHWND() const				{ return m_hDialogBox; }
+	void InstallHWND(HWND hWnd) { m_hDialogBox = hWnd; }
+	HWND GetHWND() const { return m_hDialogBox; }
 
-	void AddTitle( const std::string& sTitle, const std::string& sFilename, unsigned int nGameID );
+	void AddTitle(const std::string& sTitle, const std::string& sFilename, unsigned int nGameID);
 	void ClearTitles();
-	
+
 	void LoadAll();
 	void SaveAll();
 
 	void KillThread();
-	
+
 private:
-	void SetupColumns( HWND hList );
+	void SetupColumns(HWND hList);
 	void ReloadGameListData();
-	void ScanAndAddRomsRecursive( const std::string& sBaseDir );
+	void ScanAndAddRomsRecursive(const std::string& sBaseDir);
 	BOOL LaunchSelected();
 	void RefreshList();
 
@@ -61,7 +58,7 @@ private:
 	static void ThreadedScanProc();
 	static bool ThreadProcessingAllowed;
 	static bool ThreadProcessingActive;
-	
+
 private:
 	HWND m_hDialogBox;
 
@@ -71,3 +68,6 @@ private:
 	std::vector<GameEntry> m_vGameEntries;
 };
 extern Dlg_GameLibrary g_GameLibrary;
+
+
+#endif // !RA_DLG_GAMELIBRARY_H

--- a/src/RA_Dlg_GameTitle.cpp
+++ b/src/RA_Dlg_GameTitle.cpp
@@ -1,14 +1,8 @@
 #include "RA_Dlg_GameTitle.h"
 
-//#include <windowsx.h>
-//#include <stdio.h>
-//#include <sstream>
 
-#include "RA_Defs.h"
 #include "RA_Core.h"
-#include "RA_Resource.h"
 #include "RA_User.h"
-#include "RA_Achievement.h"
 #include "RA_AchievementSet.h"
 #include "RA_httpthread.h"
 #include "RA_GameData.h"

--- a/src/RA_Dlg_GameTitle.h
+++ b/src/RA_Dlg_GameTitle.h
@@ -1,17 +1,16 @@
+#ifndef RA_DLG_GAMETITLE_H
+#define RA_DLG_GAMETITLE_H
 #pragma once
-
-#include <wtypes.h>
-#include <map>
 
 #include "RA_Defs.h"
 
 class Dlg_GameTitle
 {
 public:
-	std::string CleanRomName( const std::string& sTryName );
-	static void DoModalDialog( HINSTANCE hInst, HWND hParent, std::string& sMD5InOut, std::string& sEstimatedGameTitleInOut, GameID& nGameIDOut );
-	
-	INT_PTR GameTitleProc( HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam );
+	std::string CleanRomName(const std::string& sTryName);
+	static void DoModalDialog(HINSTANCE hInst, HWND hParent, std::string& sMD5InOut, std::string& sEstimatedGameTitleInOut, GameID& nGameIDOut);
+
+	INT_PTR GameTitleProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
 
 private:
 	GameID m_nReturnedGameID;
@@ -22,3 +21,6 @@ private:
 };
 
 extern Dlg_GameTitle g_GameTitleDialog;
+
+
+#endif // !RA_DLG_GAMETITLE_H

--- a/src/RA_Dlg_Login.cpp
+++ b/src/RA_Dlg_Login.cpp
@@ -1,9 +1,5 @@
 #include "RA_Dlg_Login.h"
 
-#include <stdio.h>
-#include <string>
-
-#include "RA_Resource.h"
 #include "RA_User.h"
 #include "RA_httpthread.h"
 #include "RA_PopupWindows.h"

--- a/src/RA_Dlg_Login.h
+++ b/src/RA_Dlg_Login.h
@@ -1,6 +1,7 @@
+#ifndef RA_DLG_LOGIN_H
+#define RA_DLG_LOGIN_H
 #pragma once
 
-#include <wtypes.h>
 
 class RA_Dlg_Login
 {
@@ -8,5 +9,8 @@ public:
 	static BOOL DoModalLogin();
 
 public:
-	static INT_PTR CALLBACK RA_Dlg_LoginProc( HWND, UINT, WPARAM, LPARAM );
+	static INT_PTR CALLBACK RA_Dlg_LoginProc(HWND, UINT, WPARAM, LPARAM);
 };
+
+
+#endif // !RA_DLG_LOGIN_H

--- a/src/RA_Dlg_MemBookmark.cpp
+++ b/src/RA_Dlg_MemBookmark.cpp
@@ -1,12 +1,10 @@
 #include "RA_Dlg_MemBookmark.h"
 
 #include "RA_Core.h"
-#include "RA_Resource.h"
 #include "RA_GameData.h"
 #include "RA_Dlg_Memory.h"
-#include "RA_MemManager.h"
 
-#include <strsafe.h>
+
 
 Dlg_MemBookmark g_MemBookmarkDialog;
 std::vector<ResizeContent> vDlgMemBookmarkResize;

--- a/src/RA_Dlg_MemBookmark.h
+++ b/src/RA_Dlg_MemBookmark.h
@@ -1,33 +1,32 @@
+#ifndef RA_DLG_MEMBOOKMARK_H
+#define RA_DLG_MEMBOOKMARK_H
 #pragma once
-
-#include <wtypes.h>
-#include <vector>
 
 #include "RA_Defs.h"
 
 class MemBookmark
 {
 public:
-	void SetDescription( const std::wstring& string )		{ m_sDescription = string; }
-	void SetAddress( unsigned int nVal )					{ m_nAddress = nVal; }
-	void SetType( unsigned int nVal )						{ m_nType = nVal; }
-	void SetValue( unsigned int nVal )						{ m_sValue = nVal; }
-	void SetPrevious( unsigned int nVal )					{ m_sPrevious = nVal; }
-	void IncreaseCount()									{ m_nCount++; }
-	void ResetCount()										{ m_nCount = 0; }
+	void SetDescription(const std::wstring& string) { m_sDescription = string; }
+	void SetAddress(unsigned int nVal) { m_nAddress = nVal; }
+	void SetType(unsigned int nVal) { m_nType = nVal; }
+	void SetValue(unsigned int nVal) { m_sValue = nVal; }
+	void SetPrevious(unsigned int nVal) { m_sPrevious = nVal; }
+	void IncreaseCount() { m_nCount++; }
+	void ResetCount() { m_nCount = 0; }
 
-	void SetFrozen( bool b )								{ m_bFrozen = b; }
-	void SetDecimal( bool b )								{ m_bDecimal = b; }
+	void SetFrozen(bool b) { m_bFrozen = b; }
+	void SetDecimal(bool b) { m_bDecimal = b; }
 
-	inline const std::wstring& Description() const			{ return m_sDescription; }
-	unsigned int Address() const							{ return m_nAddress; }
-	unsigned int Type() const								{ return m_nType; }
-	unsigned int Value() const								{ return m_sValue; }
-	unsigned int Previous() const							{ return m_sPrevious; }
-	unsigned int Count() const								{ return m_nCount; }
+	inline const std::wstring& Description() const { return m_sDescription; }
+	unsigned int Address() const { return m_nAddress; }
+	unsigned int Type() const { return m_nType; }
+	unsigned int Value() const { return m_sValue; }
+	unsigned int Previous() const { return m_sPrevious; }
+	unsigned int Count() const { return m_nCount; }
 
-	bool Frozen() const										{ return m_bFrozen; }
-	bool Decimal() const									{ return m_bDecimal; }
+	bool Frozen() const { return m_bFrozen; }
+	bool Decimal() const { return m_bDecimal; }
 
 private:
 	std::wstring m_sDescription;
@@ -46,17 +45,17 @@ public:
 	//Dlg_MemBookmark();
 	//~Dlg_MemBookmark();
 
-	static INT_PTR CALLBACK s_MemBookmarkDialogProc( HWND, UINT, WPARAM, LPARAM );
-	INT_PTR MemBookmarkDialogProc( HWND, UINT, WPARAM, LPARAM );
+	static INT_PTR CALLBACK s_MemBookmarkDialogProc(HWND, UINT, WPARAM, LPARAM);
+	INT_PTR MemBookmarkDialogProc(HWND, UINT, WPARAM, LPARAM);
 
-	void InstallHWND( HWND hWnd )						{ m_hMemBookmarkDialog = hWnd; }
-	HWND GetHWND() const								{ return m_hMemBookmarkDialog; }
+	void InstallHWND(HWND hWnd) { m_hMemBookmarkDialog = hWnd; }
+	HWND GetHWND() const { return m_hMemBookmarkDialog; }
 	BOOL IsActive() const;
 
-	std::vector<MemBookmark*> Bookmarks()				{ return m_vBookmarks; }
-	void UpdateBookmarks( bool bForceWrite );
-	void AddBookmark( MemBookmark* newBookmark )		{ m_vBookmarks.push_back(newBookmark); }
-	void WriteFrozenValue( const MemBookmark& Bookmark );
+	std::vector<MemBookmark*> Bookmarks() { return m_vBookmarks; }
+	void UpdateBookmarks(bool bForceWrite);
+	void AddBookmark(MemBookmark* newBookmark) { m_vBookmarks.push_back(newBookmark); }
+	void WriteFrozenValue(const MemBookmark& Bookmark);
 
 	void OnLoad_NewRom();
 
@@ -64,31 +63,31 @@ private:
 	int m_nNumOccupiedRows;
 
 	void PopulateList();
-	void SetupColumns( HWND hList );
-	BOOL EditLabel ( int nItem, int nSubItem );
+	void SetupColumns(HWND hList);
+	BOOL EditLabel(int nItem, int nSubItem);
 	void AddAddress();
 	void ClearAllBookmarks();
-	unsigned int GetMemory( unsigned int nAddr, int type );
+	unsigned int GetMemory(unsigned int nAddr, int type);
 
 	void ExportJSON();
-	void ImportFromFile( std::string filename );
-	void GenerateResizes( HWND hDlg );
+	void ImportFromFile(std::string filename);
+	void GenerateResizes(HWND hDlg);
 	std::string ImportDialog();
 
-	void AddBookmarkMap( MemBookmark* bookmark )
+	void AddBookmarkMap(MemBookmark* bookmark)
 	{
-		if (m_BookmarkMap.find( bookmark->Address() ) == m_BookmarkMap.end() )
-			m_BookmarkMap.insert( std::map<ByteAddress, std::vector<const MemBookmark*>>::value_type( bookmark->Address(), std::vector<const MemBookmark*>() ) );
+		if (m_BookmarkMap.find(bookmark->Address()) == m_BookmarkMap.end())
+			m_BookmarkMap.insert(std::map<ByteAddress, std::vector<const MemBookmark*>>::value_type(bookmark->Address(), std::vector<const MemBookmark*>()));
 
-		std::vector<const MemBookmark*> *v = &m_BookmarkMap[ bookmark->Address() ];
-		v->push_back( bookmark );
+		std::vector<const MemBookmark*> *v = &m_BookmarkMap[bookmark->Address()];
+		v->push_back(bookmark);
 	}
 
 public:
-	const MemBookmark* FindBookmark( const ByteAddress& nAddr ) const
+	const MemBookmark* FindBookmark(const ByteAddress& nAddr) const
 	{
-		std::map<ByteAddress, std::vector<const MemBookmark*>>::const_iterator iter = m_BookmarkMap.find( nAddr );
-		return( iter != m_BookmarkMap.end() && iter->second.size() > 0 ) ? iter->second.back() : nullptr;
+		std::map<ByteAddress, std::vector<const MemBookmark*>>::const_iterator iter = m_BookmarkMap.find(nAddr);
+		return(iter != m_BookmarkMap.end() && iter->second.size() > 0) ? iter->second.back() : nullptr;
 	}
 
 private:
@@ -98,3 +97,5 @@ private:
 };
 
 extern Dlg_MemBookmark g_MemBookmarkDialog;
+
+#endif // !RA_DLG_MEMBOOKMARK_H

--- a/src/RA_Dlg_Memory.cpp
+++ b/src/RA_Dlg_Memory.cpp
@@ -1,13 +1,9 @@
 #include "RA_Dlg_Memory.h"
 
-#include "RA_Achievement.h"
 #include "RA_AchievementSet.h"
-#include "RA_CodeNotes.h"
 #include "RA_Core.h"
 #include "RA_GameData.h"
 #include "RA_httpthread.h"
-#include "RA_MemManager.h"
-#include "RA_Resource.h"
 #include "RA_User.h"
 #include "RA_Dlg_MemBookmark.h"
 
@@ -634,6 +630,10 @@ void MemoryViewerControl::RenderMemViewer(HWND hTarget)
 
 				g_MemManager.ActiveBankRAMRead(data, addr, 16);
 
+                // TODO: Remove this pragma warning disable if tinyformat ever
+                //       gets accepted or if another approach is done.
+				//       Do we even need wide strings here?
+                #pragma warning(disable : 4995) 
 				TCHAR* ptr = bufferNative + wsprintf(bufferNative, TEXT("0x%06x  "), addr);
 				switch (m_nDataSize)
 				{

--- a/src/RA_Dlg_Memory.h
+++ b/src/RA_Dlg_Memory.h
@@ -1,11 +1,11 @@
+#ifndef RA_DLG_MEMORY_H
+#define RA_DLG_MEMORY_H
 #pragma once
 
-#include "RA_Defs.h"
 #include "RA_CodeNotes.h"
 #include "RA_MemManager.h"
-#include "RA_Condition.h"
 
-class CodeNotes;
+class CodeNotes; // what's the point of this forward declare?
 
 class MemoryViewerControl
 {
@@ -13,19 +13,19 @@ public:
 	static INT_PTR CALLBACK s_MemoryDrawProc(HWND, UINT, WPARAM, LPARAM);
 
 public:
-	static void RenderMemViewer( HWND hTarget );
+	static void RenderMemViewer(HWND hTarget);
 
-	static void createEditCaret( int w, int h );
+	static void createEditCaret(int w, int h);
 	static void destroyEditCaret();
 	static void SetCaretPos();
-	static void OnClick( POINT point );
+	static void OnClick(POINT point);
 
-	static bool OnKeyDown( UINT nChar );
-	static bool OnEditInput( UINT c );
+	static bool OnKeyDown(UINT nChar);
+	static bool OnEditInput(UINT c);
 
-	static void setAddress( unsigned int nAddr );
-	static void moveAddress( int offset, int nibbleOff );
-	static void editData( unsigned int nByteAddress, bool bLowerNibble, unsigned int value );
+	static void setAddress(unsigned int nAddr);
+	static void moveAddress(int offset, int nibbleOff);
+	static void editData(unsigned int nByteAddress, bool bLowerNibble, unsigned int value);
 	static void Invalidate();
 
 public:
@@ -48,16 +48,16 @@ private:
 
 class SearchResult
 {
-	public:
-		SearchResult() {}
-	public:
-		std::vector<MemCandidate> m_ResultCandidate;
-		unsigned int m_nCount = 0;
-		unsigned int m_nLastQueryVal = 0;
-		bool m_bUseLastValue;
-		tstring m_sFirstLine;
-		tstring m_sSecondLine;
-		ComparisonType m_nCompareType;
+public:
+	SearchResult() {}
+public:
+	std::vector<MemCandidate> m_ResultCandidate;
+	unsigned int m_nCount = 0;
+	unsigned int m_nLastQueryVal = 0;
+	bool m_bUseLastValue;
+	tstring m_sFirstLine;
+	tstring m_sSecondLine;
+	ComparisonType m_nCompareType;
 };
 
 class Dlg_Memory
@@ -67,39 +67,39 @@ public:
 
 public:
 	void Init();
-	
+
 	void ClearLogOutput();
 
 	static INT_PTR CALLBACK s_MemoryProc(HWND, UINT, WPARAM, LPARAM);
 	INT_PTR MemoryProc(HWND, UINT, WPARAM, LPARAM);
 
-	void InstallHWND( HWND hWnd )				{ m_hWnd = hWnd; }
-	HWND GetHWND() const						{ return m_hWnd; }
-	
+	void InstallHWND(HWND hWnd) { m_hWnd = hWnd; }
+	HWND GetHWND() const { return m_hWnd; }
+
 	void OnLoad_NewRom();
 
 	void OnWatchingMemChange();
 
 	void RepopulateMemNotesFromFile();
 	void Invalidate();
-	
-	void SetWatchingAddress( unsigned int nAddr );
+
+	void SetWatchingAddress(unsigned int nAddr);
 	BOOL IsActive() const;
 
-	const CodeNotes& Notes() const				{ return m_CodeNotes; }
+	const CodeNotes& Notes() const { return m_CodeNotes; }
 
 	void ClearBanks();
-	void AddBank( size_t nBankID );
-	void GenerateResizes( HWND hDlg );
+	void AddBank(size_t nBankID);
+	void GenerateResizes(HWND hDlg);
 
 private:
-	bool GetSystemMemoryRange( ByteAddress& start, ByteAddress& end );
-	bool GetGameMemoryRange( ByteAddress& start, ByteAddress& end );
+	bool GetSystemMemoryRange(ByteAddress& start, ByteAddress& end);
+	bool GetGameMemoryRange(ByteAddress& start, ByteAddress& end);
 
-	bool GetSelectedMemoryRange( ByteAddress& start, ByteAddress& end );
+	bool GetSelectedMemoryRange(ByteAddress& start, ByteAddress& end);
 
-	void UpdateSearchResult( unsigned int index, unsigned int &nMemVal, TCHAR ( &buffer )[ 1024 ] );
-	bool CompareSearchResult ( unsigned int nCurVal, unsigned int nPrevVal );
+	void UpdateSearchResult(unsigned int index, unsigned int &nMemVal, TCHAR(&buffer)[1024]);
+	bool CompareSearchResult(unsigned int nCurVal, unsigned int nPrevVal);
 
 	static CodeNotes m_CodeNotes;
 	static HWND m_hWnd;
@@ -112,3 +112,6 @@ private:
 };
 
 extern Dlg_Memory g_MemoryDialog;
+
+
+#endif // !RA_DLG_MEMORY_H

--- a/src/RA_Dlg_RichPresence.cpp
+++ b/src/RA_Dlg_RichPresence.cpp
@@ -1,7 +1,6 @@
 #include "RA_Dlg_RichPresence.h"
 
 #include "RA_Core.h"
-#include "RA_Resource.h"
 #include "RA_RichPresence.h"
 
 Dlg_RichPresence g_RichPresenceDialog;

--- a/src/RA_Dlg_RichPresence.h
+++ b/src/RA_Dlg_RichPresence.h
@@ -1,6 +1,7 @@
+#ifndef RA_DLG_RICHPRESENCE_H
+#define RA_DLG_RICHPRESENCE_H
 #pragma once
 
-#include <WTypes.h>
 
 class Dlg_RichPresence
 {
@@ -28,3 +29,6 @@ private:
 extern Dlg_RichPresence g_RichPresenceDialog;
 
 
+
+
+#endif // !RA_DLG_RICHPRESENCE_H

--- a/src/RA_Dlg_RomChecksum.cpp
+++ b/src/RA_Dlg_RomChecksum.cpp
@@ -1,6 +1,5 @@
 #include "RA_Dlg_RomChecksum.h"
 
-#include "RA_Resource.h"
 #include "RA_Core.h"
 
 //static 

--- a/src/RA_Dlg_RomChecksum.h
+++ b/src/RA_Dlg_RomChecksum.h
@@ -1,6 +1,7 @@
+#ifndef RA_DLG_ROMCHECKSUM_H
+#define RA_DLG_ROMCHECKSUM_H
 #pragma once
 
-#include <wtypes.h>
 
 class RA_Dlg_RomChecksum
 {
@@ -8,5 +9,8 @@ public:
 	static BOOL DoModalDialog();
 
 public:
-	static INT_PTR CALLBACK RA_Dlg_RomChecksumProc( HWND, UINT, WPARAM, LPARAM );
+	static INT_PTR CALLBACK RA_Dlg_RomChecksumProc(HWND, UINT, WPARAM, LPARAM);
 };
+
+
+#endif // !RA_DLG_ROMCHECKSUM_H

--- a/src/RA_GameData.h
+++ b/src/RA_GameData.h
@@ -1,6 +1,8 @@
+#ifndef RA_GAMEDATA_H
+#define RA_GAMEDATA_H
 #pragma once
 
-#include <string>
+
 #include "RA_Defs.h"
 
 class GameData
@@ -27,3 +29,5 @@ private:
 };
 
 extern GameData* g_pCurrentGameData;
+
+#endif // !RA_GAMEDATA_H

--- a/src/RA_ImageFactory.cpp
+++ b/src/RA_ImageFactory.cpp
@@ -1,14 +1,7 @@
-#include <wincodec.h>
-#include <WTypes.h>
-#include <windows.h>
-#include <windowsx.h>
-#include <commdlg.h>
-#include <stdio.h>
-
-#include "RA_Defs.h"
-#include "RA_Core.h"
-#include "RA_Resource.h"
 #include "RA_ImageFactory.h"
+
+
+#include "RA_Core.h"
 #include "RA_Achievement.h"
 #include "RA_httpthread.h"
 

--- a/src/RA_ImageFactory.h
+++ b/src/RA_ImageFactory.h
@@ -1,7 +1,6 @@
+#ifndef RA_IMAGEFACTORY_H
+#define RA_IMAGEFACTORY_H
 #pragma once
-
-#include <wincodec.h>
-#include <WTypes.h>
 
 #include "RA_Defs.h"
 
@@ -14,21 +13,24 @@ struct IWICImagingFactory;
 class UserImageFactoryVars
 {
 public:
-	UserImageFactoryVars() :m_pOriginalBitmapSource( NULL ), m_pIWICFactory( NULL ) {}
+    UserImageFactoryVars() :m_pOriginalBitmapSource(NULL), m_pIWICFactory(NULL) {}
 
 public:
-	IWICBitmapSource* m_pOriginalBitmapSource;
-	IWICImagingFactory* m_pIWICFactory; 
+    IWICBitmapSource * m_pOriginalBitmapSource;
+    IWICImagingFactory* m_pIWICFactory;
 };
 
 
-BOOL InitializeUserImageFactory( HINSTANCE hInst );
-HBITMAP LoadOrFetchBadge( const std::string& sBadgeURI, const RASize& nSZ = RA_BADGE_PX );
-HBITMAP LoadOrFetchUserPic( const std::string& sUser, const RASize& nSZ = RA_USERPIC_PX );
-HBITMAP LoadLocalPNG( const std::string& sPath, const RASize& nSZ );
+BOOL InitializeUserImageFactory(HINSTANCE hInst);
+HBITMAP LoadOrFetchBadge(const std::string& sBadgeURI, const RASize& nSZ = RA_BADGE_PX);
+HBITMAP LoadOrFetchUserPic(const std::string& sUser, const RASize& nSZ = RA_USERPIC_PX);
+HBITMAP LoadLocalPNG(const std::string& sPath, const RASize& nSZ);
 
 extern UserImageFactoryVars g_UserImageFactoryInst;
 
-extern void DrawImage( HDC hDC, HBITMAP hBitmap, int nX, int nY, int nW, int nH );
-extern void DrawImageTiled( HDC hDC, HBITMAP hBitmap, RECT& rcSource, RECT& rcDest );
-extern void DrawImageStretched( HDC hDC, HBITMAP hBitmap, RECT& rcSource, RECT& rcDest );
+extern void DrawImage(HDC hDC, HBITMAP hBitmap, int nX, int nY, int nW, int nH);
+extern void DrawImageTiled(HDC hDC, HBITMAP hBitmap, RECT& rcSource, RECT& rcDest);
+extern void DrawImageStretched(HDC hDC, HBITMAP hBitmap, RECT& rcSource, RECT& rcDest);
+
+
+#endif // !RA_IMAGEFACTORY_H

--- a/src/RA_Integration.vcxproj
+++ b/src/RA_Integration.vcxproj
@@ -50,6 +50,9 @@
     <ClCompile Include="RA_ProgressPopup.cpp" />
     <ClCompile Include="RA_RichPresence.cpp" />
     <ClCompile Include="RA_User.cpp" />
+    <ClCompile Include="stdafx.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="md5.h" />
@@ -85,10 +88,14 @@
     <ClInclude Include="RA_Resource.h" />
     <ClInclude Include="RA_RichPresence.h" />
     <ClInclude Include="RA_User.h" />
+    <ClInclude Include="stdafx.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="RA_Shared.rc" />
     <ResourceCompile Include="RA_Version.rc" />
+  </ItemGroup>
+  <ItemGroup>
+    <Text Include="transitive_includes.txt" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectName>RA_Integration</ProjectName>
@@ -130,6 +137,7 @@
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="build_macros.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='DebugUnicode|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
@@ -168,13 +176,15 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_DEBUG;RA_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;RA_EXPORTS;_SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING;_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DisableSpecificWarnings>4091</DisableSpecificWarnings>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>$(SrcDir)stdafx.h</PrecompiledHeaderFile>
     </ClCompile>
     <Link>
       <AdditionalDependencies>windowscodecs.lib;winmm.lib;Winhttp.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/src/RA_Integration.vcxproj.filters
+++ b/src/RA_Integration.vcxproj.filters
@@ -16,22 +16,13 @@
     <Filter Include="Services">
       <UniqueIdentifier>{35979a09-2dc1-4255-9e37-d40bf000e961}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Notes">
+      <UniqueIdentifier>{2747c1aa-687e-44a7-ba2f-b977463edc9a}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="md5.c">
       <Filter>Services</Filter>
-    </ClCompile>
-    <ClCompile Include="RA_Achievement.cpp">
-      <Filter>Data</Filter>
-    </ClCompile>
-    <ClCompile Include="RA_AchievementSet.cpp">
-      <Filter>Data</Filter>
-    </ClCompile>
-    <ClCompile Include="RA_CodeNotes.cpp">
-      <Filter>Data</Filter>
-    </ClCompile>
-    <ClCompile Include="RA_Condition.cpp">
-      <Filter>Data</Filter>
     </ClCompile>
     <ClCompile Include="RA_Dlg_AchEditor.cpp">
       <Filter>UI</Filter>
@@ -62,18 +53,6 @@
     </ClCompile>
     <ClCompile Include="RA_Dlg_RomChecksum.cpp">
       <Filter>UI</Filter>
-    </ClCompile>
-    <ClCompile Include="RA_GameData.cpp">
-      <Filter>Data</Filter>
-    </ClCompile>
-    <ClCompile Include="RA_Leaderboard.cpp">
-      <Filter>Data</Filter>
-    </ClCompile>
-    <ClCompile Include="RA_RichPresence.cpp">
-      <Filter>Data</Filter>
-    </ClCompile>
-    <ClCompile Include="RA_User.cpp">
-      <Filter>Data</Filter>
     </ClCompile>
     <ClCompile Include="RA_httpthread.cpp">
       <Filter>Services</Filter>
@@ -110,6 +89,33 @@
     </ClCompile>
     <ClCompile Include="RA_ImageFactory.cpp">
       <Filter>Services</Filter>
+    </ClCompile>
+    <ClCompile Include="stdafx.cpp">
+      <Filter>Interface</Filter>
+    </ClCompile>
+    <ClCompile Include="RA_Achievement.cpp">
+      <Filter>Data</Filter>
+    </ClCompile>
+    <ClCompile Include="RA_AchievementSet.cpp">
+      <Filter>Data</Filter>
+    </ClCompile>
+    <ClCompile Include="RA_CodeNotes.cpp">
+      <Filter>Data</Filter>
+    </ClCompile>
+    <ClCompile Include="RA_Condition.cpp">
+      <Filter>Data</Filter>
+    </ClCompile>
+    <ClCompile Include="RA_GameData.cpp">
+      <Filter>Data</Filter>
+    </ClCompile>
+    <ClCompile Include="RA_Leaderboard.cpp">
+      <Filter>Data</Filter>
+    </ClCompile>
+    <ClCompile Include="RA_User.cpp">
+      <Filter>Data</Filter>
+    </ClCompile>
+    <ClCompile Include="RA_RichPresence.cpp">
+      <Filter>Data</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -212,6 +218,9 @@
     <ClInclude Include="RA_ImageFactory.h">
       <Filter>Services</Filter>
     </ClInclude>
+    <ClInclude Include="stdafx.h">
+      <Filter>Interface</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="RA_Shared.rc">
@@ -220,5 +229,10 @@
     <ResourceCompile Include="RA_Version.rc">
       <Filter>Resources</Filter>
     </ResourceCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <Text Include="transitive_includes.txt">
+      <Filter>Notes</Filter>
+    </Text>
   </ItemGroup>
 </Project>

--- a/src/RA_Interface.cpp
+++ b/src/RA_Interface.cpp
@@ -1,6 +1,6 @@
 #include "RA_Interface.h"
 
-#include <stdio.h>
+#include <stdio.h> // not sure if this should go or not
 
 //	Exposed, shared
 //	App-level:

--- a/src/RA_Interface.h
+++ b/src/RA_Interface.h
@@ -1,3 +1,5 @@
+#ifndef RA_INTERFACE_H
+#define RA_INTERFACE_H
 #pragma once
 
 //	NB. Shared between RA_Integration and emulator
@@ -97,22 +99,22 @@ enum ConsoleID
 };
 
 
-extern bool (*_RA_GameIsActive)();
-extern void (*_RA_CauseUnpause)();
-extern void (*_RA_CausePause)();
-extern void (*_RA_RebuildMenu)();
-extern void (*_RA_GetEstimatedGameTitle)( char* sNameOut );
-extern void (*_RA_ResetEmulation)();
-extern void (*_RA_LoadROM)( const char* sFullPath );
+extern bool(*_RA_GameIsActive)();
+extern void(*_RA_CauseUnpause)();
+extern void(*_RA_CausePause)();
+extern void(*_RA_RebuildMenu)();
+extern void(*_RA_GetEstimatedGameTitle)(char* sNameOut);
+extern void(*_RA_ResetEmulation)();
+extern void(*_RA_LoadROM)(const char* sFullPath);
 
 //	Shared funcs, should be implemented by emulator.
 extern bool RA_GameIsActive();
 extern void RA_CauseUnpause();
 extern void RA_CausePause();
 extern void RA_RebuildMenu();
-extern void RA_GetEstimatedGameTitle( char* sNameOut );
+extern void RA_GetEstimatedGameTitle(char* sNameOut);
 extern void RA_ResetEmulation();
-extern void RA_LoadROM( const char* sFullPath );
+extern void RA_LoadROM(const char* sFullPath);
 
 #ifndef RA_EXPORTS
 
@@ -131,10 +133,10 @@ extern void RA_LoadROM( const char* sFullPath );
 
 //	Captures the RA_DLL and installs/allocs all required information.
 //	Populates all function pointers so they can be used by the app.
-extern void RA_Init( HWND hMainHWND, /*enum ConsoleType*/int console, const char* sClientVersion );
+extern void RA_Init(HWND hMainHWND, /*enum ConsoleType*/int console, const char* sClientVersion);
 
 //	Call with shared function pointers from app.
-extern void RA_InstallSharedFunctions( bool(*fpIsActive)(void), void(*fpCauseUnpause)(void), void(*fpCausePause)(void), void(*fpRebuildMenu)(void), void(*fpEstimateTitle)(char*), void(*fpResetEmulator)(void), void(*fpLoadROM)(const char*) );
+extern void RA_InstallSharedFunctions(bool(*fpIsActive)(void), void(*fpCauseUnpause)(void), void(*fpCausePause)(void), void(*fpRebuildMenu)(void), void(*fpEstimateTitle)(char*), void(*fpResetEmulator)(void), void(*fpLoadROM)(const char*));
 
 //	Shuts down, tidies up and deallocs the RA DLL from the app's perspective.
 extern void RA_Shutdown();
@@ -145,7 +147,7 @@ extern void RA_DoAchievementsFrame();
 
 
 //	Updates and renders all on-screen overlays.
-extern void RA_UpdateRenderOverlay( HDC hDC, ControllerInput* pInput, float fDeltaTime, RECT* prcSize, bool Full_Screen, bool Paused );
+extern void RA_UpdateRenderOverlay(HDC hDC, ControllerInput* pInput, float fDeltaTime, RECT* prcSize, bool Full_Screen, bool Paused);
 
 //	Returns true if the user has successfully logged in.
 extern bool RA_UserLoggedIn();
@@ -154,10 +156,10 @@ extern bool RA_UserLoggedIn();
 extern const char* RA_Username();
 
 //	Attempts to login, or show login dialog.
-extern void RA_AttemptLogin( bool bBlocking );
+extern void RA_AttemptLogin(bool bBlocking);
 
 //	Should be called immediately after a new ROM is loaded.
-extern void RA_OnLoadNewRom( BYTE* pROMData, unsigned int nROMSize );
+extern void RA_OnLoadNewRom(BYTE* pROMData, unsigned int nROMSize);
 
 //	Clear all memory banks before installing any new ones!
 extern void RA_ClearMemoryBanks();
@@ -165,13 +167,13 @@ extern void RA_ClearMemoryBanks();
 //	Call once for each memory bank found, immediately after a new rom or load
 //pReader is typedef unsigned char (_RAMByteReadFn)( size_t nOffset );
 //pWriter is typedef void (_RAMByteWriteFn)( unsigned int nOffs, unsigned int nVal );
-extern void RA_InstallMemoryBank( int nBankID, void* pReader, void* pWriter, int nBankSize );
+extern void RA_InstallMemoryBank(int nBankID, void* pReader, void* pWriter, int nBankSize);
 
 //	Call this before loading a new ROM or quitting, to ensure no developer changes are lost.
-extern bool RA_ConfirmLoadNewRom( bool bIsQuitting );
+extern bool RA_ConfirmLoadNewRom(bool bIsQuitting);
 
 //	Should be called every time the app's title should change.
-extern void RA_UpdateAppTitle( const char* sCustomMsg );
+extern void RA_UpdateAppTitle(const char* sCustomMsg);
 
 //	Call when you wish to recreate the popup menu.
 extern HMENU RA_CreatePopupMenu();
@@ -180,29 +182,32 @@ extern HMENU RA_CreatePopupMenu();
 extern void RA_HandleHTTPResults();
 
 //	Should be called to update RA whenever the emulator's 'paused' state changes.
-extern void RA_SetPaused( bool bIsPaused );
+extern void RA_SetPaused(bool bIsPaused);
 
 //	With multiple platform emulators, call this immediately before loading a new ROM.
-extern void RA_SetConsoleID( unsigned int nConsoleID );
+extern void RA_SetConsoleID(unsigned int nConsoleID);
 
 //	Should be called immediately after loading or saving a new state.
-extern void RA_OnLoadState( const char* sFilename );
-extern void RA_OnSaveState( const char* sFilename );
+extern void RA_OnLoadState(const char* sFilename);
+extern void RA_OnSaveState(const char* sFilename);
 
 
 //	Call this when initializing DirectX. TBD: clarify this.
 extern void RA_InitDirectX();
 
 //	Call this onpaint (TBD)
-extern void	RA_OnPaint( HWND hWnd );
+extern void	RA_OnPaint(HWND hWnd);
 
 //	Call this on response to a menu selection for any RA ID:
-extern void RA_InvokeDialog( LPARAM nID );
+extern void RA_InvokeDialog(LPARAM nID);
 
 //	Returns TRUE if HC mode is ongoing
 extern int RA_HardcoreModeIsActive();
 
 //	Returns TRUE if the page requested is currently being parsed.
-extern int RA_HTTPRequestExists( const char* sPageName );
+extern int RA_HTTPRequestExists(const char* sPageName);
 
 #endif //RA_EXPORTS
+
+
+#endif // !RA_INTERFACE_H

--- a/src/RA_Leaderboard.cpp
+++ b/src/RA_Leaderboard.cpp
@@ -4,7 +4,7 @@
 #include "RA_md5factory.h"
 #include "RA_httpthread.h"
 
-#include <time.h>
+
 
 RA_LeaderboardManager g_LeaderboardManager;
 

--- a/src/RA_Leaderboard.h
+++ b/src/RA_Leaderboard.h
@@ -1,5 +1,7 @@
+#ifndef RA_LEADERBOARD_H
+#define RA_LEADERBOARD_H
 #pragma once
-#include <vector>
+
 #include "RA_Defs.h"
 #include "RA_Condition.h"
 
@@ -9,17 +11,17 @@ class MemValue
 {
 public:
 	MemValue()
-		: m_nAddress( 0 ), m_fModifier( 1.0f ), m_nVarSize( EightBit ), m_bBCDParse( false ), m_bParseVal( false ) {}
-	MemValue( unsigned int nAddr, double fMod, ComparisonVariableSize nSize, bool bBCDParse, bool bParseVal )
-		: m_nAddress( nAddr ), m_fModifier( fMod ), m_nVarSize( nSize ), m_bBCDParse( bBCDParse ), m_bParseVal( bParseVal ) {}
-	
+		: m_nAddress(0), m_fModifier(1.0f), m_nVarSize(EightBit), m_bBCDParse(false), m_bParseVal(false) {}
+	MemValue(unsigned int nAddr, double fMod, ComparisonVariableSize nSize, bool bBCDParse, bool bParseVal)
+		: m_nAddress(nAddr), m_fModifier(fMod), m_nVarSize(nSize), m_bBCDParse(bBCDParse), m_bParseVal(bParseVal) {}
+
 public:
-	char* ParseFromString( char* pBuffer );		//	Parse string into values, returns end of string
+	char* ParseFromString(char* pBuffer);		//	Parse string into values, returns end of string
 	double GetValue() const;					//	Get the value in-memory with modifiers
 
 public:
 	unsigned int			m_nAddress;					//	Raw address of an 8-bit, or value.
-	ComparisonVariableSize	m_nVarSize;				
+	ComparisonVariableSize	m_nVarSize;
 	double					m_fModifier;				//	* 60 etc
 	bool					m_bBCDParse;				//	Parse as a binary coded decimal.
 	bool					m_bParseVal;				//	Parse as a value
@@ -41,13 +43,13 @@ public:
 	};
 
 public:
-	void ParseMemString( char* sBuffer );
+	void ParseMemString(char* sBuffer);
 	double GetValue() const;
-	double GetOperationsValue( std::vector<OperationType> ) const;
-	void AddNewValue( MemValue nVal );
+	double GetOperationsValue(std::vector<OperationType>) const;
+	void AddNewValue(MemValue nVal);
 	void Clear();
 
-	size_t NumValues() const	{ return m_Values.size(); }
+	size_t NumValues() const { return m_Values.size(); }
 
 protected:
 	std::vector<MemValue> m_Values;
@@ -75,15 +77,15 @@ public:
 
 		Format__MAX
 	};
-	
+
 public:
-	RA_Leaderboard( const LeaderboardID nLBID );
+	RA_Leaderboard(const LeaderboardID nLBID);
 	~RA_Leaderboard();
 
 public:
-	void LoadFromJSON( const Value& element );
-	void ParseLine( char* sBuffer );
-	void ParseLBData( char* sBuffer );
+	void LoadFromJSON(const Value& element);
+	void ParseLine(char* sBuffer);
+	void ParseLBData(char* sBuffer);
 
 	void Test();
 	double GetCurrentValue();
@@ -91,21 +93,21 @@ public:
 	void Clear();
 
 	//	Helper: tbd; refactor *into* RA_Formattable
-	static std::string RA_Leaderboard::FormatScore( FormatType nType, int nScoreIn );
-	std::string FormatScore( int nScoreIn ) const;
+	static std::string RA_Leaderboard::FormatScore(FormatType nType, int nScoreIn);
+	std::string FormatScore(int nScoreIn) const;
 	void Reset();
 
-	LeaderboardID ID() const								{ return m_nID; }
-	const std::string& Title() const						{ return m_sTitle; }
-	const std::string& Description() const					{ return m_sDescription; }
+	LeaderboardID ID() const { return m_nID; }
+	const std::string& Title() const { return m_sTitle; }
+	const std::string& Description() const { return m_sDescription; }
 
-	void SubmitRankInfo( unsigned int nRank, const std::string& sUsername, int nScore, time_t nAchieved );
-	void ClearRankInfo()									{ m_RankInfo.clear(); }
-	const LB_Entry& GetRankInfo( unsigned int nAt ) const	{ return m_RankInfo.at( nAt ); }
-	size_t GetRankInfoCount() const							{ return m_RankInfo.size(); }
+	void SubmitRankInfo(unsigned int nRank, const std::string& sUsername, int nScore, time_t nAchieved);
+	void ClearRankInfo() { m_RankInfo.clear(); }
+	const LB_Entry& GetRankInfo(unsigned int nAt) const { return m_RankInfo.at(nAt); }
+	size_t GetRankInfoCount() const { return m_RankInfo.size(); }
 	void SortRankInfo();
 
-	FormatType GetFormatType() const						{ return m_format; }
+	FormatType GetFormatType() const { return m_format; }
 	std::vector< ValueSet::OperationType > m_sOperations;
 
 private:
@@ -131,21 +133,23 @@ private:
 class RA_LeaderboardManager
 {
 public:
-	static void OnSubmitEntry( const Document& doc );
+	static void OnSubmitEntry(const Document& doc);
 
 public:
 	void Reset();
 
-	void AddLeaderboard( const RA_Leaderboard& lb );
+	void AddLeaderboard(const RA_Leaderboard& lb);
 	void Test();
-	void Clear()								{ m_Leaderboards.clear(); }
-	size_t Count() const						{ return m_Leaderboards.size(); }
-	inline RA_Leaderboard& GetLB( size_t iter )	{ return m_Leaderboards[ iter ]; }
+	void Clear() { m_Leaderboards.clear(); }
+	size_t Count() const { return m_Leaderboards.size(); }
+	inline RA_Leaderboard& GetLB(size_t iter) { return m_Leaderboards[iter]; }
 
-	RA_Leaderboard* FindLB( unsigned int nID );
+	RA_Leaderboard* FindLB(unsigned int nID);
 
 public:
 	std::vector<RA_Leaderboard> m_Leaderboards;
 };
 
 extern RA_LeaderboardManager g_LeaderboardManager;
+
+#endif // !RA_LEADERBOARD_H

--- a/src/RA_LeaderboardPopup.cpp
+++ b/src/RA_LeaderboardPopup.cpp
@@ -1,9 +1,5 @@
 #include "RA_LeaderboardPopup.h"
 
-#include <windows.h>
-#include <stdio.h>
-
-#include "RA_Achievement.h"
 #include "RA_AchievementOverlay.h"
 #include "RA_ImageFactory.h"
 #include "RA_Leaderboard.h"

--- a/src/RA_LeaderboardPopup.h
+++ b/src/RA_LeaderboardPopup.h
@@ -1,9 +1,8 @@
+#ifndef RA_LEADERBOARDPOPUP_H
+#define RA_LEADERBOARDPOPUP_H
 #pragma once
 
-#include <wtypes.h>
 #include "RA_AchievementOverlay.h"
-#include <vector>
-#include <queue>
 
 //	Graphic to display current leaderboard progress
 
@@ -20,14 +19,14 @@ public:
 public:
 	LeaderboardPopup();
 
-	void Update( ControllerInput input, float fDelta, BOOL bFullScreen, BOOL bPaused );
-	void Render( HDC hDC, RECT& rcDest );
+	void Update(ControllerInput input, float fDelta, BOOL bFullScreen, BOOL bPaused);
+	void Render(HDC hDC, RECT& rcDest);
 
 	void Reset();
-	BOOL Activate( LeaderboardID nLBID );
-	BOOL Deactivate( LeaderboardID nLBID );
+	BOOL Activate(LeaderboardID nLBID);
+	BOOL Deactivate(LeaderboardID nLBID);
 
-	void ShowScoreboard( LeaderboardID nLBID );
+	void ShowScoreboard(LeaderboardID nLBID);
 
 private:
 	float GetOffsetPct() const;
@@ -38,3 +37,6 @@ private:
 	std::vector<unsigned int> m_vActiveLBIDs;
 	std::queue<unsigned int> m_vScoreboardQueue;
 };
+
+
+#endif // !RA_LEADERBOARDPOPUP_H

--- a/src/RA_MemManager.h
+++ b/src/RA_MemManager.h
@@ -1,3 +1,5 @@
+#ifndef RA_MEMMANAGER_H
+#define RA_MEMMANAGER_H
 #pragma once
 
 #include "RA_Condition.h"
@@ -6,12 +8,12 @@ class MemCandidate
 {
 public:
 	MemCandidate()
-	 :	m_nAddr( 0 ),
-		m_nLastKnownValue( 0 ),
-		m_bUpperNibble( FALSE ),
-		m_bHasChanged( FALSE )
+		: m_nAddr(0),
+		m_nLastKnownValue(0),
+		m_bUpperNibble(FALSE),
+		m_bHasChanged(FALSE)
 	{}
-	
+
 public:
 	unsigned int m_nAddr;
 	unsigned int m_nLastKnownValue;		//	A Candidate MAY be a 32-bit candidate!
@@ -19,8 +21,8 @@ public:
 	bool m_bHasChanged;
 };
 
-typedef unsigned char (_RAMByteReadFn)( unsigned int nOffs );
-typedef void (_RAMByteWriteFn)( unsigned int nOffs, unsigned int nVal );
+typedef unsigned char (_RAMByteReadFn)(unsigned int nOffs);
+typedef void (_RAMByteWriteFn)(unsigned int nOffs, unsigned int nVal);
 
 class MemManager
 {
@@ -28,21 +30,21 @@ private:
 	class BankData
 	{
 	public:
-		BankData() 
-		 :	Reader( nullptr ), Writer( nullptr ), BankSize( 0 ) 
+		BankData()
+			: Reader(nullptr), Writer(nullptr), BankSize(0)
 		{}
 
-		BankData( _RAMByteReadFn* pReadFn, _RAMByteWriteFn* pWriteFn, size_t nBankSize )
-		 :	Reader( pReadFn ), Writer( pWriteFn ), BankSize( nBankSize )
+		BankData(_RAMByteReadFn* pReadFn, _RAMByteWriteFn* pWriteFn, size_t nBankSize)
+			: Reader(pReadFn), Writer(pWriteFn), BankSize(nBankSize)
 		{}
-		
+
 	private:
 		//	Copying disabled
-		BankData( const BankData& );
-		BankData& operator=( BankData& );
-	
+		BankData(const BankData&);
+		BankData& operator=(BankData&);
+
 	public:
-		_RAMByteReadFn* Reader;
+		_RAMByteReadFn * Reader;
 		_RAMByteWriteFn* Writer;
 		size_t BankSize;
 	};
@@ -53,32 +55,32 @@ public:
 
 public:
 	void ClearMemoryBanks();
-	void AddMemoryBank( size_t nBankID, _RAMByteReadFn* pReader, _RAMByteWriteFn* pWriter, size_t nBankSize );
-	size_t NumMemoryBanks() const									{ return m_Banks.size(); }
+	void AddMemoryBank(size_t nBankID, _RAMByteReadFn* pReader, _RAMByteWriteFn* pWriter, size_t nBankSize);
+	size_t NumMemoryBanks() const { return m_Banks.size(); }
 
-	void Reset( unsigned short nSelectedMemBank, ComparisonVariableSize nNewComparisonVariableSize );
-	void ResetAll( ComparisonVariableSize nNewComparisonVariableSize, ByteAddress start, ByteAddress end );
+	void Reset(unsigned short nSelectedMemBank, ComparisonVariableSize nNewComparisonVariableSize);
+	void ResetAll(ComparisonVariableSize nNewComparisonVariableSize, ByteAddress start, ByteAddress end);
 
-	size_t Compare( ComparisonType nCompareType, unsigned int nTestValue, bool& bResultsFound );
-	
-	inline DWORD ValidMemAddrFound( size_t iter ) const				{ return m_Candidates[ iter ].m_nAddr; }
-	inline ComparisonVariableSize MemoryComparisonSize() const		{ return m_nComparisonSizeMode; }
-	inline bool UseLastKnownValue() const							{ return m_bUseLastKnownValue; }
-	inline void SetUseLastKnownValue( bool bUseLastKnownValue )		{ m_bUseLastKnownValue = bUseLastKnownValue; }
-	inline size_t BankSize( unsigned short nBank ) const			{ return m_Banks.at( nBank ).BankSize; }
+	size_t Compare(ComparisonType nCompareType, unsigned int nTestValue, bool& bResultsFound);
+
+	inline DWORD ValidMemAddrFound(size_t iter) const { return m_Candidates[iter].m_nAddr; }
+	inline ComparisonVariableSize MemoryComparisonSize() const { return m_nComparisonSizeMode; }
+	inline bool UseLastKnownValue() const { return m_bUseLastKnownValue; }
+	inline void SetUseLastKnownValue(bool bUseLastKnownValue) { m_bUseLastKnownValue = bUseLastKnownValue; }
+	inline size_t BankSize(unsigned short nBank) const { return m_Banks.at(nBank).BankSize; }
 	//inline size_t ActiveBankSize() const							{ return m_Banks.at( m_nActiveMemBank ).BankSize; }
 	//inline unsigned short ActiveBankID() const					{ return m_nActiveMemBank; }
-	inline size_t TotalBankSize() const								{ return m_nTotalBankSize; }
+	inline size_t TotalBankSize() const { return m_nTotalBankSize; }
 
 	std::vector<size_t> GetBankIDs() const;
-	
-	size_t NumCandidates() const									{ return m_nNumCandidates; }
-	const MemCandidate& GetCandidate( size_t nAt ) const			{ return m_Candidates[ nAt ]; }
 
-	inline void ChangeNumCandidates( unsigned int size )			{ m_nNumCandidates = size; }
-	MemCandidate* GetCandidatePointer()								{ return m_Candidates; }
+	size_t NumCandidates() const { return m_nNumCandidates; }
+	const MemCandidate& GetCandidate(size_t nAt) const { return m_Candidates[nAt]; }
 
-	void ChangeActiveMemBank( unsigned short nMemBank );
+	inline void ChangeNumCandidates(unsigned int size) { m_nNumCandidates = size; }
+	MemCandidate* GetCandidatePointer() { return m_Candidates; }
+
+	void ChangeActiveMemBank(unsigned short nMemBank);
 
 	unsigned char ActiveBankRAMByteRead(ByteAddress nOffs) const;
 	void ActiveBankRAMByteWrite(ByteAddress nOffs, unsigned int nVal);
@@ -98,3 +100,6 @@ private:
 };
 
 extern MemManager g_MemManager;
+
+
+#endif // !RA_MEMMANAGER_H

--- a/src/RA_PopupWindows.h
+++ b/src/RA_PopupWindows.h
@@ -1,6 +1,8 @@
+#ifndef RA_POPUPWINDOWS_H
+#define RA_POPUPWINDOWS_H
 #pragma once
 
-#include "RA_PopupWindows.h"
+// why was this file including itself?
 
 #include "RA_ProgressPopup.h"
 #include "RA_AchievementPopup.h"
@@ -11,18 +13,18 @@
 class PopupWindows
 {
 public:
-	static void Update( ControllerInput* pInput, float fDelta, bool bFullscreen, bool bPaused )
+	static void Update(ControllerInput* pInput, float fDelta, bool bFullscreen, bool bPaused)
 	{
-		m_ProgressPopups.Update( *pInput, fDelta, bFullscreen, bPaused );
-		m_AchievementPopups.Update( *pInput, fDelta, bFullscreen, bPaused );
-		m_LeaderboardPopups.Update( *pInput, fDelta, bFullscreen, bPaused );
+		m_ProgressPopups.Update(*pInput, fDelta, bFullscreen, bPaused);
+		m_AchievementPopups.Update(*pInput, fDelta, bFullscreen, bPaused);
+		m_LeaderboardPopups.Update(*pInput, fDelta, bFullscreen, bPaused);
 	}
 
-	static void Render( HDC hDC, RECT* rcDest )
+	static void Render(HDC hDC, RECT* rcDest)
 	{
-		m_ProgressPopups.Render( hDC, *rcDest );
-		m_AchievementPopups.Render( hDC, *rcDest );
-		m_LeaderboardPopups.Render( hDC, *rcDest );
+		m_ProgressPopups.Render(hDC, *rcDest);
+		m_AchievementPopups.Render(hDC, *rcDest);
+		m_LeaderboardPopups.Render(hDC, *rcDest);
 	}
 
 	static void Clear()
@@ -31,9 +33,9 @@ public:
 		m_AchievementPopups.Clear();
 	}
 
-	static ProgressPopup& ProgressPopups()			{ return m_ProgressPopups; }
-	static AchievementPopup& AchievementPopups()	{ return m_AchievementPopups; }
-	static LeaderboardPopup& LeaderboardPopups()	{ return m_LeaderboardPopups; }
+	static ProgressPopup& ProgressPopups() { return m_ProgressPopups; }
+	static AchievementPopup& AchievementPopups() { return m_AchievementPopups; }
+	static LeaderboardPopup& LeaderboardPopups() { return m_LeaderboardPopups; }
 
 private:
 	static ProgressPopup m_ProgressPopups;
@@ -44,8 +46,11 @@ private:
 //	Exposed to DLL
 extern "C"
 {
-API extern int _RA_UpdatePopups( ControllerInput* input, float fDTime, bool Full_Screen, bool Paused );
-API extern int _RA_RenderPopups( HDC hDC, RECT* rcSize );
+	API extern int _RA_UpdatePopups(ControllerInput* input, float fDTime, bool Full_Screen, bool Paused);
+	API extern int _RA_RenderPopups(HDC hDC, RECT* rcSize);
 }
 
 extern PopupWindows g_PopupWindows;
+
+
+#endif // !RA_POPUPWINDOWS_H

--- a/src/RA_ProgressPopup.cpp
+++ b/src/RA_ProgressPopup.cpp
@@ -1,8 +1,6 @@
 #include "RA_ProgressPopup.h"
 
-#include <stdio.h>
 
-#include "RA_Achievement.h"
 #include "RA_AchievementOverlay.h"
 #include "RA_ImageFactory.h"
 

--- a/src/RA_ProgressPopup.h
+++ b/src/RA_ProgressPopup.h
@@ -1,7 +1,6 @@
 #ifndef _PROGRESSPOPUP_H_
 #define _PROGRESSPOPUP_H_
 
-#include <wtypes.h>
 #include "RA_AchievementOverlay.h"
 
 //	Graphic to display an progress towards an achievement

--- a/src/RA_RichPresence.h
+++ b/src/RA_RichPresence.h
@@ -1,8 +1,9 @@
+#ifndef RA_RICHPRESENCE_H
+#define RA_RICHPRESENCE_H
 #pragma once
-#include <vector>
-#include <map>
+
 #include "RA_Leaderboard.h"
-#include "RA_Defs.h"
+
 
 typedef unsigned int DataPos;
 
@@ -10,13 +11,13 @@ typedef unsigned int DataPos;
 class RA_Lookup
 {
 public:
-	RA_Lookup( const std::string& sDesc );
-	
-public:
-	void AddLookupData( DataPos nValue, const std::string& sLookupData )	{ m_lookupData[ nValue ] = sLookupData; }
-	const std::string& Lookup( DataPos nValue ) const;
+	RA_Lookup(const std::string& sDesc);
 
-	const std::string& Description() const									{ return m_sLookupDescription; }
+public:
+	void AddLookupData(DataPos nValue, const std::string& sLookupData) { m_lookupData[nValue] = sLookupData; }
+	const std::string& Lookup(DataPos nValue) const;
+
+	const std::string& Description() const { return m_sLookupDescription; }
 
 private:
 	std::string m_sLookupDescription;
@@ -26,7 +27,7 @@ private:
 class RA_ConditionalDisplayString
 {
 public:
-	RA_ConditionalDisplayString( char* pLine );
+	RA_ConditionalDisplayString(char* pLine);
 
 	bool Test();
 	const std::string& GetDisplayString() const { return m_sDisplayString; }
@@ -39,11 +40,11 @@ private:
 class RA_Formattable
 {
 public:
-	RA_Formattable( const std::string& sDesc, RA_Leaderboard::FormatType nType );
+	RA_Formattable(const std::string& sDesc, RA_Leaderboard::FormatType nType);
 
-	std::string Lookup( DataPos nValue ) const;
+	std::string Lookup(DataPos nValue) const;
 
-	const std::string& Description() const									{ return m_sLookupDescription; }
+	const std::string& Description() const { return m_sLookupDescription; }
 
 private:
 	std::string m_sLookupDescription;
@@ -53,16 +54,16 @@ private:
 class RA_RichPresenceInterpretter
 {
 public:
-	static void PersistAndParseScript( GameID nGameID, const std::string& sScript );
+	static void PersistAndParseScript(GameID nGameID, const std::string& sScript);
 
 public:
 	RA_RichPresenceInterpretter() {}
 
 public:
-	void ParseRichPresenceFile( const std::string& sFilename );
+	void ParseRichPresenceFile(const std::string& sFilename);
 
 	const std::string& GetRichPresenceString();
-	const std::string& Lookup( const std::string& sLookupName, const std::string& sMemString ) const;
+	const std::string& Lookup(const std::string& sLookupName, const std::string& sMemString) const;
 
 	bool Enabled() const;
 
@@ -75,3 +76,5 @@ private:
 };
 
 extern RA_RichPresenceInterpretter g_RichPresenceInterpretter;
+
+#endif // !RA_RICHPRESENCE_H

--- a/src/RA_User.cpp
+++ b/src/RA_User.cpp
@@ -1,19 +1,15 @@
 #include "RA_User.h"
 
-#include "RA_Achievement.h"
 #include "RA_AchievementOverlay.h"
 #include "RA_AchievementSet.h"
 #include "RA_Core.h"
-#include "RA_Defs.h"
 #include "RA_Dlg_Achievement.h"
 #include "RA_Dlg_AchEditor.h"
 #include "RA_Dlg_Login.h"
 #include "RA_GameData.h"
-#include "RA_httpthread.h"
 #include "RA_ImageFactory.h"
-#include "RA_Interface.h"
 #include "RA_PopupWindows.h"
-#include "RA_Resource.h"
+
 
 //static 
 LocalRAUser RAUsers::ms_LocalUser("");

--- a/src/RA_User.h
+++ b/src/RA_User.h
@@ -1,3 +1,5 @@
+#ifndef RA_USER_H
+#define RA_USER_H
 #pragma once
 
 #include "RA_Defs.h"
@@ -30,27 +32,27 @@ enum ActivityType
 class RAUser
 {
 public:
-	RAUser( const std::string& sUsername );
+	RAUser(const std::string& sUsername);
 	virtual ~RAUser();
 
 public:
 	void FlushBitmap();
 	void LoadOrFetchUserImage();
 
-	unsigned int GetScore() const					{ return m_nScore; }
-	void SetScore( unsigned int nScore )			{ m_nScore = nScore; }
-	
-	void SetUsername( const std::string& sUser )	{ m_sUsername = sUser; }
-	const std::string& Username() const				{ return m_sUsername; }
-	
-	void UpdateActivity( const std::string& sAct )	{ m_sActivity = sAct; }
-	const std::string& Activity() const				{ return m_sActivity; }
+	unsigned int GetScore() const { return m_nScore; }
+	void SetScore(unsigned int nScore) { m_nScore = nScore; }
 
-	HBITMAP GetUserImage() const					{ return m_hUserImage; }
-	void InstallUserImage( HBITMAP hImg )			{ m_hUserImage = hImg; }
+	void SetUsername(const std::string& sUser) { m_sUsername = sUser; }
+	const std::string& Username() const { return m_sUsername; }
 
-	BOOL IsFetchingUserImage() const				{ return m_bFetchingUserImage; }
-	
+	void UpdateActivity(const std::string& sAct) { m_sActivity = sAct; }
+	const std::string& Activity() const { return m_sActivity; }
+
+	HBITMAP GetUserImage() const { return m_hUserImage; }
+	void InstallUserImage(HBITMAP hImg) { m_hUserImage = hImg; }
+
+	BOOL IsFetchingUserImage() const { return m_bFetchingUserImage; }
+
 private:
 	/*const*/std::string	m_sUsername;
 	std::string				m_sActivity;
@@ -63,35 +65,35 @@ private:
 class LocalRAUser : public RAUser
 {
 public:
-	LocalRAUser( const std::string& sUser );
+	LocalRAUser(const std::string& sUser);
 
 public:
-	void AttemptLogin( bool bBlocking );
+	void AttemptLogin(bool bBlocking);
 
 	void AttemptSilentLogin();
-	void HandleSilentLoginResponse( Document& doc );
+	void HandleSilentLoginResponse(Document& doc);
 
-	void ProcessSuccessfulLogin( const std::string& sUser, const std::string& sToken, unsigned int nPoints, unsigned int nMessages, BOOL bRememberLogin );
+	void ProcessSuccessfulLogin(const std::string& sUser, const std::string& sToken, unsigned int nPoints, unsigned int nMessages, BOOL bRememberLogin);
 	void Logout();
 
 	void RequestFriendList();
-	void OnFriendListResponse( const Document& doc );
-	
-	RAUser* AddFriend( const std::string& sFriend, unsigned int nScore );
-	RAUser* FindFriend( const std::string& sName );
+	void OnFriendListResponse(const Document& doc);
 
-	RAUser* GetFriendByIter( size_t nOffs )				{ return nOffs < m_aFriends.size() ? m_aFriends[ nOffs ] : NULL; }
-	const size_t NumFriends() const						{ return m_aFriends.size(); }
+	RAUser* AddFriend(const std::string& sFriend, unsigned int nScore);
+	RAUser* FindFriend(const std::string& sName);
 
-	void SetStoreToken( BOOL bStoreToken )				{ bStoreToken = bStoreToken; }
+	RAUser* GetFriendByIter(size_t nOffs) { return nOffs < m_aFriends.size() ? m_aFriends[nOffs] : NULL; }
+	const size_t NumFriends() const { return m_aFriends.size(); }
 
-	void SetToken( const std::string& sToken )			{ m_sToken = sToken; }
-	const std::string& Token() const					{ return m_sToken; }
-	
-	BOOL IsLoggedIn() const		{ return m_bIsLoggedIn; }
+	void SetStoreToken(BOOL bStoreToken) { bStoreToken = bStoreToken; }
 
-	void PostActivity( ActivityType nActivityType );
-	
+	void SetToken(const std::string& sToken) { m_sToken = sToken; }
+	const std::string& Token() const { return m_sToken; }
+
+	BOOL IsLoggedIn() const { return m_bIsLoggedIn; }
+
+	void PostActivity(ActivityType nActivityType);
+
 	void Clear();
 
 private:
@@ -105,15 +107,18 @@ private:
 class RAUsers
 {
 public:
-	static LocalRAUser& LocalUser()												{ return ms_LocalUser; }
-	static BOOL DatabaseContainsUser( const std::string& sUser );
-	static void OnUserPicDownloaded( const RequestObject& obj );
+	static LocalRAUser& LocalUser() { return ms_LocalUser; }
+	static BOOL DatabaseContainsUser(const std::string& sUser);
+	static void OnUserPicDownloaded(const RequestObject& obj);
 
-	static void RegisterUser( const std::string& sUsername, RAUser* pUser )		{ UserDatabase[ sUsername ] = pUser; }
+	static void RegisterUser(const std::string& sUsername, RAUser* pUser) { UserDatabase[sUsername] = pUser; }
 
-	static RAUser* GetUser( const std::string& sUser );
+	static RAUser* GetUser(const std::string& sUser);
 
 private:
 	static LocalRAUser ms_LocalUser;
 	static std::map<std::string, RAUser*> UserDatabase;
 };
+
+
+#endif // !RA_USER_H

--- a/src/RA_httpthread.cpp
+++ b/src/RA_httpthread.cpp
@@ -1,9 +1,8 @@
 #include "RA_httpthread.h"
 
-#include "RA_Defs.h"
+
 #include "RA_Core.h"
 #include "RA_User.h"
-#include "RA_Achievement.h"
 #include "RA_AchievementSet.h"
 #include "RA_Dlg_AchEditor.h"
 #include "RA_Dlg_Memory.h"
@@ -11,10 +10,8 @@
 #include "RA_GameData.h"
 #include "RA_RichPresence.h"
 
-#include <winhttp.h>
-#include <fstream>
-#include <time.h>
-#include <algorithm>	//	std::replace
+
+
 
 
 const char* RequestTypeToString[] = 

--- a/src/RA_httpthread.h
+++ b/src/RA_httpthread.h
@@ -1,3 +1,5 @@
+#ifndef RA_HTTPTHREAD_H
+#define RA_HTTPTHREAD_H
 #pragma once
 
 #include "RA_Defs.h"
@@ -18,7 +20,7 @@ enum RequestType
 {
 	//	Login
 	RequestLogin,
-	
+
 	//	Fetch
 	RequestScore,
 	RequestNews,
@@ -45,14 +47,14 @@ enum RequestType
 	RequestSubmitAchievementData,
 	RequestSubmitTicket,
 	RequestSubmitNewTitle,
-	
+
 	//	Media:
 	RequestUserPic,
 	RequestBadge,
-	
+
 	//	Special:
 	StopThread,
-	
+
 	NumRequestTypes
 };
 
@@ -68,25 +70,25 @@ extern const char* RequestTypeToString[];
 
 typedef std::map<char, std::string> PostArgs;
 
-extern std::string PostArgsToString( const PostArgs& args );
+extern std::string PostArgsToString(const PostArgs& args);
 
 class RequestObject
 {
 public:
-	RequestObject( RequestType nType, const PostArgs& PostArgs = PostArgs(), const std::string& sData = "" ) :
-		m_nType( nType ), m_PostArgs( PostArgs ), m_sData( sData )
-		{}
+	RequestObject(RequestType nType, const PostArgs& PostArgs = PostArgs(), const std::string& sData = "") :
+		m_nType(nType), m_PostArgs(PostArgs), m_sData(sData)
+	{}
 
 public:
-	const RequestType GetRequestType() const						{ return m_nType; }
-	const PostArgs& GetPostArgs() const								{ return m_PostArgs; }
-	const std::string& GetData() const								{ return m_sData; }
-	
-	DataStream& GetResponse()										{ return m_sResponse; }
-	const DataStream& GetResponse() const							{ return m_sResponse; }
-	void SetResponse( const DataStream& sResponse )					{ m_sResponse = sResponse; }
+	const RequestType GetRequestType() const { return m_nType; }
+	const PostArgs& GetPostArgs() const { return m_PostArgs; }
+	const std::string& GetData() const { return m_sData; }
 
-	BOOL ParseResponseToJSON( Document& rDocOut );
+	DataStream& GetResponse() { return m_sResponse; }
+	const DataStream& GetResponse() const { return m_sResponse; }
+	void SetResponse(const DataStream& sResponse) { m_sResponse = sResponse; }
+
+	BOOL ParseResponseToJSON(Document& rDocOut);
 
 private:
 	const RequestType m_nType;
@@ -100,12 +102,12 @@ class HttpResults
 {
 public:
 	//	Caller must manage: SAFE_DELETE when finished
-	RequestObject* PopNextItem();
+	RequestObject * PopNextItem();
 	const RequestObject* PeekNextItem() const;
-	void PushItem( RequestObject* pObj );
+	void PushItem(RequestObject* pObj);
 	void Clear();
 	size_t Count() const;
-	BOOL PageRequestExists( RequestType nType, const std::string& sData ) const;
+	BOOL PageRequestExists(RequestType nType, const std::string& sData) const;
 
 private:
 	std::deque<RequestObject*> m_aRequests;
@@ -117,26 +119,29 @@ public:
 	static void RA_InitializeHTTPThreads();
 	static void RA_KillHTTPThreads();
 
-	static void LogJSON( const Document& doc );
+	static void LogJSON(const Document& doc);
 
-	static void CreateThreadedHTTPRequest( RequestType nType, const PostArgs& PostData = PostArgs(), const std::string& sData = "" );
-	static BOOL HTTPRequestExists( RequestType nType, const std::string& sData );
-	static BOOL HTTPResponseExists( RequestType nType, const std::string& sData );
-	
-	static BOOL DoBlockingRequest( RequestType nType, const PostArgs& PostData, Document& JSONResponseOut );
-	static BOOL DoBlockingRequest( RequestType nType, const PostArgs& PostData, DataStream& ResponseOut );
+	static void CreateThreadedHTTPRequest(RequestType nType, const PostArgs& PostData = PostArgs(), const std::string& sData = "");
+	static BOOL HTTPRequestExists(RequestType nType, const std::string& sData);
+	static BOOL HTTPResponseExists(RequestType nType, const std::string& sData);
 
-	static BOOL DoBlockingHttpGet( const std::string& sRequestedPage, DataStream& ResponseOut, bool bIsImageRequest );
-	static BOOL DoBlockingHttpPost( const std::string& sRequestedPage, const std::string& sPostString, DataStream& ResponseOut );
+	static BOOL DoBlockingRequest(RequestType nType, const PostArgs& PostData, Document& JSONResponseOut);
+	static BOOL DoBlockingRequest(RequestType nType, const PostArgs& PostData, DataStream& ResponseOut);
 
-	static BOOL DoBlockingImageUpload( UploadType nType, const std::string& sFilename, Document& ResponseOut );
+	static BOOL DoBlockingHttpGet(const std::string& sRequestedPage, DataStream& ResponseOut, bool bIsImageRequest);
+	static BOOL DoBlockingHttpPost(const std::string& sRequestedPage, const std::string& sPostString, DataStream& ResponseOut);
 
-	static DWORD WINAPI HTTPWorkerThread( LPVOID lpParameter );
+	static BOOL DoBlockingImageUpload(UploadType nType, const std::string& sFilename, Document& ResponseOut);
 
-	static HANDLE Mutex()								{ return ms_hHTTPMutex; }
-	static RequestObject* PopNextHttpResult()			{ return ms_LastHttpResults.PopNextItem(); }
+	static DWORD WINAPI HTTPWorkerThread(LPVOID lpParameter);
 
-private:	
+	static HANDLE Mutex() { return ms_hHTTPMutex; }
+	static RequestObject* PopNextHttpResult() { return ms_LastHttpResults.PopNextItem(); }
+
+private:
 	static HANDLE ms_hHTTPMutex;
 	static HttpResults ms_LastHttpResults;
 };
+
+
+#endif // !RA_HTTPTHREAD_H

--- a/src/RA_md5factory.cpp
+++ b/src/RA_md5factory.cpp
@@ -1,10 +1,6 @@
 #include "RA_md5factory.h"
 
-#include <string.h>
-#include <stdio.h>
 
-#include "md5.h"
-#include "RA_Defs.h"
 
 namespace
 {	

--- a/src/RA_md5factory.h
+++ b/src/RA_md5factory.h
@@ -1,8 +1,12 @@
+#ifndef RA_MD5FACTORY_H
+#define RA_MD5FACTORY_H
 #pragma once
 
-#include <string>
+
 #include "RA_Defs.h"
 
-extern std::string RAGenerateMD5( const std::string& sStringToMD5 );
-extern std::string RAGenerateMD5( const BYTE* pIn, size_t nLen );
-extern std::string RAGenerateMD5( const std::vector<BYTE> DataIn );
+extern std::string RAGenerateMD5(const std::string& sStringToMD5);
+extern std::string RAGenerateMD5(const BYTE* pIn, size_t nLen);
+extern std::string RAGenerateMD5(const std::vector<BYTE> DataIn);
+
+#endif // !RA_MD5FACTORY_H

--- a/src/build_macros.props
+++ b/src/build_macros.props
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros">
+    <SrcDir>$(SolutionDir)src/</SrcDir>
+  </PropertyGroup>
+  <PropertyGroup>
+    <_PropertySheetDisplayName>build_properties</_PropertySheetDisplayName>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(SolutionDir)rapidjson/include/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <WarningLevel>EnableAllWarnings</WarningLevel>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <SDLCheck>true</SDLCheck>
+      <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>$(SrcDir)stdafx.h</PrecompiledHeaderFile>
+      <CompileAs>CompileAsCpp</CompileAs>
+      <ForcedIncludeFiles>%(PrecompiledHeaderFile);%(ForcedIncludeFiles)</ForcedIncludeFiles>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <BuildMacro Include="SrcDir">
+      <Value>$(SrcDir)</Value>
+      <EnvironmentVariable>true</EnvironmentVariable>
+    </BuildMacro>
+  </ItemGroup>
+</Project>

--- a/src/stdafx.cpp
+++ b/src/stdafx.cpp
@@ -1,0 +1,6 @@
+// header is forced include but file still needs to exist
+// targetsdkver.h is in Windows.h
+
+
+
+

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -1,0 +1,108 @@
+#ifndef STDAFX_H
+#define STDAFX_H
+#pragma once
+
+// Only library files, or project files that almost never change should be here
+
+// Look at "transitive_includes.txt" in the "Notes" section if you want to know
+// why some aren't here.
+
+// Strangely this doesn't disable all warnings
+#pragma warning(push, 0)
+
+// It's now our job to fix standard/3rd party libraries
+#pragma warning(disable : 4365 4571 4623 4625 4626 4774 5026 5027 5039)
+
+
+// There's also a few errors with our own code
+// W4: 2 warnings
+// Wall: 2 warnings, 14 errors
+
+// TODO: Set warning level back to /Wall after those issues have been addressed
+
+#define WIN32_LEAN_AND_MEAN // doesn't include all of Windows.h
+#pragma region Windows
+#include <wincodec.h> // must be at the top
+
+#ifdef WIN32_LEAN_AND_MEAN
+#include <MMSystem.h>
+#include <ShellAPI.h>
+#include <CommDlg.h>
+#endif // WIN32_LEAN_AND_MEAN
+
+#include <winhttp.h>
+#include <ddraw.h>
+#include <WindowsX.h> // Message Crackers, casts stuff for us
+#include <ShlObj.h>
+#include <tchar.h>
+#include <io.h>
+#include <direct.h>
+#include <strsafe.h> // pretty sure it's included somewhere, putting it here just incase
+#include <atlbase.h>
+#pragma endregion
+
+
+
+
+#pragma region Standard C++
+#include <sstream>
+#include <queue>
+#include <stack>
+#include <mutex>
+#include <fstream>
+#include <map> // unordered_map will be included regardless because of mutex
+
+// For these two I noticed some of classes that could benefit from these to enforce uniqueness.
+// I think it was in leaderboardpopups
+#include <unordered_set> // if you don't care about order
+#include <set>
+#pragma endregion
+
+
+
+
+
+
+
+
+#pragma region Standard C
+#include <cassert> // might not need it later
+#include <cstdio> // might not need it
+#pragma endregion
+
+
+#pragma region 3rd Party Libraries
+#ifdef RA_EXPORTS
+
+// TODO: Remove "_SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING" from the project defines
+// after RapidJSON has been updated
+
+
+// TODO: Replace filestream.h with IStreamWrapper.h and OStreamWrapper.h later
+//	RA-Only
+#include <rapidjson/document.h>
+#include <rapidjson/writer.h>
+#include <rapidjson/filestream.h>
+#include <rapidjson/error/en.h>
+
+
+#include "md5.h"
+#endif // RA_EXPORTS
+
+#pragma region Project Files
+#include "RA_Resource.h"
+#pragma endregion
+
+
+
+
+#pragma endregion
+
+
+
+
+#pragma warning(pop)
+
+
+#endif // !STDAFX_H
+

--- a/src/transitive_includes.txt
+++ b/src/transitive_includes.txt
@@ -1,0 +1,125 @@
+This text file is to show what file includes what to limit the size of the precompiled header.
+Deep includes will be included as well.
+
+They are written in the order they were found. Sometimes they were shown more than once because of macro 
+conditionals, so only the first instance will be kept. Some special cases will be accounted for (Windows.h mostly).
+
+
+We will also state the reasoning for some project files that are in the precompiled header as well.
+There are also several "NO{something}" in Windows.h, but those have not been accounted for.
+If there is part of the Windows NT API that we don't need, speak up.
+
+=========================================================================================================
+											Windows API (SDK 7.0/1A)
+=========================================================================================================
+wincodec.h: rpc.h, rpcndr.h", windows.h, ole2.h, wtypes.h, propidl.h, ocidl.h, intsafe.h
+
+---------------------------------------------------------------------------------------------------------
+|	Windows.h (SDK 7.0/1A)     |	Removed from WIN32_LEAN_AND_MEAN	|	Removed Includes we Need	|
+---------------------------------------------------------------------------------------------------------
+|		sdkddkver.h            |				cderr.h                 |			mmsystem.h          |
+|		winresrc.h             |				dde.h                   |			shellapi.h          |
+|		excpt.h                |				ddeml.h                 |			commdlg.h			|
+|		stdarg.h               |			    dlgs.h                  |								|
+|		windef.h               |			    lzexpand.h              |								|
+|		winbase.h              |                mmsystem.h              |								|
+|		wingdi.h               |                nb30.h                  |								|
+|		winuser.h              |                rpc.h					|								|
+|		winnls.h               |                shellapi.h              |								|
+|		wincon.h               |                winperf.h               |								|
+|		winver.h               |                winsock.h               |								|
+|		winreg.h               |                wincrypt.h              |								|
+|		winnetwk.h             |                winefs.h                |								|
+|		cderr.h                |                winscard.h              |								|
+|		dde.h                  |                winspool.h              |								|
+|		ddeml.h                |                ole.h                   |								|
+|		dlgs.h                 |                commdlg.h               |								|
+|		lzexpand.h             |                                        |								|
+|		mmsystem.h             |                                        |								|
+|		nb30.h                 |                                        |								|
+|		rpc.h                  |                                        |								|
+|		shellapi.h,            |                                        |								|
+|		winperf.h              |                                        |								|
+|		winsock.h              |                                        |								|
+|		wincrypt.h             |                                        |								|
+|		winefs.h               |                                        |								|
+|		winscard.h             |                                        |								|
+|		winspool.h             |                                        |								|
+|		ole.h                  |                                        |								|
+|		ole2.h                 |                                        |								|
+|		commdlg.h              |                                        |								|
+|		stralign.h             |                                        |								|
+|		winwlm.h               |                                        |								|
+|		winsvc.h               |                                        |								|
+|		mcx.h                  |                                        |								|
+|		imm.h                  |                                        |								|
+---------------------------------------------------------------------------------------------------------
+
+ShlObj.h: CommCtl.h
+tchar.h:  corecrt.h, wchar.h, string.h, mbstring.h
+
+=========================================================================================================
+												Standard C++
+=========================================================================================================
+Almost every stream type library includes an iostream variant
+Almost every container library includes a memory variant (usually xmemory)
+Almost every library file includes stdexcept
+
+Some stuff are double included in the STL, but it's header-only so different rules applay
+
+
+
+sstream:  string
+queue: algorithm, deque, vector
+map: tuple, xtree, xpolymorphic_allocator.h
+memory: xmemory(cmemory), exception, typeinfo, type_traits
+stack: deque
+
+This has a lot in it, another one "future", has mutex in it as well
+mutex: chrono, functional(memory, unorded_map), system_error(cstdlib, cerrno), thread, tuple, utility
+
+
+=========================================================================================================
+												Standard C
+=========================================================================================================
+
+
+
+=========================================================================================================
+												RapidJSON
+=========================================================================================================
+Difference between old and new isn't that different.
+Yes, RapidJSON does double includes but it's header only.
+
+document.h: reader.h, internal/meta.h, internal/strfunc.h, new, string, iterator
+writer.h: rapidjson.h, internal/stack.h, internal/strfunc.h, internal/dtoa.h, internal/itoa.h, stringbuffer.h, new
+
+This will be replaced with IStreamWrapper and OStreamWrapper later
+filestream.h: cstdio
+
+
+=========================================================================================================
+											  Project Files
+=========================================================================================================
+Noticed some files that were being double included in header files. This will also help us filter
+out what's needed in the source files.
+
+These will not be in the PCH, but are just a reference to see why they aren't there in some files
+-------------------------------------------------------------------------------------------------
+RA_Achievement.h:        RA_Condition.h
+RA_AchievementOverlay.h: RA_Achievement.h, RA_User.h, RA_Core.h
+RA_AchievementSet.h:     RA_Achievement.h
+RA_Condition.h:          RA_Defs.h
+RA_Core.h:               RA_Interface.h, RA_Defs.h
+RA_Dlg_AchEditor.h:      RA_httpthread.h
+RA_Dlg_Memory.h:         RA_CodeNotes.h, RA_MemManager.h
+RA_MemManager.h:         RA_Condition.h
+RA_RichPresence.h:       RA_Leaderboard.h
+RA_Leaderboard.h:        RA_Defs.h
+
+
+Files that should be in PCH:
+----------------------------
+RA_Resource.h: almost never changes
+
+


### PR DESCRIPTION
From my PRs, this should probably be accepted last because it moves the includes of almost every header file.

It moves all library files to "stdafx.h", but keeps RA_Defs.h includes under the RA_EXPORTS define since emulators won't be required to use it. Also added include guards everywhere. Cleaned up includes in source files. Another thing we could do is forward declare as much as possible but that'll be for another time.

This should probably be accepted last, putting up here so you guys can see it. Tried my absolute hardest not to do any whitespace changes, they just happen automatically from Visual Studio.