### PR TITLE
reset leaderboards and initial processing delay when switching between hardcore/non-hardcore modes

### DIFF
--- a/src/RA_AchievementOverlay.cpp
+++ b/src/RA_AchievementOverlay.cpp
@@ -1497,85 +1497,6 @@ void AchievementOverlay::OnUserPicDownloaded(const char* sUsername)
     RA_LOG("Overlay detected Userpic downloaded (%s)", sUsername);		//##SD unhandled?
 }
 
-void AchievementOverlay::InitDirectX()
-{
-    if (g_RAMainWnd == nullptr)
-    {
-        MessageBox(g_RAMainWnd, TEXT("InitDirectX failed: g_RAMainWnd invalid (check RA_Init has a valid HWND!)"), TEXT("Error!"), MB_OK);
-        return;
-    }
-
-    //LPDIRECTDRAW lpDD_Init;
-    //if (DirectDrawCreate(nullptr, &lpDD_Init, nullptr) != DD_OK)
-    //{
-    //	MessageBox( g_RAMainWnd, "DirectDrawCreate failed!", "Error!", MB_OK );
-    //	return;
-    //}
-    //
-    //if (lpDD_Init->QueryInterface(IID_IDirectDraw4, (LPVOID *) &m_lpDD) != DD_OK)
-    //{
-    //	MessageBox( g_RAMainWnd, "Error with QueryInterface!", "Error!", MB_OK );
-    //	return;
-    //}
-
-    //lpDD_Init->Release();
-    //lpDD_Init = nullptr;
-
-    //m_lpDD->SetCooperativeLevel( g_RAMainWnd, DDSCL_NORMAL );
-
-    ResetDirectX();
-}
-
-void AchievementOverlay::ResetDirectX()
-{
-    //if( m_lpDD == nullptr )
-    //	return;
-
-    //RECT rcTgtSize;
-    //SetRect( &rcTgtSize, 0, 0, 640, 480 );
-
-    //if( m_lpDDS_Overlay != nullptr )
-    //{
-    //	m_lpDDS_Overlay->Release();
-    //	m_lpDDS_Overlay = nullptr;
-    //}
-
-    //DDSURFACEDESC2 ddsd;
-    //memset(&ddsd, 0, sizeof(ddsd));
-    //ddsd.dwSize = sizeof(ddsd);
-    //ddsd.dwFlags = DDSD_CAPS | DDSD_HEIGHT | DDSD_WIDTH;
-    //
-    //ddsd.ddsCaps.dwCaps = DDSCAPS_OFFSCREENPLAIN | DDSCAPS_VIDEOMEMORY;
-    //ddsd.dwWidth = rcTgtSize.right - rcTgtSize.left;
-    //ddsd.dwHeight = rcTgtSize.bottom - rcTgtSize.top;
-
-    //HRESULT hr = m_lpDD->CreateSurface(&ddsd, &m_lpDDS_Overlay, nullptr);
-    //if( hr != DD_OK )
-    //{
-    //	assert(!"Cannot create overlay surface!");
-    //	return;
-    //}
-
-}
-
-void AchievementOverlay::Flip(HWND hWnd)
-{
-    //if( m_lpDDS_Overlay == nullptr )
-    //	return;
-
-    //RECT rcDest;
-    //GetWindowRect( g_RAMainWnd, &rcDest );
-    //OffsetRect( &rcDest, -rcDest.left, -rcDest.top);
-
-    //HDC hDC;
-    //if( m_lpDDS_Overlay->GetDC( &hDC )== DD_OK )
-    //{
-    //	g_AchievementOverlay.Render( hDC, &rcDest );
-
-    //	m_lpDDS_Overlay->ReleaseDC( hDC );
-    //}
-}
-
 void AchievementOverlay::InstallNewsArticlesFromFile()
 {
     m_LatestNews.clear();
@@ -1777,14 +1698,4 @@ API void _RA_RenderOverlay(HDC hDC, RECT* rcSize)
 API bool _RA_IsOverlayFullyVisible()
 {
     return g_AchievementOverlay.IsFullyVisible();
-}
-
-API void _RA_InitDirectX()
-{
-    g_AchievementOverlay.InitDirectX();
-}
-
-API void _RA_OnPaint(HWND hWnd)
-{
-    g_AchievementOverlay.Flip(hWnd);
 }

--- a/src/RA_AchievementOverlay.h
+++ b/src/RA_AchievementOverlay.h
@@ -145,10 +145,6 @@ public:
 
     void SelectNextTopLevelPage(BOOL bPressedRight);
 
-    void InitDirectX();
-    void ResetDirectX();
-    void Flip(HWND hWnd);
-
     void InstallNewsArticlesFromFile();
 
 public:

--- a/src/RA_AchievementSet.cpp
+++ b/src/RA_AchievementSet.cpp
@@ -243,6 +243,14 @@ void AchievementSet::Test()
     }
 }
 
+void AchievementSet::Reset()
+{
+    for (Achievement& ach : m_Achievements)
+        ach.Reset();
+
+    m_bProcessingActive = TRUE;
+}
+
 BOOL AchievementSet::SaveToFile()
 {
     //	Takes all achievements in this group and dumps them in the filename provided.

--- a/src/RA_AchievementSet.h
+++ b/src/RA_AchievementSet.h
@@ -26,6 +26,7 @@ public:
 public:
     void Clear();
     void Test();
+    void Reset();
 
     BOOL Serialize(FileStream& Stream);
     BOOL LoadFromFile(GameID nGameID);

--- a/src/RA_Core.cpp
+++ b/src/RA_Core.cpp
@@ -225,9 +225,6 @@ API BOOL CCONV _RA_InitI(HWND hMainHWND, /*enum EmulatorID*/int nEmulatorID, con
     //	Setup min required directories:
     SetCurrentDirectory(NativeStr(g_sHomeDir).c_str());
 
-    if (strcmp(sClientVer, "OFFLINE"))
-        return FALSE;
-
     //////////////////////////////////////////////////////////////////////////
     //	Update news:
     PostArgs args;

--- a/src/RA_Core.cpp
+++ b/src/RA_Core.cpp
@@ -225,6 +225,9 @@ API BOOL CCONV _RA_InitI(HWND hMainHWND, /*enum EmulatorID*/int nEmulatorID, con
     //	Setup min required directories:
     SetCurrentDirectory(NativeStr(g_sHomeDir).c_str());
 
+    if (strcmp(sClientVer, "OFFLINE"))
+        return FALSE;
+
     //////////////////////////////////////////////////////////////////////////
     //	Update news:
     PostArgs args;
@@ -354,12 +357,6 @@ API int CCONV _RA_HardcoreModeIsActive()
     return g_bHardcoreModeActive;
 }
 
-API int CCONV _RA_HTTPGetRequestExists(const char* sPageName)
-{
-    //return RAWeb::HTTPRequestExists( sPageName );	//	Deprecated
-    return 0;
-}
-
 API int CCONV _RA_OnLoadNewRom(const BYTE* pROM, unsigned int nROMSize)
 {
     static std::string sMD5NULL = RAGenerateMD5(nullptr, 0);
@@ -461,6 +458,14 @@ API int CCONV _RA_OnLoadNewRom(const BYTE* pROM, unsigned int nROMSize)
     g_nProcessTimer = 0;
 
     return 0;
+}
+
+API void CCONV _RA_OnReset()
+{
+    g_LeaderboardManager.Reset();
+    g_PopupWindows.LeaderboardPopups().Reset();
+
+    g_nProcessTimer = 0;
 }
 
 API void CCONV _RA_InstallMemoryBank(int nBankID, void* pReader, void* pWriter, int nBankSize)
@@ -809,7 +814,19 @@ API HMENU CCONV _RA_CreatePopupMenu()
 API void CCONV _RA_UpdateAppTitle(const char* sMessage)
 {
     std::stringstream sstr;
-    sstr << std::string(g_sClientName) << " - " << std::string(g_sClientVersion);
+    sstr << std::string(g_sClientName) << " - ";
+
+    // only copy the first two parts of the version string to the title bar: 0.12.7.1 => 0.12
+    const char* ptr = g_sClientVersion;
+    while (*ptr && *ptr != '.')
+        sstr << *ptr++;
+    if (*ptr)
+    {
+        do
+        {
+            sstr << *ptr++;
+        } while (*ptr && *ptr != '.');
+    }
 
     if (sMessage != nullptr)
         sstr << " - " << sMessage;
@@ -1234,6 +1251,7 @@ API void CCONV _RA_InvokeDialog(LPARAM nID)
         {
             g_bHardcoreModeActive = !g_bHardcoreModeActive;
             _RA_ResetEmulation();
+            _RA_OnReset();
 
             g_PopupWindows.Clear();
 
@@ -1394,11 +1412,6 @@ API void CCONV _RA_SetPaused(bool bIsPaused)
         g_AchievementOverlay.Activate();
     else
         g_AchievementOverlay.Deactivate();
-}
-
-API const char* CCONV _RA_Username()
-{
-    return RAUsers::LocalUser().Username().c_str();
 }
 
 API void CCONV _RA_AttemptLogin(bool bBlocking)

--- a/src/RA_Core.cpp
+++ b/src/RA_Core.cpp
@@ -462,6 +462,7 @@ API int CCONV _RA_OnLoadNewRom(const BYTE* pROM, unsigned int nROMSize)
 
 API void CCONV _RA_OnReset()
 {
+    g_pActiveAchievements->Reset();
     g_LeaderboardManager.Reset();
     g_PopupWindows.LeaderboardPopups().Reset();
 

--- a/src/RA_Core.h
+++ b/src/RA_Core.h
@@ -49,6 +49,8 @@ extern "C" {
     //	Immediately after saving a new state.
     API void CCONV _RA_OnSaveState(const char* sFileName);
 
+    //	Immediately after resetting the system.
+    API void CCONV _RA_OnReset();
 
     //	Perform one test for all achievements in the current set. Call this once per frame/cycle.
     API void CCONV _RA_DoAchievementsFrame();
@@ -81,17 +83,11 @@ extern "C" {
     //	Call this when the pause state changes, to update RA with the new state.
     API void CCONV _RA_SetPaused(bool bIsPaused);
 
-    //	Returns the currently active user
-    API const char* CCONV _RA_Username();
-
     //	Attempt to login, or present login dialog.
     API void CCONV _RA_AttemptLogin(bool bBlocking);
 
     //	Return whether or not the hardcore mode is active.
     API int CCONV _RA_HardcoreModeIsActive();
-
-    //	Return whether a HTTPGetRequest already exists
-    API int CCONV _RA_HTTPGetRequestExists(const char* sPageName);
 
     //	Install user-side functions that can be called from the DLL
     API void CCONV _RA_InstallSharedFunctions(bool(*fpIsActive)(void), void(*fpCauseUnpause)(void), void(*fpRebuildMenu)(void), void(*fpEstimateTitle)(char*), void(*fpResetEmulation)(void), void(*fpLoadROM)(const char*));

--- a/src/RA_Interface.cpp
+++ b/src/RA_Interface.cpp
@@ -68,59 +68,40 @@ void RA_GetEstimatedGameTitle(char* sNameOut)
 //	Expose to app:
 
 //	Generic:
-const char* (CCONV *_RA_IntegrationVersion) () = nullptr;
-int		(CCONV *_RA_InitI) (HWND hMainWnd, int nConsoleID, const char* sClientVer) = nullptr;
-int		(CCONV *_RA_Shutdown) () = nullptr;
+const char* (CCONV *_RA_IntegrationVersion)() = nullptr;
+int     (CCONV *_RA_InitI)(HWND hMainWnd, int nConsoleID, const char* sClientVer) = nullptr;
+int     (CCONV *_RA_Shutdown)() = nullptr;
 //	Load/Save
-bool	(CCONV *_RA_ConfirmLoadNewRom)(bool bQuitting) = nullptr;
-int		(CCONV *_RA_OnLoadNewRom)(const BYTE* pROM, unsigned int nROMSize) = nullptr;
-void	(CCONV *_RA_InstallMemoryBank)(int nBankID, void* pReader, void* pWriter, int nBankSize) = nullptr;
-void	(CCONV *_RA_ClearMemoryBanks)() = nullptr;
-void	(CCONV *_RA_OnLoadState)(const char* sFilename) = nullptr;
-void	(CCONV *_RA_OnSaveState)(const char* sFilename) = nullptr;
+bool    (CCONV *_RA_ConfirmLoadNewRom)(bool bQuitting) = nullptr;
+int     (CCONV *_RA_OnLoadNewRom)(const BYTE* pROM, unsigned int nROMSize) = nullptr;
+void    (CCONV *_RA_InstallMemoryBank)(int nBankID, void* pReader, void* pWriter, int nBankSize) = nullptr;
+void    (CCONV *_RA_ClearMemoryBanks)() = nullptr;
+void    (CCONV *_RA_OnLoadState)(const char* sFilename) = nullptr;
+void    (CCONV *_RA_OnSaveState)(const char* sFilename) = nullptr;
+void    (CCONV *_RA_OnReset)() = nullptr;
 //	Achievements:
-void	(CCONV *_RA_DoAchievementsFrame)() = nullptr;
+void    (CCONV *_RA_DoAchievementsFrame)() = nullptr;
 //	User:
-bool	(CCONV *_RA_UserLoggedIn)() = nullptr;
-const char*	(CCONV *_RA_Username)() = nullptr;
-void	(CCONV *_RA_AttemptLogin)(bool bBlocking) = nullptr;
-//	Graphics:
-void	(CCONV *_RA_InitDirectX) (void) = nullptr;
-void	(CCONV *_RA_OnPaint)(HWND hWnd) = nullptr;
+void    (CCONV *_RA_AttemptLogin)(bool bBlocking) = nullptr;
 //	Tools:
-void	(CCONV *_RA_SetPaused)(bool bIsPaused) = nullptr;
-HMENU(CCONV *_RA_CreatePopupMenu)() = nullptr;
-void	(CCONV *_RA_UpdateAppTitle) (const char* pMessage) = nullptr;
-void	(CCONV *_RA_HandleHTTPResults) (void) = nullptr;
-void	(CCONV *_RA_InvokeDialog)(LPARAM nID) = nullptr;
-void	(CCONV *_RA_InstallSharedFunctions)(bool(*)(), void(*)(), void(*)(), void(*)(), void(*)(char*), void(*)(), void(*)(const char*)) = nullptr;
-int		(CCONV *_RA_SetConsoleID)(unsigned int nConsoleID) = nullptr;
-int		(CCONV *_RA_HardcoreModeIsActive)(void) = nullptr;
-int		(CCONV *_RA_HTTPGetRequestExists)(const char* sPageName) = nullptr;
+void    (CCONV *_RA_SetPaused)(bool bIsPaused) = nullptr;
+HMENU   (CCONV *_RA_CreatePopupMenu)() = nullptr;
+void    (CCONV *_RA_UpdateAppTitle)(const char* pMessage) = nullptr;
+void    (CCONV *_RA_HandleHTTPResults)(void) = nullptr;
+void    (CCONV *_RA_InvokeDialog)(LPARAM nID) = nullptr;
+void    (CCONV *_RA_InstallSharedFunctions)(bool(*)(), void(*)(), void(*)(), void(*)(), void(*)(char*), void(*)(), void(*)(const char*)) = nullptr;
+int     (CCONV *_RA_SetConsoleID)(unsigned int nConsoleID) = nullptr;
+int     (CCONV *_RA_HardcoreModeIsActive)(void) = nullptr;
+//  Overlay:
+int     (CCONV *_RA_UpdateOverlay)(ControllerInput* pInput, float fDeltaTime, bool Full_Screen, bool Paused) = nullptr;
+int     (CCONV *_RA_UpdatePopups)(ControllerInput* pInput, float fDeltaTime, bool Full_Screen, bool Paused) = nullptr;
+void    (CCONV *_RA_RenderOverlay)(HDC hDC, RECT* prcSize) = nullptr;
+void    (CCONV *_RA_RenderPopups)(HDC hDC, RECT* prcSize) = nullptr;
+bool    (CCONV *_RA_IsOverlayFullyVisible) () = nullptr;
+
 
 //	Don't expose to app
 HINSTANCE g_hRADLL = nullptr;
-
-
-int		(CCONV *_RA_UpdateOverlay) (ControllerInput* pInput, float fDeltaTime, bool Full_Screen, bool Paused) = nullptr;
-int		(CCONV *_RA_UpdatePopups) (ControllerInput* pInput, float fDeltaTime, bool Full_Screen, bool Paused) = nullptr;
-void	(CCONV *_RA_RenderOverlay) (HDC hDC, RECT* prcSize) = nullptr;
-void	(CCONV *_RA_RenderPopups) (HDC hDC, RECT* prcSize) = nullptr;
-bool    (CCONV *_RA_IsOverlayFullyVisible) () = nullptr;
-
-//	Helpers:
-bool RA_UserLoggedIn()
-{
-    if (_RA_UserLoggedIn != nullptr)
-        return _RA_UserLoggedIn();
-
-    return false;
-}
-
-const char* RA_Username()
-{
-    return _RA_Username ? _RA_Username() : "";
-}
 
 void RA_AttemptLogin(bool bBlocking)
 {
@@ -192,18 +173,6 @@ bool RA_ConfirmLoadNewRom(bool bIsQuitting)
     return _RA_ConfirmLoadNewRom ? _RA_ConfirmLoadNewRom(bIsQuitting) : true;
 }
 
-void RA_InitDirectX()
-{
-    if (_RA_InitDirectX != nullptr)
-        _RA_InitDirectX();
-}
-
-void RA_OnPaint(HWND hWnd)
-{
-    if (_RA_OnPaint != nullptr)
-        _RA_OnPaint(hWnd);
-}
-
 void RA_InvokeDialog(LPARAM nID)
 {
     if (_RA_InvokeDialog != nullptr)
@@ -228,6 +197,12 @@ void RA_OnSaveState(const char* sFilename)
         _RA_OnSaveState(sFilename);
 }
 
+void RA_OnReset()
+{
+    if (_RA_OnReset != nullptr)
+        _RA_OnReset();
+}
+
 void RA_DoAchievementsFrame()
 {
     if (_RA_DoAchievementsFrame != nullptr)
@@ -244,12 +219,6 @@ int RA_HardcoreModeIsActive()
 {
     return (_RA_HardcoreModeIsActive != nullptr) ? _RA_HardcoreModeIsActive() : 0;
 }
-
-int RA_HTTPRequestExists(const char* sPageName)
-{
-    return (_RA_HTTPGetRequestExists != nullptr) ? _RA_HTTPGetRequestExists(sPageName) : 0;
-}
-
 
 BOOL DoBlockingHttpGet(const char* sRequestedPage, char* pBufferOut, const unsigned int /*nBufferOutSize*/, DWORD* pBytesRead)
 {
@@ -417,34 +386,30 @@ const char* CCONV _RA_InstallIntegration()
 
     //	Install function pointers one by one
 
-    _RA_IntegrationVersion = (const char*(CCONV *)())								GetProcAddress(g_hRADLL, "_RA_IntegrationVersion");
-    _RA_InitI = (int(CCONV *)(HWND, int, const char*))				GetProcAddress(g_hRADLL, "_RA_InitI");
-    _RA_Shutdown = (int(CCONV *)())										GetProcAddress(g_hRADLL, "_RA_Shutdown");
-    _RA_UserLoggedIn = (bool(CCONV *)())										GetProcAddress(g_hRADLL, "_RA_UserLoggedIn");
-    _RA_Username = (const char*(CCONV *)())								GetProcAddress(g_hRADLL, "_RA_Username");
-    _RA_AttemptLogin = (void(CCONV *)(bool))									GetProcAddress(g_hRADLL, "_RA_AttemptLogin");
-    _RA_UpdateOverlay = (int(CCONV *)(ControllerInput*, float, bool, bool))	GetProcAddress(g_hRADLL, "_RA_UpdateOverlay");
-    _RA_UpdatePopups = (int(CCONV *)(ControllerInput*, float, bool, bool))	GetProcAddress(g_hRADLL, "_RA_UpdatePopups");
-    _RA_RenderOverlay = (void(CCONV *)(HDC, RECT*))							GetProcAddress(g_hRADLL, "_RA_RenderOverlay");
+    _RA_IntegrationVersion = (const char*(CCONV *)())                                 GetProcAddress(g_hRADLL, "_RA_IntegrationVersion");
+    _RA_InitI = (int(CCONV *)(HWND, int, const char*))                                GetProcAddress(g_hRADLL, "_RA_InitI");
+    _RA_Shutdown = (int(CCONV *)())                                                   GetProcAddress(g_hRADLL, "_RA_Shutdown");
+    _RA_AttemptLogin = (void(CCONV *)(bool))                                          GetProcAddress(g_hRADLL, "_RA_AttemptLogin");
+    _RA_UpdateOverlay = (int(CCONV *)(ControllerInput*, float, bool, bool))           GetProcAddress(g_hRADLL, "_RA_UpdateOverlay");
+    _RA_UpdatePopups = (int(CCONV *)(ControllerInput*, float, bool, bool))            GetProcAddress(g_hRADLL, "_RA_UpdatePopups");
+    _RA_RenderOverlay = (void(CCONV *)(HDC, RECT*))                                   GetProcAddress(g_hRADLL, "_RA_RenderOverlay");
     _RA_IsOverlayFullyVisible = (bool(CCONV *)())                                     GetProcAddress(g_hRADLL, "_RA_IsOverlayFullyVisible");
-    _RA_RenderPopups = (void(CCONV *)(HDC, RECT*))							GetProcAddress(g_hRADLL, "_RA_RenderPopups");
-    _RA_OnLoadNewRom = (int(CCONV *)(const BYTE*, unsigned int))				GetProcAddress(g_hRADLL, "_RA_OnLoadNewRom");
-    _RA_InstallMemoryBank = (void(CCONV *)(int, void*, void*, int))				GetProcAddress(g_hRADLL, "_RA_InstallMemoryBank");
-    _RA_ClearMemoryBanks = (void(CCONV *)())										GetProcAddress(g_hRADLL, "_RA_ClearMemoryBanks");
-    _RA_UpdateAppTitle = (void(CCONV *)(const char*))							GetProcAddress(g_hRADLL, "_RA_UpdateAppTitle");
-    _RA_HandleHTTPResults = (void(CCONV *)())										GetProcAddress(g_hRADLL, "_RA_HandleHTTPResults");
-    _RA_ConfirmLoadNewRom = (bool(CCONV *)(bool))									GetProcAddress(g_hRADLL, "_RA_ConfirmLoadNewRom");
-    _RA_CreatePopupMenu = (HMENU(CCONV *)(void))								GetProcAddress(g_hRADLL, "_RA_CreatePopupMenu");
-    _RA_InitDirectX = (void(CCONV *)(void))									GetProcAddress(g_hRADLL, "_RA_InitDirectX");
-    _RA_OnPaint = (void(CCONV *)(HWND))									GetProcAddress(g_hRADLL, "_RA_OnPaint");
-    _RA_InvokeDialog = (void(CCONV *)(LPARAM))								GetProcAddress(g_hRADLL, "_RA_InvokeDialog");
-    _RA_SetPaused = (void(CCONV *)(bool))									GetProcAddress(g_hRADLL, "_RA_SetPaused");
-    _RA_OnLoadState = (void(CCONV *)(const char*))							GetProcAddress(g_hRADLL, "_RA_OnLoadState");
-    _RA_OnSaveState = (void(CCONV *)(const char*))							GetProcAddress(g_hRADLL, "_RA_OnSaveState");
-    _RA_DoAchievementsFrame = (void(CCONV *)())										GetProcAddress(g_hRADLL, "_RA_DoAchievementsFrame");
-    _RA_SetConsoleID = (int(CCONV *)(unsigned int))							GetProcAddress(g_hRADLL, "_RA_SetConsoleID");
-    _RA_HardcoreModeIsActive = (int(CCONV *)())										GetProcAddress(g_hRADLL, "_RA_HardcoreModeIsActive");
-    _RA_HTTPGetRequestExists = (int(CCONV *)(const char*))							GetProcAddress(g_hRADLL, "_RA_HTTPGetRequestExists");
+    _RA_RenderPopups = (void(CCONV *)(HDC, RECT*))                                    GetProcAddress(g_hRADLL, "_RA_RenderPopups");
+    _RA_OnLoadNewRom = (int(CCONV *)(const BYTE*, unsigned int))                      GetProcAddress(g_hRADLL, "_RA_OnLoadNewRom");
+    _RA_InstallMemoryBank = (void(CCONV *)(int, void*, void*, int))                   GetProcAddress(g_hRADLL, "_RA_InstallMemoryBank");
+    _RA_ClearMemoryBanks = (void(CCONV *)())                                          GetProcAddress(g_hRADLL, "_RA_ClearMemoryBanks");
+    _RA_UpdateAppTitle = (void(CCONV *)(const char*))                                 GetProcAddress(g_hRADLL, "_RA_UpdateAppTitle");
+    _RA_HandleHTTPResults = (void(CCONV *)())                                         GetProcAddress(g_hRADLL, "_RA_HandleHTTPResults");
+    _RA_ConfirmLoadNewRom = (bool(CCONV *)(bool))                                     GetProcAddress(g_hRADLL, "_RA_ConfirmLoadNewRom");
+    _RA_CreatePopupMenu = (HMENU(CCONV *)(void))                                      GetProcAddress(g_hRADLL, "_RA_CreatePopupMenu");
+    _RA_InvokeDialog = (void(CCONV *)(LPARAM))                                        GetProcAddress(g_hRADLL, "_RA_InvokeDialog");
+    _RA_SetPaused = (void(CCONV *)(bool))                                             GetProcAddress(g_hRADLL, "_RA_SetPaused");
+    _RA_OnLoadState = (void(CCONV *)(const char*))                                    GetProcAddress(g_hRADLL, "_RA_OnLoadState");
+    _RA_OnSaveState = (void(CCONV *)(const char*))                                    GetProcAddress(g_hRADLL, "_RA_OnSaveState");
+    _RA_OnReset = (void(CCONV *)())                                                   GetProcAddress(g_hRADLL, "_RA_OnReset");
+    _RA_DoAchievementsFrame = (void(CCONV *)())                                       GetProcAddress(g_hRADLL, "_RA_DoAchievementsFrame");
+    _RA_SetConsoleID = (int(CCONV *)(unsigned int))                                   GetProcAddress(g_hRADLL, "_RA_SetConsoleID");
+    _RA_HardcoreModeIsActive = (int(CCONV *)())                                       GetProcAddress(g_hRADLL, "_RA_HardcoreModeIsActive");
 
     _RA_InstallSharedFunctions = (void(CCONV *)(bool(*)(), void(*)(), void(*)(), void(*)(), void(*)(char*), void(*)(), void(*)(const char*))) GetProcAddress(g_hRADLL, "_RA_InstallSharedFunctionsExt");
 
@@ -502,7 +467,6 @@ void RA_Init(HWND hMainHWND, int nConsoleID, const char* sClientVersion)
         _RA_InitI(hMainHWND, nConsoleID, sClientVersion);
     else
         RA_Shutdown();
-
 }
 
 void RA_InstallSharedFunctions(bool(*fpIsActive)(void), void(*fpCauseUnpause)(void), void(*fpCausePause)(void), void(*fpRebuildMenu)(void), void(*fpEstimateTitle)(char*), void(*fpResetEmulation)(void), void(*fpLoadROM)(const char*))
@@ -530,8 +494,6 @@ void RA_Shutdown()
     _RA_IntegrationVersion = nullptr;
     _RA_InitI = nullptr;
     _RA_Shutdown = nullptr;
-    _RA_UserLoggedIn = nullptr;
-    _RA_Username = nullptr;
     _RA_UpdateOverlay = nullptr;
     _RA_UpdatePopups = nullptr;
     _RA_RenderOverlay = nullptr;
@@ -543,12 +505,11 @@ void RA_Shutdown()
     _RA_HandleHTTPResults = nullptr;
     _RA_ConfirmLoadNewRom = nullptr;
     _RA_CreatePopupMenu = nullptr;
-    _RA_InitDirectX = nullptr;
-    _RA_OnPaint = nullptr;
     _RA_InvokeDialog = nullptr;
     _RA_SetPaused = nullptr;
     _RA_OnLoadState = nullptr;
     _RA_OnSaveState = nullptr;
+    _RA_OnReset = nullptr;
     _RA_DoAchievementsFrame = nullptr;
     _RA_InstallSharedFunctions = nullptr;
 
@@ -561,12 +522,10 @@ void RA_Shutdown()
     _RA_LoadROM = nullptr;
     _RA_SetConsoleID = nullptr;
     _RA_HardcoreModeIsActive = nullptr;
-    _RA_HTTPGetRequestExists = nullptr;
     _RA_AttemptLogin = nullptr;
 
     //	Uninstall DLL
     FreeLibrary(g_hRADLL);
 }
-
 
 #endif //RA_EXPORTS

--- a/src/RA_Interface.h
+++ b/src/RA_Interface.h
@@ -152,12 +152,6 @@ extern void RA_UpdateRenderOverlay(HDC hDC, ControllerInput* pInput, float fDelt
 //  Determines if the overlay is completely covering the screen.
 extern bool RA_IsOverlayFullyVisible();
 
-//	Returns true if the user has successfully logged in.
-extern bool RA_UserLoggedIn();
-
-//	Returns the currently logged in user.
-extern const char* RA_Username();
-
 //	Attempts to login, or show login dialog.
 extern void RA_AttemptLogin(bool bBlocking);
 
@@ -194,21 +188,14 @@ extern void RA_SetConsoleID(unsigned int nConsoleID);
 extern void RA_OnLoadState(const char* sFilename);
 extern void RA_OnSaveState(const char* sFilename);
 
-
-//	Call this when initializing DirectX. TBD: clarify this.
-extern void RA_InitDirectX();
-
-//	Call this onpaint (TBD)
-extern void	RA_OnPaint(HWND hWnd);
+//  Should be called immediately after resetting the system.
+extern void RA_OnReset();
 
 //	Call this on response to a menu selection for any RA ID:
 extern void RA_InvokeDialog(LPARAM nID);
 
 //	Returns TRUE if HC mode is ongoing
 extern int RA_HardcoreModeIsActive();
-
-//	Returns TRUE if the page requested is currently being parsed.
-extern int RA_HTTPRequestExists(const char* sPageName);
 
 #endif //RA_EXPORTS
 


### PR DESCRIPTION
Made the following changes to the DLL interface:
* added `_RA_OnReset` export
* removed `_RA_InitDirectX`/`_RA_OnPaint` (code was commented out)
* removed `_RA_HttpRequestExists`/`_RA_UserLoggedIn`/`_RA_Username` (functions were unused)

When switching between hardcore and non-hardcore modes, `_RA_OnReset` is called to disable any in-progress leaderboards, and reset the delay timer for processing achievements.

As this function is exposed, the emulators can call it to address #14.