### PR TITLE
show code note tooltips when hovering over memory addresses in the achievement editor

### DIFF
--- a/src/RA_Dlg_AchEditor.h
+++ b/src/RA_Dlg_AchEditor.h
@@ -71,6 +71,9 @@ private:
     void PopulateConditions(Achievement* pCheevo);
     void SetupColumns(HWND hList);
 
+    static LRESULT CALLBACK ListViewWndProc(HWND, UINT, WPARAM, LPARAM);
+    void GetListViewTooltip();
+
     const int AddCondition(HWND hList, const Condition& Cond);
     void UpdateCondition(HWND hList, LV_ITEM& item, const Condition& Cond);
 
@@ -79,6 +82,11 @@ private:
 
     HWND m_hAchievementEditorDlg;
     HWND m_hICEControl;
+
+    HWND m_hTooltip;
+    int m_nTooltipLocation;
+    std::string m_sTooltip;
+    WNDPROC m_pListViewWndProc;
 
     char m_lbxData[MAX_CONDITIONS][m_nNumCols][MEM_STRING_TEXT_LEN];
     TCHAR m_lbxGroupNames[MAX_CONDITIONS][MEM_STRING_TEXT_LEN];

--- a/src/RA_Dlg_Memory.cpp
+++ b/src/RA_Dlg_Memory.cpp
@@ -1494,6 +1494,16 @@ void Dlg_Memory::OnWatchingMemChange()
 
 void Dlg_Memory::RepopulateMemNotesFromFile()
 {
+    size_t nSize = 0;
+
+    GameID nGameID = g_pCurrentGameData->GetGameID();
+    if (nGameID != 0)
+    {
+        char sNotesFilename[1024];
+        sprintf_s(sNotesFilename, 1024, "%s%d-Notes2.txt", RA_DIR_DATA, nGameID);
+        nSize = m_CodeNotes.Load(sNotesFilename);
+    }
+
     HWND hMemWatch = GetDlgItem(g_MemoryDialog.m_hWnd, IDC_RA_WATCHING);
     if (hMemWatch != nullptr)
     {
@@ -1502,40 +1512,32 @@ void Dlg_Memory::RepopulateMemNotesFromFile()
 
         while (ComboBox_DeleteString(hMemWatch, 0) != CB_ERR) {}
 
-        GameID nGameID = g_pCurrentGameData->GetGameID();
-        if (nGameID != 0)
+        //	Issue a fetch instead!
+        std::map<ByteAddress, CodeNotes::CodeNoteObj>::const_iterator iter = m_CodeNotes.FirstNote();
+        while (iter != m_CodeNotes.EndOfNotes())
         {
-            char sNotesFilename[1024];
-            sprintf_s(sNotesFilename, 1024, "%s%d-Notes2.txt", RA_DIR_DATA, nGameID);
-            size_t nSize = m_CodeNotes.Load(sNotesFilename);
+            const std::string sAddr = ByteAddressToString(iter->first);
+            ComboBox_AddString(hMemWatch, NativeStr(sAddr).c_str());
+            iter++;
+        }
 
-            //	Issue a fetch instead!
-            std::map<ByteAddress, CodeNotes::CodeNoteObj>::const_iterator iter = m_CodeNotes.FirstNote();
-            while (iter != m_CodeNotes.EndOfNotes())
+        if (nSize > 0)
+        {
+            //	Select the first one.
+            ComboBox_SetCurSel(hMemWatch, 0);
+
+            //	Note: as this is sorted, we should grab the desc again
+            TCHAR sAddrBuffer[64];
+            ComboBox_GetLBText(hMemWatch, 0, sAddrBuffer);
+            const std::string sAddr = Narrow(sAddrBuffer);
+
+            ByteAddress nAddr = static_cast<ByteAddress>(std::strtoul(sAddr.c_str() + 2, nullptr, 16));
+            const CodeNotes::CodeNoteObj* pSavedNote = m_CodeNotes.FindCodeNote(nAddr);
+            if ((pSavedNote != nullptr) && (pSavedNote->Note().length() > 0))
             {
-                const std::string sAddr = ByteAddressToString(iter->first);
-                ComboBox_AddString(hMemWatch, NativeStr(sAddr).c_str());
-                iter++;
-            }
-
-            if (nSize > 0)
-            {
-                //	Select the first one.
-                ComboBox_SetCurSel(hMemWatch, 0);
-
-                //	Note: as this is sorted, we should grab the desc again
-                TCHAR sAddrBuffer[64];
-                ComboBox_GetLBText(hMemWatch, 0, sAddrBuffer);
-                const std::string sAddr = Narrow(sAddrBuffer);
-
-                ByteAddress nAddr = static_cast<ByteAddress>(std::strtoul(sAddr.c_str() + 2, nullptr, 16));
-                const CodeNotes::CodeNoteObj* pSavedNote = m_CodeNotes.FindCodeNote(nAddr);
-                if ((pSavedNote != nullptr) && (pSavedNote->Note().length() > 0))
-                {
-                    SetDlgItemText(m_hWnd, IDC_RA_MEMSAVENOTE, NativeStr(pSavedNote->Note()).c_str());
-                    MemoryViewerControl::setAddress((nAddr & ~(0xf)) - ((int)(MemoryViewerControl::m_nDisplayedLines / 2) << 4) + (0x50));
-                    MemoryViewerControl::setWatchedAddress(nAddr);
-                }
+                SetDlgItemText(m_hWnd, IDC_RA_MEMSAVENOTE, NativeStr(pSavedNote->Note()).c_str());
+                MemoryViewerControl::setAddress((nAddr & ~(0xf)) - ((int)(MemoryViewerControl::m_nDisplayedLines / 2) << 4) + (0x50));
+                MemoryViewerControl::setWatchedAddress(nAddr);
             }
         }
     }


### PR DESCRIPTION
Works on Mem or Delta fields:
![image](https://user-images.githubusercontent.com/32680403/41233426-a43e3e82-6d46-11e8-8d33-ffba26ed1e46.png)
If no notes are available, tooltip indicates such:
![image](https://user-images.githubusercontent.com/32680403/41233473-c3a1ab38-6d46-11e8-82d8-a0baf440ad57.png)

