### PR TITLE
Add unit tests for leaderboards

### DIFF
--- a/src/RA_AchievementOverlay.cpp
+++ b/src/RA_AchievementOverlay.cpp
@@ -1071,7 +1071,7 @@ void AchievementOverlay::DrawLeaderboardExaminePage(HDC hDC, int nDX, int nDY, c
         {
             for (size_t i = 0; i < pLB->GetRankInfoCount(); ++i)
             {
-                const LB_Entry& rEntry = pLB->GetRankInfo(i);
+                const RA_Leaderboard::Entry& rEntry = pLB->GetRankInfo(i);
                 std::string sScoreFormatted = pLB->FormatScore(rEntry.m_nScore);
 
                 char sRankText[256];

--- a/src/RA_AchievementOverlay.cpp
+++ b/src/RA_AchievementOverlay.cpp
@@ -9,7 +9,7 @@
 #include "RA_ImageFactory.h"
 #include "RA_PopupWindows.h"
 #include "RA_Core.h"
-#include "RA_Leaderboard.h"
+#include "RA_LeaderboardManager.h"
 #include "RA_GameData.h"
 
 #include <time.h>

--- a/src/RA_AchievementSet.cpp
+++ b/src/RA_AchievementSet.cpp
@@ -515,8 +515,14 @@ BOOL AchievementSet::LoadFromFile(GameID nGameID)
                 {
                     //"Leaderboards":[{"ID":"2","Mem":"STA:0xfe10=h0000_0xhf601=h0c_d0xhf601!=h0c_0xfff0=0_0xfffb=0::CAN:0xhfe13<d0xhfe13::SUB:0xf7cc!=0_d0xf7cc=0::VAL:0xhfe24*1_0xhfe25*60_0xhfe22*3600","Format":"TIME","Title":"Green Hill Act 1","Description":"Complete this act in the fastest time!"},
 
-                    RA_Leaderboard lb(LeaderboardsData[i]["ID"].GetUint());
-                    lb.LoadFromJSON(LeaderboardsData[i]);
+                    auto& lbData = LeaderboardsData[i];
+                    RA_Leaderboard lb(lbData["ID"].GetUint());
+
+                    lb.SetTitle(lbData["Title"].GetString());
+                    lb.SetDescription(lbData["Description"].GetString());
+
+                    auto nFormat = MemValue::ParseFormat(lbData["Format"].GetString());
+                    lb.ParseFromString(lbData["Mem"].GetString(), nFormat);
 
                     g_LeaderboardManager.AddLeaderboard(lb);
                 }

--- a/src/RA_AchievementSet.cpp
+++ b/src/RA_AchievementSet.cpp
@@ -4,6 +4,7 @@
 #include "RA_Core.h"
 #include "RA_Dlg_Achievement.h"
 #include "RA_Dlg_AchEditor.h"
+#include "RA_LeaderboardManager.h"
 #include "RA_User.h"
 #include "RA_PopupWindows.h"
 #include "RA_httpthread.h"

--- a/src/RA_Core.cpp
+++ b/src/RA_Core.cpp
@@ -10,7 +10,7 @@
 #include "RA_httpthread.h"
 #include "RA_ImageFactory.h"
 #include "RA_Interface.h"
-#include "RA_Leaderboard.h"
+#include "RA_LeaderboardManager.h"
 #include "RA_md5factory.h"
 #include "RA_MemManager.h"
 #include "RA_PopupWindows.h"

--- a/src/RA_Defs.h
+++ b/src/RA_Defs.h
@@ -249,8 +249,13 @@ const int SERVER_PING_DURATION = 2 * 60;
 #define RA_LOG RADebugLog
 
 #ifdef _DEBUG
+#ifndef RA_UTEST
 #undef ASSERT
 #define ASSERT( x ) assert( x )
+#else
+#undef ASSERT
+#define ASSERT( x ) {}
+#endif
 #else
 #undef ASSERT
 #define ASSERT( x ) {}

--- a/src/RA_Integration.vcxproj
+++ b/src/RA_Integration.vcxproj
@@ -43,9 +43,11 @@
     <ClCompile Include="RA_ImageFactory.cpp" />
     <ClCompile Include="RA_Interface.cpp" />
     <ClCompile Include="RA_Leaderboard.cpp" />
+    <ClCompile Include="RA_LeaderboardManager.cpp" />
     <ClCompile Include="RA_LeaderboardPopup.cpp" />
     <ClCompile Include="RA_md5factory.cpp" />
     <ClCompile Include="RA_MemManager.cpp" />
+    <ClCompile Include="RA_MemValue.cpp" />
     <ClCompile Include="RA_PopupWindows.cpp" />
     <ClCompile Include="RA_ProgressPopup.cpp" />
     <ClCompile Include="RA_RichPresence.cpp" />
@@ -77,9 +79,11 @@
     <ClInclude Include="RA_ImageFactory.h" />
     <ClInclude Include="RA_Interface.h" />
     <ClInclude Include="RA_Leaderboard.h" />
+    <ClInclude Include="RA_LeaderboardManager.h" />
     <ClInclude Include="RA_LeaderboardPopup.h" />
     <ClInclude Include="RA_md5factory.h" />
     <ClInclude Include="RA_MemManager.h" />
+    <ClInclude Include="RA_MemValue.h" />
     <ClInclude Include="RA_PopupWindows.h" />
     <ClInclude Include="RA_ProgressPopup.h" />
     <ClInclude Include="RA_Resource.h" />

--- a/src/RA_Integration.vcxproj.filters
+++ b/src/RA_Integration.vcxproj.filters
@@ -111,6 +111,12 @@
     <ClCompile Include="RA_ImageFactory.cpp">
       <Filter>Services</Filter>
     </ClCompile>
+    <ClCompile Include="RA_LeaderboardManager.cpp">
+      <Filter>Services</Filter>
+    </ClCompile>
+    <ClCompile Include="RA_MemValue.cpp">
+      <Filter>Data</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="md5.h">
@@ -211,6 +217,12 @@
     </ClInclude>
     <ClInclude Include="RA_ImageFactory.h">
       <Filter>Services</Filter>
+    </ClInclude>
+    <ClInclude Include="RA_LeaderboardManager.h">
+      <Filter>Services</Filter>
+    </ClInclude>
+    <ClInclude Include="RA_MemValue.h">
+      <Filter>Data</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/RA_Leaderboard.cpp
+++ b/src/RA_Leaderboard.cpp
@@ -1,32 +1,14 @@
 #include "RA_Leaderboard.h"
 
+#ifndef RA_UTEST
 #include "RA_LeaderboardManager.h"
-#include "RA_MemManager.h"
-#include "RA_PopupWindows.h"
-#include "RA_md5factory.h"
-#include "RA_httpthread.h"
-
-#include <time.h>
-
-
-namespace {
-const char* FormatTypeToString[] =
-{
-    "TIME",			//	TimeFrames
-    "TIMESECS",		//	TimeSecs
-    "MILLISECS",	//	TimeMillisecs
-    "SCORE",		//	Score	/POINTS
-    "VALUE",		//	Value
-    "OTHER",		//	Other
-};
-static_assert(SIZEOF_ARRAY(FormatTypeToString) == RA_Leaderboard::Format__MAX, "These must match!");
-}
+#endif
 
 RA_Leaderboard::RA_Leaderboard(const LeaderboardID nLeaderboardID) :
     m_nID(nLeaderboardID),
     m_bStarted(false),
     m_bSubmitted(false),
-    m_format(Format_Value)
+    m_format(MemValue::Format::Value)
 {
 }
 
@@ -36,35 +18,11 @@ RA_Leaderboard::~RA_Leaderboard()
 
 //{"ID":"3","Mem":"STA:0xfe10=h0001_0xhf601=h0c_d0xhf601!=h0c_0xhfffb=0::CAN:0xhfe13<d0xhfe13::SUB:0xf7cc!=0_d0xf7cc=0::VAL:0xhfe24*1_0xhfe25*60_0xhfe22*3600","Format":"TIME","Title":"Green Hill Act 2","Description":"Complete this act in the fastest time!"},
 
-void RA_Leaderboard::LoadFromJSON(const Value& element)
+void RA_Leaderboard::ParseFromString(const char* pChar, MemValue::Format nFormat)
 {
-    const LeaderboardID nID = element["ID"].GetUint();
-    ASSERT(nID == m_nID);	//	Must match!
-
-    const std::string sMem = element["Mem"].GetString();
-    char buffer[4096];
-    strcpy_s(buffer, 4096, sMem.c_str());
-    ParseLBData(buffer);
-
-    m_sTitle = element["Title"].GetString();
-    m_sDescription = element["Description"].GetString();
-
-    const std::string sFmt = element["Format"].GetString();
-    for (size_t i = 0; i < Format__MAX; ++i)
+    while (*pChar != '\n' && *pChar != '\0')
     {
-        if (sFmt.compare(FormatTypeToString[i]) == 0)
-        {
-            m_format = (FormatType)i;
-            break;
-        }
-    }
-}
-
-void RA_Leaderboard::ParseLBData(const char* pChar)
-{
-    while (((*pChar) != '\n') && ((*pChar) != '\0'))
-    {
-        if ((pChar[0] == ':') && (pChar[1] == ':'))	//	New Phrase (double colon)
+        if (pChar[0] == ':' && pChar[1] == ':')	//	New Phrase (double colon)
             pChar += 2;
 
         if (std::string("STA:").compare(0, 4, pChar, 0, 4) == 0)
@@ -98,147 +56,35 @@ void RA_Leaderboard::ParseLBData(const char* pChar)
         else if (std::string("VAL:").compare(0, 4, pChar, 0, 4) == 0)
         {
             pChar += 4;
-            //	Parse Value condition
-            //	Value is a collection of memory addresses and modifiers.
-            do
-            {
-                while ((*pChar) == ' ' || (*pChar) == '_' || (*pChar) == '|' || (*pChar) == '$')
-                    pChar++; // Skip any chars up til this point :S
-
-                MemValue newMemVal;
-                pChar = newMemVal.ParseFromString(pChar);
-                m_value.AddNewValue(newMemVal);
-
-                switch (*pChar)
-                {
-                    case ('$'): m_sOperations.push_back(MemValueSet::Operation_Maximum); break;
-                    case ('_'): m_sOperations.push_back(MemValueSet::Operation_Addition); break;
-                }
-            } while (*pChar == '_' || (*pChar) == '$');
+            pChar = m_value.ParseFromString(pChar);
         }
         else if (std::string("PRO:").compare(0, 4, pChar, 0, 4) == 0)
         {
             pChar += 4;
-            //	Progress: normally same as value:
-            //	Progress is a collection of memory addresses and modifiers.
-            do
-            {
-                while ((*pChar) == ' ' || (*pChar) == '_' || (*pChar) == '|')
-                    pChar++; // Skip any chars up til this point :S
-
-                MemValue newMemVal;
-                pChar = newMemVal.ParseFromString(pChar);
-                m_progress.AddNewValue(newMemVal);
-            } while (*pChar == '_');
-        }
-        else if (std::string("FOR:").compare(0, 4, pChar, 0, 4) == 0)
-        {
-            pChar += 4;
-
-            //	Format
-            if (strncmp(pChar, "TIMESECS", sizeof("TIMESECS") - 1) == 0)
-            {
-                m_format = Format_TimeSecs;
-                pChar += sizeof("TIMESECS") - 1;
-            }
-            else if (strncmp(pChar, "TIME", sizeof("TIME") - 1) == 0)
-            {
-                m_format = Format_TimeFrames;
-                pChar += sizeof("TIME") - 1;
-            }
-            else if (strncmp(pChar, "MILLISECS", sizeof("MILLISECS") - 1) == 0)
-            {
-                m_format = Format_TimeMillisecs;
-                pChar += sizeof("MILLISECS") - 1;
-            }
-            else if (strncmp(pChar, "POINTS", sizeof("POINTS") - 1) == 0)
-            {
-                m_format = Format_Score;
-                pChar += sizeof("POINTS") - 1;
-            }
-            else if (strncmp(pChar, "SCORE", sizeof("SCORE") - 1) == 0)	//dupe
-            {
-                m_format = Format_Score;
-                pChar += sizeof("SCORE") - 1;
-            }
-            else if (strncmp(pChar, "VALUE", sizeof("VALUE") - 1) == 0)
-            {
-                m_format = Format_Value;
-                pChar += sizeof("VALUE") - 1;
-            }
-            else
-            {
-                m_format = Format_Other;
-                while (isalnum(*pChar))
-                    pChar++;
-            }
-        }
-        else if (std::string("TTL:").compare(0, 4, pChar, 0, 4) == 0)
-        {
-            pChar += 4;
-            //	Title:
-            char* pDest = &m_sTitle[0];
-            while (!(pChar[0] == ':' && pChar[1] == ':'))
-            {
-                *pDest = *pChar;	//	char copy
-                pDest++;
-                pChar++;
-            }
-            *pDest = '\0';
-        }
-        else if (std::string("DES:").compare(0, 4, pChar, 0, 4) == 0)
-        {
-            pChar += 4;
-            //	Description:
-            char* pDest = &m_sDescription[0];
-            while ((pChar[0] != '\n') && (pChar[0] != '\0'))
-            {
-                *pDest = *pChar;	//	char copy
-                pDest++;
-                pChar++;
-            }
-            *pDest = '\0';
+            pChar = m_progress.ParseFromString(pChar);
         }
         else
         {
             //	badly formatted... cannot progress!
+            m_startCond.Clear();
             ASSERT(!"Badly formatted: this leaderboard makes no sense!");
             break;
         }
     }
 }
 
-void RA_Leaderboard::ParseLine(char* sBuffer)
+unsigned int RA_Leaderboard::GetCurrentValueProgress() const
 {
-    char* pChar = &sBuffer[0];
-    pChar++;											//	Skip over 'L' character
-    ASSERT(m_nID == strtol(pChar, &pChar, 10));		//	Skip over Leaderboard ID
-    ParseLBData(pChar);
-}
-
-double RA_Leaderboard::GetCurrentValue()
-{
-    return m_value.GetValue();
-}
-
-double RA_Leaderboard::GetCurrentValueProgress() const
-{
-    if (m_progress.NumValues() > 0)
+    if (!m_progress.IsEmpty())
         return m_progress.GetValue();
     else
-        return m_value.GetOperationsValue(m_sOperations);
-}
-
-void RA_Leaderboard::Clear()
-{
-    m_value.Clear();
-    m_progress.Clear();
-    //	Clear all locally stored lb info too tbd
+        return m_value.GetValue();
 }
 
 void RA_Leaderboard::Reset()
 {
     m_bStarted = false;
+    m_bSubmitted = false;
 
     m_startCond.Reset();
     m_cancelCond.Reset();
@@ -249,90 +95,54 @@ void RA_Leaderboard::Test()
 {
     bool bUnused;
 
-    //	Ensure these are always tested once every frame, to ensure delta
-    //	 variables work properly :)
-    BOOL bStartOK = m_startCond.Test(bUnused, bUnused);
-    BOOL bCancelOK = m_cancelCond.Test(bUnused, bUnused);
-    BOOL bSubmitOK = m_submitCond.Test(bUnused, bUnused);
+    //	ASSERT: these are always tested once every frame, to ensure delta variables work properly
+    bool bStartOK = m_startCond.Test(bUnused, bUnused);
+    bool bCancelOK = m_cancelCond.Test(bUnused, bUnused);
+    bool bSubmitOK = m_submitCond.Test(bUnused, bUnused);
 
     if (m_bSubmitted)
     {
-        // if we've already submitted or canceled the leaderboard, don't reactivate it until it becomes unactive.
+        // if we've already submitted or canceled the leaderboard, don't reactivate it until it becomes inactive.
         if (!bStartOK)
             m_bSubmitted = false;
     }
     else if (!m_bStarted)
     {
-        if (bStartOK)
+        // leaderboard is not active, if the start condition is true, activate it
+        if (bStartOK && !bCancelOK)
         {
-            m_bStarted = true;
-
-            if (g_bLBDisplayNotification)
+            if (bSubmitOK)
             {
-                g_PopupWindows.AchievementPopups().AddMessage(
-                    MessagePopup("Challenge Available: " + m_sTitle,
-                        m_sDescription,
-                        PopupLeaderboardInfo,
-                        nullptr));
-            }
+                // start and submit both true in the same frame, just submit without announcing the leaderboard is available
+                Submit(GetCurrentValue());
 
-            g_PopupWindows.LeaderboardPopups().Activate(m_nID);
+                // prevent multiple submissions/notifications
+                m_bSubmitted = true;
+            }
+            else if (m_startCond.GroupCount() > 0)
+            {
+                m_bStarted = true;
+                Start();
+            }
         }
     }
     else
     {
+        // leaderboard is active
         if (bCancelOK)
         {
+            // cancel condition is true, deactivate the leaderboard
             m_bStarted = false;
-            g_PopupWindows.LeaderboardPopups().Deactivate(m_nID);
-
-            if (g_bLBDisplayNotification)
-            {
-                g_PopupWindows.AchievementPopups().AddMessage(
-                    MessagePopup("Leaderboard attempt cancelled!",
-                        m_sTitle,
-                        PopupLeaderboardCancel,
-                        nullptr));
-            }
+            Cancel();
 
             // prevent multiple cancel notifications
             m_bSubmitted = true;
         }
         else if (bSubmitOK)
         {
+            // submit condition is true, submit the current value
             m_bStarted = false;
-            g_PopupWindows.LeaderboardPopups().Deactivate(m_nID);
-
-            if (g_bRAMTamperedWith)
-            {
-                g_PopupWindows.AchievementPopups().AddMessage(
-                    MessagePopup("Not posting to leaderboard: memory tamper detected!",
-                        "Reset game to reenable posting.",
-                        PopupInfo));
-            }
-            else if (g_bHardcoreModeActive)
-            {
-                //	TBD: move to keys!
-                char sValidationSig[50];
-                sprintf_s(sValidationSig, 50, "%d%s%d", m_nID, RAUsers::LocalUser().Username().c_str(), m_nID);
-                std::string sValidationMD5 = RAGenerateMD5(sValidationSig);
-
-                PostArgs args;
-                args['u'] = RAUsers::LocalUser().Username();
-                args['t'] = RAUsers::LocalUser().Token();
-                args['i'] = std::to_string(m_nID);
-                args['v'] = sValidationMD5;
-                args['s'] = std::to_string(static_cast<int>(m_value.GetOperationsValue(m_sOperations)));	//	Concern about rounding?
-
-                RAWeb::CreateThreadedHTTPRequest(RequestSubmitLeaderboardEntry, args);
-            }
-            else
-            {
-                g_PopupWindows.AchievementPopups().AddMessage(
-                    MessagePopup("Leaderboard submission post cancelled.",
-                        "Enable Hardcore Mode to enable posting.",
-                        PopupInfo));
-            }
+            Submit(GetCurrentValue());
 
             // prevent multiple submissions/notifications
             m_bSubmitted = true;
@@ -340,15 +150,36 @@ void RA_Leaderboard::Test()
     }
 }
 
+void RA_Leaderboard::Start()
+{
+#ifndef RA_UTEST
+    g_LeaderboardManager.ActivateLeaderboard(*this);
+#endif
+}
+
+void RA_Leaderboard::Cancel()
+{
+#ifndef RA_UTEST
+    g_LeaderboardManager.DeactivateLeaderboard(*this);
+#endif
+}
+
+void RA_Leaderboard::Submit(unsigned int nScore)
+{
+#ifndef RA_UTEST
+    g_LeaderboardManager.SubmitLeaderboardEntry(*this, nScore);
+#endif
+}
+
 void RA_Leaderboard::SubmitRankInfo(unsigned int nRank, const std::string& sUsername, int nScore, time_t nAchieved)
 {
-    LB_Entry newEntry;
+    Entry newEntry;
     newEntry.m_nRank = nRank;
     newEntry.m_sUsername = sUsername;
     newEntry.m_nScore = nScore;
     newEntry.m_TimeAchieved = nAchieved;
 
-    std::vector<LB_Entry>::iterator iter = m_RankInfo.begin();
+    std::vector<Entry>::iterator iter = m_RankInfo.begin();
     while (iter != m_RankInfo.end())
     {
         if ((*iter).m_nRank == nRank)
@@ -367,14 +198,11 @@ void RA_Leaderboard::SortRankInfo()
 {
     for (size_t i = 0; i < m_RankInfo.size(); ++i)
     {
-        for (size_t j = i; j < m_RankInfo.size(); ++j)
+        for (size_t j = i + 1; j < m_RankInfo.size(); ++j)
         {
-            if (i == j)
-                continue;
-
             if (m_RankInfo.at(i).m_nRank > m_RankInfo.at(j).m_nRank)
             {
-                LB_Entry temp = m_RankInfo[i];
+                Entry temp = m_RankInfo[i];
                 m_RankInfo[i] = m_RankInfo[j];
                 m_RankInfo[j] = temp;
             }
@@ -382,55 +210,3 @@ void RA_Leaderboard::SortRankInfo()
     }
 }
 
-//	static
-std::string RA_Leaderboard::FormatScore(FormatType nType, int nScoreIn)
-{
-    //	NB. This is accessed by RA_Formattable... ought to be refactored really
-    char buffer[256];
-    switch (nType)
-    {
-        case Format_TimeFrames:
-        {
-            int nMins = nScoreIn / 3600;
-            int nSecs = (nScoreIn % 3600) / 60;
-            int nMilli = static_cast<int>(((nScoreIn % 3600) % 60) * (100.0 / 60.0));	//	Convert from frames to 'millisecs'
-            sprintf_s(buffer, 256, "%02d:%02d.%02d", nMins, nSecs, nMilli);
-        }
-        break;
-
-        case Format_TimeSecs:
-        {
-            int nMins = nScoreIn / 60;
-            int nSecs = nScoreIn % 60;
-            sprintf_s(buffer, 256, "%02d:%02d", nMins, nSecs);
-        }
-        break;
-
-        case Format_TimeMillisecs:
-        {
-            int nMins = nScoreIn / 6000;
-            int nSecs = (nScoreIn % 6000) / 100;
-            int nMilli = static_cast<int>(nScoreIn % 100);
-            sprintf_s(buffer, 256, "%02d:%02d.%02d", nMins, nSecs, nMilli);
-        }
-        break;
-
-        case Format_Score:
-            sprintf_s(buffer, 256, "%06d Points", nScoreIn);
-            break;
-
-        case Format_Value:
-            sprintf_s(buffer, 256, "%01d", nScoreIn);
-            break;
-
-        default:
-            sprintf_s(buffer, 256, "%06d", nScoreIn);
-            break;
-    }
-    return buffer;
-}
-
-std::string RA_Leaderboard::FormatScore(int nScoreIn) const
-{
-    return FormatScore(m_format, nScoreIn);
-}

--- a/src/RA_Leaderboard.cpp
+++ b/src/RA_Leaderboard.cpp
@@ -1,4 +1,6 @@
 #include "RA_Leaderboard.h"
+
+#include "RA_LeaderboardManager.h"
 #include "RA_MemManager.h"
 #include "RA_PopupWindows.h"
 #include "RA_md5factory.h"
@@ -6,7 +8,6 @@
 
 #include <time.h>
 
-RA_LeaderboardManager g_LeaderboardManager;
 
 namespace {
 const char* FormatTypeToString[] =
@@ -21,171 +22,7 @@ const char* FormatTypeToString[] =
 static_assert(SIZEOF_ARRAY(FormatTypeToString) == RA_Leaderboard::Format__MAX, "These must match!");
 }
 
-//////////////////////////////////////////////////////////////////////////
-double MemValue::GetValue() const
-{
-    int nRetVal = 0;
-    if (m_bParseVal)
-    {
-        nRetVal = m_nAddress;	//	insert address as value.
-    }
-    else
-    {
-        nRetVal = g_MemManager.ActiveBankRAMRead(m_nAddress, m_nVarSize);
-
-        if (m_bInvertBit && (m_nVarSize >= ComparisonVariableSize::Bit_0) && (m_nVarSize <= ComparisonVariableSize::Bit_7))
-        {
-            nRetVal = (nRetVal == 1) ? 0 : 1;
-        }
-
-        if (m_bBCDParse)
-        {
-            //	Reparse this value as a binary coded decimal.
-            nRetVal = (((nRetVal >> 4) & 0xf) * 10) + (nRetVal & 0xf);
-        }
-    }
-
-    if (m_nSecondAddress > 0)
-    {
-        MemValue tempMem;
-        tempMem.m_bInvertBit = m_bInvertBit;
-        tempMem.m_nAddress = m_nSecondAddress;
-        tempMem.m_nVarSize = m_nSecondVarSize;
-
-        return nRetVal * tempMem.GetValue();
-    }
-
-    return nRetVal * m_fModifier;
-}
-
-const char* MemValue::ParseFromString(const char* pBuffer)
-{
-    const char* pIter = &pBuffer[0];
-
-    //	Borrow parsing from CompVariable
-
-    m_bBCDParse = false;
-    if (toupper(*pIter) == 'B')
-    {
-        m_bBCDParse = true;
-        pIter++;
-    }
-    else if (toupper(*pIter) == 'V')
-    {
-        m_bParseVal = true;
-        pIter++;
-    }
-
-    CompVariable varTemp;
-    varTemp.ParseVariable(pIter);
-    m_nAddress = varTemp.RawValue();	//	Fetch value ('address') as parsed. Note RawValue! Do not parse memory!
-    m_nVarSize = varTemp.Size();
-
-    m_fModifier = 1.0;
-    if (*pIter == '*')
-    {
-        pIter++;						//	Skip over modifier type.. assume mult( '*' );
-
-        // Invert bit flag results
-        if (*pIter == '~')
-        {
-            m_bInvertBit = true;
-            pIter++;
-        }
-
-        // Multiply by addresses
-        if (strncmp(pIter, "0x", sizeof("0x") - 1) == 0)
-        {
-            varTemp.ParseVariable(pIter);
-            m_nSecondAddress = varTemp.RawValue();
-            m_nSecondVarSize = varTemp.Size();
-        }
-        else
-        {
-            char* pOut;
-            m_fModifier = strtod(pIter, &pOut);
-            pIter = pOut;
-        }
-    }
-
-    return pIter;
-}
-
-//////////////////////////////////////////////////////////////////////////
-double ValueSet::GetValue() const
-{
-    double fVal = 0.0;
-    std::vector<MemValue>::const_iterator iter = m_Values.begin();
-    while (iter != m_Values.end())
-    {
-        fVal += (*iter).GetValue();
-        iter++;
-    }
-
-    return fVal;
-}
-
-double ValueSet::GetOperationsValue(std::vector<OperationType> sOperations) const
-{
-    double fVal = 0.0;
-    std::vector<MemValue>::const_iterator iter = m_Values.begin();
-    std::vector<OperationType>::const_iterator sOp = sOperations.begin();
-
-    if (iter != m_Values.end())
-    {
-        fVal += (*iter).GetValue();
-        iter++;
-    }
-
-    while (iter != m_Values.end())
-    {
-        if (sOp != sOperations.end() && *sOp == Operation_Maximum)
-        {
-            double maxValue = (*iter).GetValue();
-            iter++;
-            maxValue = (maxValue < (*iter).GetValue()) ? (*iter).GetValue() : maxValue;
-            fVal = (fVal < maxValue) ? maxValue : fVal;
-        }
-        else
-            fVal += (*iter).GetValue();
-
-        if (sOp == sOperations.end())
-            break;
-
-        iter++;
-        sOp++;
-    }
-
-    return fVal;
-}
-
-void ValueSet::AddNewValue(MemValue nMemVal)
-{
-    m_Values.push_back(nMemVal);
-}
-
-void ValueSet::ParseMemString(const char* pChar)
-{
-    do
-    {
-        {
-            while ((*pChar) == ' ' || (*pChar) == '_' || (*pChar) == '|')
-                pChar++; // Skip any chars up til this point :S
-        }
-
-        MemValue newMemVal;
-        pChar = newMemVal.ParseFromString(pChar);
-        AddNewValue(newMemVal);
-    } while (*pChar == '_');
-}
-
-void ValueSet::Clear()
-{
-    m_Values.clear();
-}
-
-//////////////////////////////////////////////////////////////////////////
-RA_Leaderboard::RA_Leaderboard(const unsigned nLeaderboardID) :
+RA_Leaderboard::RA_Leaderboard(const LeaderboardID nLeaderboardID) :
     m_nID(nLeaderboardID),
     m_bStarted(false),
     m_bSubmitted(false),
@@ -274,8 +111,8 @@ void RA_Leaderboard::ParseLBData(const char* pChar)
 
                 switch (*pChar)
                 {
-                    case ('$'): m_sOperations.push_back(ValueSet::Operation_Maximum); break;
-                    case ('_'): m_sOperations.push_back(ValueSet::Operation_Addition); break;
+                    case ('$'): m_sOperations.push_back(MemValueSet::Operation_Maximum); break;
+                    case ('_'): m_sOperations.push_back(MemValueSet::Operation_Addition); break;
                 }
             } while (*pChar == '_' || (*pChar) == '$');
         }
@@ -596,114 +433,4 @@ std::string RA_Leaderboard::FormatScore(FormatType nType, int nScoreIn)
 std::string RA_Leaderboard::FormatScore(int nScoreIn) const
 {
     return FormatScore(m_format, nScoreIn);
-}
-
-RA_Leaderboard* RA_LeaderboardManager::FindLB(LeaderboardID nID)
-{
-    std::vector<RA_Leaderboard>::iterator iter = m_Leaderboards.begin();
-    while (iter != m_Leaderboards.end())
-    {
-        if ((*iter).ID() == nID)
-            return &(*iter);
-
-        iter++;
-    }
-
-    return nullptr;
-}
-
-
-//////////////////////////////////////////////////////////////////////////
-//static
-void RA_LeaderboardManager::OnSubmitEntry(const Document& doc)
-{
-    if (!doc.HasMember("Response"))
-    {
-        ASSERT(!"Cannot process this LB Response!");
-        return;
-    }
-
-    const Value& Response = doc["Response"];
-
-    const Value& LBData = Response["LBData"];
-
-    const std::string& sFormat = LBData["Format"].GetString();
-    const LeaderboardID nLBID = static_cast<LeaderboardID>(LBData["LeaderboardID"].GetUint());
-    const GameID nGameID = static_cast<GameID>(LBData["GameID"].GetUint());
-    const std::string& sLBTitle = LBData["Title"].GetString();
-    const bool bLowerIsBetter = (LBData["LowerIsBetter"].GetUint() == 1);
-
-    RA_Leaderboard* pLB = g_LeaderboardManager.FindLB(nLBID);
-
-    const int nSubmittedScore = Response["Score"].GetInt();
-    const int nBestScore = Response["BestScore"].GetInt();
-    const std::string& sScoreFormatted = Response["ScoreFormatted"].GetString();
-
-    pLB->ClearRankInfo();
-
-    RA_LOG("LB Data, Top Entries:\n");
-    const Value& TopEntries = Response["TopEntries"];
-    for (SizeType i = 0; i < TopEntries.Size(); ++i)
-    {
-        const Value& NextEntry = TopEntries[i];
-
-        const unsigned int nRank = NextEntry["Rank"].GetUint();
-        const std::string& sUser = NextEntry["User"].GetString();
-        const int nUserScore = NextEntry["Score"].GetInt();
-        time_t nSubmitted = NextEntry["DateSubmitted"].GetUint();
-
-        RA_LOG(std::string("(" + std::to_string(nRank) + ") " + sUser + ": " + pLB->FormatScore(nUserScore)).c_str());
-
-        pLB->SubmitRankInfo(nRank, sUser, nUserScore, nSubmitted);
-    }
-
-    pLB->SortRankInfo();
-
-    const Value& TopEntriesFriends = Response["TopEntriesFriends"];
-    const Value& RankData = Response["RankInfo"];
-
-    //	TBD!
-    //char sTestData[ 4096 ];
-    //sprintf_s( sTestData, 4096, "Leaderboard for %s (%s)\n\n", pLB->Title().c_str(), pLB->Description().c_str() );
-    //for( size_t i = 0; i < pLB->GetRankInfoCount(); ++i )
-    //{
-    //	const LB_Entry& NextScore = pLB->GetRankInfo( i );
-
-    //	std::string sScoreFormatted = pLB->FormatScore( NextScore.m_nScore );
-
-    //	char bufferMessage[ 512 ];
-    //	sprintf_s( bufferMessage, 512, "%02d: %s - %s\n", NextScore.m_nRank, NextScore.m_sUsername, sScoreFormatted.c_str() );
-    //	strcat_s( sTestData, 4096, bufferMessage );
-    //}
-
-    g_PopupWindows.LeaderboardPopups().ShowScoreboard(pLB->ID());
-}
-
-void RA_LeaderboardManager::AddLeaderboard(const RA_Leaderboard& lb)
-{
-    if (g_bLeaderboardsActive)	//	If not, simply ignore them.
-        m_Leaderboards.push_back(lb);
-}
-
-void RA_LeaderboardManager::Test()
-{
-    if (g_bLeaderboardsActive)
-    {
-        std::vector<RA_Leaderboard>::iterator iter = m_Leaderboards.begin();
-        while (iter != m_Leaderboards.end())
-        {
-            (*iter).Test();
-            iter++;
-        }
-    }
-}
-
-void RA_LeaderboardManager::Reset()
-{
-    std::vector<RA_Leaderboard>::iterator iter = m_Leaderboards.begin();
-    while (iter != m_Leaderboards.end())
-    {
-        (*iter).Reset();
-        iter++;
-    }
 }

--- a/src/RA_Leaderboard.h
+++ b/src/RA_Leaderboard.h
@@ -1,61 +1,8 @@
 #pragma once
+
+#include "RA_MemValue.h"
+
 #include <vector>
-#include "RA_Defs.h"
-#include "RA_Condition.h"
-
-
-
-class MemValue
-{
-public:
-    MemValue()
-        : m_nAddress(0), m_fModifier(1.0f), m_nVarSize(EightBit), m_bBCDParse(false), m_bParseVal(false)
-    {
-    }
-    MemValue(unsigned int nAddr, double fMod, ComparisonVariableSize nSize, bool bBCDParse, bool bParseVal)
-        : m_nAddress(nAddr), m_fModifier(fMod), m_nVarSize(nSize), m_bBCDParse(bBCDParse), m_bParseVal(bParseVal)
-    {
-    }
-
-public:
-    const char* ParseFromString(const char* pBuffer);		//	Parse string into values, returns end of string
-    double GetValue() const;					//	Get the value in-memory with modifiers
-
-public:
-    unsigned int			m_nAddress;					//	Raw address of an 8-bit, or value.
-    ComparisonVariableSize	m_nVarSize;
-    double					m_fModifier;				//	* 60 etc
-    bool					m_bBCDParse;				//	Parse as a binary coded decimal.
-    bool					m_bParseVal;				//	Parse as a value
-    bool					m_bInvertBit = false;
-    unsigned int			m_nSecondAddress = 0;
-    ComparisonVariableSize	m_nSecondVarSize;
-};
-
-
-//	Encapsulates a vector of MemValues
-class ValueSet
-{
-public:
-    enum OperationType
-    {
-        Operation_None,
-        Operation_Addition,
-        Operation_Maximum
-    };
-
-public:
-    void ParseMemString(const char* sBuffer);
-    double GetValue() const;
-    double GetOperationsValue(std::vector<OperationType>) const;
-    void AddNewValue(MemValue nVal);
-    void Clear();
-
-    size_t NumValues() const { return m_Values.size(); }
-
-protected:
-    std::vector<MemValue> m_Values;
-};
 
 struct LB_Entry
 {
@@ -110,7 +57,6 @@ public:
     void SortRankInfo();
 
     FormatType GetFormatType() const { return m_format; }
-    std::vector< ValueSet::OperationType > m_sOperations;
 
 private:
     const LeaderboardID		m_nID;			//	DB ID for this LB
@@ -118,11 +64,13 @@ private:
     ConditionSet			m_cancelCond;	//	Cancel monitoring if this is true
     ConditionSet			m_submitCond;	//	Submit new score if this is true
 
+    std::vector<MemValueSet::OperationType> m_sOperations;
+
     bool					m_bStarted;		//	False = check start condition. True = check cancel or submit conditions.
     bool                    m_bSubmitted;   //  True if already submitted.
 
-    ValueSet				m_value;		//	A collection of memory addresses and values to produce one value.
-    ValueSet				m_progress;		//	A collection of memory addresses, used to show progress towards completion.
+    MemValueSet				m_value;		//	A collection of memory addresses and values to produce one value.
+    MemValueSet				m_progress;		//	A collection of memory addresses, used to show progress towards completion.
     FormatType				m_format;		//	A format to output. Typically "%d" for score or "%02d:%02d.%02d" for time
 
     std::string				m_sTitle;		//	
@@ -130,26 +78,3 @@ private:
 
     std::vector<LB_Entry>	m_RankInfo;		//	Recent users ranks
 };
-
-
-class RA_LeaderboardManager
-{
-public:
-    static void OnSubmitEntry(const Document& doc);
-
-public:
-    void Reset();
-
-    void AddLeaderboard(const RA_Leaderboard& lb);
-    void Test();
-    void Clear() { m_Leaderboards.clear(); }
-    size_t Count() const { return m_Leaderboards.size(); }
-    inline RA_Leaderboard& GetLB(size_t iter) { return m_Leaderboards[iter]; }
-
-    RA_Leaderboard* FindLB(unsigned int nID);
-
-public:
-    std::vector<RA_Leaderboard> m_Leaderboards;
-};
-
-extern RA_LeaderboardManager g_LeaderboardManager;

--- a/src/RA_Leaderboard.h
+++ b/src/RA_Leaderboard.h
@@ -4,59 +4,51 @@
 
 #include <vector>
 
-struct LB_Entry
-{
-    unsigned int m_nRank;
-    std::string	 m_sUsername;
-    int m_nScore;
-    time_t m_TimeAchieved;
-};
-
 class RA_Leaderboard
 {
-public:
-    enum FormatType
-    {
-        Format_TimeFrames,		//	Value is a number describing the amount of frames.
-        Format_TimeSecs,		//	Value is a number in amount of seconds.
-        Format_TimeMillisecs,	//	Value is the number of milliseconds. * 100 to get seconds.
-        Format_Score,			//	Value is a nondescript 'score' Points.
-        Format_Value,			//	Generic value - %01d
-        Format_Other,			//	Point-based value (i.e. 1942 ships killed). %06d
-
-        Format__MAX
-    };
-
 public:
     RA_Leaderboard(const LeaderboardID nLBID);
     ~RA_Leaderboard();
 
-public:
-    void LoadFromJSON(const Value& element);
-    void ParseLine(char* sBuffer);
-    void ParseLBData(const char* sBuffer);
+    void ParseFromString(const char* sBuffer, MemValue::Format format);
 
     void Test();
-    double GetCurrentValue();
-    double GetCurrentValueProgress() const;	//	Attempt to get a 'progress' alternative
-    void Clear();
+    virtual void Reset();
 
-    //	Helper: tbd; refactor *into* RA_Formattable
-    static std::string RA_Leaderboard::FormatScore(FormatType nType, int nScoreIn);
-    std::string FormatScore(int nScoreIn) const;
-    void Reset();
+    unsigned int GetCurrentValue() const { return m_value.GetValue(); } // Gets the final value for submission
+    unsigned int GetCurrentValueProgress() const;	                    // Gets the value to display while the leaderboard is active
 
     LeaderboardID ID() const { return m_nID; }
+
     const std::string& Title() const { return m_sTitle; }
+    void SetTitle(const std::string& sValue) { m_sTitle = sValue; }
+
     const std::string& Description() const { return m_sDescription; }
+    void SetDescription(const std::string& sValue) { m_sDescription = sValue; }
+
+    std::string FormatScore(unsigned int nValue) const
+    {
+        return MemValue::FormatValue(nValue, m_format);
+    }
+
+    struct Entry
+    {
+        unsigned int m_nRank;
+        std::string	 m_sUsername;
+        int m_nScore;
+        time_t m_TimeAchieved;
+    };
 
     void SubmitRankInfo(unsigned int nRank, const std::string& sUsername, int nScore, time_t nAchieved);
     void ClearRankInfo() { m_RankInfo.clear(); }
-    const LB_Entry& GetRankInfo(unsigned int nAt) const { return m_RankInfo.at(nAt); }
+    const Entry& GetRankInfo(unsigned int nAt) const { return m_RankInfo.at(nAt); }
     size_t GetRankInfoCount() const { return m_RankInfo.size(); }
     void SortRankInfo();
 
-    FormatType GetFormatType() const { return m_format; }
+protected:
+    virtual void Start();
+    virtual void Cancel();
+    virtual void Submit(unsigned int nScore);
 
 private:
     const LeaderboardID		m_nID;			//	DB ID for this LB
@@ -64,17 +56,15 @@ private:
     ConditionSet			m_cancelCond;	//	Cancel monitoring if this is true
     ConditionSet			m_submitCond;	//	Submit new score if this is true
 
-    std::vector<MemValueSet::OperationType> m_sOperations;
-
     bool					m_bStarted;		//	False = check start condition. True = check cancel or submit conditions.
     bool                    m_bSubmitted;   //  True if already submitted.
 
-    MemValueSet				m_value;		//	A collection of memory addresses and values to produce one value.
-    MemValueSet				m_progress;		//	A collection of memory addresses, used to show progress towards completion.
-    FormatType				m_format;		//	A format to output. Typically "%d" for score or "%02d:%02d.%02d" for time
+    MemValue				m_value;		//	A collection of memory addresses and values to produce one value.
+    MemValue				m_progress;		//	A collection of memory addresses, used to show progress towards completion.
+    MemValue::Format        m_format;		//	A format to output. Typically "%d" for score or "%02d:%02d.%02d" for time
 
-    std::string				m_sTitle;		//	
+    std::string				m_sTitle;		//	The title of the leaderboard
     std::string				m_sDescription;	//	
 
-    std::vector<LB_Entry>	m_RankInfo;		//	Recent users ranks
+    std::vector<Entry>	    m_RankInfo;		//	Recent users ranks
 };

--- a/src/RA_LeaderboardManager.cpp
+++ b/src/RA_LeaderboardManager.cpp
@@ -1,0 +1,116 @@
+#include "RA_LeaderboardManager.h"
+#include "RA_MemManager.h"
+#include "RA_PopupWindows.h"
+#include "RA_md5factory.h"
+#include "RA_httpthread.h"
+
+#include <time.h>
+
+RA_LeaderboardManager g_LeaderboardManager;
+
+RA_Leaderboard* RA_LeaderboardManager::FindLB(LeaderboardID nID)
+{
+    std::vector<RA_Leaderboard>::iterator iter = m_Leaderboards.begin();
+    while (iter != m_Leaderboards.end())
+    {
+        if ((*iter).ID() == nID)
+            return &(*iter);
+
+        iter++;
+    }
+
+    return nullptr;
+}
+
+void RA_LeaderboardManager::OnSubmitEntry(const Document& doc)
+{
+    if (!doc.HasMember("Response"))
+    {
+        ASSERT(!"Cannot process this LB Response!");
+        return;
+    }
+
+    const Value& Response = doc["Response"];
+
+    const Value& LBData = Response["LBData"];
+
+    const std::string& sFormat = LBData["Format"].GetString();
+    const LeaderboardID nLBID = static_cast<LeaderboardID>(LBData["LeaderboardID"].GetUint());
+    const GameID nGameID = static_cast<GameID>(LBData["GameID"].GetUint());
+    const std::string& sLBTitle = LBData["Title"].GetString();
+    const bool bLowerIsBetter = (LBData["LowerIsBetter"].GetUint() == 1);
+
+    RA_Leaderboard* pLB = g_LeaderboardManager.FindLB(nLBID);
+
+    const int nSubmittedScore = Response["Score"].GetInt();
+    const int nBestScore = Response["BestScore"].GetInt();
+    const std::string& sScoreFormatted = Response["ScoreFormatted"].GetString();
+
+    pLB->ClearRankInfo();
+
+    RA_LOG("LB Data, Top Entries:\n");
+    const Value& TopEntries = Response["TopEntries"];
+    for (SizeType i = 0; i < TopEntries.Size(); ++i)
+    {
+        const Value& NextEntry = TopEntries[i];
+
+        const unsigned int nRank = NextEntry["Rank"].GetUint();
+        const std::string& sUser = NextEntry["User"].GetString();
+        const int nUserScore = NextEntry["Score"].GetInt();
+        time_t nSubmitted = NextEntry["DateSubmitted"].GetUint();
+
+        RA_LOG(std::string("(" + std::to_string(nRank) + ") " + sUser + ": " + pLB->FormatScore(nUserScore)).c_str());
+
+        pLB->SubmitRankInfo(nRank, sUser, nUserScore, nSubmitted);
+    }
+
+    pLB->SortRankInfo();
+
+    const Value& TopEntriesFriends = Response["TopEntriesFriends"];
+    const Value& RankData = Response["RankInfo"];
+
+    //	TBD!
+    //char sTestData[ 4096 ];
+    //sprintf_s( sTestData, 4096, "Leaderboard for %s (%s)\n\n", pLB->Title().c_str(), pLB->Description().c_str() );
+    //for( size_t i = 0; i < pLB->GetRankInfoCount(); ++i )
+    //{
+    //	const LB_Entry& NextScore = pLB->GetRankInfo( i );
+
+    //	std::string sScoreFormatted = pLB->FormatScore( NextScore.m_nScore );
+
+    //	char bufferMessage[ 512 ];
+    //	sprintf_s( bufferMessage, 512, "%02d: %s - %s\n", NextScore.m_nRank, NextScore.m_sUsername, sScoreFormatted.c_str() );
+    //	strcat_s( sTestData, 4096, bufferMessage );
+    //}
+
+    g_PopupWindows.LeaderboardPopups().ShowScoreboard(pLB->ID());
+}
+
+void RA_LeaderboardManager::AddLeaderboard(const RA_Leaderboard& lb)
+{
+    if (g_bLeaderboardsActive)	//	If not, simply ignore them.
+        m_Leaderboards.push_back(lb);
+}
+
+void RA_LeaderboardManager::Test()
+{
+    if (g_bLeaderboardsActive)
+    {
+        std::vector<RA_Leaderboard>::iterator iter = m_Leaderboards.begin();
+        while (iter != m_Leaderboards.end())
+        {
+            (*iter).Test();
+            iter++;
+        }
+    }
+}
+
+void RA_LeaderboardManager::Reset()
+{
+    std::vector<RA_Leaderboard>::iterator iter = m_Leaderboards.begin();
+    while (iter != m_Leaderboards.end())
+    {
+        (*iter).Reset();
+        iter++;
+    }
+}

--- a/src/RA_LeaderboardManager.h
+++ b/src/RA_LeaderboardManager.h
@@ -2,12 +2,13 @@
 
 #include "RA_Leaderboard.h"
 
+#include <rapidjson\include\rapidjson\document.h>
 #include <vector>
 
 class RA_LeaderboardManager
 {
 public:
-    static void OnSubmitEntry(const Document& doc);
+    static void OnSubmitEntry(const rapidjson::Document& doc);
 
 public:
     void Reset();
@@ -18,9 +19,13 @@ public:
     size_t Count() const { return m_Leaderboards.size(); }
     inline RA_Leaderboard& GetLB(size_t iter) { return m_Leaderboards[iter]; }
 
-    RA_Leaderboard* FindLB(unsigned int nID);
+    RA_Leaderboard* FindLB(LeaderboardID nID);
 
-public:
+    void ActivateLeaderboard(const RA_Leaderboard& lb) const;
+    void DeactivateLeaderboard(const RA_Leaderboard& lb) const;
+    void SubmitLeaderboardEntry(const RA_Leaderboard& lb, unsigned int nValue) const;
+
+private:
     std::vector<RA_Leaderboard> m_Leaderboards;
 };
 

--- a/src/RA_LeaderboardManager.h
+++ b/src/RA_LeaderboardManager.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "RA_Leaderboard.h"
+
+#include <vector>
+
+class RA_LeaderboardManager
+{
+public:
+    static void OnSubmitEntry(const Document& doc);
+
+public:
+    void Reset();
+
+    void AddLeaderboard(const RA_Leaderboard& lb);
+    void Test();
+    void Clear() { m_Leaderboards.clear(); }
+    size_t Count() const { return m_Leaderboards.size(); }
+    inline RA_Leaderboard& GetLB(size_t iter) { return m_Leaderboards[iter]; }
+
+    RA_Leaderboard* FindLB(unsigned int nID);
+
+public:
+    std::vector<RA_Leaderboard> m_Leaderboards;
+};
+
+extern RA_LeaderboardManager g_LeaderboardManager;

--- a/src/RA_LeaderboardPopup.cpp
+++ b/src/RA_LeaderboardPopup.cpp
@@ -6,7 +6,7 @@
 #include "RA_Achievement.h"
 #include "RA_AchievementOverlay.h"
 #include "RA_ImageFactory.h"
-#include "RA_Leaderboard.h"
+#include "RA_LeaderboardManager.h"
 
 //	No emulator-specific code here please!
 

--- a/src/RA_LeaderboardPopup.cpp
+++ b/src/RA_LeaderboardPopup.cpp
@@ -274,7 +274,7 @@ void LeaderboardPopup::Render(HDC hDC, RECT& rcDest)
                 RECT rcScoreboard = { nScoreboardX + 2, nScoreboardY + 32, nRightLim - 2, nHeight - 16 };
                 for (size_t i = 0; i < pLB->GetRankInfoCount(); ++i)
                 {
-                    const LB_Entry& lbInfo = pLB->GetRankInfo(i);
+                    const RA_Leaderboard::Entry& lbInfo = pLB->GetRankInfo(i);
 
                     if (lbInfo.m_sUsername.compare(RAUsers::LocalUser().Username()) == 0)
                     {

--- a/src/RA_MemValue.cpp
+++ b/src/RA_MemValue.cpp
@@ -1,0 +1,167 @@
+#include "RA_MemValue.h"
+
+#include "RA_MemManager.h"
+
+#include <time.h>
+
+double MemValue::GetValue() const
+{
+    int nRetVal = 0;
+    if (m_bParseVal)
+    {
+        nRetVal = m_nAddress;	//	insert address as value.
+    }
+    else
+    {
+        nRetVal = g_MemManager.ActiveBankRAMRead(m_nAddress, m_nVarSize);
+
+        if (m_bInvertBit && (m_nVarSize >= ComparisonVariableSize::Bit_0) && (m_nVarSize <= ComparisonVariableSize::Bit_7))
+        {
+            nRetVal = (nRetVal == 1) ? 0 : 1;
+        }
+
+        if (m_bBCDParse)
+        {
+            //	Reparse this value as a binary coded decimal.
+            nRetVal = (((nRetVal >> 4) & 0xf) * 10) + (nRetVal & 0xf);
+        }
+    }
+
+    if (m_nSecondAddress > 0)
+    {
+        MemValue tempMem;
+        tempMem.m_bInvertBit = m_bInvertBit;
+        tempMem.m_nAddress = m_nSecondAddress;
+        tempMem.m_nVarSize = m_nSecondVarSize;
+
+        return nRetVal * tempMem.GetValue();
+    }
+
+    return nRetVal * m_fModifier;
+}
+
+const char* MemValue::ParseFromString(const char* pBuffer)
+{
+    const char* pIter = &pBuffer[0];
+
+    //	Borrow parsing from CompVariable
+
+    m_bBCDParse = false;
+    if (toupper(*pIter) == 'B')
+    {
+        m_bBCDParse = true;
+        pIter++;
+    }
+    else if (toupper(*pIter) == 'V')
+    {
+        m_bParseVal = true;
+        pIter++;
+    }
+
+    CompVariable varTemp;
+    varTemp.ParseVariable(pIter);
+    m_nAddress = varTemp.RawValue();	//	Fetch value ('address') as parsed. Note RawValue! Do not parse memory!
+    m_nVarSize = varTemp.Size();
+
+    m_fModifier = 1.0;
+    if (*pIter == '*')
+    {
+        pIter++;						//	Skip over modifier type.. assume mult( '*' );
+
+        // Invert bit flag results
+        if (*pIter == '~')
+        {
+            m_bInvertBit = true;
+            pIter++;
+        }
+
+        // Multiply by addresses
+        if (strncmp(pIter, "0x", sizeof("0x") - 1) == 0)
+        {
+            varTemp.ParseVariable(pIter);
+            m_nSecondAddress = varTemp.RawValue();
+            m_nSecondVarSize = varTemp.Size();
+        }
+        else
+        {
+            char* pOut;
+            m_fModifier = strtod(pIter, &pOut);
+            pIter = pOut;
+        }
+    }
+
+    return pIter;
+}
+
+//////////////////////////////////////////////////////////////////////////
+double MemValueSet::GetValue() const
+{
+    double fVal = 0.0;
+    std::vector<MemValue>::const_iterator iter = m_Values.begin();
+    while (iter != m_Values.end())
+    {
+        fVal += (*iter).GetValue();
+        iter++;
+    }
+
+    return fVal;
+}
+
+double MemValueSet::GetOperationsValue(std::vector<OperationType> sOperations) const
+{
+    double fVal = 0.0;
+    std::vector<MemValue>::const_iterator iter = m_Values.begin();
+    std::vector<OperationType>::const_iterator sOp = sOperations.begin();
+
+    if (iter != m_Values.end())
+    {
+        fVal += (*iter).GetValue();
+        iter++;
+    }
+
+    while (iter != m_Values.end())
+    {
+        if (sOp != sOperations.end() && *sOp == Operation_Maximum)
+        {
+            double maxValue = (*iter).GetValue();
+            iter++;
+            maxValue = (maxValue < (*iter).GetValue()) ? (*iter).GetValue() : maxValue;
+            fVal = (fVal < maxValue) ? maxValue : fVal;
+        }
+        else
+            fVal += (*iter).GetValue();
+
+        if (sOp == sOperations.end())
+            break;
+
+        iter++;
+        sOp++;
+    }
+
+    return fVal;
+}
+
+void MemValueSet::AddNewValue(MemValue nMemVal)
+{
+    m_Values.push_back(nMemVal);
+}
+
+void MemValueSet::ParseMemString(const char* pChar)
+{
+    do
+    {
+        {
+            while ((*pChar) == ' ' || (*pChar) == '_' || (*pChar) == '|')
+                pChar++; // Skip any chars up til this point :S
+        }
+
+        MemValue newMemVal;
+        pChar = newMemVal.ParseFromString(pChar);
+        AddNewValue(newMemVal);
+    } while (*pChar == '_');
+}
+
+void MemValueSet::Clear()
+{
+    m_Values.clear();
+}

--- a/src/RA_MemValue.h
+++ b/src/RA_MemValue.h
@@ -4,40 +4,61 @@
 
 #include <vector>
 
+// Represents a value expression (one or more values which are added together to create a single value)
 class MemValue
 {
 public:
-    const char* ParseFromString(const char* pBuffer);       //	Parse string into values, returns end of string
-    double GetValue() const;                                //	Get the value in-memory with modifiers
+    const char* ParseFromString(const char* sBuffer);
+    unsigned int GetValue() const;
 
-    unsigned int			m_nAddress = 0;                 //	Raw address of an 8-bit, or value.
-    ComparisonVariableSize	m_nVarSize = EightBit;
-    double					m_fModifier = 1.0f;             //	* 60 etc
-    bool					m_bBCDParse = false;            //	Parse as a binary coded decimal.
-    bool					m_bParseVal = false;            //	Parse as a value
-    bool					m_bInvertBit = false;
-    unsigned int			m_nSecondAddress = 0;
-    ComparisonVariableSize	m_nSecondVarSize = EightBit;
-};
+    bool IsEmpty() const { return m_vClauses.empty(); }
 
-class MemValueSet
-{
-public:
-    enum OperationType
+
+    enum class Format
     {
-        Operation_None,
-        Operation_Addition,
-        Operation_Maximum
+        TimeFrames,     //	Value is a number describing the amount of frames.
+        TimeSecs,       //	Value is a number in amount of seconds.
+        TimeMillisecs,  //	Value is a number accurate to hundredths of a second (not actually milliseconds)
+        Score,          //	Value is a nondescript 'score' Points.
+        Value,          //	Generic value - %01d
+        Other,          //	Point-based value (i.e. 1942 ships killed). %06d
     };
 
-    void ParseMemString(const char* sBuffer);
-    double GetValue() const;
-    double GetOperationsValue(std::vector<OperationType>) const;
-    void AddNewValue(MemValue nVal);
-    void Clear();
+    std::string GetFormattedValue(Format nFormat) const { return FormatValue(GetValue(), nFormat); }
 
-    size_t NumValues() const { return m_Values.size(); }
+    static std::string FormatValue(unsigned int nValue, Format nFormat);
+    static Format ParseFormat(const std::string& sFormat);
+    static const char* GetFormatString(Format format);
 
 protected:
-    std::vector<MemValue> m_Values;
+    enum class ClauseOperation
+    {
+        None,
+        Addition,
+        Maximum
+    };
+
+    // Represents a single value which may be scaled (multiplied by another value)
+    class Clause
+    {
+    public:
+        Clause(ClauseOperation nOperation) : m_nOperation(nOperation) {}
+
+        const char* ParseFromString(const char* pBuffer);       //	Parse string into values, returns end of string
+        double GetValue() const;                                //	Get the value in-memory with modifiers
+        ClauseOperation GetOperation() const { return m_nOperation; }
+
+    protected:
+        unsigned int			m_nAddress = 0;                 //	Raw address of an 8-bit, or value.
+        ComparisonVariableSize	m_nVarSize = EightBit;
+        double					m_fModifier = 1.0f;             //	* 60 etc
+        bool					m_bBCDParse = false;            //	Parse as a binary coded decimal.
+        bool					m_bParseVal = false;            //	Parse as a value
+        bool					m_bInvertBit = false;
+        unsigned int			m_nSecondAddress = 0;
+        ComparisonVariableSize	m_nSecondVarSize = EightBit;
+        ClauseOperation         m_nOperation;
+    };
+
+    std::vector<Clause> m_vClauses;
 };

--- a/src/RA_MemValue.h
+++ b/src/RA_MemValue.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "RA_Condition.h"
+
+#include <vector>
+
+class MemValue
+{
+public:
+    const char* ParseFromString(const char* pBuffer);       //	Parse string into values, returns end of string
+    double GetValue() const;                                //	Get the value in-memory with modifiers
+
+    unsigned int			m_nAddress = 0;                 //	Raw address of an 8-bit, or value.
+    ComparisonVariableSize	m_nVarSize = EightBit;
+    double					m_fModifier = 1.0f;             //	* 60 etc
+    bool					m_bBCDParse = false;            //	Parse as a binary coded decimal.
+    bool					m_bParseVal = false;            //	Parse as a value
+    bool					m_bInvertBit = false;
+    unsigned int			m_nSecondAddress = 0;
+    ComparisonVariableSize	m_nSecondVarSize = EightBit;
+};
+
+class MemValueSet
+{
+public:
+    enum OperationType
+    {
+        Operation_None,
+        Operation_Addition,
+        Operation_Maximum
+    };
+
+    void ParseMemString(const char* sBuffer);
+    double GetValue() const;
+    double GetOperationsValue(std::vector<OperationType>) const;
+    void AddNewValue(MemValue nVal);
+    void Clear();
+
+    size_t NumValues() const { return m_Values.size(); }
+
+protected:
+    std::vector<MemValue> m_Values;
+};

--- a/src/RA_RichPresence.cpp
+++ b/src/RA_RichPresence.cpp
@@ -20,17 +20,6 @@ const std::string& RA_Lookup::Lookup(DataPos nValue) const
     return sUnknown;
 }
 
-RA_Formattable::RA_Formattable(const std::string& sDesc, RA_Leaderboard::FormatType nType)
-    : m_sLookupDescription(sDesc),
-    m_nFormatType(nType)
-{
-}
-
-std::string RA_Formattable::Lookup(DataPos nValue) const
-{
-    return RA_Leaderboard::FormatScore(m_nFormatType, nValue);
-}
-
 RA_ConditionalDisplayString::RA_ConditionalDisplayString(const char* pBuffer)
 {
     ++pBuffer; // skip first question mark
@@ -121,35 +110,10 @@ void RA_RichPresenceInterpretter::ParseRichPresenceFile(const std::string& sFile
                     const char* pUnused = _ReadStringTil('=', pBuf, TRUE);
                     const char* pType = _ReadStringTil(EndLine, pBuf, TRUE);
 
-                    RA_Leaderboard::FormatType nType;
-
-                    if (strcmp(pType, "SCORE") == 0 || strcmp(pType, "POINTS") == 0)
-                    {
-                        nType = RA_Leaderboard::Format_Score;
-                    }
-                    else if (strcmp(pType, "TIME") == 0 || strcmp(pType, "FRAMES") == 0)
-                    {
-                        nType = RA_Leaderboard::Format_TimeFrames;
-                    }
-                    else if (strcmp(pType, "SECS") == 0)
-                    {
-                        nType = RA_Leaderboard::Format_TimeSecs;
-                    }
-                    else if (strcmp(pType, "MILLISECS") == 0)
-                    {
-                        nType = RA_Leaderboard::Format_TimeMillisecs;
-                    }
-                    else if (strcmp(pType, "VALUE") == 0)
-                    {
-                        nType = RA_Leaderboard::Format_Value;
-                    }
-                    else
-                    {
-                        nType = RA_Leaderboard::Format_Other;
-                    }
+                    MemValue::Format nType = MemValue::ParseFormat(pType);
 
                     RA_LOG("RP: Adding Formatter %s (%s)\n", sDesc.c_str(), pType);
-                    m_formats.push_back(RA_Formattable(sDesc, nType));
+                    m_formats[sDesc] = nType;
                 }
             }
             else if (strncmp(DisplayableStr, buffer, strlen(DisplayableStr)) == 0)
@@ -177,46 +141,29 @@ void RA_RichPresenceInterpretter::ParseRichPresenceFile(const std::string& sFile
     }
 }
 
-const std::string& RA_RichPresenceInterpretter::Lookup(const std::string& sName, const std::string& sMemString) const
+const std::string RA_RichPresenceInterpretter::Lookup(const std::string& sName, const std::string& sMemString) const
 {
-    static std::string sReturnVal;
-    sReturnVal.clear();
-
     //	check lookups
     for (size_t i = 0; i < m_lookups.size(); ++i)
     {
         if (m_lookups.at(i).Description().compare(sName) == 0)
         {
-            //	This lookup! (ugh must be non-const)
-            char buffer[1024];
-            sprintf_s(buffer, 1024, (char*)sMemString.c_str());
-
-            MemValueSet nValue;
-            nValue.ParseMemString(buffer);
-            sReturnVal = m_lookups.at(i).Lookup(static_cast<DataPos>(nValue.GetValue()));
-
-            return sReturnVal;
+            MemValue nValue;
+            nValue.ParseFromString(sMemString.c_str());
+            return m_lookups.at(i).Lookup(static_cast<DataPos>(nValue.GetValue()));
         }
     }
 
     //	check formatters
-    for (size_t i = 0; i < m_formats.size(); ++i)
+    auto iter = m_formats.find(sName);
+    if (iter != m_formats.end())
     {
-        if (m_formats.at(i).Description().compare(sName) == 0)
-        {
-            //	This lookup! (ugh must be non-const)
-            char buffer[1024];
-            sprintf_s(buffer, 1024, (char*)sMemString.c_str());
-
-            MemValueSet nValue;
-            nValue.ParseMemString(buffer);
-            sReturnVal = m_formats.at(i).Lookup(static_cast<DataPos>(nValue.GetValue()));
-
-            return sReturnVal;
-        }
+        MemValue nValue;
+        nValue.ParseFromString(sMemString.c_str());
+        return nValue.GetFormattedValue(iter->second);
     }
 
-    return sReturnVal;
+    return "";
 }
 
 bool RA_RichPresenceInterpretter::Enabled() const

--- a/src/RA_RichPresence.cpp
+++ b/src/RA_RichPresence.cpp
@@ -2,6 +2,7 @@
 
 #include "RA_Core.h"
 #include "RA_GameData.h"
+#include "RA_MemValue.h"
 
 RA_RichPresenceInterpretter g_RichPresenceInterpretter;
 
@@ -190,7 +191,7 @@ const std::string& RA_RichPresenceInterpretter::Lookup(const std::string& sName,
             char buffer[1024];
             sprintf_s(buffer, 1024, (char*)sMemString.c_str());
 
-            ValueSet nValue;
+            MemValueSet nValue;
             nValue.ParseMemString(buffer);
             sReturnVal = m_lookups.at(i).Lookup(static_cast<DataPos>(nValue.GetValue()));
 
@@ -207,7 +208,7 @@ const std::string& RA_RichPresenceInterpretter::Lookup(const std::string& sName,
             char buffer[1024];
             sprintf_s(buffer, 1024, (char*)sMemString.c_str());
 
-            ValueSet nValue;
+            MemValueSet nValue;
             nValue.ParseMemString(buffer);
             sReturnVal = m_formats.at(i).Lookup(static_cast<DataPos>(nValue.GetValue()));
 

--- a/src/RA_RichPresence.h
+++ b/src/RA_RichPresence.h
@@ -36,20 +36,6 @@ private:
     ConditionSet m_conditions;
 };
 
-class RA_Formattable
-{
-public:
-    RA_Formattable(const std::string& sDesc, RA_Leaderboard::FormatType nType);
-
-    std::string Lookup(DataPos nValue) const;
-
-    const std::string& Description() const { return m_sLookupDescription; }
-
-private:
-    std::string m_sLookupDescription;
-    RA_Leaderboard::FormatType m_nFormatType;
-};
-
 class RA_RichPresenceInterpretter
 {
 public:
@@ -62,13 +48,13 @@ public:
     void ParseRichPresenceFile(const std::string& sFilename);
 
     const std::string& GetRichPresenceString();
-    const std::string& Lookup(const std::string& sLookupName, const std::string& sMemString) const;
+    const std::string Lookup(const std::string& sLookupName, const std::string& sMemString) const;
 
     bool Enabled() const;
 
 private:
     std::vector<RA_Lookup> m_lookups;
-    std::vector<RA_Formattable> m_formats;
+    std::map<std::string, MemValue::Format> m_formats;
 
     std::vector<RA_ConditionalDisplayString> m_conditionalDisplayStrings;
     std::string m_sDisplay;

--- a/tests/RA_Integration.Tests.vcxproj
+++ b/tests/RA_Integration.Tests.vcxproj
@@ -64,7 +64,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>$(MSBuildProjectDirectory)\..;$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;RA_UTEST;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
@@ -96,7 +96,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <AdditionalIncludeDirectories>$(MSBuildProjectDirectory)\..;$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;RA_UTEST;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
@@ -129,15 +129,21 @@
   <ItemGroup>
     <ClInclude Include="..\src\RA_Condition.h" />
     <ClInclude Include="..\src\RA_Defs.h" />
+    <ClInclude Include="..\src\RA_Leaderboard.h" />
     <ClInclude Include="..\src\RA_MemManager.h" />
     <ClCompile Include="..\src\RA_Condition.cpp" />
     <ClCompile Include="..\src\RA_Defs.cpp" />
+    <ClCompile Include="..\src\RA_Leaderboard.cpp" />
     <ClCompile Include="..\src\RA_MemManager.cpp" />
+    <ClInclude Include="..\src\RA_MemValue.h" />
     <ClInclude Include="RA_UnitTestHelpers.h" />
+    <ClCompile Include="..\src\RA_MemValue.cpp" />
     <ClCompile Include="RA_CompVariable_Tests.cpp" />
     <ClCompile Include="RA_ConditionSet_Tests.cpp" />
     <ClCompile Include="RA_Condition_Tests.cpp" />
     <ClCompile Include="RA_Defs_Tests.cpp" />
+    <ClCompile Include="RA_Leaderboard_Tests.cpp" />
+    <ClCompile Include="RA_MemValue_Tests.cpp" />
     <ClCompile Include="RA_UnitTestHelpers.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/tests/RA_Integration.Tests.vcxproj.filters
+++ b/tests/RA_Integration.Tests.vcxproj.filters
@@ -27,6 +27,18 @@
     <ClInclude Include="..\src\RA_Defs.h">
       <Filter>Code</Filter>
     </ClInclude>
+    <ClCompile Include="..\src\RA_MemValue.cpp">
+      <Filter>Code</Filter>
+    </ClCompile>
+    <ClCompile Include="RA_MemValue_Tests.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\RA_Leaderboard.cpp">
+      <Filter>Code</Filter>
+    </ClCompile>
+    <ClCompile Include="RA_Leaderboard_Tests.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="RA_Condition_Tests.cpp">
@@ -47,5 +59,13 @@
     <ClCompile Include="RA_Defs_Tests.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\src\RA_MemValue.h">
+      <Filter>Code</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\RA_Leaderboard.h">
+      <Filter>Code</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/tests/RA_Leaderboard_Tests.cpp
+++ b/tests/RA_Leaderboard_Tests.cpp
@@ -1,0 +1,382 @@
+#include "CppUnitTest.h"
+
+#include "RA_Leaderboard.h"
+#include "RA_UnitTestHelpers.h"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace ra {
+namespace data {
+namespace tests {
+
+class LeaderboardHarness : public RA_Leaderboard
+{
+public:
+    LeaderboardHarness() : RA_Leaderboard(1) {}
+
+    bool IsActive() const { return m_bActive; }
+    bool IsScoreSubmitted() const { return m_bScoreSubmitted; }
+    unsigned int SubmittedScore() const { return m_nSubmittedScore; }
+
+public:
+    void Reset() override
+    {
+        RA_Leaderboard::Reset();
+
+        m_bActive = false;
+        m_bScoreSubmitted = false;
+        m_nSubmittedScore = 0;
+    }
+
+    void Start() override
+    {
+        m_bActive = true;
+    }
+
+    void Cancel() override
+    {
+        m_bActive = false;
+    }
+
+    void Submit(unsigned int nScore) override
+    {
+        m_bActive = false;
+        m_bScoreSubmitted = true;
+        m_nSubmittedScore = nScore;
+    }
+
+private:
+    unsigned int m_nSubmittedScore = 0;
+    bool m_bScoreSubmitted = false;
+    bool m_bActive = false;
+};
+
+TEST_CLASS(RA_Leaderboard_Tests)
+{
+public:
+    TEST_METHOD(TestSimpleLeaderboard)
+    {
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        LeaderboardHarness lb;
+        lb.ParseFromString("STA:0xH00=1::CAN:0xH00=2::SUB:0xH00=3::VAL:0xH02", MemValue::Format::Value);
+        Assert::IsFalse(lb.IsActive());
+        Assert::IsFalse(lb.IsScoreSubmitted());
+
+        lb.Test();
+        Assert::IsFalse(lb.IsActive());
+        Assert::IsFalse(lb.IsScoreSubmitted());
+
+        memory[0] = 3; // submit value, but not active
+        lb.Test();
+        Assert::IsFalse(lb.IsActive());
+        Assert::IsFalse(lb.IsScoreSubmitted());
+
+        memory[0] = 2; // cancel value, but not active
+        lb.Test();
+        Assert::IsFalse(lb.IsActive());
+        Assert::IsFalse(lb.IsScoreSubmitted());
+
+        memory[0] = 1; // start value
+        lb.Test();
+        Assert::IsTrue(lb.IsActive());
+        Assert::IsFalse(lb.IsScoreSubmitted());
+
+        memory[0] = 2; // cancel value
+        lb.Test();
+        Assert::IsFalse(lb.IsActive());
+        Assert::IsFalse(lb.IsScoreSubmitted());
+
+        memory[0] = 3; // submit value, but not active
+        lb.Test();
+        Assert::IsFalse(lb.IsActive());
+        Assert::IsFalse(lb.IsScoreSubmitted());
+
+        memory[0] = 1; // start value
+        lb.Test();
+        Assert::IsTrue(lb.IsActive());
+        Assert::IsFalse(lb.IsScoreSubmitted());
+
+        memory[0] = 3; // submit value
+        lb.Test();
+        Assert::IsFalse(lb.IsActive());
+        Assert::IsTrue(lb.IsScoreSubmitted());
+        Assert::AreEqual(0x34U, lb.SubmittedScore());
+    }
+
+    TEST_METHOD(TestStartAndCancelSameFrame)
+    {
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        LeaderboardHarness lb;
+        lb.ParseFromString("STA:0xH00=0::CAN:0xH01=18::SUB:0xH00=3::VAL:0xH02", MemValue::Format::Value);
+
+        lb.Test();
+        Assert::IsFalse(lb.IsActive());
+        Assert::IsFalse(lb.IsScoreSubmitted());
+
+        memory[1] = 0x13; // disables cancel
+        lb.Test();
+        Assert::IsTrue(lb.IsActive());
+        Assert::IsFalse(lb.IsScoreSubmitted());
+
+        memory[1] = 0x12; // enables cancel
+        lb.Test();
+        Assert::IsFalse(lb.IsActive());
+        Assert::IsFalse(lb.IsScoreSubmitted());
+
+        memory[1] = 0x13; // disables cancel, but start condition still true, so it shouldn't restart
+        lb.Test();
+        Assert::IsFalse(lb.IsActive());
+        Assert::IsFalse(lb.IsScoreSubmitted());
+
+        memory[0] = 0x01; // disables start; no effect this frame, but next frame can restart
+        lb.Test();
+        Assert::IsFalse(lb.IsActive());
+        Assert::IsFalse(lb.IsScoreSubmitted());
+
+        memory[0] = 0x00; // enables start
+        lb.Test();
+        Assert::IsTrue(lb.IsActive());
+        Assert::IsFalse(lb.IsScoreSubmitted());
+    }
+
+    TEST_METHOD(TestStartAndSubmitSameFrame)
+    {
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        LeaderboardHarness lb;
+        lb.ParseFromString("STA:0xH00=0::CAN:0xH01=10::SUB:0xH01=18::VAL:0xH02", MemValue::Format::Value);
+
+        lb.Test();
+        Assert::IsFalse(lb.IsActive());
+        Assert::IsTrue(lb.IsScoreSubmitted());
+        Assert::AreEqual(0x34U, lb.SubmittedScore());
+
+        memory[1] = 0; // disable submit, value should not be resubmitted, 
+        lb.Test();     // start is still true, but leaderboard should not reactivate
+        Assert::IsFalse(lb.IsActive());
+
+        memory[0] = 1; // disable start
+        lb.Test();
+        Assert::IsFalse(lb.IsActive());
+
+        memory[0] = 0; // reenable start, leaderboard should reactivate
+        lb.Test();
+        Assert::IsTrue(lb.IsActive());
+    }
+
+    TEST_METHOD(TestProgress)
+    {
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        // if PRO: mapping is available, use that for GetCurrentValueProgress
+        LeaderboardHarness lb;
+        lb.ParseFromString("STA:0xH00=0::CAN:0xH00=2::SUB:0xH00=3::PRO:0xH04::VAL:0xH02", MemValue::Format::Value);
+        lb.Test();
+        Assert::IsTrue(lb.IsActive());
+        Assert::AreEqual(0x34U, lb.GetCurrentValue());
+        Assert::AreEqual(0x56U, lb.GetCurrentValueProgress());
+
+        // if PRO: mapping is not available, use VAL: for GetCurrentValueProgress
+        LeaderboardHarness lb2;
+        lb2.ParseFromString("STA:0xH00=0::CAN:0xH00=2::SUB:0xH00=3::VAL:0xH02", MemValue::Format::Value);
+        lb2.Test();
+        Assert::IsTrue(lb2.IsActive());
+        Assert::AreEqual(0x34U, lb2.GetCurrentValue());
+        Assert::AreEqual(0x34U, lb2.GetCurrentValueProgress());
+    }
+
+    TEST_METHOD(TestStartAndCondition)
+    {
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        LeaderboardHarness lb;
+        lb.ParseFromString("STA:0xH00=0_0xH01=0::CAN:0xH01=10::SUB:0xH01=18::VAL:0xH02", MemValue::Format::Value);
+
+        lb.Test();
+        Assert::IsFalse(lb.IsActive());
+
+        memory[1] = 0; // second part of start condition is true
+        lb.Test();
+        Assert::IsTrue(lb.IsActive());
+    }
+
+    TEST_METHOD(TestStartOrCondition)
+    {
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        LeaderboardHarness lb;
+        lb.ParseFromString("STA:S0xH00=1S0xH01=1::CAN:0xH01=10::SUB:0xH01=18::VAL:0xH02", MemValue::Format::Value);
+
+        lb.Test();
+        Assert::IsFalse(lb.IsActive());
+
+        memory[1] = 1; // second part of start condition is true
+        lb.Test();
+        Assert::IsTrue(lb.IsActive());
+
+        memory[1] = 0;
+        lb.Reset();
+        lb.Test();
+        Assert::IsFalse(lb.IsActive());
+
+        memory[0] = 1; // first part of start condition is true
+        lb.Test();
+        Assert::IsTrue(lb.IsActive());
+    }
+
+    // NOTE: This test is invalid as long as the backwards compatibility code that treats underscores as ORs is present
+    //TEST_METHOD(TestCancelAndCondition)
+    //{
+    //    unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+    //    InitializeMemory(memory, 5);
+
+    //    LeaderboardHarness lb;
+    //    lb.ParseFromString("STA:0xH00=0::CAN:0xH01=18_0xH02=18::SUB:0xH00=3::VAL:0xH02", MemValueFormat::Value);
+
+    //    lb.Test();
+    //    Assert::IsTrue(lb.IsActive());
+
+    //    memory[2] = 0x12; // second part of cancel condition is true
+    //    lb.Test();
+    //    Assert::IsFalse(lb.IsActive());
+    //    Assert::IsFalse(lb.IsScoreSubmitted());
+    //}
+
+    TEST_METHOD(TestCancelOrCondition)
+    {
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        LeaderboardHarness lb;
+        lb.ParseFromString("STA:0xH00=0::CAN:S0xH01=12S0xH02=12::SUB:0xH00=3::VAL:0xH02", MemValue::Format::Value);
+
+        lb.Test();
+        Assert::IsTrue(lb.IsActive());
+
+        memory[2] = 12; // second part of cancel condition is true
+        lb.Test();
+        Assert::IsFalse(lb.IsActive());
+
+        memory[2] = 0; // second part of cancel condition is false
+        lb.Reset();
+        lb.Test();
+        Assert::IsTrue(lb.IsActive());
+
+        memory[1] = 12; // first part of cancel condition is true
+        lb.Test();
+        Assert::IsFalse(lb.IsActive());
+    }
+
+    TEST_METHOD(TestSubmitAndCondition)
+    {
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        LeaderboardHarness lb;
+        lb.ParseFromString("STA:0xH00=0::CAN:0xH01=10::SUB:0xH01=18_0xH03=18::VAL:0xH02", MemValue::Format::Value);
+
+        lb.Test();
+        Assert::IsTrue(lb.IsActive());
+
+        memory[3] = 18; 
+        lb.Test();
+        Assert::IsFalse(lb.IsActive());
+        Assert::IsTrue(lb.IsScoreSubmitted());
+    }
+
+    TEST_METHOD(TestSubmitOrCondition)
+    {
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        LeaderboardHarness lb;
+        lb.ParseFromString("STA:0xH00=0::CAN:0xH01=10::SUB:S0xH01=12S0xH03=12::VAL:0xH02", MemValue::Format::Value);
+
+        lb.Test();
+        Assert::IsTrue(lb.IsActive());
+
+        memory[3] = 12; // second part of submit condition is true
+        lb.Test();
+        Assert::IsFalse(lb.IsActive());
+        Assert::IsTrue(lb.IsScoreSubmitted());
+
+        memory[3] = 0;
+        lb.Reset();
+        lb.Test();
+        Assert::IsTrue(lb.IsActive());
+
+        memory[1] = 12; // first part of submit condition is true
+        lb.Test();
+        Assert::IsFalse(lb.IsActive());
+        Assert::IsTrue(lb.IsScoreSubmitted());
+    }
+
+    TEST_METHOD(TestUnparsableStringWillNotStart)
+    {
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        LeaderboardHarness lb;
+        lb.ParseFromString("STA:0xH00=0::CAN:0x0H00=1::SUB:0xH01=18::GARBAGE", MemValue::Format::Value);
+
+        lb.Test();
+        Assert::IsFalse(lb.IsActive());
+    }
+
+    TEST_METHOD(TestSubmitRankInfo)
+    {
+        LeaderboardHarness lb;
+        lb.SubmitRankInfo(1U, "George", 100, 1234567890U);
+        lb.SubmitRankInfo(2U, "Jane", 80, 1234567891U);
+        lb.SubmitRankInfo(3U, "Paul", 70, 1234567892U);
+
+        Assert::AreEqual(3U, lb.GetRankInfoCount());
+        Assert::AreEqual("George", lb.GetRankInfo(0).m_sUsername.c_str());
+        Assert::AreEqual("Jane", lb.GetRankInfo(1).m_sUsername.c_str());
+        Assert::AreEqual("Paul", lb.GetRankInfo(2).m_sUsername.c_str());
+
+        Assert::AreEqual(1234567890, static_cast<int>(lb.GetRankInfo(0).m_TimeAchieved));
+        Assert::AreEqual(2U, lb.GetRankInfo(1).m_nRank);
+        Assert::AreEqual(70, lb.GetRankInfo(2).m_nScore);
+
+        lb.ClearRankInfo();
+        Assert::AreEqual(0U, lb.GetRankInfoCount());
+    }
+
+    TEST_METHOD(TestSortRankInfo)
+    {
+        LeaderboardHarness lb;
+        lb.SubmitRankInfo(4U, "Betty", 60, 1234567893U);
+        lb.SubmitRankInfo(2U, "Jane", 80, 1234567891U);
+        lb.SubmitRankInfo(5U, "Roger", 50, 1234567894U);
+        lb.SubmitRankInfo(1U, "George", 100, 1234567890U);
+        lb.SubmitRankInfo(3U, "Paul", 70, 1234567892U);
+
+        Assert::AreEqual(5U, lb.GetRankInfoCount());
+        lb.SortRankInfo();
+
+        Assert::AreEqual("George", lb.GetRankInfo(0).m_sUsername.c_str());
+        Assert::AreEqual("Jane", lb.GetRankInfo(1).m_sUsername.c_str());
+        Assert::AreEqual("Paul", lb.GetRankInfo(2).m_sUsername.c_str());
+        Assert::AreEqual("Betty", lb.GetRankInfo(3).m_sUsername.c_str());
+        Assert::AreEqual("Roger", lb.GetRankInfo(4).m_sUsername.c_str());
+
+        Assert::AreEqual(1234567890, static_cast<int>(lb.GetRankInfo(0).m_TimeAchieved));
+        Assert::AreEqual(2U, lb.GetRankInfo(1).m_nRank);
+        Assert::AreEqual(70, lb.GetRankInfo(2).m_nScore);
+        Assert::AreEqual(4U, lb.GetRankInfo(3).m_nRank);
+        Assert::AreEqual(50, lb.GetRankInfo(4).m_nScore);
+    }
+};
+
+} // namespace tests
+} // namespace data
+} // namespace ra

--- a/tests/RA_MemValue_Tests.cpp
+++ b/tests/RA_MemValue_Tests.cpp
@@ -1,0 +1,280 @@
+#include "CppUnitTest.h"
+
+#include "RA_MemValue.h"
+#include "RA_UnitTestHelpers.h"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace ra {
+namespace data {
+namespace tests {
+
+class MemValueHarness : public MemValue
+{
+public:
+    size_t NumValues() const { return m_vClauses.size(); }
+    const Clause& GetMemValue(size_t index) const { return m_vClauses[index]; }
+    bool IsAddition(size_t index) const { return m_vClauses[index].GetOperation() == ClauseOperation::Addition; }
+    bool IsMaximum(size_t index) const { return m_vClauses[index].GetOperation() == ClauseOperation::Maximum; }
+
+    class ClauseHarness : public Clause
+    {
+    public:
+        ClauseHarness() : Clause(ClauseOperation::None) {}
+
+        unsigned int GetAddress() const { return m_nAddress; }
+        ComparisonVariableSize GetVarSize() const { return m_nVarSize; }
+        double GetModifier() const { return m_fModifier; }
+        bool GetBcdParse() const { return m_bBCDParse; }
+        bool GetParseVal() const { return m_bParseVal; }
+        bool GetInvertBit() const { return m_bInvertBit; }
+        unsigned int GetSecondAddress() const { return m_nSecondAddress; }
+        ComparisonVariableSize GetSecondVarSize() const { return m_nSecondVarSize; }
+    };
+};
+
+TEST_CLASS(RA_MemValue_Tests)
+{
+    void AssertParseFromString(const char* sSerialized, ComparisonVariableSize nExpectedVarSize, unsigned int nExpectedAddress, bool bExpectedBcdParse = false, bool bExpectedParseVal = false)
+    {
+        std::wstring wsSerialized = Widen(sSerialized);
+        MemValueHarness::ClauseHarness value;
+        Assert::AreEqual("", value.ParseFromString(sSerialized));
+
+        Assert::AreEqual(nExpectedVarSize, value.GetVarSize(), wsSerialized.c_str());
+        Assert::AreEqual(nExpectedAddress, value.GetAddress(), wsSerialized.c_str());
+        Assert::AreEqual(bExpectedBcdParse, value.GetBcdParse(), wsSerialized.c_str());
+        Assert::AreEqual(bExpectedParseVal, value.GetParseVal(), wsSerialized.c_str());
+        Assert::AreEqual(false, value.GetInvertBit(), wsSerialized.c_str());
+        Assert::AreEqual(1.0, value.GetModifier(), wsSerialized.c_str());
+        Assert::AreEqual(0U, value.GetSecondAddress(), wsSerialized.c_str());
+        Assert::AreEqual(EightBit, value.GetSecondVarSize(), wsSerialized.c_str());
+    }
+
+    void AssertParseFromString(const char* sSerialized, ComparisonVariableSize nExpectedVarSize, unsigned int nExpectedAddress, double fExpectedModifier)
+    {
+        std::wstring wsSerialized = Widen(sSerialized);
+        MemValueHarness::ClauseHarness value;
+        Assert::AreEqual("", value.ParseFromString(sSerialized));
+
+        Assert::AreEqual(nExpectedVarSize, value.GetVarSize(), wsSerialized.c_str());
+        Assert::AreEqual(nExpectedAddress, value.GetAddress(), wsSerialized.c_str());
+        Assert::AreEqual(false, value.GetBcdParse(), wsSerialized.c_str());
+        Assert::AreEqual(false, value.GetParseVal(), wsSerialized.c_str());
+        Assert::AreEqual(false, value.GetInvertBit(), wsSerialized.c_str());
+        Assert::AreEqual(fExpectedModifier, value.GetModifier(), wsSerialized.c_str());
+        Assert::AreEqual(0U, value.GetSecondAddress(), wsSerialized.c_str());
+        Assert::AreEqual(EightBit, value.GetSecondVarSize(), wsSerialized.c_str());
+    }
+
+    void AssertParseFromString(const char* sSerialized, ComparisonVariableSize nExpectedVarSize, unsigned int nExpectedAddress, ComparisonVariableSize nExpectedSecondVarSize, unsigned int nExpectedSecondAddress)
+    {
+        std::wstring wsSerialized = Widen(sSerialized);
+        MemValueHarness::ClauseHarness value;
+        Assert::AreEqual("", value.ParseFromString(sSerialized));
+
+        Assert::AreEqual(nExpectedVarSize, value.GetVarSize(), wsSerialized.c_str());
+        Assert::AreEqual(nExpectedAddress, value.GetAddress(), wsSerialized.c_str());
+        Assert::AreEqual(false, value.GetBcdParse(), wsSerialized.c_str());
+        Assert::AreEqual(false, value.GetParseVal(), wsSerialized.c_str());
+        Assert::AreEqual(false, value.GetInvertBit(), wsSerialized.c_str());
+        Assert::AreEqual(1.0, value.GetModifier(), wsSerialized.c_str());
+        Assert::AreEqual(nExpectedSecondAddress, value.GetSecondAddress(), wsSerialized.c_str());
+        Assert::AreEqual(nExpectedSecondVarSize, value.GetSecondVarSize(), wsSerialized.c_str());
+    }
+
+    void AssertGetValue(const char* sSerialized, double dExpectedValue)
+    {
+        std::wstring wsSerialized = Widen(sSerialized);
+        MemValueHarness::ClauseHarness value;
+        Assert::AreEqual("", value.ParseFromString(sSerialized));
+        Assert::AreEqual(dExpectedValue, value.GetValue(), wsSerialized.c_str());
+    }
+
+public:
+    TEST_METHOD(TestClauseParseFromString)
+    {
+        // sizes
+        AssertParseFromString("0xH1234", EightBit, 0x1234U);
+        AssertParseFromString("0x 1234", SixteenBit, 0x1234U);
+        AssertParseFromString("0x1234", SixteenBit, 0x1234U);
+        AssertParseFromString("0xX1234", ThirtyTwoBit, 0x1234U);
+        AssertParseFromString("0xL1234", Nibble_Lower, 0x1234U);
+        AssertParseFromString("0xU1234", Nibble_Upper, 0x1234U);
+        AssertParseFromString("0xM1234", Bit_0, 0x1234U);
+        AssertParseFromString("0xN1234", Bit_1, 0x1234U);
+        AssertParseFromString("0xO1234", Bit_2, 0x1234U);
+        AssertParseFromString("0xP1234", Bit_3, 0x1234U);
+        AssertParseFromString("0xQ1234", Bit_4, 0x1234U);
+        AssertParseFromString("0xR1234", Bit_5, 0x1234U);
+        AssertParseFromString("0xS1234", Bit_6, 0x1234U);
+        AssertParseFromString("0xT1234", Bit_7, 0x1234U);
+
+        // BCD
+        AssertParseFromString("B0xH1234", EightBit, 0x1234U, true);
+        AssertParseFromString("B0xX1234", ThirtyTwoBit, 0x1234U, true);
+        AssertParseFromString("b0xH1234", EightBit, 0x1234U, true);
+
+        // Value
+        AssertParseFromString("V0xH1234", EightBit, 0x1234U, false, true);
+        AssertParseFromString("V0x1234", SixteenBit, 0x1234U, false, true);
+        AssertParseFromString("V0xX12345678", ThirtyTwoBit, 0x12345678U, false, true);
+        AssertParseFromString("V1234", EightBit, 1234, false, true);
+        AssertParseFromString("v0x1234", SixteenBit, 0x1234U, false, true);
+    }
+
+    TEST_METHOD(TestClauseParseFromStringMultiply)
+    {
+        AssertParseFromString("0xH1234", EightBit, 0x1234U, 1.0);
+        AssertParseFromString("0xH1234*1", EightBit, 0x1234U, 1.0);
+        AssertParseFromString("0xH1234*3", EightBit, 0x1234U, 3.0);
+        AssertParseFromString("0xH1234*0.5", EightBit, 0x1234U, 0.5);
+        AssertParseFromString("0xH1234*-1", EightBit, 0x1234U, -1.0);
+    }
+
+    TEST_METHOD(TestClauseParseFromStringMultiplyAddress)
+    {
+        AssertParseFromString("0xH1234", EightBit, 0x1234U, EightBit, 0U);
+        AssertParseFromString("0xH1234*0xH3456", EightBit, 0x1234U, EightBit, 0x3456U);
+        AssertParseFromString("0xH1234*0xL2222", EightBit, 0x1234U, Nibble_Lower, 0x2222U);
+        AssertParseFromString("0xH1234*0x1111", EightBit, 0x1234U, SixteenBit, 0x1111U);
+    }
+
+    TEST_METHOD(TestClauseGetValue)
+    {
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        // value
+        AssertGetValue("V0x1234", 0x1234);
+        AssertGetValue("V6", 6);
+        AssertGetValue("V6*2", 12);
+        AssertGetValue("V6*0.5", 3);
+
+        // memory
+        AssertGetValue("0xH01", 0x12);
+        AssertGetValue("0x0001", 0x3412);
+
+        // BCD encoding
+        AssertGetValue("B0xH01", 12);
+        AssertGetValue("B0x0001", 12);               // BCD only applies to EightBit values
+
+                                                     // multiplication
+        AssertGetValue("0xH01*4", 0x12 * 4);         // multiply by constant
+        AssertGetValue("0xH01*0.5", 0x12 / 2);       // multiply by fraction
+        AssertGetValue("0xH01*0xH02", 0x12 * 0x34);  // multiply by second address
+        AssertGetValue("0xH01*0xT02", 0);            // multiply by bit
+        AssertGetValue("0xH01*~0xT02", 0x12);        // multiply by inverse bit
+        AssertGetValue("0xH01*~0xH02", 0x12 * 0x34); // ~ only applies to bit sized secondary memory addresses
+    }
+
+    TEST_METHOD(TestAdditionSimple)
+    {
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        MemValueHarness set;
+        Assert::AreEqual("", set.ParseFromString("0xH0001_0xH0002"));
+        Assert::AreEqual(2U, set.NumValues());
+        Assert::AreEqual(false, set.IsAddition(0));
+        Assert::AreEqual(false, set.IsMaximum(0));
+        Assert::AreEqual(true, set.IsAddition(1));
+        Assert::AreEqual(false, set.IsMaximum(1));
+
+        Assert::AreEqual(0x12U + 0x34U, set.GetValue());
+    }
+
+    TEST_METHOD(TestAdditionComplex)
+    {
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        MemValueHarness set;
+        Assert::AreEqual("", set.ParseFromString("0xH0001*100_0xH0002*0.5_0xL0003"));
+        Assert::AreEqual(3U, set.NumValues());
+        Assert::AreEqual(false, set.IsAddition(0));
+        Assert::AreEqual(false, set.IsMaximum(0));
+        Assert::AreEqual(true, set.IsAddition(1));
+        Assert::AreEqual(false, set.IsMaximum(1));
+        Assert::AreEqual(true, set.IsAddition(2));
+        Assert::AreEqual(false, set.IsMaximum(2));
+
+        Assert::AreEqual(0x12U * 100 + 0x34U / 2 + 0x0B, set.GetValue());
+    }
+
+    TEST_METHOD(TestMaximumSimple)
+    {
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        MemValueHarness set;
+        Assert::AreEqual("", set.ParseFromString("0xH0001$0xH0002"));
+        Assert::AreEqual(2U, set.NumValues());
+        Assert::AreEqual(false, set.IsAddition(0));
+        Assert::AreEqual(false, set.IsMaximum(0));
+        Assert::AreEqual(false, set.IsAddition(1));
+        Assert::AreEqual(true, set.IsMaximum(1));
+
+        Assert::AreEqual(0x34U, set.GetValue());
+    }
+
+    TEST_METHOD(TestMaximumComplex)
+    {
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        MemValueHarness set;
+        Assert::AreEqual("", set.ParseFromString("0xH0001_0xH0004*3$0xH0002*0xL0003"));
+        Assert::AreEqual(3U, set.NumValues());
+        Assert::AreEqual(false, set.IsAddition(0));
+        Assert::AreEqual(false, set.IsMaximum(0));
+        Assert::AreEqual(true, set.IsAddition(1));
+        Assert::AreEqual(false, set.IsMaximum(1));
+        Assert::AreEqual(false, set.IsAddition(2));
+        Assert::AreEqual(true, set.IsMaximum(2));
+
+        // 0x12 + 0x56 * 3 <> 0x34 * 0xB (0x114 <> 0x23C)
+        Assert::AreEqual(0x34U * 0xBU, set.GetValue());
+    }
+
+    TEST_METHOD(TestFormatValue)
+    {
+        Assert::AreEqual("12345", MemValue::FormatValue(12345, MemValue::Format::Value).c_str());
+        Assert::AreEqual("012345", MemValue::FormatValue(12345, MemValue::Format::Other).c_str());
+        Assert::AreEqual("012345 Points", MemValue::FormatValue(12345, MemValue::Format::Score).c_str());
+        Assert::AreEqual("205:45", MemValue::FormatValue(12345, MemValue::Format::TimeSecs).c_str());
+        Assert::AreEqual("02:03.45", MemValue::FormatValue(12345, MemValue::Format::TimeMillisecs).c_str());
+        Assert::AreEqual("03:25.75", MemValue::FormatValue(12345, MemValue::Format::TimeFrames).c_str());
+        Assert::AreEqual("05:45", MemValue::FormatValue(345, MemValue::Format::TimeSecs).c_str());
+        Assert::AreEqual("00:03.45", MemValue::FormatValue(345, MemValue::Format::TimeMillisecs).c_str());
+        Assert::AreEqual("00:05.75", MemValue::FormatValue(345, MemValue::Format::TimeFrames).c_str());
+    }
+
+    TEST_METHOD(TestParseMemValueFormat)
+    {
+        Assert::AreEqual(MemValue::Format::Value, MemValue::ParseFormat("VALUE"));
+        Assert::AreEqual(MemValue::Format::TimeSecs, MemValue::ParseFormat("SECS"));
+        Assert::AreEqual(MemValue::Format::TimeSecs, MemValue::ParseFormat("TIMESECS"));
+        Assert::AreEqual(MemValue::Format::TimeFrames, MemValue::ParseFormat("TIME"));
+        Assert::AreEqual(MemValue::Format::TimeFrames, MemValue::ParseFormat("FRAMES"));
+        Assert::AreEqual(MemValue::Format::Score, MemValue::ParseFormat("SCORE"));
+        Assert::AreEqual(MemValue::Format::Score, MemValue::ParseFormat("POINTS"));
+        Assert::AreEqual(MemValue::Format::TimeMillisecs, MemValue::ParseFormat("MILLISECS"));
+        Assert::AreEqual(MemValue::Format::Other, MemValue::ParseFormat("OTHER"));
+        Assert::AreEqual(MemValue::Format::Value, MemValue::ParseFormat("INVALID"));
+    }
+
+    TEST_METHOD(TestGetMemValueFormatString)
+    {
+        Assert::AreEqual("OTHER", MemValue::GetFormatString(MemValue::Format::Other));
+        Assert::AreEqual("POINTS", MemValue::GetFormatString(MemValue::Format::Score));
+        Assert::AreEqual("FRAMES", MemValue::GetFormatString(MemValue::Format::TimeFrames));
+        Assert::AreEqual("MILLISECS", MemValue::GetFormatString(MemValue::Format::TimeMillisecs));
+        Assert::AreEqual("SECS", MemValue::GetFormatString(MemValue::Format::TimeSecs));
+        Assert::AreEqual("VALUE", MemValue::GetFormatString(MemValue::Format::Value));
+    }
+};
+
+} // namespace tests
+} // namespace data
+} // namespace ra

--- a/tests/RA_UnitTestHelpers.h
+++ b/tests/RA_UnitTestHelpers.h
@@ -4,6 +4,7 @@
 
 #include "RA_Condition.h"
 #include "RA_Defs.h"
+#include "RA_MemValue.h"
 
 namespace Microsoft {
 namespace VisualStudio {
@@ -29,6 +30,11 @@ template<> static std::wstring ToString<ComparisonType>(const ComparisonType& t)
 template<> static std::wstring ToString<Condition::ConditionType>(const Condition::ConditionType& t)
 {
     return Widen(CONDITIONTYPE_STR[(int)t]);
+}
+
+template<> static std::wstring ToString<MemValue::Format>(const MemValue::Format& format)
+{
+    return Widen(MemValue::GetFormatString(format));
 }
 
 } // namespace CppUnitTestFramework


### PR DESCRIPTION
* Separate out `MemValueSet` from Leaderboards (also used by Rich Presence)
  * rename to `MemValue`. 
  * old `MemValue` struct is now `Clause` nested inside new `MemValue` class.
* Moved `FormatType` enum from `RA_Leaderboard` to `MemValue` (also used by Rich Presence)
* Moved popup and submission handling from `RA_Leaderboard` to `RA_LeaderboardManager`