### PR TITLE
Support for HitCount on PauseIf

### DIFF
--- a/src/RA_Condition.cpp
+++ b/src/RA_Condition.cpp
@@ -358,44 +358,64 @@ bool Condition::Compare(unsigned int nAddBuffer)
 
 bool ConditionGroup::Test(bool& bDirtyConditions, bool& bResetAll)
 {
-    unsigned int nAddBuffer = 0;
-    unsigned int nAddHits = 0;
-    bool bConditionValid = false;
-    bool bSetValid = true; // important: empty group should evaluate true
-    unsigned int i = 0;
-
     const unsigned int nNumConditions = m_Conditions.size();
+    if (nNumConditions == 0)
+        return true; // important: empty group must evaluate true
 
-    //	Now, read all Pause conditions, and if any are true, do not process further (retain old state)
-    for (i = 0; i < nNumConditions; ++i)
+    // TODO: calculate once, instead of every frame
+    std::vector<bool> vPauseConditions(nNumConditions, false);
+
+    // identify any Pause conditions and their dependent AddSource/AddHits
+    bool bInPause = false;
+    bool bHasPause = false;
+    for (int i = nNumConditions - 1; i >= 0; --i)
     {
-        Condition* pNextCond = &m_Conditions[i];
-        if (pNextCond->IsPauseCondition())
+        switch (m_Conditions[i].GetConditionType())
         {
-            //	Reset by default, set to 1 if hit!
-            pNextCond->ResetHits();
+            case Condition::PauseIf:
+                bHasPause = true;
+                bInPause = true;
+                vPauseConditions[i] = true;
+                break;
 
-            if (pNextCond->Compare())
-            {
-                pNextCond->OverrideCurrentHits(1);
-                bDirtyConditions = TRUE;
+            case Condition::AddSource:
+            case Condition::SubSource:
+            case Condition::AddHits:
+                vPauseConditions[i] = bInPause;
+                break;
 
-                //	Early out: this achievement is paused, do not process any further!
-                return FALSE;
-            }
+            default:
+                bInPause = false;
+                //vPauseConditions[i] = false;
+                break;
         }
     }
 
-    //	Read all standard conditions, and process as normal:
-    for (i = 0; i < nNumConditions; ++i)
+    if (bHasPause)
     {
-        Condition* pNextCond = &m_Conditions[i];
+        // one or more Pause conditions exists, if any of them are true, stop processing this group
+        if (Test(bDirtyConditions, bResetAll, vPauseConditions, true))
+            return false;
+    }
 
+    // process the non-Pause conditions to see if the group is true
+    return Test(bDirtyConditions, bResetAll, vPauseConditions, false);
+}
+
+bool ConditionGroup::Test(bool& bDirtyConditions, bool& bResetAll, const std::vector<bool>& vPauseConditions, bool bProcessingPauseIfs)
+{
+    unsigned int nAddBuffer = 0;
+    unsigned int nAddHits = 0;
+    bool bSetValid = true; // must start true so AND logic works
+                          
+    for (size_t i = 0; i < m_Conditions.size(); ++i)
+    {
+        if (vPauseConditions[i] != bProcessingPauseIfs)
+            continue;
+
+        Condition* pNextCond = &m_Conditions[i];
         switch (pNextCond->GetConditionType())
         {
-            case Condition::PauseIf:
-                continue;
-
             case Condition::AddSource:
                 nAddBuffer += pNextCond->CompSource().GetValue();
                 continue;
@@ -422,7 +442,7 @@ bool ConditionGroup::Test(bool& bDirtyConditions, bool& bResetAll)
         }
 
         // always evaluate the condition to ensure delta values get tracked correctly
-        bConditionValid = pNextCond->Compare(nAddBuffer);
+        bool bConditionValid = pNextCond->Compare(nAddBuffer);
 
         // if the condition has a target hit count that has already been met, it's automatically true, even if not currently true.
         if (pNextCond->RequiredHits() != 0 && (pNextCond->CurrentHits() + nAddHits >= pNextCond->RequiredHits()))
@@ -450,6 +470,27 @@ bool ConditionGroup::Test(bool& bDirtyConditions, bool& bResetAll)
 
         switch (pNextCond->GetConditionType())
         {
+            case Condition::PauseIf:
+                // as soon as we find a PauseIf that evaluates to true, stop processing the rest of the group
+                if (bConditionValid)
+                    return true;
+                
+                // if we make it to the end of the function, make sure we indicating nothing matched. if we do find
+                // a later PauseIf match, it'll automatically return true via the previous condition.
+                bSetValid = false; 
+
+                if (pNextCond->RequiredHits() == 0)
+                {
+                    // PauseIf didn't evaluate true, and doesn't have a HitCount, reset the HitCount to indicate the condition didn't match
+                    if (pNextCond->ResetHits())
+                        bDirtyConditions = true;
+                }
+                else
+                {
+                    // PauseIf has a HitCount that hasn't been met, ignore it for now.
+                }
+                break;
+
             case Condition::ResetIf:
                 if (bConditionValid)
                 {

--- a/src/RA_Condition.cpp
+++ b/src/RA_Condition.cpp
@@ -362,10 +362,8 @@ bool ConditionGroup::Test(bool& bDirtyConditions, bool& bResetAll)
     if (nNumConditions == 0)
         return true; // important: empty group must evaluate true
 
-    // TODO: calculate once, instead of every frame
-    std::vector<bool> vPauseConditions(nNumConditions, false);
-
     // identify any Pause conditions and their dependent AddSource/AddHits
+    std::vector<bool> vPauseConditions(nNumConditions, false);
     bool bInPause = false;
     bool bHasPause = false;
     for (int i = nNumConditions - 1; i >= 0; --i)
@@ -386,7 +384,6 @@ bool ConditionGroup::Test(bool& bDirtyConditions, bool& bResetAll)
 
             default:
                 bInPause = false;
-                //vPauseConditions[i] = false;
                 break;
         }
     }
@@ -475,7 +472,7 @@ bool ConditionGroup::Test(bool& bDirtyConditions, bool& bResetAll, const std::ve
                 if (bConditionValid)
                     return true;
                 
-                // if we make it to the end of the function, make sure we indicating nothing matched. if we do find
+                // if we make it to the end of the function, make sure we indicate that nothing matched. if we do find
                 // a later PauseIf match, it'll automatically return true via the previous condition.
                 bSetValid = false; 
 

--- a/src/RA_Condition.h
+++ b/src/RA_Condition.h
@@ -180,7 +180,6 @@ class ConditionGroup
 public:
     void SerializeAppend(std::string& buffer) const;
 
-    //	Final param indicates 'or'
     bool Test(bool& bDirtyConditions, bool& bResetRead);
     size_t Count() const { return m_Conditions.size(); }
 
@@ -193,6 +192,8 @@ public:
     bool Reset(bool bIncludingDeltas);	//	Returns dirty
 
 protected:
+    bool Test(bool& bDirtyConditions, bool& bResetRead, const std::vector<bool>& vPauseConditions, bool bProcessingPauseIfs);
+
     std::vector<Condition> m_Conditions;
 };
 


### PR DESCRIPTION
* PauseIf(0) has no behavioral change. When not true, it will unpause itself.
* PauseIf(N) will only pause if HitCount is N. Since we don't want to automatically reset the HitCount when the condition is not true, PauseIf(N) never resets itself. It must be reset with a ResetIf. As a paused group is no longer processed, the ResetIf must be in a different group. 
    * This includes PauseIf(1). Semantically, this means "once the condition is true, disable this group until I tell you to re-enable everything", whereas PauseIf(0) means "only disable this group while the condition is true".