### PR TITLE
include integration version and os version in user agent string

### DIFF
--- a/MakeBuildVer.bat
+++ b/MakeBuildVer.bat
@@ -11,6 +11,8 @@ if "%VERSION_REVISION%"=="" set VERSION_REVISION=0
 
 set VERSION_PRODUCT=%VERSION_MAJOR%.%VERSION_MINOR%
 
+if "%VERSION_MINOR:~0,1%"=="0" set VERSION_MINOR=%ACTIVE_TAG:~15,2%
+
 setlocal
 git diff HEAD > Temp.txt
 for /F "usebackq" %%A in ('"Temp.txt"') do set DIFF_FILE_SIZE=%%~zA

--- a/src/RA_Core.cpp
+++ b/src/RA_Core.cpp
@@ -202,6 +202,7 @@ API BOOL CCONV _RA_InitI(HWND hMainHWND, /*enum EmulatorID*/int nEmulatorID, con
 
     _RA_LoadPreferences();
 
+    RAWeb::SetUserAgentString();
     RAWeb::RA_InitializeHTTPThreads();
 
     //////////////////////////////////////////////////////////////////////////

--- a/src/RA_httpthread.h
+++ b/src/RA_httpthread.h
@@ -139,9 +139,15 @@ public:
     static HANDLE Mutex() { return ms_hHTTPMutex; }
     static RequestObject* PopNextHttpResult() { return ms_LastHttpResults.PopNextItem(); }
 
+    static void SetUserAgentString();
+    static void SetUserAgent(const std::string& sValue) { sUserAgent = Widen(sValue); }
+    static const std::wstring& GetUserAgent() { return sUserAgent; }
+
 private:
     static HANDLE ms_hHTTPMutex;
     static HttpResults ms_LastHttpResults;
+
+    static std::wstring sUserAgent;
 };
 
 


### PR DESCRIPTION
Current:
`Retro Achievements Client [emu] [version]`
i.e.
`Retro Achievements Client RASNes9x 0.022`

As implemented in this PR (format is similar to browser User Agent):
`[emu]/[version] ([os-version]) Integration/[integ-version]`

i.e.
`RANes/0.013 (WindowsNT 10.0) Integration/0.72.0.0`             // official release
`RAP64/0.058 (WindowsNT 10.0) Integration/0.72.0.1`            // local modifications
`RAGens_REWiND/0.056 (WindowsNT 10.0) Integration/0.72.69.0`   // nightly build (or local master with commits)
`RAP64/0.058 (WindowsNT 10.0) Integration/0.72.69.1`           // nightly build with local modifications
`RASnes9X/0.022 (WindowsNT 10.0) Integration/0.72.73.0-integ`   // custom branch

The integration version is already captured in the DLL properties, and is broken down as follows:
* The first number is always 0
* The second number is the tag of the last released version
* The third number is the number of commits since the tag of the last released version
* The fourth number is 0 if there is no uncommitted code, or 1 if there is.
* The "-integ" means the code was built from a branch called "integ"

If you're curious, the Windows versions are mapped here: https://msdn.microsoft.com/en-us/library/windows/desktop/ms724832(v=vs.85).aspx