### PR TITLE
correctly display UTF-8 characters in popup messages

### DIFF
--- a/src/RA_AchievementPopup.cpp
+++ b/src/RA_AchievementPopup.cpp
@@ -143,8 +143,8 @@ void AchievementPopup::Render(HDC hDC, RECT& rcDest)
         //	meh
     }
 
-    const std::wstring sTitle = L" " + ra::Widen(ActiveMessage().Title()) + L" ";
-    const std::wstring sSubTitle = L" " + ra::Widen(ActiveMessage().Subtitle()) + L" ";
+    const std::wstring sTitle = L" " + ActiveMessage().Title() + L" ";
+    const std::wstring sSubTitle = L" " + ActiveMessage().Subtitle() + L" ";
 
     SelectObject(hDC, hFontTitle);
     TextOutW(hDC, nTitleX, nTitleY, sTitle.c_str(), sTitle.length());

--- a/src/RA_AchievementPopup.cpp
+++ b/src/RA_AchievementPopup.cpp
@@ -143,20 +143,20 @@ void AchievementPopup::Render(HDC hDC, RECT& rcDest)
         //	meh
     }
 
-    const std::string sTitle = std::string(" " + ActiveMessage().Title() + " ");
-    const std::string sSubTitle = std::string(" " + ActiveMessage().Subtitle() + " ");
+    const std::wstring sTitle = L" " + ra::Widen(ActiveMessage().Title()) + L" ";
+    const std::wstring sSubTitle = L" " + ra::Widen(ActiveMessage().Subtitle()) + L" ";
 
     SelectObject(hDC, hFontTitle);
-    TextOut(hDC, nTitleX, nTitleY, NativeStr(sTitle).c_str(), sTitle.length());
+    TextOutW(hDC, nTitleX, nTitleY, sTitle.c_str(), sTitle.length());
     SIZE szTitle = { 0, 0 };
-    GetTextExtentPoint32(hDC, NativeStr(sTitle).c_str(), sTitle.length(), &szTitle);
+    GetTextExtentPoint32W(hDC, sTitle.c_str(), sTitle.length(), &szTitle);
 
     SIZE szAchievement = { 0, 0 };
     if (ActiveMessage().Subtitle().length() > 0)
     {
         SelectObject(hDC, hFontDesc);
-        TextOut(hDC, nDescX, nDescY, NativeStr(sSubTitle).c_str(), sSubTitle.length());
-        GetTextExtentPoint32(hDC, NativeStr(sSubTitle).c_str(), sSubTitle.length(), &szAchievement);
+        TextOutW(hDC, nDescX, nDescY, sSubTitle.c_str(), sSubTitle.length());
+        GetTextExtentPoint32W(hDC, sSubTitle.c_str(), sSubTitle.length(), &szAchievement);
     }
 
     HGDIOBJ hPen = CreatePen(PS_SOLID, 2, COL_POPUP_SHADOW);

--- a/src/RA_AchievementPopup.h
+++ b/src/RA_AchievementPopup.h
@@ -23,21 +23,21 @@ class MessagePopup
 {
 public:
     MessagePopup(const std::string& sTitle, const std::string& sSubtitle, PopupMessageType nMsgType = PopupInfo, HBITMAP hImg = nullptr) :
-        m_sMessageTitle(sTitle),
-        m_sMessageSubtitle(sSubtitle),
+        m_sMessageTitle(ra::Widen(sTitle)),
+        m_sMessageSubtitle(ra::Widen(sSubtitle)),
         m_nMessageType(nMsgType),
         m_hMessageImage(hImg)
     {
     }
 public:
-    const std::string& Title() const { return m_sMessageTitle; }
-    const std::string& Subtitle() const { return m_sMessageSubtitle; }
+    const std::wstring& Title() const { return m_sMessageTitle; }
+    const std::wstring& Subtitle() const { return m_sMessageSubtitle; }
     PopupMessageType Type() const { return m_nMessageType; }
     HBITMAP Image() const { return m_hMessageImage; }
 
 private:
-    const std::string m_sMessageTitle;
-    const std::string m_sMessageSubtitle;
+    const std::wstring m_sMessageTitle;
+    const std::wstring m_sMessageSubtitle;
     const PopupMessageType m_nMessageType;
     const HBITMAP m_hMessageImage;
 };

--- a/src/RA_Defs.cpp
+++ b/src/RA_Defs.cpp
@@ -53,7 +53,7 @@ _Use_decl_annotations_ std::wstring Widen(std::string&& str) noexcept
 _Use_decl_annotations_ std::wstring Widen(const char* str)
 {
     auto len{ ra::to_signed(std::strlen(str)) };
-    auto needed{::MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, str, len + 1, nullptr, 0)};
+    auto needed{::MultiByteToWideChar(CP_UTF8, 0, str, len + 1, nullptr, 0)};
     // doesn't seem wchar_t is treated like a character type by default
     std::wstring wstr(ra::to_unsigned(needed), L'\x0'); 
     ::MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, str, len + 1, wstr.data(),

--- a/tests/RA_Defs_Tests.cpp
+++ b/tests/RA_Defs_Tests.cpp
@@ -39,6 +39,9 @@ public:
         Assert::AreEqual(std::wstring(L"\xD83C\xDF0F"), Widen(L"\xD83C\xDF0F"));
         Assert::AreEqual(std::wstring(L"\xD83C\xDF0F"), Widen(std::string("\xF0\x9F\x8C\x8F")));
         Assert::AreEqual(std::wstring(L"\xD83C\xDF0F"), Widen(std::wstring(L"\xD83C\xDF0F")));
+
+        // LATIN-1 - non-UTF-8 sequences converted to unicode placeholder character
+        Assert::AreEqual(std::wstring(L"D\xFFFDj\xFFFD vu"), Widen("D\xE9j\xE0 vu"));
     }
 };
 


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/32680403/43875742-e7a5bfe8-9b4e-11e8-842a-c4eb7ed67c7e.png)

After:
![image](https://user-images.githubusercontent.com/32680403/43875748-ecaddba6-9b4e-11e8-942a-10960fa9d04f.png)
