### PR TITLE
making RALibretro cross-compilable

### DIFF
--- a/src/RA_Interface.cpp
+++ b/src/RA_Interface.cpp
@@ -59,8 +59,8 @@ void RA_GetEstimatedGameTitle( char* sNameOut )
 
 #ifndef RA_EXPORTS
 
-#include <WTypes.h>
-#include <WinHttp.h>
+#include <wtypes.h>
+#include <winhttp.h>
 #include <assert.h>
 #include <string>
 


### PR DESCRIPTION
When trying to cross-compile RALibretro on a Linux machine, the compiler complains about these header files on `src/RA_Interface.cpp`. It's just a matter of "case-sensitiveness".

Unfortunately I'm unable to compile RA_Integration right now (Visual Code doesn't run on my Windows virtual machine) and I am only 99% sure that the changes here are pretty acceptable and won't cause any problem.

Can some of you guys test it?