### PR TITLE
CppCoreCheck Class Rules (Wait for existing PRs)

### DIFF
--- a/src/RA_AchievementOverlay.cpp
+++ b/src/RA_AchievementOverlay.cpp
@@ -98,21 +98,12 @@ void AchievementOverlay::SelectNextTopLevelPage( BOOL bPressedRight )
 	}
 }
 
-AchievementOverlay::AchievementOverlay()
-{
-	m_hOverlayBackground = nullptr;
-	m_nAchievementsSelectedItem = 0;
-	m_nFriendsSelectedItem = 0;
-	m_nMessagesSelectedItem = 0;
-	m_nNewsSelectedItem = 0;
-	m_nLeaderboardSelectedItem = 0;
-}
 
-AchievementOverlay::~AchievementOverlay()
+AchievementOverlay::~AchievementOverlay() noexcept
 {
 	if( m_hOverlayBackground != nullptr )
 	{
-		DeleteObject( m_hOverlayBackground );
+		DeleteBitmap( m_hOverlayBackground );
 		m_hOverlayBackground = nullptr;
 	}
 }

--- a/src/RA_AchievementOverlay.cpp
+++ b/src/RA_AchievementOverlay.cpp
@@ -16,12 +16,13 @@
 
 namespace
 {
-	const float PAGE_TRANSITION_IN = (-0.2f);
-	const float PAGE_TRANSITION_OUT = ( 0.2f);
-	const int NUM_MESSAGES_TO_DRAW = 4;
-	const char* FONT_TO_USE = "Tahoma";
 
-	const char* PAGE_TITLES[] = { 
+	inline constexpr auto PAGE_TRANSITION_IN   = -0.2f;
+	inline constexpr auto PAGE_TRANSITION_OUT  = 0.2f;
+	inline constexpr auto NUM_MESSAGES_TO_DRAW = 4;
+	inline constexpr auto FONT_TO_USE          = "Tahoma";
+
+	inline constexpr std::array<const char*, NumOverlayPages> PAGE_TITLES {
 		" Achievements ", 
 		" Friends ", 
 		" Messages ",
@@ -35,7 +36,6 @@ namespace
 		" Message Viewer "
 
 		};
-	static_assert( SIZEOF_ARRAY( PAGE_TITLES ) == NumOverlayPages, "Must match!" );
 
 }
 

--- a/src/RA_AchievementOverlay.h
+++ b/src/RA_AchievementOverlay.h
@@ -104,8 +104,12 @@ extern AchievementExamine g_AchExamine;
 class AchievementOverlay
 {
 public:
-	AchievementOverlay();
-	~AchievementOverlay();
+	~AchievementOverlay() noexcept;
+	AchievementOverlay(const AchievementOverlay&) = delete;
+	AchievementOverlay& operator=(const AchievementOverlay&) = delete;
+	AchievementOverlay(AchievementOverlay&&) = delete;
+	AchievementOverlay& operator=(AchievementOverlay&&) = delete;
+	AchievementOverlay() noexcept = default;
 
 	void Initialize( HINSTANCE hInst );
 
@@ -162,33 +166,42 @@ public:
 	};
 
 private:
-	int	m_nAchievementsScrollOffset;
-	int	m_nFriendsScrollOffset;
-	int	m_nMessagesScrollOffset;
-	int	m_nNewsScrollOffset;
-	int	m_nLeaderboardScrollOffset;
+	/*	m_hOverlayBackground = nullptr;
+	m_nAchievementsSelectedItem = 0;
+	m_nFriendsSelectedItem = 0;
+	m_nMessagesSelectedItem = 0;
+	m_nNewsSelectedItem = 0;
+	m_nLeaderboardSelectedItem = 0;*/
 
-	int	m_nAchievementsSelectedItem;
-	int	m_nFriendsSelectedItem;
-	int	m_nMessagesSelectedItem;
-	int	m_nNewsSelectedItem;
-	int	m_nLeaderboardSelectedItem;
+	int	m_nAchievementsScrollOffset{ 0 };
+	int	m_nFriendsScrollOffset{ 0 };
+	int	m_nMessagesScrollOffset{ 0 };
+	int	m_nNewsScrollOffset{ 0 };
+	int	m_nLeaderboardScrollOffset{ 0 };
 
-	mutable int m_nNumAchievementsBeingRendered;
-	mutable int m_nNumFriendsBeingRendered;
-	mutable int m_nNumLeaderboardsBeingRendered;
+	int	m_nAchievementsSelectedItem{ 0 };
+	int	m_nFriendsSelectedItem{ 0 };
+	int	m_nMessagesSelectedItem{ 0 };
+	int	m_nNewsSelectedItem{ 0 };
+	int	m_nLeaderboardSelectedItem{ 0 };
 
-	BOOL					m_bInputLock;	//	Waiting for pad release
+	mutable int m_nNumAchievementsBeingRendered{ 0 };
+	mutable int m_nNumFriendsBeingRendered{ 0 };
+	mutable int m_nNumLeaderboardsBeingRendered{ 0 };
+
+	BOOL					m_bInputLock{ FALSE };	//	Waiting for pad release
 	std::vector<NewsItem>	m_LatestNews;
-	TransitionState			m_nTransitionState;
-	float					m_fTransitionTimer;
+	TransitionState			m_nTransitionState{ TransitionState::TS_OFF };
+	float					m_fTransitionTimer{ 0.0f };
 
+	// This looks questionable
 	OverlayPage				m_Pages[ 5 ];
-	unsigned int			m_nPageStackPointer;
+	unsigned int			m_nPageStackPointer{ 0U };
 
 	//HBITMAP m_hLockedBitmap;	//	Cached	
-	HBITMAP m_hOverlayBackground;
+	HBITMAP m_hOverlayBackground{ nullptr };
 
+	// Are these even used?
 	LPDIRECTDRAW4 m_lpDD;
 	LPDIRECTDRAWSURFACE4 m_lpDDS_Overlay;
 };

--- a/src/RA_AchievementPopup.cpp
+++ b/src/RA_AchievementPopup.cpp
@@ -7,29 +7,28 @@
 
 namespace
 {
-	const float POPUP_DIST_Y_TO_PCT = 0.856f;		//	Where on screen to end up
-	const float POPUP_DIST_Y_FROM_PCT = 0.4f;		//	Amount of screens to travel
-	const TCHAR* FONT_TO_USE = _T( "Tahoma" );
+inline constexpr auto POPUP_DIST_Y_TO_PCT   = 0.856f;		//	Where on screen to end up
+inline constexpr auto POPUP_DIST_Y_FROM_PCT = 0.4f;		//	Amount of screens to travel
+inline constexpr auto FONT_TO_USE           = _T( "Tahoma" );
 	
-	const int FONT_SIZE_TITLE = 32;
-	const int FONT_SIZE_SUBTITLE = 28;
+inline constexpr auto FONT_SIZE_TITLE    = 32;
+inline constexpr auto FONT_SIZE_SUBTITLE = 28;
 
-	const float START_AT = 0.0f;
-	const float APPEAR_AT = 0.8f;
-	const float FADEOUT_AT = 4.2f;
-	const float FINISH_AT = 5.0f;
+inline constexpr auto START_AT   = 0.0f;
+inline constexpr auto APPEAR_AT  = 0.8f;
+inline constexpr auto FADEOUT_AT = 4.2f;
+inline constexpr auto FINISH_AT  = 5.0f;
 
-	const TCHAR* MSG_SOUND[] =
-	{
-		_T( "./Overlay/login.wav" ),
-		_T( "./Overlay/info.wav" ),
-		_T( "./Overlay/unlock.wav" ),
-		_T( "./Overlay/acherror.wav" ),
-		_T( "./Overlay/lb.wav" ),
-		_T( "./Overlay/lbcancel.wav" ),
-		_T( "./Overlay/message.wav" ),
-	};
-	static_assert( SIZEOF_ARRAY( MSG_SOUND ) == NumMessageTypes, "Must match!" );
+inline constexpr std::array<LPCTSTR, NumMessageTypes> MSG_SOUND
+{
+	_T( "./Overlay/login.wav" ),
+	_T( "./Overlay/info.wav" ),
+	_T( "./Overlay/unlock.wav" ),
+	_T( "./Overlay/acherror.wav" ),
+	_T( "./Overlay/lb.wav" ),
+	_T( "./Overlay/lbcancel.wav" ),
+	_T( "./Overlay/message.wav" ),
+};
 }
 
 AchievementPopup::AchievementPopup() :

--- a/src/RA_AchievementSet.cpp
+++ b/src/RA_AchievementSet.cpp
@@ -520,10 +520,10 @@ BOOL AchievementSet::LoadFromFile( GameID nGameID )
 				{
 					//"Leaderboards":[{"ID":"2","Mem":"STA:0xfe10=h0000_0xhf601=h0c_d0xhf601!=h0c_0xfff0=0_0xfffb=0::CAN:0xhfe13<d0xhfe13::SUB:0xf7cc!=0_d0xf7cc=0::VAL:0xhfe24*1_0xhfe25*60_0xhfe22*3600","Format":"TIME","Title":"Green Hill Act 1","Description":"Complete this act in the fastest time!"},
 
-					RA_Leaderboard lb(LeaderboardsData[i]["ID"].GetUint());
+					RA_Leaderboard lb{ LeaderboardsData[i]["ID"].GetUint() };
 					lb.LoadFromJSON(LeaderboardsData[i]);
 
-					g_LeaderboardManager.AddLeaderboard(lb);
+					g_LeaderboardManager.AddLeaderboard(std::move(lb));
 				}
 			}
 			else

--- a/src/RA_AchievementSet.cpp
+++ b/src/RA_AchievementSet.cpp
@@ -11,12 +11,18 @@
 #include "RA_md5factory.h"
 #include "RA_GameData.h"
 
+// Will leave it alone for now, but having these as raw pointers is a really bad idea
+
 AchievementSet* g_pCoreAchievements = nullptr;
 AchievementSet* g_pUnofficialAchievements = nullptr;
 AchievementSet* g_pLocalAchievements = nullptr;
 
-AchievementSet** ACH_SETS[] = { &g_pCoreAchievements, &g_pUnofficialAchievements, &g_pLocalAchievements };
-static_assert( SIZEOF_ARRAY( ACH_SETS ) == NumAchievementSetTypes, "Must match!" );
+// for now
+using AchievementSets = std::array<AchievementSet*, 3>;
+// can't be constexpr because AchievementSet isn't a literal type
+inline const AchievementSets ACH_SETS{ g_pCoreAchievements, g_pUnofficialAchievements, g_pLocalAchievements };
+
+static_assert(ACH_SETS.size() == NumAchievementSetTypes, "Must match!" );
 
 AchievementSetType g_nActiveAchievementSet = Core;
 AchievementSet* g_pActiveAchievements = g_pCoreAchievements;
@@ -25,7 +31,7 @@ AchievementSet* g_pActiveAchievements = g_pCoreAchievements;
 void RASetAchievementCollection( AchievementSetType Type )
 {
 	g_nActiveAchievementSet = Type;
-	g_pActiveAchievements = *ACH_SETS[ Type ];
+	g_pActiveAchievements = ACH_SETS.at(Type);
 }
 
 std::string AchievementSet::GetAchievementSetFilename( GameID nGameID )

--- a/src/RA_Condition.cpp
+++ b/src/RA_Condition.cpp
@@ -1,14 +1,6 @@
 #include "RA_Condition.h"
 #include "RA_MemManager.h"
 
-const char* COMPARISONVARIABLESIZE_STR[] = { "Bit0", "Bit1", "Bit2", "Bit3", "Bit4", "Bit5", "Bit6", "Bit7", "Lower4", "Upper4", "8-bit", "16-bit", "32-bit" };
-static_assert( SIZEOF_ARRAY( COMPARISONVARIABLESIZE_STR ) == NumComparisonVariableSizeTypes, "Must match!" );
-const char* COMPARISONVARIABLETYPE_STR[] = { "Memory", "Value", "Delta", "DynVar" };
-static_assert( SIZEOF_ARRAY( COMPARISONVARIABLETYPE_STR ) == NumComparisonVariableTypes, "Must match!" );
-const char* COMPARISONTYPE_STR[] = { "=", "<", "<=", ">", ">=", "!=" };
-static_assert( SIZEOF_ARRAY( COMPARISONTYPE_STR ) == NumComparisonTypes, "Must match!" );
-const char* CONDITIONTYPE_STR[] = { "", "Pause If", "Reset If", "Add Source", "Sub Source", "Add Hits"};
-static_assert( SIZEOF_ARRAY( CONDITIONTYPE_STR ) == Condition::NumConditionTypes, "Must match!" );
 
 static ComparisonVariableSize PrefixToComparisonSize( char cPrefix )
 {
@@ -501,7 +493,7 @@ void ConditionGroup::RemoveAt( size_t nID )
 		iter++;
 	}
 }
-<<<<<<< HEAD
+
 
 void ConditionGroup::SerializeAppend(std::string& buffer) const
 {
@@ -641,5 +633,3 @@ bool ConditionSet::Reset()
 
 	return bWasReset;
 }
-=======
->>>>>>> global_carrays_to_stdarray

--- a/src/RA_Condition.cpp
+++ b/src/RA_Condition.cpp
@@ -501,6 +501,7 @@ void ConditionGroup::RemoveAt( size_t nID )
 		iter++;
 	}
 }
+<<<<<<< HEAD
 
 void ConditionGroup::SerializeAppend(std::string& buffer) const
 {
@@ -640,3 +641,5 @@ bool ConditionSet::Reset()
 
 	return bWasReset;
 }
+=======
+>>>>>>> global_carrays_to_stdarray

--- a/src/RA_Condition.h
+++ b/src/RA_Condition.h
@@ -181,16 +181,13 @@ private:
 	unsigned int	m_nCurrentHits;
 };
 
-<<<<<<< HEAD
-class ConditionGroup
-=======
+
 inline constexpr std::array<const char*, Condition::NumConditionTypes> CONDITIONTYPE_STR{
 	"", "Pause If", "Reset If", "Add Source", "Sub Source", "Add Hits"
 };
 
 
-class ConditionSet
->>>>>>> global_carrays_to_stdarray
+class ConditionGroup
 {
 public:
 	void SerializeAppend(std::string& buffer) const;

--- a/src/RA_Condition.h
+++ b/src/RA_Condition.h
@@ -20,7 +20,10 @@ enum ComparisonVariableSize
 
 	NumComparisonVariableSizeTypes
 };
-extern const char* COMPARISONVARIABLESIZE_STR[];
+inline constexpr std::array<const char*, NumComparisonVariableSizeTypes> COMPARISONVARIABLESIZE_STR{
+	"Bit0", "Bit1", "Bit2", "Bit3", "Bit4", "Bit5", "Bit6", "Bit7", "Lower4", "Upper4", "8-bit", "16-bit",
+	"32-bit"
+};
 
 enum ComparisonVariableType
 {
@@ -31,7 +34,9 @@ enum ComparisonVariableType
 
 	NumComparisonVariableTypes
 };
-extern const char* COMPARISONVARIABLETYPE_STR[];
+inline constexpr std::array<const char*, NumComparisonVariableTypes> COMPARISONVARIABLETYPE_STR{
+	"Memory", "Value", "Delta", "DynVar"
+};
 
 enum ComparisonType
 {
@@ -44,9 +49,11 @@ enum ComparisonType
 
 	NumComparisonTypes
 };
-extern const char* COMPARISONTYPE_STR[];
+inline constexpr std::array<const char*, NumComparisonTypes> COMPARISONTYPE_STR{
+	"=", "<", "<=", ">", ">=", "!="
+};
 
-extern const char* CONDITIONTYPE_STR[];
+
 
 class CompVariable
 {
@@ -174,7 +181,16 @@ private:
 	unsigned int	m_nCurrentHits;
 };
 
+<<<<<<< HEAD
 class ConditionGroup
+=======
+inline constexpr std::array<const char*, Condition::NumConditionTypes> CONDITIONTYPE_STR{
+	"", "Pause If", "Reset If", "Add Source", "Sub Source", "Add Hits"
+};
+
+
+class ConditionSet
+>>>>>>> global_carrays_to_stdarray
 {
 public:
 	void SerializeAppend(std::string& buffer) const;
@@ -214,3 +230,6 @@ public:
 protected:
 	std::vector<ConditionGroup> m_vConditionGroups;
 };
+//extern BOOL CompareConditionValues( unsigned int nLHS, const enum CompType nCmpType, unsigned int nRHS );
+extern ComparisonType ReadOperator( char*& pBufferInOut );
+extern unsigned int ReadHits( char*& pBufferInOut );

--- a/src/RA_Core.cpp
+++ b/src/RA_Core.cpp
@@ -33,7 +33,7 @@
 #include <codecvt>
 #include <direct.h>
 #include <io.h>		//	_access()
-
+#include <atlbase.h> // CComPtr
 
 std::string g_sKnownRAVersion;
 std::string g_sHomeDir;
@@ -1618,35 +1618,47 @@ BOOL _FileExists(const std::string& sFileName)
 	}
 }
 
+
+
 std::string GetFolderFromDialog()
 {
 	std::string sRetVal;
+<<<<<<< HEAD
 	//HRESULT hr = CoInitializeEx( nullptr, COINIT_APARTMENTTHREADED|COINIT_DISABLE_OLE1DDE );
 	IFileOpenDialog* pDlg = nullptr;
 	HRESULT hr = CoCreateInstance(CLSID_FileOpenDialog, nullptr, CLSCTX_ALL, IID_IFileOpenDialog, reinterpret_cast<void**>(&pDlg));
 	if (hr == S_OK)
+=======
+	// let me check: these are to check if they need initilizers or not, commented out most of it
+
+
+	CComPtr<IFileOpenDialog> pDlg;
+	if (auto hr = CoCreateInstance(CLSID_FileOpenDialog, nullptr, CLSCTX_ALL, IID_IFileOpenDialog, 
+		reinterpret_cast<void**>(&pDlg)); SUCCEEDED(hr))
+>>>>>>> com_smart_pointers
 	{
 		pDlg->SetOptions(FOS_PICKFOLDERS);
-		hr = pDlg->Show(nullptr);
-		if (hr == S_OK)
+
+		if (hr = pDlg->Show(nullptr); SUCCEEDED(hr))
 		{
-			IShellItem* pItem = nullptr;
-			hr = pDlg->GetResult(&pItem);
-			if (hr == S_OK)
+			CComPtr<IShellItem> pItem;
+			if (hr = pDlg->GetResult(&pItem); SUCCEEDED(hr))
 			{
-				LPWSTR pStr = nullptr;
-				hr = pItem->GetDisplayName(SIGDN_FILESYSPATH, &pStr);
-				if (hr == S_OK)
+				auto pStr = LPWSTR{};
+				// Microsoft's tripping, primitives and typedefs don't have constructors
+				// static_assert(std::is_default_constructible_v<LPWSTR>);
+				if (hr = pItem->GetDisplayName(SIGDN_FILESYSPATH, &pStr); SUCCEEDED(hr))
 				{
 					sRetVal = Narrow(pStr);
-				}
-
-				pItem->Release();
-			}
-		}
-		pDlg->Release();
-	}
-	//CoUninitialize();
+                    // https://msdn.microsoft.com/en-us/library/windows/desktop/bb761140(v=vs.85).aspx
+                    CoTaskMemFree(static_cast<LPVOID>(pStr));
+                    pStr = LPWSTR{}; // we didn't use new, so just reset it
+				} // end if
+				pItem.Release();
+			} // end if
+		} // end if
+		pDlg.Release(); // Ok, everythings nullified except the return
+	} // end if
 	return sRetVal;
 }
 

--- a/src/RA_Core.cpp
+++ b/src/RA_Core.cpp
@@ -1623,19 +1623,12 @@ BOOL _FileExists(const std::string& sFileName)
 std::string GetFolderFromDialog()
 {
 	std::string sRetVal;
-<<<<<<< HEAD
-	//HRESULT hr = CoInitializeEx( nullptr, COINIT_APARTMENTTHREADED|COINIT_DISABLE_OLE1DDE );
-	IFileOpenDialog* pDlg = nullptr;
-	HRESULT hr = CoCreateInstance(CLSID_FileOpenDialog, nullptr, CLSCTX_ALL, IID_IFileOpenDialog, reinterpret_cast<void**>(&pDlg));
-	if (hr == S_OK)
-=======
-	// let me check: these are to check if they need initilizers or not, commented out most of it
+
 
 
 	CComPtr<IFileOpenDialog> pDlg;
 	if (auto hr = CoCreateInstance(CLSID_FileOpenDialog, nullptr, CLSCTX_ALL, IID_IFileOpenDialog, 
 		reinterpret_cast<void**>(&pDlg)); SUCCEEDED(hr))
->>>>>>> com_smart_pointers
 	{
 		pDlg->SetOptions(FOS_PICKFOLDERS);
 
@@ -1644,7 +1637,7 @@ std::string GetFolderFromDialog()
 			CComPtr<IShellItem> pItem;
 			if (hr = pDlg->GetResult(&pItem); SUCCEEDED(hr))
 			{
-				auto pStr = LPWSTR{};
+				LPWSTR pStr = nullptr;
 				// Microsoft's tripping, primitives and typedefs don't have constructors
 				// static_assert(std::is_default_constructible_v<LPWSTR>);
 				if (hr = pItem->GetDisplayName(SIGDN_FILESYSPATH, &pStr); SUCCEEDED(hr))
@@ -1652,13 +1645,13 @@ std::string GetFolderFromDialog()
 					sRetVal = Narrow(pStr);
                     // https://msdn.microsoft.com/en-us/library/windows/desktop/bb761140(v=vs.85).aspx
                     CoTaskMemFree(static_cast<LPVOID>(pStr));
-                    pStr = LPWSTR{}; // we didn't use new, so just reset it
-				} // end if
+                    pStr = nullptr; // we didn't use new, so just reset it
+				}
 				pItem.Release();
-			} // end if
-		} // end if
+			}
+		}
 		pDlg.Release(); // Ok, everythings nullified except the return
-	} // end if
+	}
 	return sRetVal;
 }
 

--- a/src/RA_Core.h
+++ b/src/RA_Core.h
@@ -143,9 +143,11 @@ extern void _FetchGameHashLibraryFromWeb();
 extern void _FetchGameTitlesFromWeb();
 extern void _FetchMyProgressFromWeb();
 
+
 extern BOOL _FileExists( const std::string& sFileName );
 
 extern std::string _TimeStampToString( time_t nTime );
+
 
 extern std::string GetFolderFromDialog();
 

--- a/src/RA_Defs.cpp
+++ b/src/RA_Defs.cpp
@@ -41,6 +41,7 @@ std::wstring Widen(const std::string& str)
 std::wstring Widen(const char* str)
 {
     auto state = std::mbstate_t();
+#pragma warning(suppress : 4996)
     auto len = 1 + std::mbsrtowcs(nullptr, &str, 0, &state);
     auto wstr{ L""s };
     wstr.reserve(len);

--- a/src/RA_Defs.h
+++ b/src/RA_Defs.h
@@ -137,23 +137,30 @@ public:
 class RASize
 {
 public:
-    RASize() : m_nWidth(0), m_nHeight(0) {}
-    RASize(const RASize& rhs) : m_nWidth(rhs.m_nWidth), m_nHeight(rhs.m_nHeight) {}
-    RASize(int nW, int nH) : m_nWidth(nW), m_nHeight(nH) {}
+	inline constexpr RASize(int nW, int nH) noexcept : m_nWidth{ nW }, m_nHeight{ nH } {}
+	~RASize() noexcept = default;
+	// copying literal types should be ok
+	inline constexpr RASize(const RASize&) noexcept = default;
+	inline constexpr RASize& operator=(const RASize&) noexcept = default;
+	inline constexpr RASize(RASize&&) noexcept = default;
+	inline constexpr RASize& operator=(RASize&&) noexcept = default;
 
+	// This can be a literal type
+	// This constructor means that this type can used in constant expressions(methods with running times of O(1))
+	inline constexpr RASize() noexcept = default;
 public:
-    inline int Width() const { return m_nWidth; }
-    inline int Height() const { return m_nHeight; }
-    inline void SetWidth(int nW) { m_nWidth = nW; }
-    inline void SetHeight(int nH) { m_nHeight = nH; }
+    inline constexpr int Width() const { return m_nWidth; }
+    inline constexpr int Height() const { return m_nHeight; }
+    inline constexpr void SetWidth(int nW) { m_nWidth = nW; }
+    inline constexpr void SetHeight(int nH) { m_nHeight = nH; }
 
 private:
-    int m_nWidth;
-    int m_nHeight;
+	int m_nWidth{ 0 };
+	int m_nHeight{ 0 };
 };
 
-const RASize RA_BADGE_PX(64, 64);
-const RASize RA_USERPIC_PX(64, 64);
+inline constexpr RASize RA_BADGE_PX{ 64, 64 };
+inline constexpr RASize RA_USERPIC_PX{ 64, 64 };
 
 class ResizeContent
 {

--- a/src/RA_Defs.h
+++ b/src/RA_Defs.h
@@ -45,21 +45,14 @@
 //NB. These must NOT be accessible from the emulator!
 //#define RA_INTEGRATION_VERSION	"0.053"
 
-<<<<<<< HEAD
-#pragma warning(push, 1)
 
-#define _SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING
+
 //	RA-Only
 #define RAPIDJSON_HAS_STDSTRING 1
 #pragma warning(push, 1)
 // This is not needed the most recent version
-#define _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS
-=======
-
-#pragma warning(push, 1)
 #define _SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING
 
->>>>>>> com_smart_pointers
 //	RA-Only
 #include "rapidjson/include/rapidjson/document.h"
 #include "rapidjson/include/rapidjson/reader.h"
@@ -67,19 +60,13 @@
 #include "rapidjson/include/rapidjson/filestream.h"
 #include "rapidjson/include/rapidjson/stringbuffer.h"
 #include "rapidjson/include/rapidjson/error/en.h"
-<<<<<<< HEAD
-=======
 
->>>>>>> global_carrays_to_stdarray
 #pragma warning(pop)
 using namespace rapidjson;
 extern GetParseErrorFunc GetJSONParseErrorStr;
-<<<<<<< HEAD
 
-=======
 #pragma warning(pop)
-#endif	//RA_EXPORTS
->>>>>>> com_smart_pointers
+
 
 
 using namespace std::string_literals;
@@ -88,6 +75,7 @@ namespace ra {}
 using namespace ra;
 
 #endif	//RA_EXPORTS
+
 #define _CONSTANT_VAR inline constexpr auto
 #define _CONSTANT     inline constexpr
 

--- a/src/RA_Defs.h
+++ b/src/RA_Defs.h
@@ -13,6 +13,7 @@
 #include <queue>
 #include <deque>
 #include <map>
+#include <array>
 
 
 #ifndef RA_EXPORTS
@@ -43,6 +44,9 @@
 //NB. These must NOT be accessible from the emulator!
 //#define RA_INTEGRATION_VERSION	"0.053"
 
+#pragma warning(push, 1)
+
+#define _SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING
 //	RA-Only
 #define RAPIDJSON_HAS_STDSTRING 1
 #pragma warning(push, 1)
@@ -55,6 +59,10 @@
 #include "rapidjson/include/rapidjson/filestream.h"
 #include "rapidjson/include/rapidjson/stringbuffer.h"
 #include "rapidjson/include/rapidjson/error/en.h"
+<<<<<<< HEAD
+=======
+
+>>>>>>> global_carrays_to_stdarray
 #pragma warning(pop)
 using namespace rapidjson;
 extern GetParseErrorFunc GetJSONParseErrorStr;

--- a/src/RA_Defs.h
+++ b/src/RA_Defs.h
@@ -16,6 +16,7 @@
 #include <array>
 
 
+
 #ifndef RA_EXPORTS
 
 //	Version Information is integrated into tags
@@ -44,6 +45,7 @@
 //NB. These must NOT be accessible from the emulator!
 //#define RA_INTEGRATION_VERSION	"0.053"
 
+<<<<<<< HEAD
 #pragma warning(push, 1)
 
 #define _SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING
@@ -52,6 +54,12 @@
 #pragma warning(push, 1)
 // This is not needed the most recent version
 #define _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS
+=======
+
+#pragma warning(push, 1)
+#define _SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING
+
+>>>>>>> com_smart_pointers
 //	RA-Only
 #include "rapidjson/include/rapidjson/document.h"
 #include "rapidjson/include/rapidjson/reader.h"
@@ -66,7 +74,12 @@
 #pragma warning(pop)
 using namespace rapidjson;
 extern GetParseErrorFunc GetJSONParseErrorStr;
+<<<<<<< HEAD
 
+=======
+#pragma warning(pop)
+#endif	//RA_EXPORTS
+>>>>>>> com_smart_pointers
 
 
 using namespace std::string_literals;

--- a/src/RA_Defs.h
+++ b/src/RA_Defs.h
@@ -1,3 +1,5 @@
+#ifndef RA_DEFS_H
+#define RA_DEFS_H
 #pragma once
 
 #include <Windows.h>
@@ -19,9 +21,33 @@
 
 #else
 
+
+// Maybe an extra check just in-case
+
+#if _HAS_CXX17
+#define _DEPRECATED          [[deprecated]]
+#define _DEPRECATEDR(reason) [[deprecated(reason)]]
+#define _FALLTHROUGH         [[fallthrough]]//; you need ';' at the end
+#define _NODISCARD           [[nodiscard]]
+#define _NORETURN            [[noreturn]]
+#define _UNUSED              [[maybe_unused]]
+
+// Disables the use of const_casts, if you get an error, it's not a literal
+// type. You could use it on functions but they will need a deduction guide
+// That would probably be better with a forwarding function
+
+
+
+
+#endif // _HAS_CXX17
 //NB. These must NOT be accessible from the emulator!
 //#define RA_INTEGRATION_VERSION	"0.053"
 
+//	RA-Only
+#define RAPIDJSON_HAS_STDSTRING 1
+#pragma warning(push, 1)
+// This is not needed the most recent version
+#define _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS
 //	RA-Only
 #include "rapidjson/include/rapidjson/document.h"
 #include "rapidjson/include/rapidjson/reader.h"
@@ -29,11 +55,20 @@
 #include "rapidjson/include/rapidjson/filestream.h"
 #include "rapidjson/include/rapidjson/stringbuffer.h"
 #include "rapidjson/include/rapidjson/error/en.h"
+#pragma warning(pop)
 using namespace rapidjson;
 extern GetParseErrorFunc GetJSONParseErrorStr;
 
-#endif	//RA_EXPORTS
 
+
+using namespace std::string_literals;
+//using namespace std::chrono_literals; we could use this later
+namespace ra {}
+using namespace ra;
+
+#endif	//RA_EXPORTS
+#define _CONSTANT_VAR inline constexpr auto
+#define _CONSTANT     inline constexpr
 
 #define RA_KEYS_DLL						"RA_Keys.dll"
 #define RA_PREFERENCES_FILENAME_PREFIX	"RAPrefs_"
@@ -63,160 +98,153 @@ extern GetParseErrorFunc GetJSONParseErrorStr;
 #define SIZEOF_ARRAY( ar )	( sizeof( ar ) / sizeof( ar[ 0 ] ) )
 #define SAFE_DELETE( x )	{ if( x != nullptr ) { delete x; x = nullptr; } }
 
-typedef unsigned char	BYTE;
-typedef unsigned long	DWORD;
-typedef int				BOOL;
-typedef DWORD			ARGB;
+using ARGB = DWORD;
 
 //namespace RA
 //{
-	template<typename T>
-	static inline const T& RAClamp( const T& val, const T& lower, const T& upper )
-	{
-		return( val < lower ) ? lower : ( ( val > upper ) ? upper : val );
-	}
-	
-	class RARect : public RECT
-	{
-	public:
-		RARect() {}
-		RARect( LONG nX, LONG nY, LONG nW, LONG nH )
-		{
-			left = nX;
-			right = nX + nW;
-			top = nY;
-			bottom = nY + nH;
-		}
+template<typename T>
+static inline const T& RAClamp(const T& val, const T& lower, const T& upper)
+{
+    return(val < lower) ? lower : ((val > upper) ? upper : val);
+}
 
-	public:
-		inline int Width() const		{ return( right - left ); }
-		inline int Height() const		{ return( bottom - top ); }
-	};
+class RARect : public RECT
+{
+public:
+    RARect() {}
+    RARect(LONG nX, LONG nY, LONG nW, LONG nH)
+    {
+        left = nX;
+        right = nX + nW;
+        top = nY;
+        bottom = nY + nH;
+    }
 
-	class RASize
-	{
-	public:
-		RASize() : m_nWidth( 0 ), m_nHeight( 0 ) {}
-		RASize( const RASize& rhs ) : m_nWidth( rhs.m_nWidth ), m_nHeight( rhs.m_nHeight ) {}
-		RASize( int nW, int nH ) : m_nWidth( nW ), m_nHeight( nH ) {}
+public:
+    inline int Width() const { return(right - left); }
+    inline int Height() const { return(bottom - top); }
+};
 
-	public:
-		inline int Width() const		{ return m_nWidth; }
-		inline int Height() const		{ return m_nHeight; }
-		inline void SetWidth( int nW )	{ m_nWidth = nW; }
-		inline void SetHeight( int nH )	{ m_nHeight = nH; }
+class RASize
+{
+public:
+    RASize() : m_nWidth(0), m_nHeight(0) {}
+    RASize(const RASize& rhs) : m_nWidth(rhs.m_nWidth), m_nHeight(rhs.m_nHeight) {}
+    RASize(int nW, int nH) : m_nWidth(nW), m_nHeight(nH) {}
 
-	private:
-		int m_nWidth;
-		int m_nHeight;
-	};
+public:
+    inline int Width() const { return m_nWidth; }
+    inline int Height() const { return m_nHeight; }
+    inline void SetWidth(int nW) { m_nWidth = nW; }
+    inline void SetHeight(int nH) { m_nHeight = nH; }
 
-	const RASize RA_BADGE_PX( 64, 64 );
-	const RASize RA_USERPIC_PX( 64, 64 );
+private:
+    int m_nWidth;
+    int m_nHeight;
+};
 
-	class ResizeContent
-	{
-	public:
-		enum AlignType
-		{
-			NO_ALIGN,
-			ALIGN_RIGHT,
-			ALIGN_BOTTOM,
-			ALIGN_BOTTOM_RIGHT
-		};
+const RASize RA_BADGE_PX(64, 64);
+const RASize RA_USERPIC_PX(64, 64);
 
-	public:
-		HWND hwnd;
-		POINT pLT;
-		POINT pRB;
-		AlignType nAlignType;
-		int nDistanceX;
-		int nDistanceY;
-		bool bResize;
+class ResizeContent
+{
+public:
+    enum AlignType
+    {
+        NO_ALIGN,
+        ALIGN_RIGHT,
+        ALIGN_BOTTOM,
+        ALIGN_BOTTOM_RIGHT
+    };
 
-		ResizeContent( HWND parentHwnd, HWND contentHwnd, AlignType newAlignType, bool isResize )
-		{
-			hwnd = contentHwnd;
-			nAlignType = newAlignType;
-			bResize = isResize;
-			
-			RARect rect;
-			GetWindowRect( hwnd, &rect );
+public:
+    HWND hwnd;
+    POINT pLT;
+    POINT pRB;
+    AlignType nAlignType;
+    int nDistanceX;
+    int nDistanceY;
+    bool bResize;
 
-			pLT.x = rect.left;	pLT.y = rect.top;
-			pRB.x = rect.right; pRB.y = rect.bottom;
+    ResizeContent(HWND parentHwnd, HWND contentHwnd, AlignType newAlignType, bool isResize)
+    {
+        hwnd = contentHwnd;
+        nAlignType = newAlignType;
+        bResize = isResize;
 
-			ScreenToClient( parentHwnd, &pLT );
-			ScreenToClient( parentHwnd, &pRB );
+        RARect rect;
+        GetWindowRect(hwnd, &rect);
 
-			GetWindowRect ( parentHwnd, &rect );
-			nDistanceX = rect.Width() - pLT.x;
-			nDistanceY = rect.Height() - pLT.y;
-			
-			if ( bResize )
-			{
-				nDistanceX -= (pRB.x - pLT.x);
-				nDistanceY -= (pRB.y - pLT.y);
-			}
-		}
+        pLT.x = rect.left;	pLT.y = rect.top;
+        pRB.x = rect.right; pRB.y = rect.bottom;
 
-		void Resize(int width, int height)
-		{
-			int xPos, yPos;
+        ScreenToClient(parentHwnd, &pLT);
+        ScreenToClient(parentHwnd, &pRB);
 
-			switch ( nAlignType )
-			{
-				case ResizeContent::ALIGN_RIGHT:
-					xPos = width - nDistanceX - ( bResize ? pLT.x : 0 );
-					yPos = bResize ? ( pRB.y - pLT.x ) : pLT.y;
-					break;
-				case ResizeContent::ALIGN_BOTTOM:
-					xPos = bResize ? ( pRB.x - pLT.x ) : pLT.x;
-					yPos = height - nDistanceY - ( bResize ? pLT.y : 0 );
-					break;
-				case ResizeContent::ALIGN_BOTTOM_RIGHT:
-					xPos = width - nDistanceX - ( bResize ? pLT.x : 0 );
-					yPos = height - nDistanceY - ( bResize ? pLT.y : 0 );
-					break;
-				default:
-					xPos = bResize ? ( pRB.x - pLT.x ) : pLT.x;
-					yPos = bResize ? ( pRB.y - pLT.x ) : pLT.y;
-					break;
-			}
+        GetWindowRect(parentHwnd, &rect);
+        nDistanceX = rect.Width() - pLT.x;
+        nDistanceY = rect.Height() - pLT.y;
 
-			if ( !bResize )
-				SetWindowPos( hwnd, nullptr, xPos, yPos, 0, 0, SWP_NOSIZE | SWP_NOZORDER );
-			else
-				SetWindowPos( hwnd, nullptr, 0, 0, xPos, yPos, SWP_NOMOVE | SWP_NOZORDER );
-		}
-	};
+        if (bResize)
+        {
+            nDistanceX -= (pRB.x - pLT.x);
+            nDistanceY -= (pRB.y - pLT.y);
+        }
+    }
 
-	enum AchievementSetType
-	{
-		Core,
-		Unofficial,
-		Local,
+    void Resize(int width, int height)
+    {
+        int xPos, yPos;
 
-		NumAchievementSetTypes
-	};
-	
-	typedef std::vector<BYTE> DataStream;
-	typedef unsigned long ByteAddress;
+        switch (nAlignType)
+        {
+        case ResizeContent::ALIGN_RIGHT:
+            xPos = width - nDistanceX - (bResize ? pLT.x : 0);
+            yPos = bResize ? (pRB.y - pLT.x) : pLT.y;
+            break;
+        case ResizeContent::ALIGN_BOTTOM:
+            xPos = bResize ? (pRB.x - pLT.x) : pLT.x;
+            yPos = height - nDistanceY - (bResize ? pLT.y : 0);
+            break;
+        case ResizeContent::ALIGN_BOTTOM_RIGHT:
+            xPos = width - nDistanceX - (bResize ? pLT.x : 0);
+            yPos = height - nDistanceY - (bResize ? pLT.y : 0);
+            break;
+        default:
+            xPos = bResize ? (pRB.x - pLT.x) : pLT.x;
+            yPos = bResize ? (pRB.y - pLT.x) : pLT.y;
+            break;
+        }
 
-	typedef unsigned int AchievementID;
-	typedef unsigned int LeaderboardID;
-	typedef unsigned int GameID;
+        if (!bResize)
+            SetWindowPos(hwnd, NULL, xPos, yPos, NULL, NULL, SWP_NOSIZE | SWP_NOZORDER);
+        else
+            SetWindowPos(hwnd, NULL, 0, 0, xPos, yPos, SWP_NOMOVE | SWP_NOZORDER);
+    }
+};
 
-	char* DataStreamAsString( DataStream& stream );
+enum AchievementSetType
+{
+    Core,
+    Unofficial,
+    Local,
 
-	extern void RADebugLogNoFormat( const char* data );
-	extern void RADebugLog( const char* sFormat, ... );
-	extern BOOL DirectoryExists( const char* sPath );
+    NumAchievementSetTypes
+};
 
-	const int SERVER_PING_DURATION = 2*60;
+
+
+
+
+
+extern void RADebugLogNoFormat(const char* data);
+extern void RADebugLog(const char* sFormat, ...);
+extern BOOL DirectoryExists(const char* sPath);
+
+const int SERVER_PING_DURATION = 2 * 60;
 //};
 //using namespace RA;
-	
+
 #define RA_LOG RADebugLog
 
 #ifdef _DEBUG
@@ -226,30 +254,362 @@ typedef DWORD			ARGB;
 #undef ASSERT
 #define ASSERT( x ) {}
 #endif
-	
+
 #ifndef UNUSED
 #define UNUSED( x ) ( x );
 #endif
 
-extern std::string Narrow(const wchar_t* wstr);
-extern std::string Narrow(const std::wstring& wstr);
-extern std::wstring Widen(const char* str);
-extern std::wstring Widen(const std::string& str);
+
+
+
+
+
+
+
+namespace ra {
+
+using tstring       = std::basic_string<TCHAR>;
+using DataStream    = std::basic_string<BYTE>;
+
+using ByteAddress   = std::size_t;
+using DataPos       = std::size_t;
+using AchievementID = std::size_t;
+using LeaderboardID = std::size_t;
+using GameID        = std::size_t;
+
+// forgot to add this
+// if you are already in ra or type "using namespace ra" that's good enough
+// This must be an inline namespace
+inline namespace int_literals
+{
+
+// Don't feel like casting non-stop
+// There's also standard literals for strings and clock types
+
+// N.B.: The parameter can only be either "unsigned long long", char16_t, or char32_t
+
+/// <summary>
+///   <para>
+///     Use it if you need an unsigned integer without the need for explicit
+///     narrowing conversions.
+///   </para>
+///   <para>
+///     usage: <c>auto some_int{21_z};</c> where <c>21</c> is
+///            <paramref name="n" />.
+///   </para>
+/// </summary>
+/// <param name="n">The integer.</param>
+/// <returns>The integer as <c>std::size_t</c>.</returns>
+_CONSTANT_VAR operator""_z(unsigned long long n) noexcept {
+    return static_cast<std::size_t>(n);
+} // end operator""_z
+
+
+/// <summary>
+///   <para>
+///     Use it if you need an integer without the need for explicit narrowing
+///     conversions.
+///   </para>
+///   <para>
+///     usage: <c>auto some_int{1_i};</c> where <c>1</c> is
+///            <paramref name="n" />.
+///   </para>
+/// </summary>
+/// <param name="n">The integer.</param>
+/// <returns>The integer as <c>std::intptr_t</c>.</returns>
+_CONSTANT_VAR operator""_i(unsigned long long n) noexcept {
+    return static_cast<std::intptr_t>(n);
+} // end operator""_i
+
+  // We need one for DWORD, because it doesn't match LPDWORD for some stuff
+_CONSTANT_VAR operator""_dw(unsigned long long n) noexcept {
+    return static_cast<_CSTD DWORD>(n);
+} // end operator""_dw
+
+// streamsize varies as well
+/// <summary>
+/// A literal
+/// </summary>
+/// <param name="n">The n.</param>
+/// <returns></returns>
+_CONSTANT_VAR operator""_ss(unsigned long long n) noexcept {
+    return static_cast<std::streamsize>(n);
+} // end operator""_ss
+
+// Literal for unsigned short
+_CONSTANT_VAR operator""_hu(unsigned long long n) noexcept {
+    return static_cast<std::uint16_t>(n);
+} // end operator""_hu
+
+
+_CONSTANT_VAR operator""_dp(unsigned long long n) noexcept {
+    return static_cast<DataPos>(n);
+} // end operator""_dp
+
+// If you follow the standard every alias is considered mutually exclusive, if not don't worry about it
+// These are here if you follow the standards (starts with ISO C++11/C11) rvalue conversions
+
+
+_CONSTANT_VAR operator""_ba(unsigned long long n) noexcept
+{
+    return static_cast<ByteAddress>(n);
+} // end operator""_ba
+
+
+_CONSTANT_VAR operator""_achid(unsigned long long n) noexcept {
+    return static_cast<AchievementID>(n);
+} // end operator""_achid
+
+
+_CONSTANT_VAR operator""_lbid(unsigned long long n) noexcept {
+    return static_cast<LeaderboardID>(n);
+} // end operator""_lbid
+
+
+_CONSTANT_VAR operator""_gameid(unsigned long long n) noexcept {
+    return static_cast<GameID>(n);
+} // end operator""_gameid
+
+} // inline namespace int_literals
+
+
+
+std::string DataStreamAsString(const DataStream& stream);
+std::string Narrow(const std::wstring& wstr);
+std::string Narrow(const wchar_t* wstr);
+std::wstring Widen(const std::string& str);
+std::wstring Widen(const char* str);
+
+
+
+
 
 //	No-ops to help convert:
-//	No-ops to help convert:
-extern std::wstring Widen(const wchar_t* wstr);
-extern std::wstring Widen(const std::wstring& wstr);
-extern std::string Narrow(const char* str);
-extern std::string Narrow(const std::string& wstr);
+std::wstring Widen(const wchar_t* wstr);
+std::wstring Widen(const std::wstring& wstr);
+std::string Narrow(const char* str);
+std::string Narrow(const std::string& wstr);
+std::string ByteAddressToString(ByteAddress nAddr);
 
-typedef std::basic_string<TCHAR> tstring;
 
+template<typename Enum, typename = std::enable_if_t<std::is_enum_v<Enum>>>
+_CONSTANT_VAR etoi(Enum e) -> std::underlying_type_t<Enum>
+{
+    return static_cast<std::underlying_type_t<Enum>>(e);
+}
+
+// function alias template
+template<typename Enum>
+_CONSTANT_VAR to_integral = etoi<Enum>;
+
+/// <summary>
+///   Converts a standard string with a signed character type to a
+///   <c>DataStream</c>.
+/// </summary>
+/// <param name="str">The string.</param>
+/// <typeparam name="CharT">
+///   The character type, must be signed or you will get an intellisense error.
+/// </typeparam>
+/// <returns><paramref name="str" /> as a <c>DataStream</c>.</returns>
+/// <remarks>
+///   <c>DataStream</c> is just an alias for an unsigned standard string.
+/// </remarks>
+template<
+    typename CharT,
+    class = std::enable_if_t<is_char_v<CharT> && std::is_signed_v<CharT>>
+>
+DataStream stodata_stream(const std::basic_string<CharT>& str) noexcept
+{
+    return convert_string<DataStream>(str);
+} // end function stodata_stream
+
+
+  // This should save some pain...
+template<typename SignedType, class = std::enable_if_t<std::is_signed_v<SignedType>>>
+_CONSTANT_VAR to_unsigned(SignedType st) noexcept -> std::make_unsigned_t<SignedType>
+{
+    using unsigned_t = std::make_unsigned_t<SignedType>;
+    return static_cast<unsigned_t>(st);
+}
+
+template<typename UnsignedType, class = std::enable_if_t<std::is_unsigned_v<UnsignedType>>>
+_CONSTANT_VAR to_signed(UnsignedType ust) noexcept -> std::make_signed_t<UnsignedType>
+{
+    using signed_t = std::make_signed_t<UnsignedType>;
+    return static_cast<signed_t>(ust);
+}
+
+
+// Stuff in the detail namespace are things people using the RA_Integration API
+// shouldn't use
+namespace detail {
+
+// There helper variable templates that are much easier to use, using these
+// explicitly is not recommended because it can lead to user errors.
+
+// A lot of these are just extra compile-time validation to ensure types are used correctly
+// Like you will get an intellisense error instead of a runtime error
+
+/// <summary>
+///   A check to tell whether a type is a known character type. If this
+///   function was reached, <typeparamref name="CharT" /> is a known character
+///   type.
+/// </summary>
+/// <typeparam name="CharT">A type to be evalualted</typeparam>
+template<typename CharT>
+struct is_char :
+    std::bool_constant<std::is_integral_v<CharT> &&
+    (std::is_same_v<CharT, char> || std::is_same_v<CharT, wchar_t> ||
+        std::is_same_v<CharT, char16_t> || std::is_same_v<CharT, char32_t> ||
+        std::is_same_v<CharT, unsigned char>)> {};
+
+// for the hell of it
+template<
+    typename StringType,
+    class = std::void_t<>
+>
+struct is_string : std::false_type {};
+
+// TODO: Have implementations of concepts that are required for std::basic_string
+
+// There really should be a buttload of checks but that'll take too long for now
+template<typename StringType>
+struct is_string<StringType, std::enable_if_t<
+    is_char<typename std::char_traits<typename StringType::value_type>::char_type>::value>>
+    : std::true_type {};
+
+template<
+    typename EqualityComparable,
+    class = std::void_t<>
+>
+struct is_equality_comparable : std::false_type {};
+
+
+template<typename EqualityComparable>
+struct is_equality_comparable<EqualityComparable,
+    std::enable_if_t<std::is_convertible_v<
+    decltype(std::declval<EqualityComparable>() == std::declval<EqualityComparable>()), bool>
+    >> : std::true_type {};
+
+template<
+    typename LessThanComparable,
+    class = std::void_t<>
+>
+struct is_lessthan_comparable : std::false_type {};
+
+
+template<typename LessThanComparable>
+struct is_lessthan_comparable<LessThanComparable,
+    std::enable_if_t<std::is_convertible_v<
+    decltype(std::declval<LessThanComparable>() < std::declval<LessThanComparable>()), bool>
+    >> : std::true_type{};
+
+// nothrows: for each one of these the operator has to be marked with noexcept to pass
+template<typename EqualityComparable>
+struct is_nothrow_equality_comparable :
+    std::bool_constant<noexcept(is_equality_comparable<EqualityComparable>::value)> {};
+
+template<typename LessThanComparable>
+struct is_nothrow_lessthan_comparable :
+    std::bool_constant<noexcept(is_lessthan_comparable<LessThanComparable>::value)> {};
+
+} // namespace detail
+
+
+// is_char helper variable template
+template<typename CharT>
+_CONSTANT_VAR is_char_v = detail::is_char<CharT>::value;
+
+
+// is_string helper variable template
+template<typename StringType>
+_CONSTANT_VAR is_string_v = detail::is_string<StringType>::value;
+
+// is_equality_comparable helper variable template
+template<typename EqualityComparable>
+_CONSTANT_VAR is_equality_comparable_v = detail::is_equality_comparable<EqualityComparable>::value;
+
+// is_lessthan_comparable helper variable template
+template<typename LessThanComparable>
+_CONSTANT_VAR is_lessthan_comparable_v = detail::is_lessthan_comparable<LessThanComparable>::value;
+
+// is_nothrow_equality_comparable helper variable template
+template<typename EqualityComparable>
+_CONSTANT_VAR is_nothrow_equality_comparable_v = detail::is_nothrow_equality_comparable<EqualityComparable>::value;
+
+template<typename LessThanComparable>
+_CONSTANT_VAR is_nothrow_lessthan_comparable_v = detail::is_nothrow_lessthan_comparable<LessThanComparable>::value;
+
+// We probably don't need this now but it'll be useful later when using STL filestreams instead of C filestreams
+/// <summary>Calculates the size of any standard fstream.</summary>
+/// <param name="filename">The filename.</param>
+/// <typeparam name="CharT">
+///   The character type, it should be auto deduced if valid. Otherwise you'll
+///   get an intellisense error.
+/// </typeparam>
+/// <typeparam name="Traits">
+///   The character traits of <typeparamref name="CharT" />.
+/// </typeparam>
+/// <returns>The size of the file stream.</returns>
+template<
+    typename CharT,
+    typename Traits = std::char_traits<CharT>,
+    class = std::enable_if_t<is_char_v<CharT>>
+>
+typename Traits::pos_type filesize(std::basic_string<CharT>& filename) noexcept {
+    // It's always the little things...
+    using file_type = std::basic_fstream<CharT>;
+    file_type file{ filename, std::ios::in | std::ios::ate | std::ios::binary };
+    return file.tellg();
+} // end function filesize
+
+  // All puporse string converter
+  /// <summary>
+  ///   Converts <paramref name="in" /> into an
+  ///   <typeparamref name="OutputString" />. To use this you have to at least
+  ///   specfiy <typeparamref name="OutputString" />. It won't work between
+  ///   Mutli-Byte to UTF-16, Use Widen() instead.
+  /// </summary>
+  /// <typeparam name="InputString">
+  ///   The type of string to be converted.
+  /// </typeparam>
+  /// <typeparam name="OutputString">
+  ///   The type of string to be converted to.
+  /// </typeparam>
+  /// <param name="in">The string to be converted.</param>
+  /// <returns>An <typeparamref name="OutputString" />.</returns>
+  /// <exception cref="std::ios_base::failure">
+  ///   If this was not thrown explicitly, there are no side effects. The runtime
+  ///   throws this exception if any bit in the stream is not
+  ///   <see cref="std::ios_base::good_bit" />.
+  /// </exception>
+template<
+    typename OutputString,
+    typename InputString,
+    class = std::enable_if_t<(is_string_v<InputString> && is_string_v<OutputString>) &&
+    (!std::is_same_v<InputString, OutputString>) && (!std::is_same_v<OutputString, std::wstring>)>
+>
+OutputString convert_string(_In_ const InputString& in) noexcept {
+    using out_char_t       = typename OutputString::value_type;
+    using out_stringstream = std::basic_ostringstream<out_char_t>;
+
+    out_stringstream oss;
+
+    for (auto& i : in) {
+        oss << i;
+    }
+
+    return oss.str();
+} // end function convert_string
+
+} // namespace ra
 
 #ifdef UNICODE
-#define NativeStr(x) Widen(x)
+#define NativeStr(x) ra::Widen(x)
 #define NativeStrType std::wstring
 #else
-#define NativeStr(x) Narrow(x)
+#define NativeStr(x) ra::Narrow(x)
 #define NativeStrType std::string
 #endif
+
+#endif // !RA_DEFS_H

--- a/src/RA_Dlg_AchEditor.cpp
+++ b/src/RA_Dlg_AchEditor.cpp
@@ -14,12 +14,7 @@
 
 #pragma comment(lib, "comctl32.lib")
 
-namespace
-{
-	const char* COLUMN_TITLE[] = { "ID", "Flag", "Type", "Size", "Memory", "Cmp", "Type", "Size", "Mem/Val", "Hits" };
-	const int COLUMN_WIDTH[] = { 30, 75, 42, 50, 72, 35, 42, 50, 72, 72 };
-	static_assert(SIZEOF_ARRAY(COLUMN_TITLE) == SIZEOF_ARRAY(COLUMN_WIDTH), "Must match!");
-}
+
 
 enum CondSubItems
 {
@@ -36,6 +31,16 @@ enum CondSubItems
 
 	NumColumns
 };
+
+namespace
+{
+inline constexpr std::array<const char*, CondSubItems::NumColumns> COLUMN_TITLE{
+	"ID", "Flag", "Type", "Size", "Memory", "Cmp", "Type", "Size", "Mem/Val", "Hits"
+};
+inline constexpr std::array<int, CondSubItems::NumColumns> COLUMN_WIDTH{
+	30, 75, 42, 50, 72, 35, 42, 50, 72, 72
+};
+}
 
 BOOL g_bPreferDecimalVal = TRUE;
 Dlg_AchievementEditor g_AchievementEditorDialog;

--- a/src/RA_Dlg_AchEditor.cpp
+++ b/src/RA_Dlg_AchEditor.cpp
@@ -87,12 +87,7 @@ INT_PTR CALLBACK AchProgressProc(HWND hDlg, UINT nMsg, WPARAM wParam, LPARAM lPa
 
 
 
-Dlg_AchievementEditor::Dlg_AchievementEditor()
-	: m_hAchievementEditorDlg(nullptr),
-	m_hICEControl(nullptr),
-	m_pSelectedAchievement(nullptr),
-	m_hAchievementBadge(nullptr),
-	m_bPopulatingAchievementEditorData(false)
+Dlg_AchievementEditor::Dlg_AchievementEditor() noexcept
 {
 	for (size_t i = 0; i < MAX_CONDITIONS; ++i)
 	{
@@ -103,11 +98,11 @@ Dlg_AchievementEditor::Dlg_AchievementEditor()
 	}
 }
 
-Dlg_AchievementEditor::~Dlg_AchievementEditor()
+Dlg_AchievementEditor::~Dlg_AchievementEditor() noexcept
 {
 	if (m_hAchievementBadge != nullptr)
 	{
-		DeleteObject(m_hAchievementBadge);
+		DeleteBitmap(m_hAchievementBadge);
 		m_hAchievementBadge = nullptr;
 	}
 }

--- a/src/RA_Dlg_AchEditor.h
+++ b/src/RA_Dlg_AchEditor.h
@@ -8,8 +8,8 @@
 
 namespace
 {
-	const size_t MAX_CONDITIONS = 200;
-	const size_t MEM_STRING_TEXT_LEN = 80;
+inline constexpr auto MAX_CONDITIONS      = std::size_t{ 200 };
+inline constexpr auto MEM_STRING_TEXT_LEN = std::size_t{ 80 };
 }
 
 class BadgeNames

--- a/src/RA_Dlg_AchEditor.h
+++ b/src/RA_Dlg_AchEditor.h
@@ -8,15 +8,13 @@
 
 namespace
 {
-inline constexpr auto MAX_CONDITIONS      = std::size_t{ 200 };
-inline constexpr auto MEM_STRING_TEXT_LEN = std::size_t{ 80 };
+inline constexpr auto MAX_CONDITIONS      = 200_z;
+inline constexpr auto MEM_STRING_TEXT_LEN = 80_z;
 }
 
 class BadgeNames
 {
 public:
-	BadgeNames()
-	 :	m_hDestComboBox( nullptr ) {}
 	void InstallAchEditorCombo( HWND hCombo )	{ m_hDestComboBox = hCombo; }
 	
 	void FetchNewBadgeNamesThreaded();
@@ -24,15 +22,19 @@ public:
 	void OnNewBadgeNames( const Document& data );
 
 private:
-	HWND m_hDestComboBox;
+	HWND m_hDestComboBox{ nullptr };
 };
 
 
 class Dlg_AchievementEditor
 {
 public:
-	Dlg_AchievementEditor();
-	~Dlg_AchievementEditor();
+	Dlg_AchievementEditor() noexcept;
+	~Dlg_AchievementEditor() noexcept;
+	Dlg_AchievementEditor(const Dlg_AchievementEditor&) = delete;
+	Dlg_AchievementEditor& operator=(const Dlg_AchievementEditor&) = delete;
+	Dlg_AchievementEditor(Dlg_AchievementEditor&&) noexcept = delete;
+	Dlg_AchievementEditor& operator=(Dlg_AchievementEditor&&) noexcept = delete;
 
 public:
 	static INT_PTR CALLBACK s_AchievementEditorProc(HWND, UINT, WPARAM, LPARAM);
@@ -75,16 +77,17 @@ private:
 private:
 	static const int m_nNumCols = 10;//;sizeof( g_sColTitles ) / sizeof( g_sColTitles[0] );
 
-	HWND m_hAchievementEditorDlg;
-	HWND m_hICEControl;
+
+	HWND m_hAchievementEditorDlg{ nullptr };
+	HWND m_hICEControl{ nullptr };
 
 	char m_lbxData[ MAX_CONDITIONS ][ m_nNumCols ][ MEM_STRING_TEXT_LEN ];
 	TCHAR m_lbxGroupNames[ MAX_CONDITIONS ][ MEM_STRING_TEXT_LEN ];
-	int m_nNumOccupiedRows;
+	int m_nNumOccupiedRows{ 0 };
 
-	Achievement* m_pSelectedAchievement;
-	BOOL m_bPopulatingAchievementEditorData;
-	HBITMAP m_hAchievementBadge;
+	Achievement* m_pSelectedAchievement{ nullptr };
+	BOOL m_bPopulatingAchievementEditorData{ FALSE };
+	HBITMAP m_hAchievementBadge{ nullptr };
 
 	BadgeNames m_BadgeNames;
 };

--- a/src/RA_Dlg_Achievement.cpp
+++ b/src/RA_Dlg_Achievement.cpp
@@ -1,5 +1,6 @@
 #include "RA_Dlg_Achievement.h"
 
+#include "RA_Resource.h" // was this included twice?, when it was lower there were errors
 #include "RA_Achievement.h"
 #include "RA_AchievementSet.h"
 #include "RA_Core.h"
@@ -9,21 +10,28 @@
 #include "RA_GameData.h"
 #include "RA_httpthread.h"
 #include "RA_md5factory.h"
-#include "RA_Resource.h"
+
 #include "RA_User.h"
 #include "RA_GameData.h"
 
 
 namespace
 {
-	const char* COLUMN_TITLES_CORE[] = { "ID", "Title", "Points", "Author", "Achieved?", "Modified?" };
-	const char* COLUMN_TITLES_UNOFFICIAL[] = { "ID", "Title", "Points", "Author", "Active",	"Votes" };
-	const char* COLUMN_TITLES_LOCAL[] = { "ID", "Title", "Points", "Author", "Active",	"Votes" };
-	const int COLUMN_SIZE[] = { 45, 200, 45, 80, 65, 65 };
+inline constexpr auto NUM_COLS = 6;
+inline constexpr std::array<const char*, NUM_COLS> COLUMN_TITLES_CORE{
+	"ID", "Title", "Points", "Author", "Achieved?", "Modified?"
+};
+inline constexpr std::array<const char*, NUM_COLS> COLUMN_TITLES_UNOFFICIAL{
+	"ID", "Title", "Points", "Author", "Active", "Votes"
+};
+inline constexpr std::array<const char*, NUM_COLS> COLUMN_TITLES_LOCAL{
+	"ID", "Title", "Points", "Author", "Active", "Votes"
+};
+inline constexpr std::array<int, NUM_COLS> COLUMN_SIZE{ 45, 200, 45, 80, 65, 65 };
 
-	const int NUM_COLS = SIZEOF_ARRAY(COLUMN_SIZE);
+	
 
-	int iSelect = -1;
+int iSelect = -1;
 }
 
 Dlg_Achievements g_AchievementsDialog;

--- a/src/RA_Dlg_Achievement.h
+++ b/src/RA_Dlg_Achievement.h
@@ -5,7 +5,7 @@
 #include <wtypes.h>
 #include <assert.h>
 
-const int MAX_TEXT_ITEM_SIZE = 80;
+constexpr auto MAX_TEXT_ITEM_SIZE = 80;
 
 //extern const char* g_sColTitles[];
 //extern const int g_nColSizes[];

--- a/src/RA_Dlg_AchievementsReporter.cpp
+++ b/src/RA_Dlg_AchievementsReporter.cpp
@@ -12,14 +12,19 @@
 
 namespace
 {
-	const char* COL_TITLE[] = { "", "Title", "Description", "Author", "Achieved?" };
-	const int COL_SIZE[] = { 19, 105, 205, 75, 62 };
-	static_assert(SIZEOF_ARRAY(COL_TITLE) == SIZEOF_ARRAY(COL_SIZE), "Must match!");
-
-	const char* PROBLEM_STR[] = { "Unknown", "Triggers at wrong time", "Didn't trigger at all" };
+inline constexpr auto max_cols{ 6 };
+inline constexpr std::array<const char*, max_cols> COL_TITLE{ "", "Title", "Description", "Author", "Achieved?" };
+inline constexpr std::array<int, max_cols> COL_SIZE{ 19, 105, 205, 75, 62 };
+inline constexpr std::array<const char*, 3> PROBLEM_STR{ 
+	"Unknown", "Triggers at wrong time", "Didn't trigger at all" 
+};
 }
 
 int Dlg_AchievementsReporter::ms_nNumOccupiedRows = 0;
+
+
+// Doing this as a 2d std::array is possible, you just need to make the capacity of the string MAX_TEXT_LEN - 16
+// -16 because the capacity is always 16 more than the size in standard C++
 char Dlg_AchievementsReporter::ms_lbxData[MAX_ACHIEVEMENTS][NumReporterColumns][MAX_TEXT_LEN];
 
 Dlg_AchievementsReporter g_AchievementsReporterDialog;

--- a/src/RA_Dlg_AchievementsReporter.h
+++ b/src/RA_Dlg_AchievementsReporter.h
@@ -3,11 +3,14 @@
 
 class Achievement;
 
+
+inline constexpr auto MAX_ACHIEVEMENTS = 200;
+inline constexpr auto MAX_TEXT_LEN     = 250;
+
 class Dlg_AchievementsReporter
 {
 public:
-	static const int MAX_ACHIEVEMENTS = 200;
-	static const int MAX_TEXT_LEN = 250;
+
 
 public:
 	enum ReporterColumns

--- a/src/RA_Dlg_GameLibrary.cpp
+++ b/src/RA_Dlg_GameLibrary.cpp
@@ -25,12 +25,12 @@
 
 namespace
 {
-	const char* COL_TITLE[] = { "ID", "Game Title", "Completion", "File Path" };
-	const int COL_SIZE[] = { 30, 230, 110, 170 };
-	static_assert(SIZEOF_ARRAY(COL_TITLE) == SIZEOF_ARRAY(COL_SIZE), "Must match!");
-	const bool bCancelScan = false;
+inline constexpr auto col_max{ 4 };
+inline constexpr std::array<const char*, col_max> COL_TITLE{ "ID", "Game Title", "Completion", "File Path" };
+inline constexpr std::array<int, col_max> COL_SIZE{ 30, 230, 110, 170 };
+inline constexpr auto bCancelScan{ false };
 
-	std::mutex mtx;
+std::mutex mtx;
 }
 
 //static 

--- a/src/RA_Dlg_GameLibrary.cpp
+++ b/src/RA_Dlg_GameLibrary.cpp
@@ -90,14 +90,6 @@ bool ListFiles(std::string path, std::string mask, std::deque<std::string>& rFil
 //std::map<std::string, unsigned int> Dlg_GameLibrary::m_GameHashLibrary;
 //std::map<unsigned int, std::string> Dlg_GameLibrary::m_GameTitlesLibrary;
 //std::map<unsigned int, std::string> Dlg_GameLibrary::m_ProgressLibrary;
-Dlg_GameLibrary::Dlg_GameLibrary()
-	: m_hDialogBox(nullptr)
-{
-}
-
-Dlg_GameLibrary::~Dlg_GameLibrary()
-{
-}
 
 void ParseGameHashLibraryFromFile(std::map<std::string, GameID>& GameHashLibraryOut)
 {

--- a/src/RA_Dlg_GameLibrary.h
+++ b/src/RA_Dlg_GameLibrary.h
@@ -25,9 +25,13 @@ public:
 class Dlg_GameLibrary
 {
 public:
-	Dlg_GameLibrary();
-	~Dlg_GameLibrary();
-
+	~Dlg_GameLibrary() noexcept = default;
+	Dlg_GameLibrary(const Dlg_GameLibrary&) = delete;
+	Dlg_GameLibrary& operator=(const Dlg_GameLibrary&) = delete;
+	// We probably don't need to move if there's a global
+	Dlg_GameLibrary(Dlg_GameLibrary&&) noexcept = delete;
+	Dlg_GameLibrary& operator=(Dlg_GameLibrary&&) noexcept = delete;
+	Dlg_GameLibrary() = default; // might throw
 public:
 	//void DoModalDialog( HINSTANCE hInst, HWND hParent );
 	static INT_PTR CALLBACK s_GameLibraryProc( HWND, UINT, WPARAM, LPARAM );
@@ -63,7 +67,7 @@ private:
 	static bool ThreadProcessingActive;
 	
 private:
-	HWND m_hDialogBox;
+	HWND m_hDialogBox{ nullptr };
 
 	std::map<std::string, GameID> m_GameHashLibrary;
 	std::map<GameID, std::string> m_GameTitlesLibrary;

--- a/src/RA_Dlg_GameTitle.cpp
+++ b/src/RA_Dlg_GameTitle.cpp
@@ -113,7 +113,7 @@ INT_PTR Dlg_GameTitle::GameTitleProc( HWND hDlg, UINT uMsg, WPARAM wParam, LPARA
 			{
 				//	Existing title
 				ASSERT( m_aGameTitles.find( std::string( sSelectedTitle ) ) != m_aGameTitles.end() );
-				nGameID = m_aGameTitles[ std::string( Narrow(sSelectedTitle) ) ];
+				nGameID = m_aGameTitles[ std::string(ra::Narrow(sSelectedTitle) ) ];
 			}
 
 			PostArgs args;

--- a/src/RA_Dlg_Login.cpp
+++ b/src/RA_Dlg_Login.cpp
@@ -50,8 +50,8 @@ INT_PTR CALLBACK RA_Dlg_Login::RA_Dlg_LoginProc( HWND hDlg, UINT uMsg, WPARAM wP
 				}
 
 				PostArgs args;
-				args[ 'u' ] = Narrow( sUserEntry );
-				args[ 'p' ] = Narrow( sPassEntry );		//	Plaintext password(!)
+				args[ 'u' ] = ra::Narrow( sUserEntry );
+				args[ 'p' ] = ra::Narrow( sPassEntry );		//	Plaintext password(!)
 				
 				Document doc;
 				if( RAWeb::DoBlockingRequest( RequestLogin, args, doc ) )

--- a/src/RA_Dlg_MemBookmark.cpp
+++ b/src/RA_Dlg_MemBookmark.cpp
@@ -7,7 +7,11 @@
 #include "RA_MemManager.h"
 
 #include <strsafe.h>
+<<<<<<< HEAD
 #include <atlbase.h>
+=======
+#include <atlbase.h> // CComPtr
+>>>>>>> com_smart_pointers
 
 Dlg_MemBookmark g_MemBookmarkDialog;
 std::vector<ResizeContent> vDlgMemBookmarkResize;
@@ -704,19 +708,35 @@ void Dlg_MemBookmark::ExportJSON()
 	defaultDir.erase ( 0, 2 ); // Removes the characters (".\\")
 	defaultDir = g_sHomeDir + defaultDir;
 
+<<<<<<< HEAD
 	IFileSaveDialog* pDlg = nullptr;
 	HRESULT hr = CoCreateInstance( CLSID_FileSaveDialog, nullptr, CLSCTX_ALL, IID_IFileSaveDialog, reinterpret_cast<void**>( &pDlg ) );
 	if ( hr == S_OK )
 	{
 		hr = pDlg->SetFileTypes( c_rgFileTypes.size(), &c_rgFileTypes.front() );
 		if ( hr == S_OK )
+=======
+    // First time noticing this
+	CComPtr<IFileSaveDialog> pDlg;
+	
+	if (auto hr = CoCreateInstance(CLSID_FileSaveDialog, nullptr, CLSCTX_ALL, IID_IFileSaveDialog,
+        reinterpret_cast<void**>(&pDlg)); SUCCEEDED(hr))
+	{
+		
+		if (hr = pDlg->SetFileTypes(ARRAYSIZE(c_rgFileTypes), c_rgFileTypes); hr == S_OK )
+>>>>>>> com_smart_pointers
 		{
-			char defaultFileName[ 512 ];
-			sprintf_s ( defaultFileName, 512, "%s-Bookmarks.txt", std::to_string( g_pCurrentGameData->GetGameID() ).c_str() );
-			hr = pDlg->SetFileName( Widen( defaultFileName ).c_str() );
-			if ( hr == S_OK )
+            // Does this really need a limit?
+            std::string defaultFileName;
+            defaultFileName.reserve(512); // gives it a cap of 512+16 to prevent overflows but deallocates
+            // for now
+			sprintf_s ( defaultFileName.data(), 512, "%s-Bookmarks.txt",
+                std::to_string( g_pCurrentGameData->GetGameID() ).c_str() );
+			
+			if (hr = pDlg->SetFileName(Widen(defaultFileName).c_str()); SUCCEEDED(hr))
 			{
 				PIDLIST_ABSOLUTE pidl;
+<<<<<<< HEAD
 				hr = SHParseDisplayName( Widen( defaultDir ).c_str(), nullptr, &pidl, SFGAO_FOLDER, 0 );
 				if ( hr == S_OK )
 				{
@@ -724,30 +744,48 @@ void Dlg_MemBookmark::ExportJSON()
 					SHCreateShellItem( nullptr, nullptr, pidl, &pItem );
 					hr = pDlg->SetDefaultFolder( pItem );
 					if ( hr == S_OK )
+=======
+				
+				if (hr = SHParseDisplayName(Widen(defaultDir).c_str(), NULL, &pidl, SFGAO_FOLDER, 0); SUCCEEDED(hr))
+				{
+					CComPtr<IShellItem> pItem;
+					SHCreateShellItem( NULL, NULL, pidl, &pItem );
+					
+					if (hr = pDlg->SetDefaultFolder(pItem); SUCCEEDED(hr))
+>>>>>>> com_smart_pointers
 					{
 						pDlg->SetDefaultExtension( L"txt" );
-						hr = pDlg->Show( nullptr );
-						if ( hr == S_OK )
+						
+						if (hr = pDlg->Show(nullptr); SUCCEEDED(hr))
 						{
 
-							hr = pDlg->GetResult( &pItem );
-							if ( hr == S_OK )
+							
+							if (hr = pDlg->GetResult(&pItem); SUCCEEDED(hr))
 							{
 								LPWSTR pStr = nullptr;
-								hr = pItem->GetDisplayName( SIGDN_FILESYSPATH, &pStr );
-								if ( hr == S_OK )
+								
+								if (hr = pItem->GetDisplayName(SIGDN_FILESYSPATH, &pStr); SUCCEEDED(hr))
 								{
 									Document doc;
-									Document::AllocatorType& allocator = doc.GetAllocator();
+                                    auto& allocator = doc.GetAllocator();
 									doc.SetObject();
 
 									Value bookmarks( kArrayType );
-									for ( MemBookmark* bookmark : m_vBookmarks )
+                                    // We really shouldn't use pointers if we don't have too
+                                    // This will still use the pointer however, but that's for another time
+									for (auto bookmark : m_vBookmarks )
 									{
 										Value item( kObjectType );
+<<<<<<< HEAD
 										char buffer[ 256 ];
 										sprintf_s( buffer, ra::Narrow( bookmark->Description() ).c_str(), sizeof( buffer ) );
 										Value s( buffer, allocator );
+=======
+										std::string buffer;
+                                        buffer.reserve(256);
+										sprintf_s( buffer.data(), 256, Narrow( bookmark->Description() ).c_str(), buffer.length() );
+                                        Value s{ buffer.c_str(), allocator };
+>>>>>>> com_smart_pointers
 
 										item.AddMember( "Description", s, allocator );
 										item.AddMember( "Address", bookmark->Address(), allocator );
@@ -757,10 +795,16 @@ void Dlg_MemBookmark::ExportJSON()
 									}
 									doc.AddMember( "Bookmarks", bookmarks, allocator );
 
+<<<<<<< HEAD
 									_WriteBufferToFile(ra::Narrow( pStr ), doc );
+=======
+									_WriteBufferToFile( Narrow( pStr ), doc );
+                                    CoTaskMemFree(static_cast<LPVOID>(pStr));
+                                    pStr = nullptr;
+>>>>>>> com_smart_pointers
 								}
 
-								pItem->Release();
+								pItem.Release();
 								ILFree( pidl );
 							}
 						}
@@ -768,7 +812,7 @@ void Dlg_MemBookmark::ExportJSON()
 				}
 			}
 		}
-		pDlg->Release();
+		pDlg.Release();
 	}
 }
 
@@ -825,12 +869,21 @@ std::string Dlg_MemBookmark::ImportDialog()
 {
 	std::string str;
 
+<<<<<<< HEAD
 	if (g_pCurrentGameData->GetGameID() == 0)
+=======
+	// With how repetive this is, it should be it's own function
+	if ( g_pCurrentGameData->GetGameID() == 0 )
+>>>>>>> com_smart_pointers
 	{
 		MessageBox(nullptr, _T("ROM not loaded: please load a ROM first!"), _T("Error!"), MB_OK);
 		return str;
-	}
+	} // end if
 
+	// Never noticed this, nearly identical to the on in RA_Core
+	CComPtr<IFileOpenDialog> pDlg;
+
+<<<<<<< HEAD
 	IFileOpenDialog* pDlg = nullptr;
 <<<<<<< HEAD
 	HRESULT hr = CoCreateInstance( CLSID_FileOpenDialog, nullptr, CLSCTX_ALL, IID_IFileOpenDialog, reinterpret_cast<void**>( &pDlg ) );
@@ -860,16 +913,42 @@ std::string Dlg_MemBookmark::ImportDialog()
 						str = Narrow(pStr);
 >>>>>>> global_carrays_to_stdarray
 					}
+=======
+	// Keep the scope as local as possible
+	
+	if (auto hr = CoCreateInstance(CLSID_FileOpenDialog, nullptr, CLSCTX_ALL, IID_IFileOpenDialog, 
+		reinterpret_cast<void**>(&pDlg)); SUCCEEDED(hr))
+	{
+		// N.B. If you want to do more than one at a time it needs to be in a loop
+		
+		if (hr = pDlg->SetFileTypes(ARRAYSIZE(c_rgFileTypes), c_rgFileTypes); SUCCEEDED(hr))
+		{
+			
+			if (hr = pDlg->Show(nullptr); SUCCEEDED(hr))
+			{
+				CComPtr<IShellItem> pItem;
+				
+				if (hr = pDlg->GetResult(&pItem); SUCCEEDED(hr))
+				{
+                    LPWSTR pStr = nullptr;
+					
+					if (hr = pItem->GetDisplayName(SIGDN_FILESYSPATH, &pStr); SUCCEEDED(hr))
+					{
+						str = Narrow( pStr );
+						CoTaskMemFree(static_cast<LPVOID>(pStr));
+						pStr = nullptr;
+					} // end if
+>>>>>>> com_smart_pointers
 
-					pItem->Release();
-				}
-			}
-		}
-		pDlg->Release();
-	}
+					pItem.Release();
+				} // end if
+			} // end if
+		} // end if
+		pDlg.Release();
+	} // end if
 
 	return str;
-}
+} // end function ImportDialog
 
 void Dlg_MemBookmark::OnLoad_NewRom()
 {

--- a/src/RA_Dlg_MemBookmark.cpp
+++ b/src/RA_Dlg_MemBookmark.cpp
@@ -576,7 +576,7 @@ void Dlg_MemBookmark::AddAddress()
 	// Fetch Memory Address from Memory Inspector
 	TCHAR buffer[ 256 ];
 	GetDlgItemText( g_MemoryDialog.GetHWND(), IDC_RA_WATCHING, buffer, 256 );
-	unsigned int nAddr = strtol( Narrow( buffer ).c_str(), nullptr, 16 );
+	unsigned int nAddr = strtol(ra::Narrow( buffer ).c_str(), nullptr, 16 );
 	NewBookmark->SetAddress( nAddr );
 
 	// Check Data Type
@@ -747,7 +747,7 @@ void Dlg_MemBookmark::ExportJSON()
 									{
 										Value item( kObjectType );
 										char buffer[ 256 ];
-										sprintf_s( buffer, Narrow( bookmark->Description() ).c_str(), sizeof( buffer ) );
+										sprintf_s( buffer, ra::Narrow( bookmark->Description() ).c_str(), sizeof( buffer ) );
 										Value s( buffer, allocator );
 
 										item.AddMember( "Description", s, allocator );
@@ -758,7 +758,7 @@ void Dlg_MemBookmark::ExportJSON()
 									}
 									doc.AddMember( "Bookmarks", bookmarks, allocator );
 
-									_WriteBufferToFile( Narrow( pStr ), doc );
+									_WriteBufferToFile(ra::Narrow( pStr ), doc );
 								}
 
 								pItem->Release();
@@ -850,7 +850,7 @@ std::string Dlg_MemBookmark::ImportDialog()
 					hr = pItem->GetDisplayName( SIGDN_FILESYSPATH, &pStr );
 					if ( hr == S_OK )
 					{
-						str = Narrow( pStr );
+						str = ra::Narrow( pStr );
 					}
 
 					pItem->Release();

--- a/src/RA_Dlg_MemBookmark.cpp
+++ b/src/RA_Dlg_MemBookmark.cpp
@@ -7,6 +7,7 @@
 #include "RA_MemManager.h"
 
 #include <strsafe.h>
+#include <atlbase.h>
 
 Dlg_MemBookmark g_MemBookmarkDialog;
 std::vector<ResizeContent> vDlgMemBookmarkResize;
@@ -19,15 +20,13 @@ int nSelSubItemBM;
 
 namespace
 {
-	const char* COLUMN_TITLE[] = { "Description", "Address", "Value", "Prev.", "Changes" };
-	const int COLUMN_WIDTH[] = { 112, 64, 64, 64, 54 };
-	static_assert( SIZEOF_ARRAY( COLUMN_TITLE ) == SIZEOF_ARRAY( COLUMN_WIDTH ), "Must match!" );
+inline constexpr std::array<const char*, 5> COLUMN_TITLE{ "Description", "Address", "Value", "Prev.", "Changes" };
+inline constexpr std::array<int, 5> COLUMN_WIDTH{ 112, 64, 64, 64, 54 };
 }
 
-const COMDLG_FILTERSPEC c_rgFileTypes[] =
-{
-	{ L"Text Document (*.txt)",       L"*.txt" }
-};
+
+inline constexpr std::array<COMDLG_FILTERSPEC, 1> c_rgFileTypes{ {L"Text Document (*.txt)", L"*.txt"} };
+
 
 enum BookmarkSubItems
 {
@@ -709,7 +708,7 @@ void Dlg_MemBookmark::ExportJSON()
 	HRESULT hr = CoCreateInstance( CLSID_FileSaveDialog, nullptr, CLSCTX_ALL, IID_IFileSaveDialog, reinterpret_cast<void**>( &pDlg ) );
 	if ( hr == S_OK )
 	{
-		hr = pDlg->SetFileTypes( ARRAYSIZE( c_rgFileTypes ), c_rgFileTypes );
+		hr = pDlg->SetFileTypes( c_rgFileTypes.size(), &c_rgFileTypes.front() );
 		if ( hr == S_OK )
 		{
 			char defaultFileName[ 512 ];
@@ -826,31 +825,40 @@ std::string Dlg_MemBookmark::ImportDialog()
 {
 	std::string str;
 
-	if ( g_pCurrentGameData->GetGameID() == 0 )
+	if (g_pCurrentGameData->GetGameID() == 0)
 	{
-		MessageBox( nullptr, _T("ROM not loaded: please load a ROM first!"), _T("Error!"), MB_OK );
+		MessageBox(nullptr, _T("ROM not loaded: please load a ROM first!"), _T("Error!"), MB_OK);
 		return str;
 	}
 
 	IFileOpenDialog* pDlg = nullptr;
+<<<<<<< HEAD
 	HRESULT hr = CoCreateInstance( CLSID_FileOpenDialog, nullptr, CLSCTX_ALL, IID_IFileOpenDialog, reinterpret_cast<void**>( &pDlg ) );
 	if ( hr == S_OK )
+=======
+	HRESULT hr = CoCreateInstance(CLSID_FileOpenDialog, NULL, CLSCTX_ALL, IID_IFileOpenDialog, reinterpret_cast<void**>(&pDlg));
+	if (hr == S_OK)
+>>>>>>> global_carrays_to_stdarray
 	{
-		hr = pDlg->SetFileTypes( ARRAYSIZE( c_rgFileTypes ), c_rgFileTypes );
-		if ( hr == S_OK )
+		hr = pDlg->SetFileTypes(c_rgFileTypes.size(), &c_rgFileTypes.front());
+		if (hr == S_OK)
 		{
-			hr = pDlg->Show( nullptr );
-			if ( hr == S_OK )
+			hr = pDlg->Show(nullptr);
+			if (hr == S_OK)
 			{
 				IShellItem* pItem = nullptr;
-				hr = pDlg->GetResult( &pItem );
-				if ( hr == S_OK )
+				hr = pDlg->GetResult(&pItem);
+				if (hr == S_OK)
 				{
 					LPWSTR pStr = nullptr;
-					hr = pItem->GetDisplayName( SIGDN_FILESYSPATH, &pStr );
-					if ( hr == S_OK )
+					hr = pItem->GetDisplayName(SIGDN_FILESYSPATH, &pStr);
+					if (hr == S_OK)
 					{
+<<<<<<< HEAD
 						str = ra::Narrow( pStr );
+=======
+						str = Narrow(pStr);
+>>>>>>> global_carrays_to_stdarray
 					}
 
 					pItem->Release();

--- a/src/RA_Dlg_MemBookmark.cpp
+++ b/src/RA_Dlg_MemBookmark.cpp
@@ -7,11 +7,7 @@
 #include "RA_MemManager.h"
 
 #include <strsafe.h>
-<<<<<<< HEAD
-#include <atlbase.h>
-=======
 #include <atlbase.h> // CComPtr
->>>>>>> com_smart_pointers
 
 Dlg_MemBookmark g_MemBookmarkDialog;
 std::vector<ResizeContent> vDlgMemBookmarkResize;
@@ -708,23 +704,14 @@ void Dlg_MemBookmark::ExportJSON()
 	defaultDir.erase ( 0, 2 ); // Removes the characters (".\\")
 	defaultDir = g_sHomeDir + defaultDir;
 
-<<<<<<< HEAD
-	IFileSaveDialog* pDlg = nullptr;
-	HRESULT hr = CoCreateInstance( CLSID_FileSaveDialog, nullptr, CLSCTX_ALL, IID_IFileSaveDialog, reinterpret_cast<void**>( &pDlg ) );
-	if ( hr == S_OK )
-	{
-		hr = pDlg->SetFileTypes( c_rgFileTypes.size(), &c_rgFileTypes.front() );
-		if ( hr == S_OK )
-=======
-    // First time noticing this
+
 	CComPtr<IFileSaveDialog> pDlg;
 	
 	if (auto hr = CoCreateInstance(CLSID_FileSaveDialog, nullptr, CLSCTX_ALL, IID_IFileSaveDialog,
         reinterpret_cast<void**>(&pDlg)); SUCCEEDED(hr))
 	{
 		
-		if (hr = pDlg->SetFileTypes(ARRAYSIZE(c_rgFileTypes), c_rgFileTypes); hr == S_OK )
->>>>>>> com_smart_pointers
+		if (hr = pDlg->SetFileTypes(c_rgFileTypes.size(), &c_rgFileTypes.front()); SUCCEEDED(hr))
 		{
             // Does this really need a limit?
             std::string defaultFileName;
@@ -736,23 +723,14 @@ void Dlg_MemBookmark::ExportJSON()
 			if (hr = pDlg->SetFileName(Widen(defaultFileName).c_str()); SUCCEEDED(hr))
 			{
 				PIDLIST_ABSOLUTE pidl;
-<<<<<<< HEAD
-				hr = SHParseDisplayName( Widen( defaultDir ).c_str(), nullptr, &pidl, SFGAO_FOLDER, 0 );
-				if ( hr == S_OK )
-				{
-					IShellItem* pItem = nullptr;
-					SHCreateShellItem( nullptr, nullptr, pidl, &pItem );
-					hr = pDlg->SetDefaultFolder( pItem );
-					if ( hr == S_OK )
-=======
+
 				
-				if (hr = SHParseDisplayName(Widen(defaultDir).c_str(), NULL, &pidl, SFGAO_FOLDER, 0); SUCCEEDED(hr))
+				if (hr = SHParseDisplayName(Widen(defaultDir).c_str(), nullptr, &pidl, SFGAO_FOLDER, nullptr); SUCCEEDED(hr))
 				{
 					CComPtr<IShellItem> pItem;
-					SHCreateShellItem( NULL, NULL, pidl, &pItem );
+					SHCreateShellItem(nullptr, nullptr, pidl, &pItem );
 					
 					if (hr = pDlg->SetDefaultFolder(pItem); SUCCEEDED(hr))
->>>>>>> com_smart_pointers
 					{
 						pDlg->SetDefaultExtension( L"txt" );
 						
@@ -776,16 +754,10 @@ void Dlg_MemBookmark::ExportJSON()
 									for (auto bookmark : m_vBookmarks )
 									{
 										Value item( kObjectType );
-<<<<<<< HEAD
-										char buffer[ 256 ];
-										sprintf_s( buffer, ra::Narrow( bookmark->Description() ).c_str(), sizeof( buffer ) );
-										Value s( buffer, allocator );
-=======
 										std::string buffer;
                                         buffer.reserve(256);
 										sprintf_s( buffer.data(), 256, Narrow( bookmark->Description() ).c_str(), buffer.length() );
                                         Value s{ buffer.c_str(), allocator };
->>>>>>> com_smart_pointers
 
 										item.AddMember( "Description", s, allocator );
 										item.AddMember( "Address", bookmark->Address(), allocator );
@@ -795,13 +767,9 @@ void Dlg_MemBookmark::ExportJSON()
 									}
 									doc.AddMember( "Bookmarks", bookmarks, allocator );
 
-<<<<<<< HEAD
 									_WriteBufferToFile(ra::Narrow( pStr ), doc );
-=======
-									_WriteBufferToFile( Narrow( pStr ), doc );
-                                    CoTaskMemFree(static_cast<LPVOID>(pStr));
-                                    pStr = nullptr;
->>>>>>> com_smart_pointers
+									CoTaskMemFree(static_cast<LPVOID>(pStr));
+									pStr = nullptr;
 								}
 
 								pItem.Release();
@@ -869,51 +837,16 @@ std::string Dlg_MemBookmark::ImportDialog()
 {
 	std::string str;
 
-<<<<<<< HEAD
 	if (g_pCurrentGameData->GetGameID() == 0)
-=======
-	// With how repetive this is, it should be it's own function
-	if ( g_pCurrentGameData->GetGameID() == 0 )
->>>>>>> com_smart_pointers
 	{
 		MessageBox(nullptr, _T("ROM not loaded: please load a ROM first!"), _T("Error!"), MB_OK);
 		return str;
-	} // end if
+	}
 
 	// Never noticed this, nearly identical to the on in RA_Core
 	CComPtr<IFileOpenDialog> pDlg;
 
-<<<<<<< HEAD
-	IFileOpenDialog* pDlg = nullptr;
-<<<<<<< HEAD
-	HRESULT hr = CoCreateInstance( CLSID_FileOpenDialog, nullptr, CLSCTX_ALL, IID_IFileOpenDialog, reinterpret_cast<void**>( &pDlg ) );
-	if ( hr == S_OK )
-=======
-	HRESULT hr = CoCreateInstance(CLSID_FileOpenDialog, NULL, CLSCTX_ALL, IID_IFileOpenDialog, reinterpret_cast<void**>(&pDlg));
-	if (hr == S_OK)
->>>>>>> global_carrays_to_stdarray
-	{
-		hr = pDlg->SetFileTypes(c_rgFileTypes.size(), &c_rgFileTypes.front());
-		if (hr == S_OK)
-		{
-			hr = pDlg->Show(nullptr);
-			if (hr == S_OK)
-			{
-				IShellItem* pItem = nullptr;
-				hr = pDlg->GetResult(&pItem);
-				if (hr == S_OK)
-				{
-					LPWSTR pStr = nullptr;
-					hr = pItem->GetDisplayName(SIGDN_FILESYSPATH, &pStr);
-					if (hr == S_OK)
-					{
-<<<<<<< HEAD
-						str = ra::Narrow( pStr );
-=======
-						str = Narrow(pStr);
->>>>>>> global_carrays_to_stdarray
-					}
-=======
+
 	// Keep the scope as local as possible
 	
 	if (auto hr = CoCreateInstance(CLSID_FileOpenDialog, nullptr, CLSCTX_ALL, IID_IFileOpenDialog, 
@@ -921,7 +854,7 @@ std::string Dlg_MemBookmark::ImportDialog()
 	{
 		// N.B. If you want to do more than one at a time it needs to be in a loop
 		
-		if (hr = pDlg->SetFileTypes(ARRAYSIZE(c_rgFileTypes), c_rgFileTypes); SUCCEEDED(hr))
+		if (hr = pDlg->SetFileTypes(c_rgFileTypes.size(), &c_rgFileTypes.front()); SUCCEEDED(hr))
 		{
 			
 			if (hr = pDlg->Show(nullptr); SUCCEEDED(hr))
@@ -937,15 +870,14 @@ std::string Dlg_MemBookmark::ImportDialog()
 						str = Narrow( pStr );
 						CoTaskMemFree(static_cast<LPVOID>(pStr));
 						pStr = nullptr;
-					} // end if
->>>>>>> com_smart_pointers
+					}
 
 					pItem.Release();
-				} // end if
-			} // end if
-		} // end if
+				}
+			}
+		}
 		pDlg.Release();
-	} // end if
+	}
 
 	return str;
 } // end function ImportDialog

--- a/src/RA_Dlg_Memory.cpp
+++ b/src/RA_Dlg_Memory.cpp
@@ -61,12 +61,7 @@ int nDlgMemoryMinX;
 int nDlgMemoryMinY;
 int nDlgMemViewerGapY;
 
-std::string ByteAddressToString(ByteAddress nAddr)
-{
-	static char buffer[16];
-	sprintf_s(buffer, "0x%06x", nAddr);
-	return std::string(buffer);
-}
+
 
 INT_PTR CALLBACK MemoryViewerControl::s_MemoryDrawProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {

--- a/src/RA_Dlg_Memory.cpp
+++ b/src/RA_Dlg_Memory.cpp
@@ -20,16 +20,11 @@
 
 namespace
 {
-	const size_t MIN_RESULTS_TO_DUMP = 500000;
-	const size_t MIN_SEARCH_PAGE_SIZE = 50;
-
-	const char* COMP_STR[] = {
-		{ "EQUAL" },
-		{ "LESS THAN" },
-		{ "LESS THAN/EQUAL" },
-		{ "GREATER THAN" },
-		{ "GREATER THAN/EQUAL" },
-		{ "NOT EQUAL" } };
+inline constexpr auto MIN_RESULTS_TO_DUMP = std::size_t{ 500000 };
+inline constexpr auto MIN_SEARCH_PAGE_SIZE = std::size_t{ 50 };
+inline constexpr std::array<const char*, 6> COMP_STR {
+ "EQUAL", "LESS THAN", "LESS THAN/EQUAL", "GREATER THAN", "GREATER THAN/EQUAL", "NOT EQUAL" 
+};
 }
 
 Dlg_Memory g_MemoryDialog;

--- a/src/RA_Dlg_Memory.cpp
+++ b/src/RA_Dlg_Memory.cpp
@@ -1654,7 +1654,7 @@ BOOL Dlg_Memory::IsActive() const
 	return(g_MemoryDialog.GetHWND() != nullptr) && (IsWindowVisible(g_MemoryDialog.GetHWND()));
 }
 
-void Dlg_Memory::ClearBanks()
+void Dlg_Memory::ClearBanks() noexcept
 {
 	if (m_hWnd == nullptr)
 		return;

--- a/src/RA_Dlg_Memory.h
+++ b/src/RA_Dlg_Memory.h
@@ -87,7 +87,7 @@ public:
 
 	const CodeNotes& Notes() const				{ return m_CodeNotes; }
 
-	void ClearBanks();
+	void ClearBanks() noexcept;
 	void AddBank( size_t nBankID );
 	void GenerateResizes( HWND hDlg );
 

--- a/src/RA_Dlg_RichPresence.cpp
+++ b/src/RA_Dlg_RichPresence.cpp
@@ -64,16 +64,10 @@ INT_PTR CALLBACK Dlg_RichPresence::s_RichPresenceDialogProc(HWND hDlg, UINT uMsg
 	return g_RichPresenceDialog.RichPresenceDialogProc( hDlg, uMsg, wParam, lParam );
 }
 
-Dlg_RichPresence::Dlg_RichPresence()
-	: m_hRichPresenceDialog( nullptr ),
-	  m_bTimerActive( false )
-{
-	m_hFont = CreateFont( 15, 0, 0, 0, FW_NORMAL, FALSE, FALSE, FALSE, DEFAULT_CHARSET, OUT_DEFAULT_PRECIS, CLIP_DEFAULT_PRECIS, CLEARTYPE_QUALITY, VARIABLE_PITCH, nullptr );
-}
 
-Dlg_RichPresence::~Dlg_RichPresence()
+Dlg_RichPresence::~Dlg_RichPresence() noexcept
 {
-	DeleteObject( m_hFont );
+	DeleteFont( m_hFont );
 }
 
 void Dlg_RichPresence::StartMonitoring()

--- a/src/RA_Dlg_RichPresence.h
+++ b/src/RA_Dlg_RichPresence.h
@@ -5,8 +5,12 @@
 class Dlg_RichPresence
 {
 public:
-	Dlg_RichPresence();
-	~Dlg_RichPresence();
+	~Dlg_RichPresence() noexcept;
+	Dlg_RichPresence(const Dlg_RichPresence&) = delete;
+	Dlg_RichPresence& operator=(const Dlg_RichPresence&) = delete;
+	Dlg_RichPresence(Dlg_RichPresence&&) noexcept = default;
+	Dlg_RichPresence& operator=(Dlg_RichPresence&&) noexcept = default;
+	Dlg_RichPresence() = default; // must be at the end, might throw because of HFONT
 
 	static INT_PTR CALLBACK s_RichPresenceDialogProc(HWND, UINT, WPARAM, LPARAM);
 	INT_PTR CALLBACK RichPresenceDialogProc(HWND, UINT, WPARAM, LPARAM);
@@ -20,9 +24,12 @@ private:
 	void StartTimer();
 	void StopTimer();
 
-	HFONT m_hFont;
-	HWND m_hRichPresenceDialog;
-	bool m_bTimerActive;
+	HFONT m_hFont{ 
+		CreateFont(15, 0, 0, 0, FW_NORMAL, FALSE, FALSE, FALSE, DEFAULT_CHARSET, OUT_DEFAULT_PRECIS, 
+		CLIP_DEFAULT_PRECIS, CLEARTYPE_QUALITY, VARIABLE_PITCH, nullptr) 
+	};
+	HWND m_hRichPresenceDialog{ nullptr };
+	bool m_bTimerActive{ false };
 };
 
 extern Dlg_RichPresence g_RichPresenceDialog;

--- a/src/RA_GameData.cpp
+++ b/src/RA_GameData.cpp
@@ -1,5 +1,7 @@
 #include "RA_GameData.h"
 
+
+// TODO: Does this really need to be a pointer? If so it needs to be owned.
 GameData* g_pCurrentGameData = new GameData();
 
 void GameData::ParseData(const Document& doc)

--- a/src/RA_ImageFactory.cpp
+++ b/src/RA_ImageFactory.cpp
@@ -21,118 +21,114 @@ UserImageFactoryVars g_UserImageFactoryInst;
 /******************************************************************
 *  Creates a DIB Section from the converted IWICBitmapSource      *
 ******************************************************************/
-HRESULT UserImageFactory_CreateDIBSectionFromBitmapSource( IWICBitmapSource *pToRenderBitmapSource, HBITMAP& hBitmapInOut )
-{
-	HRESULT hr = S_OK;
 
-	UINT nWidth = 0;
-	UINT nHeight = 0;
+_Success_(return == S_OK)
+HRESULT UserImageFactory_CreateDIBSectionFromBitmapSource(_In_ IWICBitmapSource *pToRenderBitmapSource,
+	_Out_ HBITMAP& hBitmapInOut)
+{
+
+	auto nWidth  = UINT{};
+	auto nHeight = UINT{};
 
 	void *pvImageBits = nullptr;
-	BITMAPINFO bminfo;
-	HWND hWindow = nullptr;
-	HDC hdcScreen = nullptr;
 
-	WICPixelFormatGUID pixelFormat;
+	auto pixelFormat = WICPixelFormatGUID{};
 
-	UINT cbStride = 0;
-	UINT cbImage = 0;
+	auto cbStride = UINT{};
+	auto cbImage  = UINT{};
 
 
 	// Check BitmapSource format
 	//hr = IWICBitmapSource_GetPixelFormat( pToRenderBitmapSource, &pixelFormat );
-	hr = pToRenderBitmapSource->GetPixelFormat( &pixelFormat );
+	auto hr = pToRenderBitmapSource->GetPixelFormat(&pixelFormat);
 
-	if( SUCCEEDED( hr ) )
+	if (SUCCEEDED(hr))
 	{
 		//hr = IWICBitmapSource_GetSize( pToRenderBitmapSource, &nWidth, &nHeight );
-		hr = pToRenderBitmapSource->GetSize( &nWidth, &nHeight );
+		hr = pToRenderBitmapSource->GetSize(&nWidth, &nHeight);
 	}
 
 	// Create a DIB section based on Bitmap Info
 	// BITMAPINFO Struct must first be setup before a DIB can be created.
 	// Note that the height is negative for top-down bitmaps
-	if( SUCCEEDED( hr ) )
+	if (SUCCEEDED(hr))
 	{
-		ZeroMemory( &bminfo, sizeof( bminfo ) );
-		bminfo.bmiHeader.biSize = sizeof( BITMAPINFOHEADER );
-		bminfo.bmiHeader.biWidth = nWidth;
-		bminfo.bmiHeader.biHeight = -(LONG)nHeight;
-		bminfo.bmiHeader.biPlanes = 1;
-		bminfo.bmiHeader.biBitCount = 32;
-		bminfo.bmiHeader.biCompression = BI_RGB;
 
-		hWindow = GetActiveWindow();
-		while( GetParent( hWindow ) != nullptr )
-			hWindow = GetParent( hWindow );
+		// TODO: Maybe replace some of these with literals
+		BITMAPINFOHEADER info_header{
+			sizeof(BITMAPINFOHEADER), static_cast<LONG>(nWidth),
+			-static_cast<LONG>(nHeight), WORD{1}, WORD{32},
+			static_cast<DWORD>(BI_RGB), DWORD{}, LONG{}, LONG{},
+			DWORD{}, DWORD{}
+		};
+		BITMAPINFO bminfo{ info_header, RGBQUAD{} };
+
+		auto hWindow = GetActiveWindow();
+		while (GetParent(hWindow) != nullptr)
+			hWindow = GetParent(hWindow);
 
 		// Get a DC for the full screen
-		hdcScreen = GetDC( hWindow );
-		hr = hdcScreen ? S_OK : E_FAIL;
+		auto hdcScreen = GetDC(hWindow);
+
 
 		// Release the previously allocated bitmap 
-		if( SUCCEEDED( hr ) )
+		if (hr = hdcScreen ? S_OK : E_FAIL; SUCCEEDED(hr))
 		{
-			if( hBitmapInOut )
+			if (hBitmapInOut)
 			{
-				DeleteObject( hBitmapInOut );
-			}
+				DeleteBitmap(hBitmapInOut);
+			} // end if
 
 			//	TBD: check this. As a handle this should just be as-is, right?
-			hBitmapInOut = CreateDIBSection( hdcScreen, &bminfo, DIB_RGB_COLORS, &pvImageBits, nullptr, 0 );
+			hBitmapInOut = CreateDIBSection(hdcScreen, &bminfo, DIB_RGB_COLORS, &pvImageBits, nullptr, DWORD{});
 
-			ReleaseDC( nullptr, hdcScreen );
+			ReleaseDC(nullptr, hdcScreen);
 
 			hr = hBitmapInOut ? S_OK : E_FAIL;
-		}
-	}
+		} // end if
+	} // end if
 
-	if( SUCCEEDED( hr ) )
+	if (SUCCEEDED(hr))
 	{
 		// Size of a scan line represented in bytes: 4 bytes each pixel
-		hr = UIntMult( nWidth, sizeof( ARGB ), &cbStride );
-	}
+		hr = UIntMult(nWidth, sizeof(ARGB), &cbStride);
+	} // end if
 
-	if( SUCCEEDED( hr ) )
+	if (SUCCEEDED(hr))
 	{
 		// Size of the image, represented in bytes
-		hr = UIntMult( cbStride, nHeight, &cbImage );
-	}
+		hr = UIntMult(cbStride, nHeight, &cbImage);
+	} // end if
 
 	// Extract the image into the HBITMAP    
-	if( SUCCEEDED( hr ) )
+	if (SUCCEEDED(hr))
 	{
 		hr = pToRenderBitmapSource->CopyPixels(
-			//hr = IWICBitmapSource_CopyPixels( pToRenderBitmapSource,
 			nullptr,
 			cbStride,
 			cbImage,
-			(BYTE*)pvImageBits );
-	}
+			static_cast<BYTE*>(pvImageBits));
+	} // end if
 
 	// Image Extraction failed, clear allocated memory
-	if( FAILED( hr ) )
+	if (FAILED(hr))
 	{
-		DeleteObject( hBitmapInOut );
+		DeleteBitmap(hBitmapInOut);
 		hBitmapInOut = nullptr;
-	}
+	} // end if
 
 	return hr;
-}
+} // end function UserImageFactory_CreateDIBSectionFromBitmapSource
 
-BOOL InitializeUserImageFactory( HINSTANCE hInst )
+
+_Use_decl_annotations_
+BOOL InitializeUserImageFactory([[maybe_unused]] HINSTANCE hInst)
 {
-	HRESULT hr = S_OK;;
+	HeapSetInformation(nullptr, HeapEnableTerminationOnCorruption, nullptr, SIZE_T{});
 
-	g_UserImageFactoryInst.m_pIWICFactory = nullptr;
-	g_UserImageFactoryInst.m_pOriginalBitmapSource = nullptr;
-
-	HeapSetInformation( nullptr, HeapEnableTerminationOnCorruption, nullptr, 0 );
-
-	hr = CoInitializeEx( nullptr, COINIT_MULTITHREADED | COINIT_DISABLE_OLE1DDE );
+	auto hr = CoInitializeEx(nullptr, COINIT_MULTITHREADED | COINIT_DISABLE_OLE1DDE);
 
 	// Create WIC factory
-	//#define IID_PPV_ARGS(ppType) ((LPVOID*)(ppType))
 	hr = CoCreateInstance(
 
 #if defined (__cplusplus)
@@ -141,7 +137,7 @@ BOOL InitializeUserImageFactory( HINSTANCE hInst )
 		&CLSID_WICImagingFactory,
 #endif
 
-		nullptr,
+		LPUNKNOWN{},
 		CLSCTX_INPROC_SERVER,
 
 #if defined (__cplusplus)
@@ -150,19 +146,20 @@ BOOL InitializeUserImageFactory( HINSTANCE hInst )
 		&IID_IWICImagingFactory,
 #endif
 
-		//IID_PPV_ARGS( &g_UserImageFactoryInst.m_pIWICFactory )
-		(LPVOID*)( &g_UserImageFactoryInst.m_pIWICFactory )
-		);
+		reinterpret_cast<LPVOID*>(&g_UserImageFactoryInst.m_pIWICFactory)
+	);
 
-	return( hr == S_OK );
-}
+	return(hr == S_OK);
+} // end function InitializeUserImageFactory
 
-HRESULT ConvertBitmapSource( RECT rcDest, IWICBitmapSource*& pToRenderBitmapSource )
+_Use_decl_annotations_
+_Success_(return != FAILED(std::declval<HRESULT&>()))
+HRESULT ConvertBitmapSource(_In_ RECT rcDest, _Inout_ IWICBitmapSource*& pToRenderBitmapSource)
 {
-	HRESULT hr = S_OK;
-	IWICBitmapScaler* pScaler = nullptr;
+	CComPtr<IWICBitmapScaler> pScaler;
+	CComPtr<IWICFormatConverter> pConverter;
 	WICPixelFormatGUID pxformat;
-	IWICFormatConverter* pConverter = nullptr;
+
 
 	pToRenderBitmapSource = nullptr;
 
@@ -170,218 +167,222 @@ HRESULT ConvertBitmapSource( RECT rcDest, IWICBitmapSource*& pToRenderBitmapSour
 	//RECT rcClient = rcDest;
 	//hr = GetClientRect(hWnd, &rcClient) ? S_OK: E_FAIL;
 
-	if( SUCCEEDED( hr ) )
-	{
+	// This top if statement seems redundant
+
 		// Create a BitmapScaler
-		hr = g_UserImageFactoryInst.m_pIWICFactory->CreateBitmapScaler( &pScaler );
-		//hr = IWICImagingFactory_CreateBitmapScaler( g_UserImageFactoryInst.m_pIWICFactory, &pScaler );
+	auto hr = g_UserImageFactoryInst.m_pIWICFactory->CreateBitmapScaler(&pScaler);
+	//hr = IWICImagingFactory_CreateBitmapScaler( g_UserImageFactoryInst.m_pIWICFactory, &pScaler );
 
-		// Initialize the bitmap scaler from the original bitmap map bits
-		if( SUCCEEDED( hr ) )
-		{
-			pScaler->Initialize( g_UserImageFactoryInst.m_pOriginalBitmapSource,
-								 rcDest.right - rcDest.left,
-								 rcDest.bottom - rcDest.top,
-								 WICBitmapInterpolationModeFant );
-		}
-
-		//hr = IWICBitmapScaler_GetPixelFormat( pScaler, &pxformat );
-		hr = pScaler->GetPixelFormat( &pxformat );
-
-		// Format convert the bitmap into 32bppBGR, a convenient 
-		// pixel format for GDI rendering 
-		if( SUCCEEDED( hr ) )
-		{
-			//hr = IWICImagingFactory_CreateFormatConverter( g_UserImageFactoryInst.m_pIWICFactory, &pConverter );
-			hr = g_UserImageFactoryInst.m_pIWICFactory->CreateFormatConverter( &pConverter );
-
-			// Format convert to 32bppBGR
-			if( SUCCEEDED( hr ) )
-			{
-				hr = pConverter->Initialize( static_cast<IWICBitmapSource*>( pScaler ),	// Input bitmap to convert
-											 GUID_WICPixelFormat32bppBGR,				//	&GUID_WICPixelFormat32bppBGR,
-											 WICBitmapDitherTypeNone,					// Specified dither patterm
-											 nullptr,										// Specify a particular palette 
-											 0.f,										// Alpha threshold
-											 WICBitmapPaletteTypeCustom );				// Palette translation type
-
-				// Store the converted bitmap as ppToRenderBitmapSource 
-				if( SUCCEEDED( hr ) )
-					pConverter->QueryInterface( IID_IWICBitmapSource, reinterpret_cast<void**>( &pToRenderBitmapSource ) );
-			}
-			SAFE_RELEASE( pConverter );
-		}
-
-		SAFE_RELEASE( pScaler );
+	// Initialize the bitmap scaler from the original bitmap map bits
+	if (SUCCEEDED(hr))
+	{
+		pScaler->Initialize(g_UserImageFactoryInst.m_pOriginalBitmapSource,
+			rcDest.right - rcDest.left,
+			rcDest.bottom - rcDest.top,
+			WICBitmapInterpolationModeFant);
 	}
+
+	//hr = IWICBitmapScaler_GetPixelFormat( pScaler, &pxformat );
+	hr = pScaler->GetPixelFormat(&pxformat);
+
+	// Format convert the bitmap into 32bppBGR, a convenient 
+	// pixel format for GDI rendering 
+	if (SUCCEEDED(hr))
+	{
+		//hr = IWICImagingFactory_CreateFormatConverter( g_UserImageFactoryInst.m_pIWICFactory, &pConverter );
+		hr = g_UserImageFactoryInst.m_pIWICFactory->CreateFormatConverter(&pConverter);
+
+		// Format convert to 32bppBGR
+		if (SUCCEEDED(hr))
+		{
+			hr = pConverter->Initialize(static_cast<IWICBitmapSource*>(pScaler),	// Input bitmap to convert
+				GUID_WICPixelFormat32bppBGR,				//	&GUID_WICPixelFormat32bppBGR,
+				WICBitmapDitherTypeNone,					// Specified dither patterm
+				nullptr,										// Specify a particular palette 
+				0.f,										// Alpha threshold
+				WICBitmapPaletteTypeCustom);				// Palette translation type
+
+// Store the converted bitmap as ppToRenderBitmapSource 
+			if (SUCCEEDED(hr))
+				pConverter->QueryInterface(IID_IWICBitmapSource, reinterpret_cast<void**>(&pToRenderBitmapSource));
+		}
+		pConverter.Release();
+	}
+
+	pScaler.Release();
+
 
 	return hr;
 }
 
-HBITMAP LoadOrFetchBadge( const std::string& sBadgeURI, const RASize& sz )
+_Use_decl_annotations_
+HBITMAP LoadOrFetchBadge(const std::string& sBadgeURI, const RASize& sz)
 {
-	SetCurrentDirectory( NativeStr( g_sHomeDir ).c_str() );
+	SetCurrentDirectory(NativeStr(g_sHomeDir).c_str());
 
-	if( !_FileExists( RA_DIR_BADGE + sBadgeURI + ".png" ) )
+	if (!_FileExists(RA_DIR_BADGE + sBadgeURI + ".png"))
 	{
 		PostArgs args;
-		args[ 'b' ] = sBadgeURI;
+		args['b'] = sBadgeURI;
 		//	Ensure it's not in the queue to be processed or has been processed, waiting for handling:
-		if( !RAWeb::HTTPRequestExists( RequestBadge, sBadgeURI ) && !RAWeb::HTTPResponseExists( RequestBadge, sBadgeURI ) )
-			RAWeb::CreateThreadedHTTPRequest( RequestBadge, args, sBadgeURI );
+		if (!RAWeb::HTTPRequestExists(RequestBadge, sBadgeURI) && !RAWeb::HTTPResponseExists(RequestBadge, sBadgeURI))
+			RAWeb::CreateThreadedHTTPRequest(RequestBadge, args, sBadgeURI);
 
 		return nullptr;
 	}
 	else
 	{
-		return LoadLocalPNG( RA_DIR_BADGE + sBadgeURI + ".png", sz );
+		return LoadLocalPNG(RA_DIR_BADGE + sBadgeURI + ".png", sz);
 	}
 }
 
-HBITMAP LoadOrFetchUserPic( const std::string& sUserName, const RASize& sz )
+_Use_decl_annotations_
+HBITMAP LoadOrFetchUserPic(const std::string& sUserName, const RASize& sz)
 {
-	SetCurrentDirectory(NativeStr( g_sHomeDir ).c_str() );
+	SetCurrentDirectory(NativeStr(g_sHomeDir).c_str());
 
-	if( !_FileExists( RA_DIR_USERPIC + sUserName + ".png" ) )
+	if (!_FileExists(RA_DIR_USERPIC + sUserName + ".png"))
 	{
 		PostArgs args;
 		args['u'] = sUserName;
 		//	Ensure it's not in the queue to be processed or has been processed, waiting for handling:
-		if( !RAWeb::HTTPRequestExists( RequestUserPic, sUserName ) && !RAWeb::HTTPResponseExists( RequestUserPic, sUserName ) )
-			RAWeb::CreateThreadedHTTPRequest( RequestUserPic, args, sUserName );
+		if (!RAWeb::HTTPRequestExists(RequestUserPic, sUserName) && !RAWeb::HTTPResponseExists(RequestUserPic, sUserName))
+			RAWeb::CreateThreadedHTTPRequest(RequestUserPic, args, sUserName);
 
+		// This really should be handled
 		return nullptr;
 	}
 	else
 	{
-		return LoadLocalPNG( RA_DIR_USERPIC + sUserName + ".png", sz );
+		return LoadLocalPNG(RA_DIR_USERPIC + sUserName + ".png", sz);
 	}
 }
 
-HBITMAP LoadLocalPNG( const std::string& sPath, const RASize& sz )
+_Use_decl_annotations_
+HBITMAP LoadLocalPNG(const std::string& sPath, const RASize& sz)
 {
-	SetCurrentDirectory(NativeStr( g_sHomeDir ).c_str() );
+	SetCurrentDirectory(NativeStr(g_sHomeDir).c_str());
 
-	ASSERT( _FileExists( sPath ) );
-	if( !_FileExists( sPath ) )
+	ASSERT(_FileExists(sPath));
+	if (!_FileExists(sPath))
 	{
-		RA_LOG( "File could not be found: %s\n", sPath.c_str() );
+		RA_LOG("File could not be found: %s\n", sPath.c_str());
 		return nullptr;
 	}
 
 	HBITMAP hRetVal = nullptr;
 	// Step 2: Decode the source image to IWICBitmapSource
-	IWICBitmapDecoder* pDecoder = nullptr;
-	HRESULT hr = g_UserImageFactoryInst.m_pIWICFactory->CreateDecoderFromFilename( Widen( sPath ).c_str(),			// Image to be decoded
-																				   nullptr,							// Do not prefer a particular vendor
-																				   GENERIC_READ,					// Desired read access to the file
-																				   WICDecodeMetadataCacheOnDemand,	// Cache metadata when needed
-																				   &pDecoder );						// Pointer to the decoder
-	
+	CComPtr<IWICBitmapDecoder> pDecoder;
+	HRESULT hr = g_UserImageFactoryInst.m_pIWICFactory->CreateDecoderFromFilename(Widen(sPath).c_str(),			// Image to be decoded
+		nullptr,						// Do not prefer a particular vendor
+		GENERIC_READ,					// Desired read access to the file
+		WICDecodeMetadataCacheOnDemand,	// Cache metadata when needed
+		&pDecoder);						// Pointer to the decoder
+
 	// Retrieve the first frame of the image from the decoder
-	IWICBitmapFrameDecode* pFrame = nullptr;
-	if( SUCCEEDED( hr ) )
-		hr = pDecoder->GetFrame( 0, &pFrame );
+	CComPtr<IWICBitmapFrameDecode>  pFrame;
+	if (SUCCEEDED(hr))
+		hr = pDecoder->GetFrame(0, &pFrame);
 
 	// Retrieve IWICBitmapSource from the frame
-	if( SUCCEEDED( hr ) )
+	if (SUCCEEDED(hr))
 	{
-		SAFE_RELEASE( g_UserImageFactoryInst.m_pOriginalBitmapSource );	//##SD ???
-		pFrame->QueryInterface( IID_IWICBitmapSource, reinterpret_cast<void**>( &g_UserImageFactoryInst.m_pOriginalBitmapSource ) );
+		g_UserImageFactoryInst.m_pOriginalBitmapSource.Release();	//##SD ???
+		pFrame->QueryInterface(IID_IWICBitmapSource, reinterpret_cast<void**>(&g_UserImageFactoryInst.m_pOriginalBitmapSource));
 	}
 
 	// Step 3: Scale the original IWICBitmapSource to the client rect size
 	// and convert the pixel format
-	IWICBitmapSource* pToRenderBitmapSource = nullptr;
-	if( SUCCEEDED( hr ) )
-		hr = ConvertBitmapSource( { 0, 0, sz.Width(), sz.Height() }, pToRenderBitmapSource );
+	CComPtr<IWICBitmapSource> pToRenderBitmapSource;
+	if (SUCCEEDED(hr))
+		hr = ConvertBitmapSource({ 0, 0, sz.Width(), sz.Height() }, *&pToRenderBitmapSource);
 
 	// Step 4: Create a DIB from the converted IWICBitmapSource
-	if( SUCCEEDED( hr ) )
-		hr = UserImageFactory_CreateDIBSectionFromBitmapSource( pToRenderBitmapSource, hRetVal );
+	if (SUCCEEDED(hr))
+		hr = UserImageFactory_CreateDIBSectionFromBitmapSource(pToRenderBitmapSource, hRetVal);
 
-	SAFE_RELEASE( pToRenderBitmapSource );
-	SAFE_RELEASE( pDecoder );
-	SAFE_RELEASE( pFrame );
-	SAFE_RELEASE( g_UserImageFactoryInst.m_pOriginalBitmapSource );
-	
+	pToRenderBitmapSource.Release();
+	pDecoder.Release();
+	pFrame.Release();
+	g_UserImageFactoryInst.m_pOriginalBitmapSource.Release();
+
 	return hRetVal;
 }
 
 //////////////////////////////////////////////////////////////////////////
 
-void DrawImage( HDC hDC, HBITMAP hBitmap, int nX, int nY, int nW, int nH )
+void DrawImage(HDC hDC, HBITMAP hBitmap, int nX, int nY, int nW, int nH)
 {
-	ASSERT( hBitmap != nullptr );
-	HDC hdcMem = CreateCompatibleDC( hDC );
-	if( hdcMem )
+	ASSERT(hBitmap != nullptr);
+	HDC hdcMem = CreateCompatibleDC(hDC);
+	if (hdcMem)
 	{
 		//	Select new bitmap and backup old bitmap
-		HBITMAP hbmOld = SelectBitmap( hdcMem, hBitmap );
+		HBITMAP hbmOld = SelectBitmap(hdcMem, hBitmap);
 
 		//	Fetch and blit bitmap
 		BITMAP bm;
-		if( GetObject( hBitmap, sizeof( bm ), &bm ) == sizeof( bm ) )
-			BitBlt( hDC, nX, nY, nW, nH, hdcMem, 0, 0, SRCCOPY );	//	Blit!
+		if (GetObject(hBitmap, sizeof(bm), &bm) == sizeof(bm))
+			BitBlt(hDC, nX, nY, nW, nH, hdcMem, 0, 0, SRCCOPY);	//	Blit!
 
 		//	Restore old bitmap
-		SelectBitmap( hdcMem, hbmOld );
+		SelectBitmap(hdcMem, hbmOld);
 
 		//	Discard MemDC
-		DeleteDC( hdcMem );
+		DeleteDC(hdcMem);
 	}
 }
 
-void DrawImageStretched( HDC hDC, HBITMAP hBitmap, RECT& rcSource, RECT& rcDest )
+void DrawImageStretched(HDC hDC, HBITMAP hBitmap, RECT& rcSource, RECT& rcDest)
 {
-	ASSERT( hBitmap != nullptr );
-	HDC hdcMem = CreateCompatibleDC( hDC );
-	if( hdcMem )
+	ASSERT(hBitmap != nullptr);
+	HDC hdcMem = CreateCompatibleDC(hDC);
+	if (hdcMem)
 	{
 		//	Select new bitmap and backup old bitmap
-		HBITMAP hbmOld = SelectBitmap( hdcMem, hBitmap );
+		HBITMAP hbmOld = SelectBitmap(hdcMem, hBitmap);
 
 		//	Fetch and blit bitmap
 		BITMAP bm;
-		if( GetObject( hBitmap, sizeof( bm ), &bm ) == sizeof( bm ) )
+		if (GetObject(hBitmap, sizeof(bm), &bm) == sizeof(bm))
 		{
 			//	Blit!
-			SetStretchBltMode( hDC, BLACKONWHITE );
-			StretchBlt( hDC,
-						rcDest.left, rcDest.top, ( rcDest.right - rcDest.left ), ( rcDest.bottom - rcDest.top ),
-						hdcMem, 
-						rcSource.left, rcSource.top, ( rcSource.right - rcSource.left ), ( rcSource.bottom - rcSource.top ),
-						SRCCOPY );
+			SetStretchBltMode(hDC, BLACKONWHITE);
+			StretchBlt(hDC,
+				rcDest.left, rcDest.top, (rcDest.right - rcDest.left), (rcDest.bottom - rcDest.top),
+				hdcMem,
+				rcSource.left, rcSource.top, (rcSource.right - rcSource.left), (rcSource.bottom - rcSource.top),
+				SRCCOPY);
 		}
 
 		//	Restore old bitmap
-		SelectBitmap( hdcMem, hbmOld );
+		SelectBitmap(hdcMem, hbmOld);
 
 		//	Discard MemDC
-		DeleteDC( hdcMem );
+		DeleteDC(hdcMem);
 	}
 }
 
-void DrawImageTiled( HDC hDC, HBITMAP hBitmap, RECT& rcSource, RECT& rcDest )
+void DrawImageTiled(HDC hDC, HBITMAP hBitmap, RECT& rcSource, RECT& rcDest)
 {
-	ASSERT( hBitmap != nullptr );
-	HDC hdcMem = CreateCompatibleDC( hDC );
-	if( hdcMem )
+	ASSERT(hBitmap != nullptr);
+	HDC hdcMem = CreateCompatibleDC(hDC);
+	if (hdcMem)
 	{
 		//	Select new bitmap and backup old bitmap
-		HBITMAP hbmOld = SelectBitmap( hdcMem, hBitmap );
+		HBITMAP hbmOld = SelectBitmap(hdcMem, hBitmap);
 
 		//	Fetch and blit bitmap
 		BITMAP bm;
-		if( GetObject( hBitmap, sizeof( bm ), &bm ) == sizeof( bm ) )
+		if (GetObject(hBitmap, sizeof(bm), &bm) == sizeof(bm))
 		{
 			//	Blit!
 			//	Truncate the source rect if bigger than container
-			if( rcSource.left < rcDest.left )
-				rcSource.left += ( rcDest.left - rcSource.left );
+			if (rcSource.left < rcDest.left)
+				rcSource.left += (rcDest.left - rcSource.left);
 
-			if( rcSource.top < rcDest.top )
-				rcSource.top += ( rcDest.top - rcSource.top );
+			if (rcSource.top < rcDest.top)
+				rcSource.top += (rcDest.top - rcSource.top);
 
 			int nSourceWidth = rcSource.right - rcSource.left;
 			int nSourceHeight = rcSource.bottom - rcSource.top;
@@ -390,9 +391,9 @@ void DrawImageTiled( HDC hDC, HBITMAP hBitmap, RECT& rcSource, RECT& rcDest )
 			int nTargetHeight = rcDest.bottom - rcDest.top;
 
 			int nWidthRemaining = nTargetWidth;
-			for( int nXOffs = rcDest.left; nXOffs < rcDest.right; nXOffs += nSourceWidth )
+			for (int nXOffs = rcDest.left; nXOffs < rcDest.right; nXOffs += nSourceWidth)
 			{
-				for( int nYOffs = rcDest.top; nYOffs < rcDest.bottom; nYOffs += nSourceHeight )
+				for (int nYOffs = rcDest.top; nYOffs < rcDest.bottom; nYOffs += nSourceHeight)
 				{
 					int nDestLimitAtX = rcDest.right;
 					int nDestLimitAtY = rcDest.bottom;
@@ -403,22 +404,22 @@ void DrawImageTiled( HDC hDC, HBITMAP hBitmap, RECT& rcSource, RECT& rcDest )
 					//	If the full width of the source image goes outside the target area,
 					//		Clip the rightmost/lower end of it by this much
 
-					if( nXOffs+nSourceWidth > nDestLimitAtX )
-						nWidthToCopy -= ( nXOffs+nSourceWidth - nDestLimitAtX );
+					if (nXOffs + nSourceWidth > nDestLimitAtX)
+						nWidthToCopy -= (nXOffs + nSourceWidth - nDestLimitAtX);
 
-					if( nYOffs+nSourceHeight >= nDestLimitAtY )
-						nHeightToCopy -= ( nYOffs+nSourceHeight - nDestLimitAtY );
+					if (nYOffs + nSourceHeight >= nDestLimitAtY)
+						nHeightToCopy -= (nYOffs + nSourceHeight - nDestLimitAtY);
 
-					if( ( nXOffs + nWidthToCopy > 0 ) && ( nYOffs + nHeightToCopy > 0 ) )
-						BitBlt( hDC, nXOffs, nYOffs, nWidthToCopy, nHeightToCopy, hdcMem, 0, 0, SRCCOPY );
+					if ((nXOffs + nWidthToCopy > 0) && (nYOffs + nHeightToCopy > 0))
+						BitBlt(hDC, nXOffs, nYOffs, nWidthToCopy, nHeightToCopy, hdcMem, 0, 0, SRCCOPY);
 				}
 			}
 		}
 
 		//	Restore old bitmap
-		SelectBitmap( hdcMem, hbmOld );
+		SelectBitmap(hdcMem, hbmOld);
 
 		//	Discard MemDC
-		DeleteDC( hdcMem );
+		DeleteDC(hdcMem);
 	}
 }

--- a/src/RA_ImageFactory.cpp
+++ b/src/RA_ImageFactory.cpp
@@ -77,7 +77,7 @@ HRESULT UserImageFactory_CreateDIBSectionFromBitmapSource(_In_ IWICBitmapSource 
 			if (hBitmapInOut)
 			{
 				DeleteBitmap(hBitmapInOut);
-			} // end if
+			}
 
 			//	TBD: check this. As a handle this should just be as-is, right?
 			hBitmapInOut = CreateDIBSection(hdcScreen, &bminfo, DIB_RGB_COLORS, &pvImageBits, nullptr, DWORD{});
@@ -85,20 +85,20 @@ HRESULT UserImageFactory_CreateDIBSectionFromBitmapSource(_In_ IWICBitmapSource 
 			ReleaseDC(nullptr, hdcScreen);
 
 			hr = hBitmapInOut ? S_OK : E_FAIL;
-		} // end if
-	} // end if
+		}
+	}
 
 	if (SUCCEEDED(hr))
 	{
 		// Size of a scan line represented in bytes: 4 bytes each pixel
 		hr = UIntMult(nWidth, sizeof(ARGB), &cbStride);
-	} // end if
+	}
 
 	if (SUCCEEDED(hr))
 	{
 		// Size of the image, represented in bytes
 		hr = UIntMult(cbStride, nHeight, &cbImage);
-	} // end if
+	}
 
 	// Extract the image into the HBITMAP    
 	if (SUCCEEDED(hr))
@@ -108,14 +108,14 @@ HRESULT UserImageFactory_CreateDIBSectionFromBitmapSource(_In_ IWICBitmapSource 
 			cbStride,
 			cbImage,
 			static_cast<BYTE*>(pvImageBits));
-	} // end if
+	}
 
 	// Image Extraction failed, clear allocated memory
 	if (FAILED(hr))
 	{
 		DeleteBitmap(hBitmapInOut);
 		hBitmapInOut = nullptr;
-	} // end if
+	}
 
 	return hr;
 } // end function UserImageFactory_CreateDIBSectionFromBitmapSource

--- a/src/RA_ImageFactory.h
+++ b/src/RA_ImageFactory.h
@@ -4,28 +4,39 @@
 #include <WTypes.h>
 
 #include "RA_Defs.h"
-
+#include <atlbase.h>
 //////////////////////////////////////////////////////////////////////////
 //	Image Factory
 
 struct IWICBitmapSource;
 struct IWICImagingFactory;
 
-class UserImageFactoryVars
+struct UserImageFactoryVars
 {
+<<<<<<< HEAD
 public:
 	UserImageFactoryVars() :m_pOriginalBitmapSource( nullptr ), m_pIWICFactory( nullptr ) {}
 
 public:
 	IWICBitmapSource* m_pOriginalBitmapSource;
 	IWICImagingFactory* m_pIWICFactory; 
+=======
+	CComPtr<IWICBitmapSource> m_pOriginalBitmapSource;
+	CComPtr<IWICImagingFactory> m_pIWICFactory;
+>>>>>>> com_smart_pointers
 };
 
+_Success_(return != 0)
+BOOL InitializeUserImageFactory([[maybe_unused]] _In_ HINSTANCE hInst );
 
-BOOL InitializeUserImageFactory( HINSTANCE hInst );
-HBITMAP LoadOrFetchBadge( const std::string& sBadgeURI, const RASize& nSZ = RA_BADGE_PX );
-HBITMAP LoadOrFetchUserPic( const std::string& sUser, const RASize& nSZ = RA_USERPIC_PX );
-HBITMAP LoadLocalPNG( const std::string& sPath, const RASize& nSZ );
+_Success_(return != nullptr)
+HBITMAP LoadOrFetchBadge( _In_ const std::string& sBadgeURI, _In_ const RASize& nSZ = RA_BADGE_PX );
+
+_Success_(return != nullptr)
+HBITMAP LoadOrFetchUserPic(_In_ const std::string& sUser, _In_ const RASize& nSZ = RA_USERPIC_PX );
+
+_Success_(return != nullptr)
+HBITMAP LoadLocalPNG(_In_ const std::string& sPath, _In_ const RASize& nSZ );
 
 extern UserImageFactoryVars g_UserImageFactoryInst;
 

--- a/src/RA_ImageFactory.h
+++ b/src/RA_ImageFactory.h
@@ -13,17 +13,8 @@ struct IWICImagingFactory;
 
 struct UserImageFactoryVars
 {
-<<<<<<< HEAD
-public:
-	UserImageFactoryVars() :m_pOriginalBitmapSource( nullptr ), m_pIWICFactory( nullptr ) {}
-
-public:
-	IWICBitmapSource* m_pOriginalBitmapSource;
-	IWICImagingFactory* m_pIWICFactory; 
-=======
 	CComPtr<IWICBitmapSource> m_pOriginalBitmapSource;
 	CComPtr<IWICImagingFactory> m_pIWICFactory;
->>>>>>> com_smart_pointers
 };
 
 _Success_(return != 0)

--- a/src/RA_Integration.vcxproj
+++ b/src/RA_Integration.vcxproj
@@ -124,23 +124,25 @@
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="base.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseUnicode|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="base.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="base.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='DebugUnicode|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="base.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>11.0.50727.1</_ProjectFileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <OutDir>..\bin\$(Configuration)\</OutDir>
-    <IntDir>..\obj\$(Configuration)\</IntDir>
     <TargetName>RA_Integration</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugUnicode|Win32'">
@@ -167,12 +169,11 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(RA_IncludePath);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_DEBUG;RA_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DisableSpecificWarnings>4091</DisableSpecificWarnings>
     </ClCompile>
@@ -189,6 +190,9 @@
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ResourceCompile>
+    <PostBuildEvent>
+      <Command>copy /y $(TargetPath) $(LocalDebuggerWorkingDirectory)\RA_Integration.dll</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='DebugUnicode|Win32'">
     <ClCompile>

--- a/src/RA_Integration.vcxproj
+++ b/src/RA_Integration.vcxproj
@@ -112,7 +112,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v141_xp</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugUnicode|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
@@ -144,8 +144,8 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <TargetName>RA_Integration</TargetName>
-    <CodeAnalysisRuleSet>CppCoreCheckArithmeticRules.ruleset</CodeAnalysisRuleSet>
-    <RunCodeAnalysis>false</RunCodeAnalysis>
+    <CodeAnalysisRuleSet>CppCoreCheckClassRules.ruleset</CodeAnalysisRuleSet>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
     <EnableCppCoreCheck>true</EnableCppCoreCheck>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugUnicode|Win32'">
@@ -180,7 +180,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DisableSpecificWarnings>4091</DisableSpecificWarnings>
       <LanguageStandard>stdcpp17</LanguageStandard>
-      <EnablePREfast>false</EnablePREfast>
+      <EnablePREfast>true</EnablePREfast>
     </ClCompile>
     <Link>
       <AdditionalDependencies>windowscodecs.lib;winmm.lib;Winhttp.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/src/RA_Integration.vcxproj
+++ b/src/RA_Integration.vcxproj
@@ -176,6 +176,7 @@
       <WarningLevel>Level3</WarningLevel>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DisableSpecificWarnings>4091</DisableSpecificWarnings>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <AdditionalDependencies>windowscodecs.lib;winmm.lib;Winhttp.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/src/RA_Integration.vcxproj
+++ b/src/RA_Integration.vcxproj
@@ -94,7 +94,7 @@
     <ProjectName>RA_Integration</ProjectName>
     <ProjectGuid>{825CB292-F069-4B27-82CF-3417746ACDF3}</ProjectGuid>
     <RootNamespace>RA_Integration</RootNamespace>
-    <WindowsTargetPlatformVersion>7.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
@@ -144,6 +144,9 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <TargetName>RA_Integration</TargetName>
+    <CodeAnalysisRuleSet>CppCoreCheckArithmeticRules.ruleset</CodeAnalysisRuleSet>
+    <RunCodeAnalysis>false</RunCodeAnalysis>
+    <EnableCppCoreCheck>true</EnableCppCoreCheck>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugUnicode|Win32'">
     <OutDir>..\bin\$(Configuration)\</OutDir>
@@ -177,6 +180,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DisableSpecificWarnings>4091</DisableSpecificWarnings>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <EnablePREfast>false</EnablePREfast>
     </ClCompile>
     <Link>
       <AdditionalDependencies>windowscodecs.lib;winmm.lib;Winhttp.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/src/RA_Leaderboard.cpp
+++ b/src/RA_Leaderboard.cpp
@@ -186,17 +186,13 @@ void ValueSet::Clear()
 }
 
 //////////////////////////////////////////////////////////////////////////
-RA_Leaderboard::RA_Leaderboard( const unsigned nLeaderboardID ) :
-	m_nID( nLeaderboardID ),
-	m_bStarted( false ),
-	m_bSubmitted( false ),
-	m_format( Format_Value )
+RA_Leaderboard::RA_Leaderboard( const LeaderboardID nLeaderboardID ) noexcept :
+	m_nID{ nLeaderboardID }
 {
+	// The rest are initilized automatically
 }
 
-RA_Leaderboard::~RA_Leaderboard()
-{
-}
+
 
 //{"ID":"3","Mem":"STA:0xfe10=h0001_0xhf601=h0c_d0xhf601!=h0c_0xhfffb=0::CAN:0xhfe13<d0xhfe13::SUB:0xf7cc!=0_d0xf7cc=0::VAL:0xhfe24*1_0xhfe25*60_0xhfe22*3600","Format":"TIME","Title":"Green Hill Act 2","Description":"Complete this act in the fastest time!"},
 

--- a/src/RA_Leaderboard.cpp
+++ b/src/RA_Leaderboard.cpp
@@ -678,10 +678,10 @@ void RA_LeaderboardManager::OnSubmitEntry( const Document& doc )
 	g_PopupWindows.LeaderboardPopups().ShowScoreboard( pLB->ID() );
 }
 
-void RA_LeaderboardManager::AddLeaderboard( const RA_Leaderboard& lb )
+void RA_LeaderboardManager::AddLeaderboard( RA_Leaderboard&& lb )
 {
 	if( g_bLeaderboardsActive )	//	If not, simply ignore them.
-		m_Leaderboards.push_back( lb );
+		m_Leaderboards.push_back( std::move(lb) );
 }
 
 void RA_LeaderboardManager::Test()

--- a/src/RA_Leaderboard.cpp
+++ b/src/RA_Leaderboard.cpp
@@ -10,7 +10,7 @@ RA_LeaderboardManager g_LeaderboardManager;
 
 namespace
 {
-	const char* FormatTypeToString[] =
+	inline constexpr std::array<const char*, RA_Leaderboard::Format__MAX> FormatTypeToString
 	{
 		"TIME",			//	TimeFrames
 		"TIMESECS",		//	TimeSecs
@@ -19,7 +19,6 @@ namespace
 		"VALUE",		//	Value
 		"OTHER",		//	Other
 	};
-	static_assert( SIZEOF_ARRAY( FormatTypeToString ) == RA_Leaderboard::Format__MAX, "These must match!" );
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/src/RA_Leaderboard.h
+++ b/src/RA_Leaderboard.h
@@ -157,7 +157,7 @@ public:
 public:
 	void Reset();
 
-	void AddLeaderboard( const RA_Leaderboard& lb );
+	void AddLeaderboard(RA_Leaderboard&& lb);
 	void Test();
 	void Clear()								{ m_Leaderboards.clear(); }
 	size_t Count() const						{ return m_Leaderboards.size(); }

--- a/src/RA_Leaderboard.h
+++ b/src/RA_Leaderboard.h
@@ -8,24 +8,32 @@
 class MemValue
 {
 public:
-	MemValue()
-		: m_nAddress( 0 ), m_fModifier( 1.0f ), m_nVarSize( EightBit ), m_bBCDParse( false ), m_bParseVal( false ) {}
-	MemValue( unsigned int nAddr, double fMod, ComparisonVariableSize nSize, bool bBCDParse, bool bParseVal )
-		: m_nAddress( nAddr ), m_fModifier( fMod ), m_nVarSize( nSize ), m_bBCDParse( bBCDParse ), m_bParseVal( bParseVal ) {}
+	~MemValue() noexcept = default;
+	// copying should be ok, this can be a literal type
+	inline constexpr MemValue(const MemValue&) noexcept = default;
+	inline constexpr MemValue& operator=(const MemValue&) noexcept = default;
+	inline constexpr MemValue(MemValue&&) noexcept = default;
+	inline constexpr MemValue& operator=(MemValue&&) noexcept = default;
+
+	inline constexpr MemValue( unsigned int nAddr, double fMod, ComparisonVariableSize nSize, bool bBCDParse,
+		bool bParseVal ) noexcept :
+	m_nAddress{ nAddr }, m_fModifier{ fMod }, m_nVarSize{ nSize }, m_bBCDParse{ bBCDParse }, m_bParseVal{ bParseVal } {}
 	
+
+	inline constexpr MemValue() noexcept = default;
 public:
 	const char* ParseFromString( const char* pBuffer );		//	Parse string into values, returns end of string
 	double GetValue() const;					//	Get the value in-memory with modifiers
 
 public:
-	unsigned int			m_nAddress;					//	Raw address of an 8-bit, or value.
-	ComparisonVariableSize	m_nVarSize;				
-	double					m_fModifier;				//	* 60 etc
-	bool					m_bBCDParse;				//	Parse as a binary coded decimal.
-	bool					m_bParseVal;				//	Parse as a value
-	bool					m_bInvertBit = false;
-	unsigned int			m_nSecondAddress = 0;
-	ComparisonVariableSize	m_nSecondVarSize;
+	unsigned int			m_nAddress{ 0U };					//	Raw address of an 8-bit, or value.
+	ComparisonVariableSize	m_nVarSize{ ComparisonVariableSize::EightBit };
+	double					m_fModifier{ 1.0f };				//	* 60 etc
+	bool					m_bBCDParse{ false };				//	Parse as a binary coded decimal.
+	bool					m_bParseVal{ false };				//	Parse as a value
+	bool					m_bInvertBit{ false };
+	unsigned int			m_nSecondAddress{ 0U };
+	ComparisonVariableSize	m_nSecondVarSize{ ComparisonVariableSize::EightBit };
 };
 
 
@@ -55,10 +63,10 @@ protected:
 
 struct LB_Entry
 {
-	unsigned int m_nRank;
+	unsigned int m_nRank{ 0U };
 	std::string	 m_sUsername;
-	int m_nScore;
-	time_t m_TimeAchieved;
+	int m_nScore{ 0 };
+	time_t m_TimeAchieved{ 0_z }; // time_t is a typedef of size_t
 };
 
 class RA_Leaderboard
@@ -77,9 +85,15 @@ public:
 	};
 	
 public:
-	RA_Leaderboard( const LeaderboardID nLBID );
-	~RA_Leaderboard();
+	// Default doesn't throw so this shouldn't either
+	RA_Leaderboard( const LeaderboardID nLBID ) noexcept;
+	~RA_Leaderboard() noexcept = default;
 
+	RA_Leaderboard(const RA_Leaderboard&) = delete;
+	RA_Leaderboard& operator=(const RA_Leaderboard&) = delete;
+	RA_Leaderboard(RA_Leaderboard&&) noexcept = default;
+	RA_Leaderboard& operator=(RA_Leaderboard&&) noexcept = default;
+	RA_Leaderboard() noexcept = default;
 public:
 	void LoadFromJSON( const Value& element );
 	void ParseLine( char* sBuffer );
@@ -109,17 +123,24 @@ public:
 	std::vector< ValueSet::OperationType > m_sOperations;
 
 private:
-	const LeaderboardID		m_nID;			//	DB ID for this LB
-	ConditionSet			m_startCond;	//	Start monitoring if this is true
-    ConditionSet			m_cancelCond;	//	Cancel monitoring if this is true
-    ConditionSet			m_submitCond;	//	Submit new score if this is true
+	// You could delete copying instead
+	const LeaderboardID		m_nID{ 0_lbid }; //	DB ID for this LB
+	ConditionSet			m_startCond;	 //	Start monitoring if this is true
+    ConditionSet			m_cancelCond; 	 //	Cancel monitoring if this is true
+    ConditionSet			m_submitCond;	 //	Submit new score if this is true
 
-	bool					m_bStarted;		//	False = check start condition. True = check cancel or submit conditions.
-	bool                    m_bSubmitted;   //  True if already submitted.
+
+	/*	
+		m_bSubmitted(false),
+		m_format()*/
+
+
+	bool					m_bStarted{ false };   // False = check start condition. True = check cancel or submit conditions.
+	bool                    m_bSubmitted{ false }; // True if already submitted.
 
 	ValueSet				m_value;		//	A collection of memory addresses and values to produce one value.
 	ValueSet				m_progress;		//	A collection of memory addresses, used to show progress towards completion.
-	FormatType				m_format;		//	A format to output. Typically "%d" for score or "%02d:%02d.%02d" for time
+	FormatType				m_format{ FormatType::Format_Value }; // A format to output. Typically "%d" for score or "%02d:%02d.%02d" for time
 
 	std::string				m_sTitle;		//	
 	std::string				m_sDescription;	//	

--- a/src/RA_LeaderboardPopup.cpp
+++ b/src/RA_LeaderboardPopup.cpp
@@ -12,17 +12,17 @@
 
 namespace
 {
-	const float SCOREBOARD_APPEAR_AT = 0.8f;
-	const float SCOREBOARD_FADEOUT_AT = 6.2f;
-	const float SCOREBOARD_FINISH_AT = 7.0f;
+	inline constexpr auto SCOREBOARD_APPEAR_AT  = 0.8f;
+	inline constexpr auto SCOREBOARD_FADEOUT_AT = 6.2f;
+	inline constexpr auto SCOREBOARD_FINISH_AT  = 7.0f;
 
-	const char* FONT_TO_USE = "Tahoma";
+	inline constexpr auto FONT_TO_USE = "Tahoma";
 
-	const COLORREF g_ColBG = RGB( 32, 32, 32 );
+	inline constexpr auto g_ColBG = RGB( 32, 32, 32 );
 	
-	const int FONT_SIZE_TITLE = 28;
-	const int FONT_SIZE_SUBTITLE = 22;
-	const int FONT_SIZE_TEXT = 16;
+	inline constexpr auto FONT_SIZE_TITLE    = 28;
+	inline constexpr auto FONT_SIZE_SUBTITLE = 22;
+	inline constexpr auto FONT_SIZE_TEXT     = 16;
 }
 
 

--- a/src/RA_MemManager.cpp
+++ b/src/RA_MemManager.cpp
@@ -4,21 +4,15 @@
 
 MemManager g_MemManager;
 
-MemManager::MemManager()
- :	m_nComparisonSizeMode( ComparisonVariableSize::SixteenBit ),
-	m_bUseLastKnownValue( true ),
-	m_Candidates( nullptr ),
-	m_nTotalBankSize( 0 )
-{
-}
 
-//	virtual
-MemManager::~MemManager()
+
+
+MemManager::~MemManager() noexcept
 {
 	ClearMemoryBanks();
 }
 
-void MemManager::ClearMemoryBanks()
+void MemManager::ClearMemoryBanks() noexcept
 {
 	m_Banks.clear();
 	m_nTotalBankSize = 0;

--- a/src/RA_MemManager.h
+++ b/src/RA_MemManager.h
@@ -12,20 +12,11 @@ struct MemCandidate
 	bool m_bHasChanged{ false };
 };
 
-// TODO: We should try to make these function objects, or a function type, not sure the intention here
-// It's gonna have the same semantics for now it just looks weird
-// Note: It's still a function pointer
 
-using _RAMByteReadFn  = std::add_pointer_t<unsigned char(unsigned int nOffs)>;
-using _RAMByteWriteFn = std::add_pointer_t<void(unsigned int nOffs, unsigned int nVal)>;
+// putting it back
+typedef unsigned char(_RAMByteReadFn)(unsigned int nOffs);
+typedef  void(_RAMByteWriteFn)(unsigned int nOffs, unsigned int nVal);
 
-// lets check
-using test_type = unsigned char(*)(unsigned int);
-static_assert(std::is_same_v<test_type, _RAMByteReadFn>);
-
-// Ok the other one
-using test_type2 = void(*)(unsigned int, unsigned int);
-static_assert(std::is_same_v<test_type2, _RAMByteWriteFn>);
 
 class MemManager
 {
@@ -57,14 +48,15 @@ private:
 	};
 
 public:
-	
-	// unless this is inherited, making this virtual just wastes space
 	~MemManager() noexcept;
-
-	// can't be noexcept because of std::map, but that's fine, just handle it when it's thrown
+    // You have a global so I guess no copying or moving
+	MemManager(const MemManager&) = delete;
+	MemManager& operator=(const MemManager&) = delete;
+	MemManager(MemManager&&) noexcept = delete;
+	MemManager& operator=(MemManager&&) noexcept = delete;
 	MemManager() = default;
 public:
-	void ClearMemoryBanks();
+	void ClearMemoryBanks() noexcept;
 	void AddMemoryBank( size_t nBankID, _RAMByteReadFn* pReader, _RAMByteWriteFn* pWriter, size_t nBankSize );
 	size_t NumMemoryBanks() const									{ return m_Banks.size(); }
 

--- a/src/RA_MemManager.h
+++ b/src/RA_MemManager.h
@@ -19,6 +19,8 @@ public:
 	bool m_bHasChanged;
 };
 
+// TODO: We should try to make these function objects, or a function type, not sure the intention here
+
 typedef unsigned char (_RAMByteReadFn)( unsigned int nOffs );
 typedef void (_RAMByteWriteFn)( unsigned int nOffs, unsigned int nVal );
 
@@ -37,6 +39,8 @@ private:
 		{}
 		
 	private:
+        // TODO: If you really want to disable it, mark it with delete and implement move semantics unless
+        // you don't want them moved either (which would make the type useless)
 		//	Copying disabled
 		BankData( const BankData& );
 		BankData& operator=( BankData& );

--- a/src/RA_MemManager.h
+++ b/src/RA_MemManager.h
@@ -2,27 +2,30 @@
 
 #include "RA_Condition.h"
 
-class MemCandidate
+struct MemCandidate
 {
-public:
-	MemCandidate()
-	 :	m_nAddr( 0 ),
-		m_nLastKnownValue( 0 ),
-		m_bUpperNibble( FALSE ),
-		m_bHasChanged( FALSE )
-	{}
-	
-public:
-	unsigned int m_nAddr;
-	unsigned int m_nLastKnownValue;		//	A Candidate MAY be a 32-bit candidate!
-	bool m_bUpperNibble;				//	Used only for 4-bit comparisons
-	bool m_bHasChanged;
+	// If you can use 0 constructors, that's the best. Just use in-class initilizers
+	// Was this supposed be "ByteAddress"?
+	std::size_t m_nAddr{ 0_z };
+	std::size_t m_nLastKnownValue{ 0_z }; //	A Candidate MAY be a 32-bit candidate!
+	bool m_bUpperNibble{ false };		  //	Used only for 4-bit comparisons
+	bool m_bHasChanged{ false };
 };
 
 // TODO: We should try to make these function objects, or a function type, not sure the intention here
+// It's gonna have the same semantics for now it just looks weird
+// Note: It's still a function pointer
 
-typedef unsigned char (_RAMByteReadFn)( unsigned int nOffs );
-typedef void (_RAMByteWriteFn)( unsigned int nOffs, unsigned int nVal );
+using _RAMByteReadFn  = std::add_pointer_t<unsigned char(unsigned int nOffs)>;
+using _RAMByteWriteFn = std::add_pointer_t<void(unsigned int nOffs, unsigned int nVal)>;
+
+// lets check
+using test_type = unsigned char(*)(unsigned int);
+static_assert(std::is_same_v<test_type, _RAMByteReadFn>);
+
+// Ok the other one
+using test_type2 = void(*)(unsigned int, unsigned int);
+static_assert(std::is_same_v<test_type2, _RAMByteWriteFn>);
 
 class MemManager
 {
@@ -30,31 +33,36 @@ private:
 	class BankData
 	{
 	public:
-		BankData() 
-		 :	Reader( nullptr ), Writer( nullptr ), BankSize( 0 ) 
-		{}
+		~BankData() noexcept {
+			// got a access violation before
+			Reader   = nullptr;
+			Writer   = nullptr;
+			BankSize = 0_z;
+		}
 
-		BankData( _RAMByteReadFn* pReadFn, _RAMByteWriteFn* pWriteFn, size_t nBankSize )
-		 :	Reader( pReadFn ), Writer( pWriteFn ), BankSize( nBankSize )
-		{}
+		BankData( _RAMByteReadFn* pReadFn, _RAMByteWriteFn* pWriteFn, size_t nBankSize ) noexcept :
+			Reader{ pReadFn }, Writer{ pWriteFn }, BankSize{ nBankSize } {}
 		
-	private:
-        // TODO: If you really want to disable it, mark it with delete and implement move semantics unless
-        // you don't want them moved either (which would make the type useless)
-		//	Copying disabled
-		BankData( const BankData& );
-		BankData& operator=( BankData& );
-	
+		BankData( const BankData& ) = delete;
+		BankData& operator=( BankData& ) = delete;
+		// Moving invalidates pointers, meaning you cannot use the right side again
+		BankData(BankData&&) noexcept = default;
+		BankData& operator=(BankData&&) noexcept = default;
+		// parameterless constructor must be at the end or it will delete the rest
+		BankData() noexcept = default;
 	public:
-		_RAMByteReadFn* Reader;
-		_RAMByteWriteFn* Writer;
-		size_t BankSize;
+		_RAMByteReadFn * Reader{ nullptr };
+		_RAMByteWriteFn* Writer{ nullptr };
+		size_t BankSize{ 0_z };
 	};
 
 public:
-	MemManager();
-	virtual ~MemManager();
+	
+	// unless this is inherited, making this virtual just wastes space
+	~MemManager() noexcept;
 
+	// can't be noexcept because of std::map, but that's fine, just handle it when it's thrown
+	MemManager() = default;
 public:
 	void ClearMemoryBanks();
 	void AddMemoryBank( size_t nBankID, _RAMByteReadFn* pReader, _RAMByteWriteFn* pWriter, size_t nBankSize );
@@ -93,14 +101,14 @@ public:
 
 private:
 	std::map<size_t, BankData> m_Banks;
-	unsigned short m_nActiveMemBank;
+	unsigned short m_nActiveMemBank{ 0_hu };
 
-	MemCandidate* m_Candidates;		//	Pointer to an array
-	size_t m_nNumCandidates;		//	Actual quantity of legal candidates
+	MemCandidate* m_Candidates{nullptr};		//	Pointer to an array
+	size_t m_nNumCandidates{ 0_z };		//	Actual quantity of legal candidates
 
-	ComparisonVariableSize m_nComparisonSizeMode;
-	bool m_bUseLastKnownValue;
-	size_t m_nTotalBankSize;
+	ComparisonVariableSize m_nComparisonSizeMode{ ComparisonVariableSize::SixteenBit };
+	bool m_bUseLastKnownValue{ true };
+	size_t m_nTotalBankSize{ 0_z };
 };
 
 extern MemManager g_MemManager;

--- a/src/RA_ProgressPopup.cpp
+++ b/src/RA_ProgressPopup.cpp
@@ -8,16 +8,16 @@
 
 namespace
 {
-	const int FONT_SIZE_MAIN = 32;
-	const int FONT_SIZE_SUBTITLE = 28;
+inline constexpr auto FONT_SIZE_MAIN     = 32;
+inline constexpr auto FONT_SIZE_SUBTITLE = 28;
 
-	const float APPEAR_AT = 0.8f;
-	const float FADEOUT_AT = 4.2f;
-	const float FINISH_AT = 5.0f;
+inline constexpr auto APPEAR_AT  = 0.8f;
+inline constexpr auto FADEOUT_AT = 4.2f;
+inline constexpr auto FINISH_AT  = 5.0f;
 
-	const float POPUP_DIST_Y_TO_PCT = 0.856f;	//	Where on screen to end up
-	const float POPUP_DIST_Y_FROM_PCT = 0.4f;	//	Amount of screens to travel
-	const char* FONT_TO_USE = "Tahoma";
+inline constexpr auto POPUP_DIST_Y_TO_PCT   = 0.856f;	//	Where on screen to end up
+inline constexpr auto POPUP_DIST_Y_FROM_PCT = 0.4f;	    //	Amount of screens to travel
+inline constexpr auto FONT_TO_USE           = "Tahoma";
 }
 
 //ProgressPopup g_ProgressPopup;

--- a/src/RA_ProgressPopup.h
+++ b/src/RA_ProgressPopup.h
@@ -7,7 +7,7 @@
 //	Graphic to display an progress towards an achievement
 
 
-#define OVERLAY_MESSAGE_QUEUE_SIZE (5)
+inline constexpr auto OVERLAY_MESSAGE_QUEUE_SIZE = 5;
 
 class ProgressPopup
 {

--- a/src/RA_User.cpp
+++ b/src/RA_User.cpp
@@ -50,29 +50,30 @@ RAUser* RAUsers::GetUser( const std::string& sUser )
 }
 
 
-RAUser::RAUser( const std::string& sUsername ) :
-	m_sUsername( sUsername ),
-	m_nScore( 0 ),
-	m_hUserImage( nullptr ),
-	m_bFetchingUserImage( false )
+RAUser::RAUser( const std::string& sUsername ) noexcept :
+	m_sUsername( sUsername )
 {
+	// The rest are initilized automatically
+
 	//	Register
 	if( sUsername.length() > 2 )
 	{
+		// To throw or not to throw?
+
 		ASSERT( !RAUsers::DatabaseContainsUser( sUsername ) );
 		RAUsers::RegisterUser( sUsername, this );
 	}
 }
 
-RAUser::~RAUser()
+RAUser::~RAUser() noexcept
 {
 	FlushBitmap();
 }
 
-void RAUser::FlushBitmap()
+void RAUser::FlushBitmap() noexcept
 {
 	if( m_hUserImage != nullptr )
-		DeleteObject( m_hUserImage );
+		DeleteBitmap( m_hUserImage );
 	m_hUserImage = nullptr;
 }
 

--- a/src/RA_User.h
+++ b/src/RA_User.h
@@ -30,11 +30,18 @@ enum ActivityType
 class RAUser
 {
 public:
-	RAUser( const std::string& sUsername );
-	virtual ~RAUser();
+	// Noparam constructor won't throw so this shouldn't either, mark noexcept whenever you can (not blindly)
+	RAUser( const std::string& sUsername ) noexcept;
+	virtual ~RAUser() noexcept;
 
+	// Unique entries should not be copied by value, copying a nonliteral might throw anyway
+	RAUser(const RAUser&) = delete;
+	RAUser& operator=(const RAUser&) = delete;
+	RAUser(RAUser&&) noexcept = default;
+	RAUser& operator=(RAUser&&) noexcept = default;
+	RAUser() noexcept = default;
 public:
-	void FlushBitmap();
+	void FlushBitmap() noexcept;
 	void LoadOrFetchUserImage();
 
 	unsigned int GetScore() const					{ return m_nScore; }
@@ -52,12 +59,13 @@ public:
 	BOOL IsFetchingUserImage() const				{ return m_bFetchingUserImage; }
 	
 private:
-	/*const*/std::string	m_sUsername;
-	std::string				m_sActivity;
-	unsigned int			m_nScore;
 
-	HBITMAP					m_hUserImage;
-	BOOL					m_bFetchingUserImage;
+	std::string	 m_sUsername;
+	std::string	 m_sActivity;
+	unsigned int m_nScore{ 0U };
+
+	HBITMAP		 m_hUserImage{ nullptr };
+	BOOL		 m_bFetchingUserImage{ FALSE };
 };
 
 class LocalRAUser : public RAUser

--- a/src/RA_httpthread.cpp
+++ b/src/RA_httpthread.cpp
@@ -113,7 +113,7 @@ PostArgs PrevArgs;
 
 BOOL RequestObject::ParseResponseToJSON( Document& rDocOut )
 {
-	rDocOut.Parse( DataStreamAsString( GetResponse() ) );
+	rDocOut.Parse(ra::DataStreamAsString( GetResponse() ).c_str() );
 
 	if( rDocOut.HasParseError() )
 		RA_LOG( "Possible parse issue on response, %s (%s)\n", GetJSONParseErrorStr( rDocOut.GetParseError() ), RequestTypeToString[ m_nType ] );
@@ -247,7 +247,7 @@ BOOL RAWeb::DoBlockingRequest( RequestType nType, const PostArgs& PostData, Docu
 	{
 		if( response.size() > 0 )
 		{
-			JSONResponseOut.Parse( DataStreamAsString( response ) );
+			JSONResponseOut.Parse( DataStreamAsString( response ).c_str());
 			//LogJSON( JSONResponseOut );	//	Already logged during DoBlockingRequest()?
 
 			if( JSONResponseOut.HasParseError() )
@@ -479,12 +479,12 @@ BOOL RAWeb::DoBlockingHttpPost( const std::string& sRequestedPage, const std::st
 	if( ResponseOut.size() > 0 )
 	{
 		Document doc;
-		doc.Parse( DataStreamAsString( ResponseOut ) );
+		doc.Parse(ra::DataStreamAsString(ResponseOut).c_str());
 
 		if( doc.HasParseError() )
 		{
 			RA_LOG( "Cannot parse JSON!\n" );
-			RA_LOG( DataStreamAsString( ResponseOut ) );
+			RA_LOG(ra::DataStreamAsString( ResponseOut ).c_str() );
 			RA_LOG( "\n" );
 		}
 		else
@@ -636,7 +636,7 @@ BOOL RAWeb::DoBlockingImageUpload( UploadType nType, const std::string& sFilenam
 	DataStream response;
 	if( ::DoBlockingImageUpload( nType, sFilename, response ) )
 	{
-		ResponseOut.Parse(DataStreamAsString(response));
+		ResponseOut.Parse(ra::DataStreamAsString(response).c_str());
 		if( !ResponseOut.HasParseError() )
 		{
 			return TRUE;

--- a/src/RA_httpthread.cpp
+++ b/src/RA_httpthread.cpp
@@ -17,43 +17,12 @@
 #include <algorithm>	//	std::replace
 
 
-const char* RequestTypeToString[] = 
-{
-	"RequestLogin",
 
-	"RequestScore",
-	"RequestNews",
-	"RequestPatch",
-	"RequestLatestClientPage",
-	"RequestRichPresence",
-	"RequestAchievementInfo",
-	"RequestLeaderboardInfo",
-	"RequestCodeNotes",
-	"RequestFriendList",
-	"RequestBadgeIter",
-	"RequestUnlocks",
-	"RequestHashLibrary",
-	"RequestGamesList",
-	"RequestAllProgress",
-	"RequestGameID",
 
-	"RequestPing",
-	"RequestPostActivity",
-	"RequestSubmitAwardAchievement",
-	"RequestSubmitCodeNote",
-	"RequestSubmitLeaderboardEntry",
-	"RequestSubmitAchievementData",
-	"RequestSubmitTicket",
-	"RequestSubmitNewTitleEntry",
-	
-	"RequestUserPic",
-	"RequestBadge",
 
-	"STOP_THREAD",
-};
-static_assert( SIZEOF_ARRAY( RequestTypeToString ) == NumRequestTypes, "Must match up!" );
 
-const char* RequestTypeToPost[] =
+
+inline constexpr RequestTypes RequestTypeToPost
 {
 	"login",
 	"score",
@@ -86,19 +55,19 @@ const char* RequestTypeToPost[] =
 
 	"_stopthread_",			//	STOP_THREAD
 };
-static_assert( SIZEOF_ARRAY( RequestTypeToPost ) == NumRequestTypes, "Must match up!" );
 
-const char* UploadTypeToString[] = 
+
+inline constexpr UploadTypes UploadTypeToString
 {
 	"RequestUploadBadgeImage",
 };
-static_assert( SIZEOF_ARRAY( UploadTypeToString ) == NumUploadTypes, "Must match up!" );
 
-const char* UploadTypeToPost[] =
+
+inline constexpr UploadTypes UploadTypeToPost
 {
 	"uploadbadgeimage",
 };
-static_assert( SIZEOF_ARRAY( UploadTypeToPost ) == NumUploadTypes, "Must match up!" );
+
 
 //	No game-specific code here please!
 

--- a/src/RA_httpthread.h
+++ b/src/RA_httpthread.h
@@ -64,7 +64,43 @@ enum UploadType
 	NumUploadTypes
 };
 
-extern const char* RequestTypeToString[];
+using RequestTypes = std::array<const char*, NumRequestTypes>;
+using UploadTypes  = std::array<const char*, NumUploadTypes>;
+
+inline constexpr RequestTypes RequestTypeToString
+{
+	"RequestLogin",
+
+	"RequestScore",
+	"RequestNews",
+	"RequestPatch",
+	"RequestLatestClientPage",
+	"RequestRichPresence",
+	"RequestAchievementInfo",
+	"RequestLeaderboardInfo",
+	"RequestCodeNotes",
+	"RequestFriendList",
+	"RequestBadgeIter",
+	"RequestUnlocks",
+	"RequestHashLibrary",
+	"RequestGamesList",
+	"RequestAllProgress",
+	"RequestGameID",
+
+	"RequestPing",
+	"RequestPostActivity",
+	"RequestSubmitAwardAchievement",
+	"RequestSubmitCodeNote",
+	"RequestSubmitLeaderboardEntry",
+	"RequestSubmitAchievementData",
+	"RequestSubmitTicket",
+	"RequestSubmitNewTitleEntry",
+
+	"RequestUserPic",
+	"RequestBadge",
+
+	"STOP_THREAD",
+};
 
 typedef std::map<char, std::string> PostArgs;
 

--- a/src/base.props
+++ b/src/base.props
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros">
+    <RA_DIR>$(SolutionDir)</RA_DIR>
+    <RapidJSON_IncludeDir>$(RA_DIR)rapidjson/include/</RapidJSON_IncludeDir>
+    <RA_IncludePath>$(RA_DIR);$(RapidJSON_IncludeDir)</RA_IncludePath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <OutDir>$(SolutionDir)bin\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)obj\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <FloatingPointExceptions>true</FloatingPointExceptions>
+      <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <PostBuildEvent>
+      <Command>copy /y $(TargetPath) $(LocalDebuggerWorkingDirectory)$(TargetFileName)</Command>
+    </PostBuildEvent>
+    <PostBuildEvent>
+      <Message>Copies the compiled binary from the output directory to the working directory in "Debugging". Same command applies to release mode.</Message>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <BuildMacro Include="RA_DIR">
+      <Value>$(RA_DIR)</Value>
+      <EnvironmentVariable>true</EnvironmentVariable>
+    </BuildMacro>
+    <BuildMacro Include="RapidJSON_IncludeDir">
+      <Value>$(RapidJSON_IncludeDir)</Value>
+      <EnvironmentVariable>true</EnvironmentVariable>
+    </BuildMacro>
+    <BuildMacro Include="RA_IncludePath">
+      <Value>$(RA_IncludePath)</Value>
+      <EnvironmentVariable>true</EnvironmentVariable>
+    </BuildMacro>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
These basically just define and/or delete every default operation if one was defined. Default constructors where defaulted/deleted based on the context of how the classes were designed. It does not give defaults to every class.

Classes that had globals which flagged this had copying and moving deleted.