### PR TITLE
Update watched address when navigating filter results with keyboard

### DIFF
--- a/src/RA_Dlg_Memory.cpp
+++ b/src/RA_Dlg_Memory.cpp
@@ -407,8 +407,7 @@ void MemoryViewerControl::SetCaretPos()
     }
 
     g_MemoryDialog.SetWatchingAddress(m_nEditAddress);
-
-    //int nTopLeft = m_nAddressOffset - 0x40;
+    setWatchedAddress(m_nEditAddress);
 
     int subAddress = (m_nEditAddress - m_nAddressOffset);
 
@@ -958,7 +957,7 @@ INT_PTR Dlg_Memory::MemoryProc(HWND hDlg, UINT nMsg, WPARAM wParam, LPARAM lPara
             {
                 case IDC_RA_MEM_LIST:
                 {
-                    if (((LPNMHDR)lParam)->code == LVN_ITEMCHANGED)
+                    if (((LPNMHDR)lParam)->code == LVN_ITEMCHANGED || ((LPNMHDR)lParam)->code == NM_CLICK)
                     {
                         int nSelect = ListView_GetNextItem(GetDlgItem(hDlg, IDC_RA_MEM_LIST), -1, LVNI_FOCUSED);
 

--- a/src/RA_Dlg_Memory.cpp
+++ b/src/RA_Dlg_Memory.cpp
@@ -958,7 +958,7 @@ INT_PTR Dlg_Memory::MemoryProc(HWND hDlg, UINT nMsg, WPARAM wParam, LPARAM lPara
             {
                 case IDC_RA_MEM_LIST:
                 {
-                    if (((LPNMHDR)lParam)->code == NM_CLICK)
+                    if (((LPNMHDR)lParam)->code == LVN_ITEMCHANGED)
                     {
                         int nSelect = ListView_GetNextItem(GetDlgItem(hDlg, IDC_RA_MEM_LIST), -1, LVNI_FOCUSED);
 


### PR DESCRIPTION
When clicking on a filter result, the watched address updates, but then using up/down to select the next/previous item does not. This change supports both.