### PR TITLE
Use executable path as home directory

### DIFF
--- a/src/RA_AchievementOverlay.cpp
+++ b/src/RA_AchievementOverlay.cpp
@@ -1506,8 +1506,9 @@ void AchievementOverlay::InstallNewsArticlesFromFile()
 {
     m_LatestNews.clear();
 
+    std::string sNewsFile = g_sHomeDir + RA_NEWS_FILENAME;
     FILE* pf = nullptr;
-    fopen_s(&pf, RA_NEWS_FILENAME, "rb");
+    fopen_s(&pf, sNewsFile.c_str(), "rb");
     if (pf != nullptr)
     {
         Document doc;

--- a/src/RA_AchievementSet.cpp
+++ b/src/RA_AchievementSet.cpp
@@ -34,11 +34,11 @@ std::string AchievementSet::GetAchievementSetFilename(ra::GameID nGameID)
     switch (m_nSetType)
     {
         case Core:
-            return RA_DIR_DATA + std::to_string(nGameID) + ".txt";
+            return g_sHomeDir + RA_DIR_DATA + std::to_string(nGameID) + ".txt";
         case Unofficial:
-            return RA_DIR_DATA + std::to_string(nGameID) + ".txt";	// Same as Core
+            return g_sHomeDir + RA_DIR_DATA + std::to_string(nGameID) + ".txt";	// Same as Core
         case Local:
-            return RA_DIR_DATA + std::to_string(nGameID) + "-User.txt";
+            return g_sHomeDir + RA_DIR_DATA + std::to_string(nGameID) + "-User.txt";
         default:
             return "";
     }
@@ -398,9 +398,8 @@ BOOL AchievementSet::FetchFromWebBlocking(ra::GameID nGameID)
         doc.HasMember("PatchData"))
     {
         const Value& PatchData = doc["PatchData"];
-        SetCurrentDirectory(NativeStr(g_sHomeDir).c_str());
         FILE* pf = nullptr;
-        fopen_s(&pf, std::string(RA_DIR_DATA + std::to_string(nGameID) + ".txt").c_str(), "wb");
+        fopen_s(&pf, std::string(g_sHomeDir + RA_DIR_DATA + std::to_string(nGameID) + ".txt").c_str(), "wb");
         if (pf != nullptr)
         {
             FileStream fs(pf);
@@ -438,7 +437,6 @@ BOOL AchievementSet::LoadFromFile(ra::GameID nGameID)
 
     const std::string sFilename = GetAchievementSetFilename(nGameID);
 
-    SetCurrentDirectory(NativeStr(g_sHomeDir).c_str());
     FILE* pFile = nullptr;
     errno_t nErr = fopen_s(&pFile, sFilename.c_str(), "r");
     if (pFile != nullptr)
@@ -504,8 +502,7 @@ BOOL AchievementSet::LoadFromFile(ra::GameID nGameID)
                 ra::GameID nGameID = g_pCurrentGameData->GetGameID();
 
                 //	Rich Presence
-                SetCurrentDirectory(NativeStr(g_sHomeDir).c_str());
-                _WriteBufferToFile(RA_DIR_DATA + std::to_string(nGameID) + "-Rich.txt", g_pCurrentGameData->RichPresencePatch());
+                _WriteBufferToFile(g_sHomeDir + RA_DIR_DATA + std::to_string(nGameID) + "-Rich.txt", g_pCurrentGameData->RichPresencePatch());
                 g_RichPresenceInterpreter.ParseFromString(g_pCurrentGameData->RichPresencePatch().c_str());
 
                 const Value& AchievementsData = doc["Achievements"];
@@ -606,7 +603,6 @@ void AchievementSet::SaveProgress(const char* sSaveStateFilename)
     if (sSaveStateFilename == nullptr)
         return;
 
-    SetCurrentDirectory(NativeStr(g_sHomeDir).c_str());
     char buffer[4096];
     sprintf_s(buffer, 4096, "%s.rap", sSaveStateFilename);
     FILE* pf = nullptr;
@@ -688,7 +684,7 @@ void AchievementSet::LoadProgress(const char* sLoadStateFilename)
     if (sLoadStateFilename == nullptr)
         return;
 
-    sprintf_s(buffer, 4096, "%s%s.rap", RA_DIR_DATA, sLoadStateFilename);
+    sprintf_s(buffer, 4096, "%s%s%s.rap", g_sHomeDir.c_str(), RA_DIR_DATA, sLoadStateFilename);
 
     char* pRawFile = _MallocAndBulkReadFileToBuffer(buffer, nFileSize);
 

--- a/src/RA_CodeNotes.cpp
+++ b/src/RA_CodeNotes.cpp
@@ -16,7 +16,6 @@ size_t CodeNotes::Load(const std::string& sFile)
 {
     Clear();
 
-    SetCurrentDirectory(NativeStr(g_sHomeDir).c_str());
     FILE* pf = nullptr;
     if (fopen_s(&pf, sFile.c_str(), "rb") == 0)
     {
@@ -74,8 +73,7 @@ void CodeNotes::OnCodeNotesResponse(Document& doc)
     //	Persist then reload
     const ra::GameID nGameID = doc["GameID"].GetUint();
 
-    SetCurrentDirectory(NativeStr(g_sHomeDir).c_str());
-    _WriteBufferToFile(std::string(RA_DIR_DATA) + std::to_string(nGameID) + "-Notes2.txt", doc);
+    _WriteBufferToFile(g_sHomeDir + std::string(RA_DIR_DATA) + std::to_string(nGameID) + "-Notes2.txt", doc);
 
     g_MemoryDialog.RepopulateMemNotesFromFile();
 }

--- a/src/RA_Core.cpp
+++ b/src/RA_Core.cpp
@@ -111,26 +111,35 @@ API const char* CCONV _RA_HostName()
     return sHostName.c_str();
 }
 
+static void EnsureDirectoryExists(const std::string& sDirectory)
+{
+    if (DirectoryExists(sDirectory.c_str()) == FALSE)
+        _mkdir(sDirectory.c_str());
+}
+
 static void InitCommon(HWND hMainHWND, /*enum EmulatorID*/int nEmulatorID, const char* sClientVer)
 {
+    // determine the home directory from the executable's path
+    TCHAR sBuffer[MAX_PATH];
+    GetModuleFileName(0, sBuffer, MAX_PATH);
+    PathRemoveFileSpec(sBuffer);
+    g_sHomeDir = ra::Narrow(sBuffer);
+    if (g_sHomeDir.back() != '\\')
+        g_sHomeDir.push_back('\\');
+
+    RA_LOG(__FUNCTION__ " - storing \"%s\" as home dir\n", g_sHomeDir.c_str());
+
     //	Ensure all required directories are created:
-    if (DirectoryExists(RA_DIR_BASE) == FALSE)
-        _mkdir(RA_DIR_BASE);
-    if (DirectoryExists(RA_DIR_BADGE) == FALSE)
-        _mkdir(RA_DIR_BADGE);
-    if (DirectoryExists(RA_DIR_DATA) == FALSE)
-        _mkdir(RA_DIR_DATA);
-    if (DirectoryExists(RA_DIR_USERPIC) == FALSE)
-        _mkdir(RA_DIR_USERPIC);
-    if (DirectoryExists(RA_DIR_OVERLAY) == FALSE)	//	It should already, really...
-        _mkdir(RA_DIR_OVERLAY);
-    if (DirectoryExists(RA_DIR_BOOKMARKS) == FALSE)
-        _mkdir(RA_DIR_BOOKMARKS);
+    EnsureDirectoryExists(g_sHomeDir + RA_DIR_BASE);
+    EnsureDirectoryExists(g_sHomeDir + RA_DIR_BADGE);
+    EnsureDirectoryExists(g_sHomeDir + RA_DIR_DATA);
+    EnsureDirectoryExists(g_sHomeDir + RA_DIR_USERPIC);
+    EnsureDirectoryExists(g_sHomeDir + RA_DIR_OVERLAY);
+    EnsureDirectoryExists(g_sHomeDir + RA_DIR_BOOKMARKS);
 
-
+    // initialize global state
     g_EmulatorID = static_cast<EmulatorID>(nEmulatorID);
     g_RAMainWnd = hMainHWND;
-    //g_hThisDLLInst
 
     RA_LOG(__FUNCTION__ " Init called! ID: %d, ClientVer: %s\n", nEmulatorID, sClientVer);
 
@@ -213,13 +222,6 @@ static void InitCommon(HWND hMainHWND, /*enum EmulatorID*/int nEmulatorID, const
         RA_LOG("(found as: %s)\n", g_sClientName);
     }
 
-    TCHAR buffer[2048];
-    GetCurrentDirectory(2048, buffer);
-    g_sHomeDir = ra::Narrow(buffer);
-    g_sHomeDir.append("\\");
-
-    RA_LOG(__FUNCTION__ " - storing \"%s\" as home dir\n", g_sHomeDir.c_str());
-
     g_sROMDirLocation[0] = '\0';
 
     _RA_LoadPreferences();
@@ -242,10 +244,6 @@ static void InitCommon(HWND hMainHWND, /*enum EmulatorID*/int nEmulatorID, const
     //	Image rendering: Setup image factory and overlay
     ra::services::g_ImageRepository.Initialize();
     g_AchievementOverlay.Initialize(g_hThisDLLInst);
-
-    //////////////////////////////////////////////////////////////////////////
-    //	Setup min required directories:
-    SetCurrentDirectory(NativeStr(g_sHomeDir).c_str());
 }
 
 API BOOL CCONV _RA_InitOffline(HWND hMainHWND, /*enum EmulatorID*/int nEmulatorID, const char* sClientVer)
@@ -547,7 +545,6 @@ static bool RA_OfferNewRAUpdate(const char* sNewVer)
 
     if (MessageBox(g_RAMainWnd, NativeStr(oss.str()).c_str(), TEXT("Update available!"), MB_YESNO | MB_ICONINFORMATION) == IDYES)
     {
-        //SetCurrentDirectory( g_sHomeDir );
         //FetchBinaryFromWeb( g_sClientEXEName );
         //
         //char sBatchUpdater[2048];
@@ -621,9 +618,8 @@ API int CCONV _RA_HandleHTTPResults()
 
                 case RequestBadge:
                 {
-                    SetCurrentDirectory(NativeStr(g_sHomeDir).c_str());
                     const std::string& sBadgeURI = pObj->GetData();
-                    _WriteBufferToFile(RA_DIR_BADGE + sBadgeURI + ".png", pObj->GetResponse());
+                    _WriteBufferToFile(g_sHomeDir + RA_DIR_BADGE + sBadgeURI + ".png", pObj->GetResponse());
 
                     /* This block seems unnecessary. --GD
                     for( size_t i = 0; i < g_pActiveAchievements->NumAchievements(); ++i )
@@ -648,7 +644,7 @@ API int CCONV _RA_HandleHTTPResults()
                 case RequestUserPic:
                 {
                     const std::string& sUsername = pObj->GetData();
-                    _WriteBufferToFile(RA_DIR_USERPIC + sUsername + ".png", pObj->GetResponse());
+                    _WriteBufferToFile(g_sHomeDir + RA_DIR_USERPIC + sUsername + ".png", pObj->GetResponse());
                     break;
                 }
 
@@ -761,8 +757,7 @@ API int CCONV _RA_HandleHTTPResults()
                 break;
 
                 case RequestNews:
-                    SetCurrentDirectory(NativeStr(g_sHomeDir).c_str());
-                    _WriteBufferToFile(RA_NEWS_FILENAME, doc);
+                    _WriteBufferToFile(g_sHomeDir + RA_NEWS_FILENAME, doc);
                     g_AchievementOverlay.InstallNewsArticlesFromFile();
                     break;
 
@@ -926,9 +921,9 @@ API void CCONV _RA_LoadPreferences()
 {
     RA_LOG(__FUNCTION__ " - loading preferences...\n");
 
-    SetCurrentDirectory(NativeStr(g_sHomeDir).c_str());
+    std::string sPreferencesFile = g_sHomeDir + RA_PREFERENCES_FILENAME_PREFIX + g_sClientName + ".cfg";
     FILE* pf = nullptr;
-    fopen_s(&pf, std::string(std::string(RA_PREFERENCES_FILENAME_PREFIX) + g_sClientName + ".cfg").c_str(), "rb");
+    fopen_s(&pf, sPreferencesFile.c_str(), "rb");
     if (pf == nullptr)
     {
         //	Test for first-time use:
@@ -1048,9 +1043,9 @@ API void CCONV _RA_SavePreferences()
         return;
     }
 
-    SetCurrentDirectory(NativeStr(g_sHomeDir).c_str());
+    std::string sPreferencesFile = g_sHomeDir + RA_PREFERENCES_FILENAME_PREFIX + g_sClientName + ".cfg";
     FILE* pf = nullptr;
-    fopen_s(&pf, std::string(std::string(RA_PREFERENCES_FILENAME_PREFIX) + g_sClientName + ".cfg").c_str(), "wb");
+    fopen_s(&pf, sPreferencesFile.c_str(), "wb");
     if (pf != nullptr)
     {
         FileStream fs(pf);
@@ -1107,7 +1102,7 @@ void _FetchGameHashLibraryFromWeb()
     args['t'] = RAUsers::LocalUser().Token();
     std::string Response;
     if (RAWeb::DoBlockingRequest(RequestHashLibrary, args, Response))
-        _WriteBufferToFile(RA_GAME_HASH_FILENAME, Response);
+        _WriteBufferToFile(g_sHomeDir + RA_GAME_HASH_FILENAME, Response);
 }
 
 void _FetchGameTitlesFromWeb()
@@ -1118,7 +1113,7 @@ void _FetchGameTitlesFromWeb()
     args['t'] = RAUsers::LocalUser().Token();
     std::string Response;
     if (RAWeb::DoBlockingRequest(RequestGamesList, args, Response))
-        _WriteBufferToFile(RA_GAME_LIST_FILENAME, Response);
+        _WriteBufferToFile(g_sHomeDir + RA_GAME_LIST_FILENAME, Response);
 }
 
 void _FetchMyProgressFromWeb()
@@ -1129,7 +1124,7 @@ void _FetchMyProgressFromWeb()
     args['t'] = RAUsers::LocalUser().Token();
     std::string Response;
     if (RAWeb::DoBlockingRequest(RequestAllProgress, args, Response))
-        _WriteBufferToFile(RA_MY_PROGRESS_FILENAME, Response);
+        _WriteBufferToFile(g_sHomeDir + RA_MY_PROGRESS_FILENAME, Response);
 }
 
 void RestoreWindowPosition(HWND hDlg, const char* sDlgKey, bool bToRight, bool bToBottom)
@@ -1584,7 +1579,6 @@ void _ReadStringTil(std::string& value, char nChar, const char*& pSource)
 
 void _WriteBufferToFile(const std::string& sFileName, const Document& doc)
 {
-    SetCurrentDirectory(NativeStr(g_sHomeDir).c_str());
     FILE* pf = nullptr;
     if (fopen_s(&pf, sFileName.c_str(), "wb") == 0)
     {
@@ -1597,8 +1591,6 @@ void _WriteBufferToFile(const std::string& sFileName, const Document& doc)
 
 void _WriteBufferToFile(const std::string& sFileName, const std::string& raw)
 {
-    SetCurrentDirectory(NativeStr(g_sHomeDir).c_str());
-
     using FileH = std::unique_ptr<FILE, decltype(&std::fclose)>;
 #pragma warning(push)
 #pragma warning(disable : 4996) // Deprecation from Microsoft
@@ -1606,21 +1598,6 @@ void _WriteBufferToFile(const std::string& sFileName, const std::string& raw)
 #pragma warning(pop)
 
     std::fwrite(static_cast<const void*>(raw.c_str()), sizeof(char), raw.length(), myFile.get());
-}
-
-
-void _WriteBufferToFile(const char* sFile, std::streamsize nBytes)
-{
-    SetCurrentDirectory(NativeStr(g_sHomeDir).c_str());
-
-    using FileH = std::unique_ptr<FILE, decltype(&std::fclose)>;
-#pragma warning(push)
-#pragma warning(disable : 4996) // Deprecation from Microsoft
-    FileH myFile{ std::fopen(sFile, "wb"), std::fclose };
-#pragma warning(pop)
-    
-    auto sBuffer{ std::make_unique<char[]>(static_cast<size_t>(ra::to_unsigned(nBytes))) };
-    std::fwrite(static_cast<void* const>(sBuffer.get()), sizeof(char), std::strlen(sBuffer.get()), myFile.get());
 }
 
 bool _ReadBufferFromFile(_Out_ std::string& buffer, const char* sFile)
@@ -1640,7 +1617,6 @@ bool _ReadBufferFromFile(_Out_ std::string& buffer, const char* sFile)
 
 char* _MallocAndBulkReadFileToBuffer(const char* sFilename, long& nFileSizeOut)
 {
-    SetCurrentDirectory(NativeStr(g_sHomeDir).c_str());
     FILE* pf = nullptr;
     fopen_s(&pf, sFilename, "r");
     if (pf == nullptr)
@@ -1723,8 +1699,6 @@ std::string GetFolderFromDialog()
 
 BOOL RemoveFileIfExists(const std::string& sFilePath)
 {
-    SetCurrentDirectory(NativeStr(g_sHomeDir).c_str());
-
     if (_access(sFilePath.c_str(), 06) != -1)	//	06= Read/write permission
     {
         if (remove(sFilePath.c_str()) == -1)

--- a/src/RA_Core.cpp
+++ b/src/RA_Core.cpp
@@ -1381,7 +1381,7 @@ API void CCONV _RA_InvokeDialog(LPARAM nID)
         case IDM_RA_PARSERICHPRESENCE:
         {
             char sRichPresenceFile[1024];
-            sprintf_s(sRichPresenceFile, 1024, "%s%u-Rich.txt", RA_DIR_DATA, g_pCurrentGameData->GetGameID());
+            sprintf_s(sRichPresenceFile, 1024, "%s%s%u-Rich.txt", g_sHomeDir.c_str(), RA_DIR_DATA, g_pCurrentGameData->GetGameID());
 
             std::string sRichPresence;
             bool bRichPresenceExists = _ReadBufferFromFile(sRichPresence, sRichPresenceFile);

--- a/src/RA_Core.h
+++ b/src/RA_Core.h
@@ -136,7 +136,6 @@ extern void  _ReadStringTil(std::string& sValue, char nChar, const char*& pOffse
 //	Write out the buffer to a file
 extern void _WriteBufferToFile(const std::string& sFileName, const std::string& sString);
 extern void _WriteBufferToFile(const std::string& sFileName, const Document& doc);
-extern void _WriteBufferToFile(const char* sFile, std::streamsize nBytes);
 
 //	Fetch various interim txt/data files
 extern void _FetchGameHashLibraryFromWeb();

--- a/src/RA_Defs.cpp
+++ b/src/RA_Defs.cpp
@@ -96,18 +96,23 @@ _Use_decl_annotations_ std::string Narrow(const std::string& str)
 
 } // namespace ra
 
+#ifndef RA_UTEST
+extern std::string g_sHomeDir;
+#endif
 
 void RADebugLogNoFormat(const char* data)
 {
     OutputDebugString(NativeStr(data).c_str());
 
-    //SetCurrentDirectory( g_sHomeDir.c_str() );//?
+#ifndef RA_UTEST
+    std::string sLogFile = g_sHomeDir + RA_LOG_FILENAME;
     FILE* pf = nullptr;
-    if (fopen_s(&pf, RA_LOG_FILENAME, "a") == 0)
+    if (fopen_s(&pf, sLogFile.c_str(), "a") == 0)
     {
         fwrite(data, sizeof(char), strlen(data), pf);
         fclose(pf);
     }
+#endif
 }
 
 void RADebugLog(const char* format, ...)
@@ -129,15 +134,7 @@ void RADebugLog(const char* format, ...)
     *p++ = '\n';
     *p = '\0';
 
-    OutputDebugString(NativeStr(buf).c_str());
-
-    //SetCurrentDirectory( g_sHomeDir.c_str() );//?
-    FILE* pf = nullptr;
-    if (fopen_s(&pf, RA_LOG_FILENAME, "a") == 0)
-    {
-        fwrite(buf, sizeof(char), strlen(buf), pf);
-        fclose(pf);
-    }
+    RADebugLogNoFormat(buf);
 }
 
 BOOL DirectoryExists(const char* sPath)

--- a/src/RA_Defs.h
+++ b/src/RA_Defs.h
@@ -140,8 +140,8 @@ using namespace std::string_literals;
 #define RA_KEYS_DLL						"RA_Keys.dll"
 #define RA_PREFERENCES_FILENAME_PREFIX	"RAPrefs_"
 
-#define RA_DIR_OVERLAY					".\\Overlay\\"
-#define RA_DIR_BASE						".\\RACache\\"
+#define RA_DIR_OVERLAY					"Overlay\\"
+#define RA_DIR_BASE						"RACache\\"
 #define RA_DIR_DATA						RA_DIR_BASE##"Data\\"
 #define RA_DIR_BADGE					RA_DIR_BASE##"Badge\\"
 #define RA_DIR_USERPIC					RA_DIR_BASE##"UserPic\\"

--- a/src/RA_Dlg_AchEditor.cpp
+++ b/src/RA_Dlg_AchEditor.cpp
@@ -1398,8 +1398,6 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
 
                 case IDC_RA_UPLOAD_BADGE:
                 {
-                    SetCurrentDirectory(TEXT("\\"));
-
                     const int BUF_SIZE = 1024;
                     TCHAR buffer[BUF_SIZE];
                     ZeroMemory(buffer, BUF_SIZE);

--- a/src/RA_Dlg_GameLibrary.cpp
+++ b/src/RA_Dlg_GameLibrary.cpp
@@ -91,9 +91,9 @@ Dlg_GameLibrary::~Dlg_GameLibrary()
 
 void ParseGameHashLibraryFromFile(std::map<std::string, ra::GameID>& GameHashLibraryOut)
 {
-    SetCurrentDirectory(NativeStr(g_sHomeDir).c_str());
+    std::string sGameHashFile = g_sHomeDir + RA_GAME_HASH_FILENAME;
     FILE* pf = nullptr;
-    fopen_s(&pf, RA_GAME_HASH_FILENAME, "rb");
+    fopen_s(&pf, sGameHashFile.c_str(), "rb");
     if (pf != nullptr)
     {
         Document doc;
@@ -120,9 +120,9 @@ void ParseGameHashLibraryFromFile(std::map<std::string, ra::GameID>& GameHashLib
 
 void ParseGameTitlesFromFile(std::map<ra::GameID, std::string>& GameTitlesListOut)
 {
-    SetCurrentDirectory(NativeStr(g_sHomeDir).c_str());
+    std::string sTitlesFile = g_sHomeDir + RA_TITLES_FILENAME;
     FILE* pf = nullptr;
-    fopen_s(&pf, RA_TITLES_FILENAME, "rb");
+    fopen_s(&pf, sTitlesFile.c_str(), "rb");
     if (pf != nullptr)
     {
         Document doc;
@@ -148,8 +148,9 @@ void ParseGameTitlesFromFile(std::map<ra::GameID, std::string>& GameTitlesListOu
 
 void ParseMyProgressFromFile(std::map<ra::GameID, std::string>& GameProgressOut)
 {
+    std::string sProgressFile = g_sHomeDir + RA_TITLES_FILENAME;
     FILE* pf = nullptr;
-    fopen_s(&pf, RA_MY_PROGRESS_FILENAME, "rb");
+    fopen_s(&pf, sProgressFile.c_str(), "rb");
     if (pf != nullptr)
     {
         Document doc;
@@ -468,9 +469,11 @@ BOOL Dlg_GameLibrary::LaunchSelected()
 
 void Dlg_GameLibrary::LoadAll()
 {
+    std::string sMyGameLibraryFile = g_sHomeDir + RA_MY_GAME_LIBRARY_FILENAME;
+    
     mtx.lock();
     FILE* pLoadIn = nullptr;
-    fopen_s(&pLoadIn, RA_MY_GAME_LIBRARY_FILENAME, "rb");
+    fopen_s(&pLoadIn, sMyGameLibraryFile.c_str(), "rb");
     if (pLoadIn != nullptr)
     {
         DWORD nCharsRead1 = 0;
@@ -510,9 +513,11 @@ void Dlg_GameLibrary::LoadAll()
 
 void Dlg_GameLibrary::SaveAll()
 {
+    std::string sMyGameLibraryFile = g_sHomeDir + RA_MY_GAME_LIBRARY_FILENAME;
+
     mtx.lock();
     FILE* pf = nullptr;
-    fopen_s(&pf, RA_MY_GAME_LIBRARY_FILENAME, "wb");
+    fopen_s(&pf, sMyGameLibraryFile.c_str(), "wb");
     if (pf != nullptr)
     {
         std::map<std::string, std::string>::iterator iter = Results.begin();

--- a/src/RA_Dlg_MemBookmark.cpp
+++ b/src/RA_Dlg_MemBookmark.cpp
@@ -699,9 +699,7 @@ void Dlg_MemBookmark::ExportJSON()
         return;
     }
 
-    std::string defaultDir = RA_DIR_BOOKMARKS;
-    defaultDir.erase(0, 2); // Removes the characters (".\\")
-    defaultDir = g_sHomeDir + defaultDir;
+    std::string defaultDir = g_sHomeDir + RA_DIR_BOOKMARKS;
 
     CComPtr<IFileSaveDialog> pDlg;
 

--- a/src/RA_Dlg_Memory.cpp
+++ b/src/RA_Dlg_Memory.cpp
@@ -1447,8 +1447,7 @@ void Dlg_Memory::RepopulateMemNotesFromFile()
     ra::GameID nGameID = g_pCurrentGameData->GetGameID();
     if (nGameID != 0)
     {
-        char sNotesFilename[1024];
-        sprintf_s(sNotesFilename, 1024, "%s%u-Notes2.txt", RA_DIR_DATA, nGameID);
+        std::string sNotesFilename = g_sHomeDir + RA_DIR_DATA + std::to_string(nGameID) + "-Notes2.txt";
         nSize = m_CodeNotes.Load(sNotesFilename);
     }
 


### PR DESCRIPTION
* Changes the home directory from the "startup directory" to the startup executable's directory.
* Eliminates all calls to SetCurrentDirectory and replaces relative paths with absolute paths.

Additionally adds similar logic to the LoadLibrary/download functionality for the emulators. Emulators will have to be rebuilt to pick up that functionality. 

Have tested using the "Windows Search" functionality described in #79. Requires updated emulator and DLL, but these changes seem to make the application functional whereas I couldn't load a game with the prior code. Hopefully these changes address the other issues original reported as I was not able to recreate them.