### PR TITLE
disable submission of triggering for unofficial achievements

### DIFF
--- a/src/RA_AchievementSet.cpp
+++ b/src/RA_AchievementSet.cpp
@@ -194,7 +194,7 @@ void AchievementSet::Test()
             {
                 const std::string sPoints = std::to_string(ach.Points());
 
-                if (ach.ID() == 0)
+                if (g_nActiveAchievementSet != Core)
                 {
                     g_PopupWindows.AchievementPopups().AddMessage(
                         MessagePopup("Test: Achievement Unlocked",

--- a/src/RA_Dlg_Achievement.cpp
+++ b/src/RA_Dlg_Achievement.cpp
@@ -320,7 +320,7 @@ void Dlg_Achievements::OnClickAchievementSet(AchievementSetType nAchievementSet)
 
         EnableWindow(GetDlgItem(m_hAchievementsDlg, IDC_RA_ADD_ACH), FALSE); // Cannot add direct to Unofficial
 
-        ShowWindow(GetDlgItem(m_hAchievementsDlg, IDC_RA_ACTIVATE_ALL_ACH), FALSE);
+        ShowWindow(GetDlgItem(m_hAchievementsDlg, IDC_RA_ACTIVATE_ALL_ACH), TRUE);
 
         CheckDlgButton(m_hAchievementsDlg, IDC_RA_ACTIVE_CORE, FALSE);
         CheckDlgButton(m_hAchievementsDlg, IDC_RA_ACTIVE_UNOFFICIAL, TRUE);


### PR DESCRIPTION
companion to https://github.com/RetroAchievements/RAWeb/pull/141

Since the server no longer accepts requests to award unofficial achievements, this prevents submitting the request.

This PR also includes changes to enable "Activate All" for Unofficial achievements.

Unofficial achievements should now behave like local achievements, except for the fact that they're stored on the server.

Here's an example message showing an unofficial achievement triggering:
![image](https://user-images.githubusercontent.com/32680403/40695780-f4773aaa-637f-11e8-9d82-c62642a7493e.png)
Note: this is the same message that already shows when a local achievement triggers.