### PR TITLE
move disable hardcore warning into DLL

### DIFF
--- a/src/RA_Core.cpp
+++ b/src/RA_Core.cpp
@@ -388,6 +388,52 @@ API int CCONV _RA_HardcoreModeIsActive()
     return g_bHardcoreModeActive;
 }
 
+static void DisableHardcoreMode()
+{
+    g_bHardcoreModeActive = false;
+    _RA_RebuildMenu();
+
+    g_LeaderboardManager.Reset();
+    g_PopupWindows.LeaderboardPopups().Reset();
+}
+
+API bool CCONV _RA_WarnDisableHardcore(const char* sActivity)
+{
+    // already disabled, just return success
+    if (!g_bHardcoreModeActive)
+        return true;
+
+    // prompt. if user doesn't consent, return failure - caller should not continue
+    std::string sMessage;
+    sMessage = "You cannot " + std::string(sActivity) + " while Hardcore mode is active.\nDisable Hardcore mode?";
+    if (MessageBoxA(nullptr, sMessage.c_str(), "Warning", MB_YESNO | MB_ICONWARNING) != IDYES)
+        return false;
+
+    // user consented, switch to non-hardcore mode
+    DisableHardcoreMode();
+
+    // return success
+    return true;
+}
+
+static void DownloadAndActivateAchievementData(ra::GameID nGameID)
+{
+    // delete Core and Unofficial Achievements so they are redownloaded
+    g_pCoreAchievements->DeletePatchFile(nGameID);
+    g_pUnofficialAchievements->DeletePatchFile(nGameID);
+
+    g_pCoreAchievements->Clear();
+    g_pUnofficialAchievements->Clear();
+    g_pLocalAchievements->Clear();
+
+    // fetch remotely then load from file
+    AchievementSet::FetchFromWebBlocking(nGameID);
+
+    g_pCoreAchievements->LoadFromFile(nGameID);
+    g_pUnofficialAchievements->LoadFromFile(nGameID);
+    g_pLocalAchievements->LoadFromFile(nGameID);
+}
+
 API int CCONV _RA_OnLoadNewRom(const BYTE* pROM, unsigned int nROMSize)
 {
     static std::string sMD5NULL = RAGenerateMD5(nullptr, 0);
@@ -447,19 +493,7 @@ API int CCONV _RA_OnLoadNewRom(const BYTE* pROM, unsigned int nROMSize)
     {
         if (RAUsers::LocalUser().IsLoggedIn())
         {
-            //	Delete Core and Unofficial Achievements so they are redownloaded every time:
-            g_pCoreAchievements->Clear();
-            g_pUnofficialAchievements->Clear();
-            g_pLocalAchievements->Clear();
-
-            g_pCoreAchievements->DeletePatchFile(nGameID);
-            g_pUnofficialAchievements->DeletePatchFile(nGameID);
-
-            AchievementSet::FetchFromWebBlocking(nGameID);
-
-            g_pCoreAchievements->LoadFromFile(nGameID);
-            g_pUnofficialAchievements->LoadFromFile(nGameID);
-            g_pLocalAchievements->LoadFromFile(nGameID);
+            DownloadAndActivateAchievementData(nGameID);
 
             RAUsers::LocalUser().PostActivity(PlayerStartedPlaying);
         }
@@ -1283,32 +1317,32 @@ API void CCONV _RA_InvokeDialog(LPARAM nID)
 
         case IDM_RA_HARDCORE_MODE:
         {
-            g_bHardcoreModeActive = !g_bHardcoreModeActive;
-            _RA_ResetEmulation();
-            _RA_OnReset();
-
-            g_PopupWindows.Clear();
-
-            ra::GameID nGameID = g_pCurrentGameData->GetGameID();
-            if (nGameID != 0)
+            if (g_bHardcoreModeActive)
             {
-                //	Delete Core and Unofficial Achievements so it is redownloaded every time:
-                g_pCoreAchievements->DeletePatchFile(nGameID);
-                g_pUnofficialAchievements->DeletePatchFile(nGameID);
+                DisableHardcoreMode();
+            }
+            else
+            {
+                ra::GameID nGameID = g_pCurrentGameData->GetGameID();
+                if (nGameID != 0)
+                {
+                    if (MessageBox(g_RAMainWnd, TEXT("Enabling Hardcore mode will reset the emulator. You will lose any progress that has not been saved through the game. Continue?"), TEXT("Warning"), MB_YESNO | MB_ICONWARNING) == IDNO)
+                        break;
+                }
 
-                g_pCoreAchievements->Clear();
-                g_pUnofficialAchievements->Clear();
-                g_pLocalAchievements->Clear();
+                g_bHardcoreModeActive = true;
+                _RA_RebuildMenu();
 
-                //	Fetch remotely then load again from file
-                AchievementSet::FetchFromWebBlocking(nGameID);
+                // when enabling hardcore mode, force a system reset
+                _RA_ResetEmulation();
+                _RA_OnReset();
 
-                g_pCoreAchievements->LoadFromFile(nGameID);
-                g_pUnofficialAchievements->LoadFromFile(nGameID);
-                g_pLocalAchievements->LoadFromFile(nGameID);
+                // if a game was loaded, redownload the associated data
+                if (nGameID != 0)
+                    DownloadAndActivateAchievementData(nGameID);
             }
 
-            _RA_RebuildMenu();
+            g_PopupWindows.Clear();
         }
         break;
 
@@ -1482,9 +1516,7 @@ API void CCONV _RA_OnLoadState(const char* sFilename)
         if (g_bHardcoreModeActive)
         {
             MessageBox(nullptr, TEXT("Savestates are not allowed during Hardcore Mode!"), TEXT("Warning!"), MB_OK | MB_ICONEXCLAMATION);
-            g_bHardcoreModeActive = false;
-            RA_RebuildMenu();
-            RA_ResetEmulation();
+            DisableHardcoreMode();
         }
 
         g_pCoreAchievements->LoadProgress(sFilename);

--- a/src/RA_Core.cpp
+++ b/src/RA_Core.cpp
@@ -1491,16 +1491,8 @@ API void CCONV _RA_AttemptLogin(bool bBlocking)
 
 API void CCONV _RA_OnSaveState(const char* sFilename)
 {
-    //	Save State is being allowed by app (user was warned!)
     if (RAUsers::LocalUser().IsLoggedIn())
     {
-        if (g_bHardcoreModeActive)
-        {
-            g_bHardcoreModeActive = false;
-            RA_RebuildMenu();
-            //RA_ResetEmulation();
-        }
-
         if (!g_bRAMTamperedWith)
         {
             g_pCoreAchievements->SaveProgress(sFilename);
@@ -1515,7 +1507,7 @@ API void CCONV _RA_OnLoadState(const char* sFilename)
     {
         if (g_bHardcoreModeActive)
         {
-            MessageBox(nullptr, TEXT("Savestates are not allowed during Hardcore Mode!"), TEXT("Warning!"), MB_OK | MB_ICONEXCLAMATION);
+            MessageBox(nullptr, TEXT("Loading save states is not allowed in Hardcore mode. Disabling Hardcore mode."), TEXT("Warning!"), MB_OK | MB_ICONEXCLAMATION);
             DisableHardcoreMode();
         }
 

--- a/src/RA_Core.h
+++ b/src/RA_Core.h
@@ -89,6 +89,11 @@ extern "C" {
     //	Return whether or not the hardcore mode is active.
     API int CCONV _RA_HardcoreModeIsActive();
 
+    //  Should be called before performing an activity that is not allowed in hardcore mode to
+    //  give the user a chance to disable hardcore mode and continue with the activity.
+    //  Returns TRUE if hardcore was disabled, or FALSE to cancel the activity.
+    API bool CCONV _RA_WarnDisableHardcore(const char* sActivity);
+
     //	Install user-side functions that can be called from the DLL
     API void CCONV _RA_InstallSharedFunctions(bool(*fpIsActive)(void), void(*fpCauseUnpause)(void), void(*fpRebuildMenu)(void), void(*fpEstimateTitle)(char*), void(*fpResetEmulation)(void), void(*fpLoadROM)(const char*));
     API void CCONV _RA_InstallSharedFunctionsExt(bool(*fpIsActive)(void), void(*fpCauseUnpause)(void), void(*fpCausePause)(void), void(*fpRebuildMenu)(void), void(*fpEstimateTitle)(char*), void(*fpResetEmulation)(void), void(*fpLoadROM)(const char*));

--- a/src/RA_Interface.cpp
+++ b/src/RA_Interface.cpp
@@ -94,6 +94,7 @@ void    (CCONV *_RA_InvokeDialog)(LPARAM nID) = nullptr;
 void    (CCONV *_RA_InstallSharedFunctions)(bool(*)(), void(*)(), void(*)(), void(*)(), void(*)(char*), void(*)(), void(*)(const char*)) = nullptr;
 int     (CCONV *_RA_SetConsoleID)(unsigned int nConsoleID) = nullptr;
 int     (CCONV *_RA_HardcoreModeIsActive)(void) = nullptr;
+bool    (CCONV *_RA_WarnDisableHardcore)(const char* sActivity) = nullptr;
 //  Overlay:
 int     (CCONV *_RA_UpdateOverlay)(ControllerInput* pInput, float fDeltaTime, bool Full_Screen, bool Paused) = nullptr;
 int     (CCONV *_RA_UpdatePopups)(ControllerInput* pInput, float fDeltaTime, bool Full_Screen, bool Paused) = nullptr;
@@ -220,6 +221,23 @@ void RA_SetConsoleID(unsigned int nConsoleID)
 int RA_HardcoreModeIsActive()
 {
     return (_RA_HardcoreModeIsActive != nullptr) ? _RA_HardcoreModeIsActive() : 0;
+}
+
+bool RA_WarnDisableHardcore(const char* sActivity)
+{
+    // If Hardcore mode not active, allow the activity.
+    if (!RA_HardcoreModeIsActive())
+        return true;
+
+    // DLL function will display a yes/no dialog. If the user chooses yes, the DLL will disable hardcore mode, and the activity can proceed.
+    if (_RA_WarnDisableHardcore != nullptr)
+        return _RA_WarnDisableHardcore(sActivity);
+
+    // We cannot disable hardcore mode, so just warn the user and prevent the activity.
+    std::string sMessage;
+    sMessage = "You cannot " + std::string(sActivity) + " while Hardcore mode is active.";
+    MessageBoxA(nullptr, sMessage.c_str(), "Warning", MB_OK | MB_ICONWARNING);
+    return false;
 }
 
 static BOOL DoBlockingHttpGet(const char* sHostName, const char* sRequestedPage, char* pBufferOut, unsigned int nBufferOutSize, DWORD* pBytesRead, DWORD* pStatusCode)
@@ -417,7 +435,7 @@ static const char* CCONV _RA_InstallIntegration()
     _RA_DoAchievementsFrame = (void(CCONV *)())                                       GetProcAddress(g_hRADLL, "_RA_DoAchievementsFrame");
     _RA_SetConsoleID = (int(CCONV *)(unsigned int))                                   GetProcAddress(g_hRADLL, "_RA_SetConsoleID");
     _RA_HardcoreModeIsActive = (int(CCONV *)())                                       GetProcAddress(g_hRADLL, "_RA_HardcoreModeIsActive");
-
+    _RA_WarnDisableHardcore = (bool(CCONV *)(const char*))                            GetProcAddress(g_hRADLL, "_RA_WarnDisableHardcore");
     _RA_InstallSharedFunctions = (void(CCONV *)(bool(*)(), void(*)(), void(*)(), void(*)(), void(*)(char*), void(*)(), void(*)(const char*))) GetProcAddress(g_hRADLL, "_RA_InstallSharedFunctionsExt");
 
     return _RA_IntegrationVersion ? _RA_IntegrationVersion() : "0.000";
@@ -567,6 +585,7 @@ void RA_Shutdown()
     _RA_LoadROM = nullptr;
     _RA_SetConsoleID = nullptr;
     _RA_HardcoreModeIsActive = nullptr;
+    _RA_WarnDisableHardcore = nullptr;
     _RA_AttemptLogin = nullptr;
 
     //	Uninstall DLL

--- a/src/RA_Interface.h
+++ b/src/RA_Interface.h
@@ -183,6 +183,11 @@ extern void RA_SetPaused(bool bIsPaused);
 //	With multiple platform emulators, call this immediately before loading a new ROM.
 extern void RA_SetConsoleID(unsigned int nConsoleID);
 
+//  Should be called before performing an activity that is not allowed in hardcore mode to
+//  give the user a chance to disable hardcore mode and continue with the activity.
+//  Returns TRUE if hardcore was disabled, or FALSE to cancel the activity.
+extern bool RA_WarnDisableHardcore(const char* sActivity);
+
 //	Should be called immediately after loading or saving a new state.
 extern void RA_OnLoadState(const char* sFilename);
 extern void RA_OnSaveState(const char* sFilename);


### PR DESCRIPTION
Also, the user can now switch from hardcore to non-hardcore without resetting the emulator, and will be presented with a dialog warning about the reset when switching from non-hardcore back to hardcore.