### PR TITLE
Support for Rich Presence lookup default and comments, add unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ The DLL used for interfacing with RetroAchievements.org
 
 Note: the `git` binary must be in the PATH environment variable (select "Use Git from the Windows Command Prompt" on installation).
 
+### Unit Tests
+
+Unit tests are written using the Visual Studio testing framework and are automatically built when building the solution. To run them, simply open the Test Explorer window (Tests > Windows > Test Explorer) and click Run All.
+
 ### Optional
 
 - Guidleline Support Library

--- a/src/RA_AchievementSet.cpp
+++ b/src/RA_AchievementSet.cpp
@@ -495,7 +495,10 @@ BOOL AchievementSet::LoadFromFile(ra::GameID nGameID)
                 g_pCurrentGameData->ParseData(doc);
                 ra::GameID nGameID = g_pCurrentGameData->GetGameID();
 
-                RA_RichPresenceInterpretter::PersistAndParseScript(nGameID, g_pCurrentGameData->RichPresencePatch());
+                //	Rich Presence
+                SetCurrentDirectory(NativeStr(g_sHomeDir).c_str());
+                _WriteBufferToFile(RA_DIR_DATA + std::to_string(nGameID) + "-Rich.txt", g_pCurrentGameData->RichPresencePatch());
+                g_RichPresenceInterpretter.ParseFromString(g_pCurrentGameData->RichPresencePatch().c_str());
 
                 const Value& AchievementsData = doc["Achievements"];
                 for (SizeType i = 0; i < AchievementsData.Size(); ++i)

--- a/src/RA_Condition.cpp
+++ b/src/RA_Condition.cpp
@@ -663,6 +663,19 @@ bool ConditionSet::Test(bool& bDirtyConditions, bool& bResetConditions)
     return bResult;
 }
 
+void ConditionSet::SetAlwaysTrue()
+{
+    // a single empty core group always evaluates true
+    m_vConditionGroups.clear();
+    AddGroup();
+}
+
+void ConditionSet::SetAlwaysFalse()
+{
+    // an empty condition set always evaluates false
+    Clear();
+}
+
 bool ConditionSet::Reset()
 {
     bool bWasReset = false;

--- a/src/RA_Condition.h
+++ b/src/RA_Condition.h
@@ -208,6 +208,9 @@ public:
     bool Test(bool& bDirtyConditions, bool& bWasReset);
     bool Reset();
 
+    void SetAlwaysTrue();
+    void SetAlwaysFalse();
+
     void Clear() { m_vConditionGroups.clear(); }
     size_t GroupCount() const { return m_vConditionGroups.size(); }
     void AddGroup() { m_vConditionGroups.emplace_back(); }

--- a/src/RA_Core.cpp
+++ b/src/RA_Core.cpp
@@ -1379,7 +1379,18 @@ API void CCONV _RA_InvokeDialog(LPARAM nID)
                 sprintf_s(sRichPresenceFile, 1024, "%s%u-Rich.txt", RA_DIR_DATA, g_pCurrentGameData->GetGameID());
 
                 //	Then install it
-                g_RichPresenceInterpretter.ParseRichPresenceFile(sRichPresenceFile);
+                std::string sRichPresence;
+                std::ifstream file(sRichPresenceFile);
+                if (!file.fail())
+                {
+                    file.seekg(0, std::ios::end);
+                    sRichPresence.reserve(static_cast<size_t>(file.tellg()));
+                    file.seekg(0, std::ios::beg);
+
+                    sRichPresence.assign((std::istreambuf_iterator<char>(file)),
+                        (std::istreambuf_iterator<char>()));
+                }
+                g_RichPresenceInterpretter.ParseFromString(sRichPresence.c_str());
 
                 if (g_RichPresenceDialog.GetHWND() == nullptr)
                     g_RichPresenceDialog.InstallHWND(CreateDialog(g_hThisDLLInst, MAKEINTRESOURCE(IDD_RA_RICHPRESENCE), g_RAMainWnd, &Dlg_RichPresence::s_RichPresenceDialogProc));

--- a/src/RA_Core.h
+++ b/src/RA_Core.h
@@ -123,6 +123,9 @@ extern unsigned int g_nNumHTTPThreads;
 //	Read a file to a malloc'd buffer. Returns nullptr on error. Owner MUST free() buffer if not nullptr.
 extern char* _MallocAndBulkReadFileToBuffer(const char* sFilename, long& nFileSizeOut);
 
+//  Read a file to a std::string. Returns empty string on error.
+bool _ReadBufferFromFile(_Out_ std::string& buffer, const char* sFile);
+
 //	Read file until reaching the end of the file, or the specified char.
 extern BOOL _ReadTil(const char nChar, char buffer[], unsigned int nSize, DWORD* pCharsRead, FILE* pFile);
 

--- a/src/RA_Core.h
+++ b/src/RA_Core.h
@@ -123,8 +123,8 @@ extern unsigned int g_nNumHTTPThreads;
 //	Read a file to a malloc'd buffer. Returns nullptr on error. Owner MUST free() buffer if not nullptr.
 extern char* _MallocAndBulkReadFileToBuffer(const char* sFilename, long& nFileSizeOut);
 
-//  Read a file to a std::string. Returns empty string on error.
-bool _ReadBufferFromFile(_Out_ std::string& buffer, const char* sFile);
+//  Read a file to a std::string. Returns false on error.
+extern bool _ReadBufferFromFile(_Out_ std::string& buffer, const char* sFile);
 
 //	Read file until reaching the end of the file, or the specified char.
 extern BOOL _ReadTil(const char nChar, char buffer[], unsigned int nSize, DWORD* pCharsRead, FILE* pFile);

--- a/src/RA_Dlg_RichPresence.cpp
+++ b/src/RA_Dlg_RichPresence.cpp
@@ -1,6 +1,7 @@
 #include "RA_Dlg_RichPresence.h"
 
 #include "RA_Core.h"
+#include "RA_GameData.h"
 #include "RA_Resource.h"
 #include "RA_RichPresence.h"
 
@@ -20,7 +21,12 @@ INT_PTR CALLBACK Dlg_RichPresence::RichPresenceDialogProc(HWND hDlg, UINT nMsg, 
 
         case WM_TIMER:
         {
-            std::wstring sRP = ra::Widen(g_RichPresenceInterpretter.GetRichPresenceString());
+            std::wstring sRP;
+            if (g_pCurrentGameData->GetGameID() != 0)
+                sRP = ra::Widen(g_RichPresenceInterpretter.GetRichPresenceString());
+            else
+                sRP = L"No game loaded";
+
             SetDlgItemTextW(m_hRichPresenceDialog, IDC_RA_RICHPRESENCERESULTTEXT, sRP.c_str());
             return TRUE;
         }

--- a/src/RA_Dlg_RichPresence.cpp
+++ b/src/RA_Dlg_RichPresence.cpp
@@ -113,7 +113,7 @@ void Dlg_RichPresence::ClearMessage()
 
 void Dlg_RichPresence::StartTimer()
 {
-    if (!m_bTimerActive)
+    if (!m_bTimerActive && m_hRichPresenceDialog != nullptr)
     {
         SetTimer(m_hRichPresenceDialog, 1, 1000, nullptr);
         m_bTimerActive = true;

--- a/src/RA_Dlg_RichPresence.cpp
+++ b/src/RA_Dlg_RichPresence.cpp
@@ -21,12 +21,7 @@ INT_PTR CALLBACK Dlg_RichPresence::RichPresenceDialogProc(HWND hDlg, UINT nMsg, 
 
         case WM_TIMER:
         {
-            std::wstring sRP;
-            if (g_pCurrentGameData->GetGameID() != 0)
-                sRP = ra::Widen(g_RichPresenceInterpreter.GetRichPresenceString());
-            else
-                sRP = L"No game loaded";
-
+            std::wstring sRP = ra::Widen(g_RichPresenceInterpreter.GetRichPresenceString());
             SetDlgItemTextW(m_hRichPresenceDialog, IDC_RA_RICHPRESENCERESULTTEXT, sRP.c_str());
             return TRUE;
         }
@@ -82,6 +77,18 @@ Dlg_RichPresence::~Dlg_RichPresence()
     DeleteObject(m_hFont);
 }
 
+void Dlg_RichPresence::OnLoad_NewRom()
+{
+    if (g_RichPresenceInterpreter.Enabled())
+    {
+        StartTimer();
+    }
+    else
+    {
+        ClearMessage();
+    }
+}
+
 void Dlg_RichPresence::StartMonitoring()
 {
     if (g_RichPresenceInterpreter.Enabled())
@@ -92,6 +99,16 @@ void Dlg_RichPresence::StartMonitoring()
     {
         StopTimer();
     }
+}
+
+void Dlg_RichPresence::ClearMessage()
+{
+    StopTimer();
+
+    if (g_pCurrentGameData->GetGameID() == 0)
+        SetDlgItemTextW(m_hRichPresenceDialog, IDC_RA_RICHPRESENCERESULTTEXT, L"No game loaded");
+    else
+        SetDlgItemTextW(m_hRichPresenceDialog, IDC_RA_RICHPRESENCERESULTTEXT, L"No Rich Presence defined");
 }
 
 void Dlg_RichPresence::StartTimer()

--- a/src/RA_Dlg_RichPresence.h
+++ b/src/RA_Dlg_RichPresence.h
@@ -17,6 +17,9 @@ public:
     HWND GetHWND() const { return m_hRichPresenceDialog; }
 
     void StartMonitoring();
+    void ClearMessage();
+
+    void OnLoad_NewRom();
 
 private:
     void StartTimer();

--- a/src/RA_RichPresence.cpp
+++ b/src/RA_RichPresence.cpp
@@ -1,266 +1,249 @@
 #include "RA_RichPresence.h"
 
-#include "RA_Core.h"
-#include "RA_GameData.h"
+#include "RA_Defs.h"
 #include "RA_MemValue.h"
+
+#include <fstream>
+#include <streambuf>
 
 RA_RichPresenceInterpretter g_RichPresenceInterpretter;
 
-RA_Lookup::RA_Lookup(const std::string& sDesc)
+RA_RichPresenceInterpretter::Lookup::Lookup(const std::string& sDesc)
     : m_sLookupDescription(sDesc)
 {
 }
 
-const std::string& RA_Lookup::Lookup(ra::DataPos nValue) const
+const std::string& RA_RichPresenceInterpretter::Lookup::GetText(unsigned int nValue) const
 {
-    if (m_lookupData.find(nValue) != m_lookupData.end())
-        return m_lookupData.find(nValue)->second;
+    auto iter = m_mLookupData.find(nValue);
+    if (iter != m_mLookupData.end())
+        return iter->second;
 
-    static const std::string sUnknown = "";
-    return sUnknown;
+    return m_sDefault;
 }
 
-RA_ConditionalDisplayString::RA_ConditionalDisplayString(const char* pBuffer)
+RA_RichPresenceInterpretter::DisplayString::DisplayString()
 {
-    ++pBuffer; // skip first question mark
+    // add an empty core group to ensure Test() always returns true
+    m_conditions.AddGroup(); 
+}
+
+RA_RichPresenceInterpretter::DisplayString::DisplayString(const std::string& sCondition)
+{
+    const char* pBuffer = sCondition.data();
     m_conditions.ParseFromString(pBuffer);
 
-    if (*pBuffer == '?')
-    {
-        // valid condition
-        *pBuffer++;
-        m_sDisplayString = pBuffer;
-    }
-    else
+    if (*pBuffer != '\0')
     {
         // not a valid condition, ensure Test() never returns true
         m_conditions.Clear();
     }
 }
 
-bool RA_ConditionalDisplayString::Test()
+void RA_RichPresenceInterpretter::DisplayString::InitializeParts(const std::string& sDisplayString,
+    std::map<std::string, MemValue::Format>& mFormats, std::vector<Lookup>& vLookups)
+{
+    size_t nIndex = 0;
+    size_t nStart = 0;
+    do
+    {
+        if (nIndex < sDisplayString.length() && sDisplayString[nIndex] != '@')
+        {
+            nIndex++;
+            continue;
+        }
+
+        Part& part = m_vParts.emplace_back();
+        if (nIndex > nStart)
+            part.m_sDisplayString.assign(sDisplayString, nStart, nIndex - nStart);
+
+        if (nIndex == sDisplayString.length())
+            break;
+
+        nStart = nIndex + 1;
+        nIndex = nStart;
+        while (nIndex < sDisplayString.length() && sDisplayString[nIndex] != '(')
+            nIndex++;
+        if (nIndex == sDisplayString.length())
+            break;
+
+        std::string sLookup(sDisplayString, nStart, nIndex - nStart);
+
+        nStart = nIndex + 1;
+        nIndex = nStart;
+        while (nIndex < sDisplayString.length() && sDisplayString[nIndex] != ')')
+            nIndex++;
+        if (nIndex == sDisplayString.length())
+            break;
+
+        std::string sMemValue(sDisplayString, nStart, nIndex - nStart);
+        nStart = nIndex + 1;
+
+        auto iter = mFormats.find(sLookup);
+        if (iter != mFormats.end())
+        {
+            part.m_nFormat = iter->second;
+            part.m_memValue.ParseFromString(sMemValue.c_str());
+        }
+        else
+        {
+            for (std::vector<Lookup>::const_iterator lookup = vLookups.begin(); lookup != vLookups.end(); ++lookup)
+            {
+                if (lookup->Description() == sLookup)
+                {
+                    part.m_pLookup = &(*lookup);
+                    part.m_memValue.ParseFromString(sMemValue.c_str());
+                    break;
+                }
+            }
+        }
+    } while (true);
+}
+
+bool RA_RichPresenceInterpretter::DisplayString::Test()
 {
     bool bDirtyConditions, bResetRead; // for HitCounts - not supported in RichPresence
     return m_conditions.Test(bDirtyConditions, bResetRead);
 }
 
-void RA_RichPresenceInterpretter::ParseRichPresenceFile(const std::string& sFilename)
+std::string RA_RichPresenceInterpretter::DisplayString::GetDisplayString() const
 {
-    m_formats.clear();
-    m_lookups.clear();
-    m_sDisplay.clear();
-    m_conditionalDisplayStrings.clear();
-
-    const char EndLine = '\n';
-
-    const char* LookupStr = "Lookup:";
-    const char* FormatStr = "Format:";
-    const char* FormatTypeStr = "FormatType=";
-    const char* DisplayableStr = "Display:";
-
-    FILE* pFile = nullptr;
-    fopen_s(&pFile, sFilename.c_str(), "r");
-    if (pFile != nullptr)
+    std::string sResult;
+    for (const auto& part : m_vParts)
     {
-        DWORD nCharsRead = 0;
-        char buffer[4096];
+        if (!part.m_sDisplayString.empty())
+            sResult.append(part.m_sDisplayString);
 
-        _ReadTil(EndLine, buffer, 4096, &nCharsRead, pFile);
-        while (nCharsRead != 0)
+        if (!part.m_memValue.IsEmpty())
         {
-            if (strncmp(LookupStr, buffer, strlen(LookupStr)) == 0)
+            unsigned int nValue = part.m_memValue.GetValue();
+
+            if (part.m_pLookup != nullptr)
+                sResult.append(part.m_pLookup->GetText(nValue));
+            else
+                sResult.append(MemValue::FormatValue(nValue, part.m_nFormat));
+        }
+    }
+
+    return sResult;
+}
+
+static bool GetLine(std::stringstream& stream, std::string& sLine)
+{
+    if (!std::getline(stream, sLine, '\n'))
+        return false;
+
+    if (sLine.length() > 0 && sLine[sLine.length() - 1] == '\r')
+        sLine.resize(sLine.length() - 1);
+
+    return true;
+}
+
+void RA_RichPresenceInterpretter::ParseFromString(const char* sRichPresence)
+{
+    m_vLookups.clear();
+    m_vDisplayStrings.clear();
+
+    std::map<std::string, std::string> mDisplayStrings;
+    std::string sDisplayString;
+
+    std::map<std::string, MemValue::Format> mFormats;
+
+    std::stringstream ssRichPresence(sRichPresence);
+    std::string sLine;
+    while (GetLine(ssRichPresence, sLine))
+    {
+        if (strncmp("Lookup:", sLine.c_str(), 7) == 0)
+        {
+            std::string sLookupName(sLine, 7);
+            Lookup& newLookup = m_vLookups.emplace_back(sLookupName);
+            do
             {
-                //	Lookup type
-                char* pBuf = buffer + (strlen(LookupStr));
-                RA_Lookup newLookup(_ReadStringTil(EndLine, pBuf, TRUE));
-                while (nCharsRead != 0 && (buffer[0] != EndLine))
+                if (!GetLine(ssRichPresence, sLine) || sLine.length() < 2)
+                    break;
+
+                size_t nIndex = sLine.find('=');
+                if (nIndex == std::string::npos)
+                    continue;
+
+                std::string sLabel(sLine, nIndex + 1);
+
+                if (sLine[0] == '*')
                 {
-                    _ReadTil(EndLine, buffer, 4096, &nCharsRead, pFile);
-                    if (nCharsRead > 2)
+                    newLookup.SetDefault(sLabel);
+                    continue;
+                }
+
+                unsigned int nVal;
+                if (sLine[0] == '0' && sLine[1] == 'x')
+                    nVal = strtoul(&sLine[2], nullptr, 16);
+                else
+                    nVal = strtoul(&sLine[0], nullptr, 10);
+
+                newLookup.AddLookupData(nVal, sLabel);
+            } while (true);
+
+            RA_LOG("RP: Adding Lookup %s (%zu items)\n", sLookupName.c_str(), newLookup.NumItems());
+        }
+        else if (strncmp("Format:", sLine.c_str(), 7) == 0)
+        {
+            std::string sFormatName(sLine, 7);
+            if (GetLine(ssRichPresence, sLine) && strncmp("FormatType=", sLine.c_str(), 11) == 0)
+            {
+                std::string sFormatType(sLine, 11);
+                MemValue::Format nType = MemValue::ParseFormat(sFormatType);
+
+                RA_LOG("RP: Adding Formatter %s (%s)\n", sFormatName.c_str(), sFormatType.c_str());
+                mFormats[sFormatName] = nType;
+            }
+        }
+        else if (strncmp("Display:", sLine.c_str(), 8) == 0)
+        {
+            do
+            {
+                if (!GetLine(ssRichPresence, sLine) || sLine.length() < 2)
+                    break;
+
+                if (sLine[0] == '?')
+                {
+                    size_t nIndex = sLine.find('?', 1);
+                    if (nIndex != std::string::npos)
                     {
-                        char* pBuf = &buffer[0];
-                        const char* pValue = _ReadStringTil('=', pBuf, TRUE);
-                        const char* pName = _ReadStringTil(EndLine, pBuf, TRUE);
+                        std::string sCondition(sLine, 1, nIndex - 1);
+                        std::string sDisplay(sLine, nIndex + 1);
 
-                        int nBase = 10;
-                        if (pValue[0] == '0' && pValue[1] == 'x')
-                            nBase = 16;
-
-                        ra::DataPos nVal = static_cast<ra::DataPos>(strtoul(pValue, nullptr, nBase));
-
-                        newLookup.AddLookupData(nVal, pName);
+                        mDisplayStrings[sCondition] = sDisplay;
+                        continue;
                     }
                 }
 
-                RA_LOG("RP: Adding Lookup %s\n", newLookup.Description().c_str());
-                m_lookups.push_back(newLookup);
+                sDisplayString = sLine;
+                break;
+            } while (true);
+        }
+    }
 
-            }
-            else if (strncmp(FormatStr, buffer, strlen(FormatStr)) == 0)
-            {
-                //	
-                char* pBuf = &buffer[0];
-                const char* pUnused = _ReadStringTil(':', pBuf, TRUE);
-                std::string sDesc = _ReadStringTil(EndLine, pBuf, TRUE);
-
-                _ReadTil(EndLine, buffer, 4096, &nCharsRead, pFile);
-                if (nCharsRead > 0 && strncmp(FormatTypeStr, buffer, strlen(FormatTypeStr)) == 0)
-                {
-                    char* pBuf = &buffer[0];
-                    const char* pUnused = _ReadStringTil('=', pBuf, TRUE);
-                    const char* pType = _ReadStringTil(EndLine, pBuf, TRUE);
-
-                    MemValue::Format nType = MemValue::ParseFormat(pType);
-
-                    RA_LOG("RP: Adding Formatter %s (%s)\n", sDesc.c_str(), pType);
-                    m_formats[sDesc] = nType;
-                }
-            }
-            else if (strncmp(DisplayableStr, buffer, strlen(DisplayableStr)) == 0)
-            {
-                _ReadTil(EndLine, buffer, 4096, &nCharsRead, pFile);
-
-                char* pBuf = &buffer[0];
-                m_sDisplay = _ReadStringTil('\n', pBuf, TRUE);	//	Terminates \n instead
-
-                while (buffer[0] == '?')
-                {
-                    RA_ConditionalDisplayString conditionalString(buffer);
-                    m_conditionalDisplayStrings.push_back(conditionalString);
-
-                    _ReadTil(EndLine, buffer, 4096, &nCharsRead, pFile);
-                    pBuf = &buffer[0];
-                    m_sDisplay = _ReadStringTil('\n', pBuf, TRUE);
-                }
-            }
-
-            _ReadTil(EndLine, buffer, 4096, &nCharsRead, pFile);
+    if (!sDisplayString.empty())
+    {
+        for (std::map<std::string, std::string>::const_iterator iter = mDisplayStrings.begin(); iter != mDisplayStrings.end(); ++iter)
+        {
+            auto& displayString = m_vDisplayStrings.emplace_back(iter->first);
+            displayString.InitializeParts(iter->second, mFormats, m_vLookups);
         }
 
-        fclose(pFile);
+        auto& displayString = m_vDisplayStrings.emplace_back();
+        displayString.InitializeParts(sDisplayString, mFormats, m_vLookups);
     }
 }
 
-const std::string RA_RichPresenceInterpretter::Lookup(const std::string& sName, const std::string& sMemString) const
+std::string RA_RichPresenceInterpretter::GetRichPresenceString()
 {
-    //	check lookups
-    for (size_t i = 0; i < m_lookups.size(); ++i)
+    for (auto& displayString : m_vDisplayStrings)
     {
-        if (m_lookups.at(i).Description().compare(sName) == 0)
-        {
-            MemValue nValue;
-            nValue.ParseFromString(sMemString.c_str());
-            return m_lookups.at(i).Lookup(static_cast<ra::DataPos>(nValue.GetValue()));
-        }
+        if (displayString.Test())
+            return displayString.GetDisplayString();
     }
 
-    //	check formatters
-    auto iter = m_formats.find(sName);
-    if (iter != m_formats.end())
-    {
-        MemValue nValue;
-        nValue.ParseFromString(sMemString.c_str());
-        return nValue.GetFormattedValue(iter->second);
-    }
-
-    return "";
-}
-
-bool RA_RichPresenceInterpretter::Enabled() const
-{
-    return !m_sDisplay.empty();
-}
-
-const std::string& RA_RichPresenceInterpretter::GetRichPresenceString()
-{
-    static std::string sReturnVal;
-    sReturnVal.clear();
-
-    if (g_pCurrentGameData->GetGameID() == 0)
-    {
-        sReturnVal = "No game loaded";
-        return sReturnVal;
-    }
-
-    bool bParsingLookupName = false;
-    bool bParsingLookupContent = false;
-
-    std::string sLookupName;
-    std::string sLookupValue;
-
-    const std::string* sDisplayString = &m_sDisplay;
-    for (std::vector<RA_ConditionalDisplayString>::iterator iter = m_conditionalDisplayStrings.begin(); iter != m_conditionalDisplayStrings.end(); ++iter)
-    {
-        if (iter->Test())
-        {
-            sDisplayString = &iter->GetDisplayString();
-            break;
-        }
-    }
-
-    for (size_t i = 0; i < sDisplayString->size(); ++i)
-    {
-        char c = sDisplayString->at(i);
-
-        if (bParsingLookupContent)
-        {
-            if (c == ')')
-            {
-                //	End of content
-                bParsingLookupContent = false;
-
-                //	Lookup!
-
-                sReturnVal.append(Lookup(sLookupName, sLookupValue));
-
-                sLookupName.clear();
-                sLookupValue.clear();
-            }
-            else
-            {
-                sLookupValue.push_back(c);
-            }
-        }
-        else if (bParsingLookupName)
-        {
-            if (c == '(')
-            {
-                //	Now parsing lookup content
-                bParsingLookupContent = true;
-                bParsingLookupName = false;
-            }
-            else
-            {
-                //	Continue to parse lookup name
-                sLookupName.push_back(c);
-            }
-        }
-        else
-        {
-            //	Not parsing a lookup at all.
-            if (c == '@')
-            {
-                bParsingLookupName = true;
-            }
-            else
-            {
-                //	Standard text.
-                sReturnVal.push_back(c);
-            }
-        }
-    }
-
-    return sReturnVal;
-}
-
-//	static
-void RA_RichPresenceInterpretter::PersistAndParseScript(ra::GameID nGameID, const std::string& str)
-{
-    //	Read to file:
-    SetCurrentDirectory(NativeStr(g_sHomeDir).c_str());
-    _WriteBufferToFile(RA_DIR_DATA + std::to_string(nGameID) + "-Rich.txt", str);
-
-    //	Then install it
-    g_RichPresenceInterpretter.ParseRichPresenceFile(RA_DIR_DATA + std::to_string(nGameID) + "-Rich.txt");
+    return std::string();
 }
 

--- a/src/RA_RichPresence.cpp
+++ b/src/RA_RichPresence.cpp
@@ -133,8 +133,21 @@ static bool GetLine(std::stringstream& stream, std::string& sLine)
     if (!std::getline(stream, sLine, '\n'))
         return false;
 
-    if (sLine.length() > 0 && sLine[sLine.length() - 1] == '\r')
-        sLine.resize(sLine.length() - 1);
+    if (!sLine.empty())
+    {
+        size_t index = sLine.find("//");
+        if (index != std::string::npos)
+        {
+            while (index > 0 && isspace(sLine[index - 1]))
+                index--;
+
+            sLine.resize(index);
+        }
+        else if (sLine[sLine.length() - 1] == '\r')
+        {
+            sLine.resize(sLine.length() - 1);
+        }
+    }
 
     return true;
 }

--- a/src/ra_fwd.h
+++ b/src/ra_fwd.h
@@ -26,7 +26,6 @@ using tstring = std::basic_string<TCHAR>;
 using DWORD         = unsigned long;
 using ARGB          = DWORD;
 using ByteAddress   = std::size_t;
-using DataPos       = std::size_t;
 using AchievementID = std::size_t;
 using LeaderboardID = std::size_t;
 using GameID        = std::size_t;

--- a/src/ra_utility.h
+++ b/src/ra_utility.h
@@ -68,11 +68,6 @@ _NODISCARD _CONSTANT_FN operator""_hu(_In_ unsigned long long n) noexcept
 } // end operator""_hu
 
 
-_NODISCARD _CONSTANT_FN operator""_dp(_In_ unsigned long long n) noexcept
-{
-    return static_cast<ra::DataPos>(n);
-} // end operator""_dp
-
   // If you follow the standard every alias is considered mutually exclusive, if not don't worry about it
   // These are here if you follow the standards (starts with ISO C++11/C11) rvalue conversions
 

--- a/tests/RA_ConditionSet_Tests.cpp
+++ b/tests/RA_ConditionSet_Tests.cpp
@@ -738,6 +738,20 @@ public:
         memory[0] = 2; // trigger win condition. alt group has no normal conditions, it should be considered false
         AssertSetTest(set, false, true, false);
     }
+
+    TEST_METHOD(TestAlwaysTrue)
+    {
+        ConditionSet set;
+        set.SetAlwaysTrue();
+        AssertSetTest(set, true, false, false);
+    }
+
+    TEST_METHOD(TestAlwaysFalse)
+    {
+        ConditionSet set;
+        set.SetAlwaysFalse();
+        AssertSetTest(set, false, false, false);
+    }
 };
 
 } // namespace tests

--- a/tests/RA_Integration.Tests.vcxproj
+++ b/tests/RA_Integration.Tests.vcxproj
@@ -129,7 +129,9 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\src\RA_RichPresence.cpp" />
     <ClCompile Include="..\src\services\SearchResults.cpp" />
+    <ClCompile Include="RA_RichPresence_Tests.cpp" />
     <ClCompile Include="SearchResults_Tests.cpp" />
     <ClInclude Include="..\src\RA_Condition.h" />
     <ClInclude Include="..\src\RA_Defs.h" />

--- a/tests/RA_Integration.Tests.vcxproj.filters
+++ b/tests/RA_Integration.Tests.vcxproj.filters
@@ -45,6 +45,12 @@
     <ClCompile Include="..\src\services\SearchResults.cpp">
       <Filter>Code</Filter>
     </ClCompile>
+    <ClCompile Include="RA_RichPresence_Tests.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\RA_RichPresence.cpp">
+      <Filter>Code</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="RA_Condition_Tests.cpp">

--- a/tests/RA_RichPresence_Tests.cpp
+++ b/tests/RA_RichPresence_Tests.cpp
@@ -1,0 +1,232 @@
+#include "CppUnitTest.h"
+
+#include "RA_RichPresence.h"
+#include "RA_UnitTestHelpers.h"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace ra {
+namespace data {
+namespace tests {
+
+TEST_CLASS(RA_RichPresence_Tests)
+{
+public:
+    TEST_METHOD(TestValue)
+    {
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        RA_RichPresenceInterpretter rp;
+        rp.ParseFromString("Format:Points\nFormatType=VALUE\n\nDisplay:\n@Points(0x 0001) Points");
+
+        Assert::AreEqual("13330 Points", rp.GetRichPresenceString().c_str());
+
+        memory[1] = 20;
+        Assert::AreEqual("13332 Points", rp.GetRichPresenceString().c_str());
+    }
+    
+    TEST_METHOD(TestValueFormula)
+    {
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        RA_RichPresenceInterpretter rp;
+        rp.ParseFromString("Format:Points\nFormatType=VALUE\n\nDisplay:\n@Points(0xH0001*100_0xH0002) Points");
+
+        Assert::AreEqual("1852 Points", rp.GetRichPresenceString().c_str());
+
+        memory[1] = 0x20;
+        Assert::AreEqual("3252 Points", rp.GetRichPresenceString().c_str());
+    }
+    
+    TEST_METHOD(TestLookup)
+    {
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        RA_RichPresenceInterpretter rp;
+        rp.ParseFromString("Lookup:Location\n0=Zero\n1=One\n\nDisplay:\nAt @Location(0xH0000)");
+
+        Assert::AreEqual("At Zero", rp.GetRichPresenceString().c_str());
+
+        memory[0] = 1;
+        Assert::AreEqual("At One", rp.GetRichPresenceString().c_str());
+
+        memory[0] = 2; // no entry
+        Assert::AreEqual("At ", rp.GetRichPresenceString().c_str());
+    }
+                
+    TEST_METHOD(TestLookupFormula)
+    {
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        RA_RichPresenceInterpretter rp;
+        rp.ParseFromString("Lookup:Location\n0=Zero\n1=One\n\nDisplay:\nAt @Location(0xH0000*0.5)");
+
+        Assert::AreEqual("At Zero", rp.GetRichPresenceString().c_str());
+
+        memory[0] = 1;
+        Assert::AreEqual("At Zero", rp.GetRichPresenceString().c_str());
+
+        memory[0] = 2;
+        Assert::AreEqual("At One", rp.GetRichPresenceString().c_str());
+    }
+                
+    TEST_METHOD(TestLookupRepeated)
+    {
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        RA_RichPresenceInterpretter rp;
+        rp.ParseFromString("Lookup:Location\n0=Zero\n1=One\n\nDisplay:\nAt @Location(0xH0000), Near @Location(0xH0001)");
+
+        Assert::AreEqual("At Zero, Near ", rp.GetRichPresenceString().c_str());
+
+        memory[1] = 1;
+        Assert::AreEqual("At Zero, Near One", rp.GetRichPresenceString().c_str());
+
+        memory[0] = 1; 
+        Assert::AreEqual("At One, Near One", rp.GetRichPresenceString().c_str());
+    }
+    
+    TEST_METHOD(TestLookupHex)
+    {
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        RA_RichPresenceInterpretter rp;
+        rp.ParseFromString("Lookup:Location\n0x00=Zero\n0x01=One\n\nDisplay:\nAt @Location(0xH0000)");
+
+        Assert::AreEqual("At Zero", rp.GetRichPresenceString().c_str());
+
+        memory[0] = 1;
+        Assert::AreEqual("At One", rp.GetRichPresenceString().c_str());
+
+        memory[0] = 2; // no entry
+        Assert::AreEqual("At ", rp.GetRichPresenceString().c_str());
+    }
+
+    TEST_METHOD(TestLookupDefault)
+    {
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        RA_RichPresenceInterpretter rp;
+        rp.ParseFromString("Lookup:Location\n0=Zero\n1=One\n*=Star\n\nDisplay:\nAt @Location(0xH0000)");
+
+        Assert::AreEqual("At Zero", rp.GetRichPresenceString().c_str());
+
+        memory[0] = 1;
+        Assert::AreEqual("At One", rp.GetRichPresenceString().c_str());
+
+        memory[0] = 2; // no entry
+        Assert::AreEqual("At Star", rp.GetRichPresenceString().c_str());
+    }
+
+    TEST_METHOD(TestLookupCRLF)
+    {
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        RA_RichPresenceInterpretter rp;
+        rp.ParseFromString("Lookup:Location\r\n0=Zero\r\n1=One\r\n\r\nDisplay:\r\nAt @Location(0xH0000)\r\n");
+
+        Assert::AreEqual("At Zero", rp.GetRichPresenceString().c_str());
+
+        memory[0] = 1;
+        Assert::AreEqual("At One", rp.GetRichPresenceString().c_str());
+
+        memory[0] = 2; // no entry
+        Assert::AreEqual("At ", rp.GetRichPresenceString().c_str());
+    }
+
+    TEST_METHOD(TestLookupAfterDisplay)
+    {
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        RA_RichPresenceInterpretter rp;
+        rp.ParseFromString("Display:\nAt @Location(0xH0000)\n\nLookup:Location\n0=Zero\n1=One");
+
+        Assert::AreEqual("At Zero", rp.GetRichPresenceString().c_str());
+
+        memory[0] = 1;
+        Assert::AreEqual("At One", rp.GetRichPresenceString().c_str());
+
+        memory[0] = 2; // no entry
+        Assert::AreEqual("At ", rp.GetRichPresenceString().c_str());
+    }
+
+    TEST_METHOD(TestRandomText)
+    {
+        // anything that doesn't begin with "Format:" "Lookup:" or "Display:" is ignored. people sometimes
+        // use this logic to add comments to the Rich Presence script - particularly author comments
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        RA_RichPresenceInterpretter rp;
+        rp.ParseFromString("Locations are fun!\nLookup:Location\n0=Zero\n1=One\n\nDisplay goes here\nDisplay:\nAt @Location(0xH0000)\n\nWritten by User3");
+
+        Assert::AreEqual("At Zero", rp.GetRichPresenceString().c_str());
+
+        memory[0] = 1;
+        Assert::AreEqual("At One", rp.GetRichPresenceString().c_str());
+
+        memory[0] = 2; // no entry
+        Assert::AreEqual("At ", rp.GetRichPresenceString().c_str());
+    }
+    
+    TEST_METHOD(TestConditionalDisplay)
+    {
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        RA_RichPresenceInterpretter rp;
+        rp.ParseFromString("Display:\n?0xH0000=0?Zero\n?0xH0000=1?One\nOther");
+
+        Assert::AreEqual("Zero", rp.GetRichPresenceString().c_str());
+
+        memory[0] = 1;
+        Assert::AreEqual("One", rp.GetRichPresenceString().c_str());
+
+        memory[0] = 2; // no entry
+        Assert::AreEqual("Other", rp.GetRichPresenceString().c_str());
+    }
+        
+    TEST_METHOD(TestConditionalDisplaySharedLookup)
+    {
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        RA_RichPresenceInterpretter rp;
+        rp.ParseFromString("Lookup:Location\n0x00=Zero\n0x01=One\n\nDisplay:\n?0xH0001=18?At @Location(0xH0000)\nNear @Location(0xH0000)");
+
+        Assert::AreEqual("At Zero", rp.GetRichPresenceString().c_str());
+
+        memory[0] = 1;
+        Assert::AreEqual("At One", rp.GetRichPresenceString().c_str());
+
+        memory[1] = 17;
+        Assert::AreEqual("Near One", rp.GetRichPresenceString().c_str());
+
+        memory[0] = 0;
+        Assert::AreEqual("Near Zero", rp.GetRichPresenceString().c_str());
+    }
+    
+    TEST_METHOD(TestUndefinedTag)
+    {
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        RA_RichPresenceInterpretter rp;
+        rp.ParseFromString("Display:\n@Points(0x 0001) Points");
+
+        Assert::AreEqual(" Points", rp.GetRichPresenceString().c_str());
+    }
+};
+
+} // namespace tests
+} // namespace data
+} // namespace ra

--- a/tests/RA_RichPresence_Tests.cpp
+++ b/tests/RA_RichPresence_Tests.cpp
@@ -159,6 +159,20 @@ public:
         Assert::AreEqual("At ", rp.GetRichPresenceString().c_str());
     }
 
+    TEST_METHOD(TestLookupWhitespace)
+    {
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        RA_RichPresenceInterpretter rp;
+        rp.ParseFromString("Lookup:Location\n0= Zero \n1= One \n\nDisplay:\nAt '@Location(0xH0000)' ");
+
+        Assert::AreEqual("At ' Zero ' ", rp.GetRichPresenceString().c_str());
+
+        memory[0] = 1;
+        Assert::AreEqual("At ' One ' ", rp.GetRichPresenceString().c_str());
+    }
+
     TEST_METHOD(TestRandomText)
     {
         // anything that doesn't begin with "Format:" "Lookup:" or "Display:" is ignored. people sometimes
@@ -168,6 +182,24 @@ public:
 
         RA_RichPresenceInterpretter rp;
         rp.ParseFromString("Locations are fun!\nLookup:Location\n0=Zero\n1=One\n\nDisplay goes here\nDisplay:\nAt @Location(0xH0000)\n\nWritten by User3");
+
+        Assert::AreEqual("At Zero", rp.GetRichPresenceString().c_str());
+
+        memory[0] = 1;
+        Assert::AreEqual("At One", rp.GetRichPresenceString().c_str());
+
+        memory[0] = 2; // no entry
+        Assert::AreEqual("At ", rp.GetRichPresenceString().c_str());
+    }
+
+    TEST_METHOD(TestComments)
+    {
+        // double slash indicates the remaining portion of the line is a comment
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        RA_RichPresenceInterpretter rp;
+        rp.ParseFromString("// Locations are fun!\nLookup:Location // lookup\n0=Zero // 0\n1=One // 1\n\n//Display goes here\nDisplay: // display\nAt @Location(0xH0000) // text\n\n//Written by User3");
 
         Assert::AreEqual("At Zero", rp.GetRichPresenceString().c_str());
 


### PR DESCRIPTION
Moved reading/writing the `XXX-Rich.txt` file outside of the interpreter.

Added support for:
* default item in lookup map (#12)
* official comment format `//`
```
// This is an example Rich Presence script for Some Game written by User
Lookup:Level
1=Level 1-1
2=Level 1-2
*=Titles           // Anything that's not explicitly defined will display "Titles"

Display:
@Level(0x1234)
```