### PR TITLE
fix persisting achievement state with save states

### DIFF
--- a/src/RA_Achievement.cpp
+++ b/src/RA_Achievement.cpp
@@ -1,9 +1,22 @@
 #include "RA_Achievement.h"
 
-#include "RA_Core.h"
-#include "RA_ImageFactory.h"
+#include "RA_md5factory.h"
 
-//	No game-specific code here please!
+#ifndef RA_UTEST
+#include "RA_Core.h"
+#else
+// duplicate of code in RA_Core, but RA_Core needs to be cleaned up before it can be pulled into the unit test build
+void _ReadStringTil(std::string& value, char nChar, const char*& pSource)
+{
+    const char* pStartString = pSource;
+
+    while (*pSource != '\0' && *pSource != nChar)
+        pSource++;
+
+    value.assign(pStartString, pSource - pStartString);
+    pSource++;
+}
+#endif
 
 //////////////////////////////////////////////////////////////////////////
 
@@ -14,6 +27,8 @@ Achievement::Achievement(AchievementSetType nType) :
 
     m_vConditions.AddGroup();
 }
+
+#ifndef RA_UTEST
 
 void Achievement::Parse(const Value& element)
 {
@@ -42,6 +57,8 @@ void Achievement::Parse(const Value& element)
 
     SetActive(IsCoreAchievement());	//	Activate core by default
 }
+
+#endif
 
 const char* Achievement::ParseLine(const char* pBuffer)
 {
@@ -140,11 +157,13 @@ BOOL Achievement::Test()
 
     if (bResetConditions && bNotifyOnReset)
     {
+#ifndef RA_UTEST
         RA_CausePause();
 
         char buffer[256];
         sprintf_s(buffer, 256, "Pause on Reset: %s", Title().c_str());
         MessageBox(g_RAMainWnd, NativeStr(buffer).c_str(), TEXT("Paused"), MB_OK);
+#endif
     }
 
     return bRetVal;
@@ -545,3 +564,141 @@ void Achievement::Set(const Achievement& rRHS)
 //		g_PopupWindows.ProgressPopups().AddMessage( progressTitle, progressDesc );
 //	}
 // }
+
+std::string Achievement::CreateStateString(const std::string& sSalt) const
+{
+    // build the progress string
+    std::ostringstream oss;
+
+    for (unsigned int nGroup = 0; nGroup < NumConditionGroups(); ++nGroup)
+    {
+        const ConditionGroup& group = m_vConditions.GetGroup(nGroup);
+        oss << ID() << ":" << group.Count() << ":";
+
+        for (unsigned int j = 0; j < group.Count(); ++j)
+        {
+            const Condition& cond = group.GetAt(j);
+            oss << cond.CurrentHits() << ":" <<
+                cond.CompSource().RawValue() << ":" << cond.CompSource().RawPreviousValue() << ":" <<
+                cond.CompTarget().RawValue() << ":" << cond.CompTarget().RawPreviousValue() << ":";
+        }
+    }
+
+    std::string sProgressString = oss.str();
+
+    // Checksum the progress string (including the salt value)
+    std::string sModifiedProgressString;
+    sModifiedProgressString.resize(sProgressString.length() + sSalt.length() * 2 + 10);
+    size_t nNewSize = sprintf_s(sModifiedProgressString.data(), sModifiedProgressString.capacity(),
+        "%s%s%s%u", sSalt.c_str(), sProgressString.c_str(), sSalt.c_str(), static_cast<unsigned int>(ID()));
+    sModifiedProgressString.resize(nNewSize);
+    std::string sMD5Progress = RAGenerateMD5(sModifiedProgressString);
+
+    sProgressString.append(sMD5Progress);
+    sProgressString.push_back(':');
+
+    // Also checksum the achievement string itself
+    std::string sMD5Achievement = RAGenerateMD5(CreateMemString());
+    sProgressString.append(sMD5Achievement);
+    sProgressString.push_back(':');
+
+    return sProgressString;
+}
+
+const char* Achievement::ParseStateString(const char* sBuffer, const std::string& sSalt)
+{
+    std::vector<Condition> vConditions;
+    const char* pIter = sBuffer;
+    bool bSuccess = true;
+
+    // recalculate the current achievement checksum
+    std::string sMD5Achievement = RAGenerateMD5(CreateMemString());
+
+    // parse achievement id and conditions
+    while (*pIter)
+    {
+        char* pEnd;
+
+        const char* pStart = pIter;
+        unsigned int nID = strtoul(pIter, &pEnd, 10); pIter = pEnd + 1;
+        if (nID != ID())
+        {
+            pIter = pStart;
+            break;
+        }
+
+        unsigned int nNumCond = strtoul(pIter, &pEnd, 10); pIter = pEnd + 1;
+        vConditions.reserve(vConditions.size() + nNumCond);
+
+        for (size_t i = 0; i < nNumCond; ++i)
+        {
+            // Parse next condition state
+            unsigned int nHits = strtoul(pIter, &pEnd, 10); pIter = pEnd + 1;
+            unsigned int nSourceVal = strtoul(pIter, &pEnd, 10); pIter = pEnd + 1;
+            unsigned int nSourcePrev = strtoul(pIter, &pEnd, 10); pIter = pEnd + 1;
+            unsigned int nTargetVal = strtoul(pIter, &pEnd, 10); pIter = pEnd + 1;
+            unsigned int nTargetPrev = strtoul(pIter, &pEnd, 10); pIter = pEnd + 1;
+
+            Condition& cond = vConditions.emplace_back();
+            cond.OverrideCurrentHits(nHits);
+            cond.CompSource().SetValues(nSourceVal, nSourcePrev);
+            cond.CompTarget().SetValues(nTargetVal, nTargetPrev);
+        }
+    }
+
+    const char* pEnd = pIter;
+
+    // read the given md5s
+    std::string sGivenMD5Progress;
+    _ReadStringTil(sGivenMD5Progress, ':', pIter);
+
+    std::string sGivenMD5Achievement;
+    _ReadStringTil(sGivenMD5Achievement, ':', pIter);
+
+    // if the achievement is still compatible
+    if (sGivenMD5Achievement == sMD5Achievement)
+    {
+        // regenerate the md5 and see if it sticks
+        std::string sModifiedProgressString;
+        sModifiedProgressString.resize(pEnd - sBuffer + sSalt.length() * 2 + 10);
+        size_t nNewSize = sprintf_s(sModifiedProgressString.data(), sModifiedProgressString.capacity(),
+            "%s%.*s%s%u", sSalt.c_str(), pEnd - sBuffer, sBuffer, sSalt.c_str(), ID());
+        sModifiedProgressString.resize(nNewSize);
+        std::string sMD5Progress = RAGenerateMD5(sModifiedProgressString);
+        if (sMD5Progress == sGivenMD5Progress)
+        {
+            // compatible - merge
+            size_t nCondition = 0;
+            for (size_t nConditionGroup = 0; nConditionGroup < m_vConditions.GroupCount(); ++nConditionGroup)
+            {
+                ConditionGroup& group = m_vConditions.GetGroup(nConditionGroup);
+                for (size_t i = 0; i < group.Count(); ++i)
+                {
+                    Condition& condSource = vConditions.at(nCondition++);
+                    Condition& condTarget = group.GetAt(i);
+
+                    condTarget.OverrideCurrentHits(condSource.CurrentHits());
+                    condTarget.CompSource().SetValues(condSource.CompSource().RawValue(), condSource.CompSource().RawPreviousValue());
+                    condTarget.CompTarget().SetValues(condSource.CompTarget().RawValue(), condSource.CompTarget().RawPreviousValue());
+                }
+            }
+        }
+        else
+        {
+            // state checksum fail
+            bSuccess = false;
+        }
+    }
+    else
+    {
+        // achievment checksum fail
+        bSuccess = false;
+    }
+
+    if (bSuccess)
+        SetDirtyFlag(Dirty_Conditions);
+    else
+        Reset();
+
+    return pIter;
+}

--- a/src/RA_Achievement.h
+++ b/src/RA_Achievement.h
@@ -94,14 +94,18 @@ public:
     Condition& GetCondition(size_t nCondGroup, size_t i) { return m_vConditions.GetGroup(nCondGroup).GetAt(i); }
 
     std::string CreateMemString() const;
+    std::string CreateStateString(const std::string& sSalt) const;
 
     void Reset();
 
     //	Returns the new char* offset after parsing.
-    const char* ParseLine(const char* buffer);
+    const char* ParseLine(const char* sBuffer);
+    const char* ParseStateString(const char* sBuffer, const std::string& sSalt);
 
+#ifndef RA_UTEST
     //	Parse from json element
     void Parse(const Value& element);
+#endif
 
     //	Used for rendering updates when editing achievements. Usually always false.
     unsigned int GetDirtyFlags() const { return m_nDirtyFlags; }

--- a/src/RA_AchievementSet.cpp
+++ b/src/RA_AchievementSet.cpp
@@ -620,44 +620,11 @@ void AchievementSet::SaveProgress(const char* sSaveStateFilename)
     for (size_t i = 0; i < NumAchievements(); ++i)
     {
         Achievement* pAch = &m_Achievements[i];
-        if (!pAch->Active())
-            continue;
-
-        //	Write ID of achievement and num conditions:
-        char cheevoProgressString[4096];
-        memset(cheevoProgressString, '\0', 4096);
-
-        for (unsigned int nGrp = 0; nGrp < pAch->NumConditionGroups(); ++nGrp)
+        if (pAch->Active())
         {
-            sprintf_s(buffer, "%u:%u:", pAch->ID(), pAch->NumConditions(nGrp));
-            strcat_s(cheevoProgressString, 4096, buffer);
-
-            for (unsigned int j = 0; j < pAch->NumConditions(nGrp); ++j)
-            {
-                Condition& cond = pAch->GetCondition(nGrp, j);
-                sprintf_s(buffer, 4096, "%u:%u:%u:%u:%u:",
-                    cond.CurrentHits(),
-                    cond.CompSource().RawValue(),
-                    cond.CompSource().RawPreviousValue(),
-                    cond.CompTarget().RawValue(),
-                    cond.CompTarget().RawPreviousValue());
-                strcat_s(cheevoProgressString, 4096, buffer);
-            }
+            std::string sProgress = pAch->CreateStateString(RAUsers::LocalUser().Username());
+            fwrite(sProgress.data(), sizeof(char), sProgress.length(), pf);
         }
-
-        //	Generate a slightly different key to md5ify:
-        char sCheevoProgressMangled[4096];
-        sprintf_s(sCheevoProgressMangled, 4096, "%s%s%s%u",
-            RAUsers::LocalUser().Username().c_str(), cheevoProgressString, RAUsers::LocalUser().Username().c_str(), pAch->ID());
-
-        std::string sMD5Progress = RAGenerateMD5(std::string(sCheevoProgressMangled));
-        std::string sMD5Achievement = RAGenerateMD5(pAch->CreateMemString());
-
-        fwrite(cheevoProgressString, sizeof(char), strlen(cheevoProgressString), pf);
-        fwrite(sMD5Progress.c_str(), sizeof(char), sMD5Progress.length(), pf);
-        fwrite(":", sizeof(char), 1, pf);
-        fwrite(sMD5Achievement.c_str(), sizeof(char), sMD5Achievement.length(), pf);
-        fwrite(":", sizeof(char), 1, pf);	//	Check!
     }
 
     fclose(pf);
@@ -666,21 +633,7 @@ void AchievementSet::SaveProgress(const char* sSaveStateFilename)
 void AchievementSet::LoadProgress(const char* sLoadStateFilename)
 {
     char buffer[4096];
-    long nFileSize = 0;
-    unsigned int CondNumHits[50];	//	50 conditions per achievement
-    unsigned int CondSourceVal[50];
-    unsigned int CondSourceLastVal[50];
-    unsigned int CondTargetVal[50];
-    unsigned int CondTargetLastVal[50];
-    unsigned int nID = 0;
-    unsigned int nNumCond = 0;
-    char cheevoProgressString[4096];
-    unsigned int i = 0;
-    unsigned int j = 0;
-    char* pGivenProgressMD5 = nullptr;
-    char* pGivenCheevoMD5 = nullptr;
-    char cheevoMD5TestMangled[4096];
-    int nMemStringLen = 0;
+    long nFileSize;
 
     if (!RAUsers::LocalUser().IsLoggedIn())
         return;
@@ -688,108 +641,31 @@ void AchievementSet::LoadProgress(const char* sLoadStateFilename)
     if (sLoadStateFilename == nullptr)
         return;
 
-    sprintf_s(buffer, 4096, "%s%s.rap", RA_DIR_DATA, sLoadStateFilename);
+    sprintf_s(buffer, sizeof(buffer), "%s.rap", sLoadStateFilename);
 
     char* pRawFile = _MallocAndBulkReadFileToBuffer(buffer, nFileSize);
-
     if (pRawFile != nullptr)
     {
-        unsigned int nOffs = 0;
-        while (nOffs < (unsigned int)(nFileSize - 2) && pRawFile[nOffs] != '\0')
+        const char* pIter = pRawFile;
+        while (*pIter)
         {
-            char* pIter = &pRawFile[nOffs];
-
-            //	Parse achievement id and num conditions
-            nID = strtoul(pIter, &pIter, 10); pIter++;
-            nNumCond = strtoul(pIter, &pIter, 10);	pIter++;
-
-            //	Concurrently build the md5 checkstring
-            sprintf_s(cheevoProgressString, 4096, "%u:%u:", nID, nNumCond);
-
-            ZeroMemory(CondNumHits, 50 * sizeof(unsigned int));
-            ZeroMemory(CondSourceVal, 50 * sizeof(unsigned int));
-            ZeroMemory(CondSourceLastVal, 50 * sizeof(unsigned int));
-            ZeroMemory(CondTargetVal, 50 * sizeof(unsigned int));
-            ZeroMemory(CondTargetLastVal, 50 * sizeof(unsigned int));
-
-            for (i = 0; i < nNumCond && i < 50; ++i)
+            char* pUnused;
+            unsigned int nID = strtoul(pIter, &pUnused, 10);
+            Achievement* pAch = Find(nID);
+            if (pAch != nullptr && pAch->Active())
             {
-                //	Parse next condition state
-                CondNumHits[i] = strtoul(pIter, &pIter, 10); pIter++;
-                CondSourceVal[i] = strtoul(pIter, &pIter, 10); pIter++;
-                CondSourceLastVal[i] = strtoul(pIter, &pIter, 10); pIter++;
-                CondTargetVal[i] = strtoul(pIter, &pIter, 10); pIter++;
-                CondTargetLastVal[i] = strtoul(pIter, &pIter, 10); pIter++;
-
-                //	Concurrently build the md5 checkstring
-                sprintf_s(buffer, 4096, "%u:%u:%u:%u:%u:",
-                    CondNumHits[i],
-                    CondSourceVal[i],
-                    CondSourceLastVal[i],
-                    CondTargetVal[i],
-                    CondTargetLastVal[i]);
-
-                strcat_s(cheevoProgressString, 4096, buffer);
-            }
-
-            //	Read the given md5:
-            pGivenProgressMD5 = strtok_s(pIter, ":", &pIter);
-            pGivenCheevoMD5 = strtok_s(pIter, ":", &pIter);
-
-            //	Regenerate the md5 and see if it sticks:
-            sprintf_s(cheevoMD5TestMangled, 4096, "%s%s%s%u",
-                RAUsers::LocalUser().Username().c_str(), cheevoProgressString, RAUsers::LocalUser().Username().c_str(), nID);
-
-            std::string sRecalculatedProgressMD5 = RAGenerateMD5(cheevoMD5TestMangled);
-
-            if (sRecalculatedProgressMD5.compare(pGivenProgressMD5) == 0)
-            {
-                //	Embed in achievement:
-                Achievement* pAch = Find(nID);
-                if (pAch != nullptr)
-                {
-                    std::string sMemStr = pAch->CreateMemString();
-
-                    //	Recalculate the current achievement to see if it's compatible:
-                    std::string sMemMD5 = RAGenerateMD5(sMemStr);
-                    if (sMemMD5.compare(0, 32, pGivenCheevoMD5) == 0)
-                    {
-                        for (size_t nGrp = 0; nGrp < pAch->NumConditionGroups(); ++nGrp)
-                        {
-                            for (j = 0; j < pAch->NumConditions(nGrp); ++j)
-                            {
-                                Condition& cond = pAch->GetCondition(nGrp, j);
-
-                                cond.OverrideCurrentHits(CondNumHits[j]);
-                                cond.CompSource().SetValues(CondSourceVal[j], CondSourceLastVal[j]);
-                                cond.CompTarget().SetValues(CondTargetVal[j], CondTargetLastVal[j]);
-
-                                pAch->SetDirtyFlag(Dirty_Conditions);
-                            }
-                        }
-                    }
-                    else
-                    {
-                        ASSERT(!"Achievement progress savestate incompatible (achievement has changed?)");
-                        RA_LOG("Achievement progress savestate incompatible (achievement has changed?)");
-                    }
-                }
-                else
-                {
-                    ASSERT(!"Achievement doesn't exist!");
-                    RA_LOG("Achievement doesn't exist!");
-                }
+                pIter = pAch->ParseStateString(pIter, RAUsers::LocalUser().Username());
             }
             else
             {
-                //assert(!"MD5 invalid... what to do... maybe they're trying to hack achievements?");
+                // achievement no longer exists, or is no longer active, skip to next one
+                Achievement ach(AchievementSetType::Local);
+                ach.SetID(nID);
+                pIter = ach.ParseStateString(pIter, "");
             }
-
-            nOffs = (pIter - pRawFile);
         }
 
         free(pRawFile);
-        pRawFile = nullptr;
     }
 }
 

--- a/tests/RA_Achievement_Tests.cpp
+++ b/tests/RA_Achievement_Tests.cpp
@@ -42,7 +42,7 @@ public:
         Assert::AreEqual(12U, ach.GetCondition(0, 0).CompTarget().RawValue());
         Assert::AreEqual(12U, ach.GetCondition(0, 0).CompTarget().RawPreviousValue());
 
-        // correct user should not load
+        // correct user should load
         pIter = sState.c_str();
         pIter = ach.ParseStateString(pIter, "user1");
         Assert::AreEqual('\0', *pIter);

--- a/tests/RA_Achievement_Tests.cpp
+++ b/tests/RA_Achievement_Tests.cpp
@@ -1,0 +1,202 @@
+#include "CppUnitTest.h"
+
+#include "RA_Achievement.h"
+#include "RA_UnitTestHelpers.h"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace ra {
+namespace data {
+namespace tests {
+
+TEST_CLASS(RA_Achievement_Tests)
+{
+public:
+    TEST_METHOD(TestStateEmpty)
+    {
+        Achievement ach(AchievementSetType::Local);
+        std::string sState = ach.CreateStateString("user1");
+
+        Assert::AreEqual(std::string("0:0:a9bf5b6918bb43ec1d430f09d6606fbd:d41d8cd98f00b204e9800998ecf8427e:"), sState);
+    }
+
+    TEST_METHOD(TestStateSimple)
+    {
+        Achievement ach(AchievementSetType::Local);
+        ach.SetID(12345);
+        ach.ParseLine("12345:0xh1234=6");
+        ach.GetCondition(0, 0).OverrideCurrentHits(4);
+        ach.GetCondition(0, 0).CompSource().SetValues(12, 12);
+        ach.GetCondition(0, 0).CompTarget().SetValues(12, 12);
+
+        std::string sState = ach.CreateStateString("user1");
+        Assert::IsFalse(sState.empty());
+
+        // incorrect user should cause the achievement to reset (which only affects hit count)
+        const char* pIter = sState.c_str();
+        pIter = ach.ParseStateString(pIter, "user2");
+        Assert::AreEqual('\0', *pIter);
+        Assert::AreEqual(0U, ach.GetCondition(0, 0).CurrentHits());
+        Assert::AreEqual(12U, ach.GetCondition(0, 0).CompSource().RawValue());
+        Assert::AreEqual(12U, ach.GetCondition(0, 0).CompSource().RawPreviousValue());
+        Assert::AreEqual(12U, ach.GetCondition(0, 0).CompTarget().RawValue());
+        Assert::AreEqual(12U, ach.GetCondition(0, 0).CompTarget().RawPreviousValue());
+
+        // correct user should not load
+        pIter = sState.c_str();
+        pIter = ach.ParseStateString(pIter, "user1");
+        Assert::AreEqual('\0', *pIter);
+        Assert::AreEqual(4U, ach.GetCondition(0, 0).CurrentHits());
+        Assert::AreEqual(12U, ach.GetCondition(0, 0).CompSource().RawValue());
+        Assert::AreEqual(12U, ach.GetCondition(0, 0).CompSource().RawPreviousValue());
+        Assert::AreEqual(12U, ach.GetCondition(0, 0).CompTarget().RawValue());
+        Assert::AreEqual(12U, ach.GetCondition(0, 0).CompTarget().RawPreviousValue());
+    }
+
+    TEST_METHOD(TestStateDelta)
+    {
+        Achievement ach(AchievementSetType::Local);
+        ach.SetID(12345);
+        ach.ParseLine("12345:0xh1234=d0x1234");
+        ach.GetCondition(0, 0).OverrideCurrentHits(4);
+        ach.GetCondition(0, 0).CompSource().SetValues(12, 11);
+        ach.GetCondition(0, 0).CompTarget().SetValues(12, 11);
+
+        std::string sState = ach.CreateStateString("user1");
+        Assert::IsFalse(sState.empty());
+
+        const char* pIter = sState.c_str();
+        pIter = ach.ParseStateString(pIter, "user1");
+        Assert::AreEqual('\0', *pIter);
+        Assert::AreEqual(4U, ach.GetCondition(0, 0).CurrentHits());
+        Assert::AreEqual(12U, ach.GetCondition(0, 0).CompSource().RawValue());
+        Assert::AreEqual(11U, ach.GetCondition(0, 0).CompSource().RawPreviousValue());
+        Assert::AreEqual(12U, ach.GetCondition(0, 0).CompTarget().RawValue());
+        Assert::AreEqual(11U, ach.GetCondition(0, 0).CompTarget().RawPreviousValue());
+    }
+
+    TEST_METHOD(TestStateMultipleConditions)
+    {
+        Achievement ach(AchievementSetType::Local);
+        ach.SetID(12345);
+        ach.ParseLine("12345:0xh1234=6.1._0xh2345!=d0xh2345_R:0xh3456=7");
+        ach.GetCondition(0, 0).OverrideCurrentHits(1);
+        ach.GetCondition(0, 0).CompSource().SetValues(12, 12);
+        ach.GetCondition(0, 0).CompTarget().SetValues(6, 6);
+        ach.GetCondition(0, 1).OverrideCurrentHits(0);
+        ach.GetCondition(0, 1).CompSource().SetValues(32, 32);
+        ach.GetCondition(0, 1).CompTarget().SetValues(32, 32);
+        ach.GetCondition(0, 2).OverrideCurrentHits(1700);
+        ach.GetCondition(0, 2).CompSource().SetValues(0, 0);
+        ach.GetCondition(0, 2).CompTarget().SetValues(0, 0);
+
+        std::string sState = ach.CreateStateString("user1");
+        Assert::IsFalse(sState.empty());
+
+        ach.Reset();
+        Assert::AreEqual(0U, ach.GetCondition(0, 0).CurrentHits());
+        Assert::AreEqual(0U, ach.GetCondition(0, 1).CurrentHits());
+        Assert::AreEqual(0U, ach.GetCondition(0, 2).CurrentHits());
+
+        const char* pIter = sState.c_str();
+        ach.ParseStateString(pIter, "user1");
+        Assert::AreEqual(1U, ach.GetCondition(0, 0).CurrentHits());
+        Assert::AreEqual(0U, ach.GetCondition(0, 1).CurrentHits());
+        Assert::AreEqual(1700U, ach.GetCondition(0, 2).CurrentHits());
+    }
+
+    TEST_METHOD(TestStateMultipleGroups)
+    {
+        Achievement ach(AchievementSetType::Local);
+        ach.SetID(12345);
+        ach.ParseLine("12345:0xh1234=6.1._0xh2345!=d0xh2345SR:0xh3456=7S0xh4567=0xh5678");
+        ach.GetCondition(0, 0).OverrideCurrentHits(1);
+        ach.GetCondition(0, 0).CompSource().SetValues(12, 12);
+        ach.GetCondition(0, 0).CompTarget().SetValues(6, 6);
+        ach.GetCondition(0, 1).OverrideCurrentHits(0);
+        ach.GetCondition(0, 1).CompSource().SetValues(32, 32);
+        ach.GetCondition(0, 1).CompTarget().SetValues(32, 32);
+        ach.GetCondition(1, 0).OverrideCurrentHits(1700);
+        ach.GetCondition(1, 0).CompSource().SetValues(0, 0);
+        ach.GetCondition(1, 0).CompTarget().SetValues(0, 0);
+        ach.GetCondition(2, 0).OverrideCurrentHits(11);
+        ach.GetCondition(2, 0).CompSource().SetValues(17, 17);
+        ach.GetCondition(2, 0).CompTarget().SetValues(18, 18);
+
+        std::string sState = ach.CreateStateString("user1");
+        Assert::IsFalse(sState.empty());
+
+        ach.Reset();
+        Assert::AreEqual(0U, ach.GetCondition(0, 0).CurrentHits());
+        Assert::AreEqual(0U, ach.GetCondition(0, 1).CurrentHits());
+        Assert::AreEqual(0U, ach.GetCondition(1, 0).CurrentHits());
+        Assert::AreEqual(0U, ach.GetCondition(2, 0).CurrentHits());
+
+        const char* pIter = sState.c_str();
+        ach.ParseStateString(pIter, "user1");
+        Assert::AreEqual(1U, ach.GetCondition(0, 0).CurrentHits());
+        Assert::AreEqual(0U, ach.GetCondition(0, 1).CurrentHits());
+        Assert::AreEqual(1700U, ach.GetCondition(1, 0).CurrentHits());
+        Assert::AreEqual(11U, ach.GetCondition(2, 0).CurrentHits());
+    }
+
+    TEST_METHOD(TestStateMultipleAchievements)
+    {
+        Achievement ach(AchievementSetType::Local);
+        ach.SetID(12345);
+        ach.ParseLine("12345:0xh1234=6.1._0xh2345!=d0xh2345_R:0xh3456=7");
+        ach.GetCondition(0, 0).OverrideCurrentHits(1);
+        ach.GetCondition(0, 0).CompSource().SetValues(12, 12);
+        ach.GetCondition(0, 0).CompTarget().SetValues(6, 6);
+        ach.GetCondition(0, 1).OverrideCurrentHits(0);
+        ach.GetCondition(0, 1).CompSource().SetValues(32, 32);
+        ach.GetCondition(0, 1).CompTarget().SetValues(32, 32);
+        ach.GetCondition(0, 2).OverrideCurrentHits(1700);
+        ach.GetCondition(0, 2).CompSource().SetValues(0, 0);
+        ach.GetCondition(0, 2).CompTarget().SetValues(0, 0);
+
+        std::string sState = ach.CreateStateString("user1");
+        sState += "54321:0:junk:junk";
+        Assert::IsFalse(sState.empty());
+
+        ach.Reset();
+        Assert::AreEqual(0U, ach.GetCondition(0, 0).CurrentHits());
+        Assert::AreEqual(0U, ach.GetCondition(0, 1).CurrentHits());
+        Assert::AreEqual(0U, ach.GetCondition(0, 2).CurrentHits());
+
+        const char* pIter = sState.c_str();
+        pIter = ach.ParseStateString(pIter, "user1");
+        Assert::AreEqual(1U, ach.GetCondition(0, 0).CurrentHits());
+        Assert::AreEqual(0U, ach.GetCondition(0, 1).CurrentHits());
+        Assert::AreEqual(1700U, ach.GetCondition(0, 2).CurrentHits());
+
+        // pointer should be ready for next achievement
+        Assert::AreEqual("54321:0:junk:junk", pIter);
+    }
+
+    TEST_METHOD(TestStateAchievementModified)
+    {
+        Achievement ach(AchievementSetType::Local);
+        ach.SetID(12345);
+        ach.ParseLine("12345:0xh1234=6");
+        ach.GetCondition(0, 0).OverrideCurrentHits(4);
+        ach.GetCondition(0, 0).CompSource().SetValues(12, 12);
+        ach.GetCondition(0, 0).CompTarget().SetValues(12, 12);
+
+        std::string sState = ach.CreateStateString("user1");
+        Assert::IsFalse(sState.empty());
+
+        // if achievement has changed, achievement checksum will fail and achievement should
+        // just be reset (which only affects hitcount)
+        ach.GetCondition(0, 0).CompSource().Set(ComparisonVariableSize::EightBit,
+            ComparisonVariableType::Address, 0x2345U);
+        
+        const char* pIter = sState.c_str();
+        ach.ParseStateString(pIter, "user1");
+        Assert::AreEqual(0U, ach.GetCondition(0, 0).CurrentHits());
+    }
+};
+
+} // namespace tests
+} // namespace data
+} // namespace ra

--- a/tests/RA_Integration.Tests.vcxproj
+++ b/tests/RA_Integration.Tests.vcxproj
@@ -129,13 +129,20 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\src\md5.c" />
+    <ClCompile Include="..\src\RA_Achievement.cpp" />
+    <ClCompile Include="..\src\RA_md5factory.cpp" />
     <ClCompile Include="..\src\RA_RichPresence.cpp" />
     <ClCompile Include="..\src\services\SearchResults.cpp" />
+    <ClCompile Include="RA_Achievement_Tests.cpp" />
     <ClCompile Include="RA_RichPresence_Tests.cpp" />
     <ClCompile Include="SearchResults_Tests.cpp" />
+    <ClInclude Include="..\src\md5.h" />
+    <ClInclude Include="..\src\RA_Achievement.h" />
     <ClInclude Include="..\src\RA_Condition.h" />
     <ClInclude Include="..\src\RA_Defs.h" />
     <ClInclude Include="..\src\RA_Leaderboard.h" />
+    <ClInclude Include="..\src\RA_md5factory.h" />
     <ClInclude Include="..\src\RA_MemManager.h" />
     <ClCompile Include="..\src\RA_Condition.cpp" />
     <ClCompile Include="..\src\RA_Defs.cpp" />

--- a/tests/RA_Integration.Tests.vcxproj.filters
+++ b/tests/RA_Integration.Tests.vcxproj.filters
@@ -51,6 +51,18 @@
     <ClCompile Include="..\src\RA_RichPresence.cpp">
       <Filter>Code</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\RA_Achievement.cpp">
+      <Filter>Code</Filter>
+    </ClCompile>
+    <ClCompile Include="RA_Achievement_Tests.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\md5.c">
+      <Filter>Code</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\RA_md5factory.cpp">
+      <Filter>Code</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="RA_Condition_Tests.cpp">
@@ -77,6 +89,15 @@
       <Filter>Code</Filter>
     </ClInclude>
     <ClInclude Include="..\src\RA_Leaderboard.h">
+      <Filter>Code</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\RA_Achievement.h">
+      <Filter>Code</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\md5.h">
+      <Filter>Code</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\RA_md5factory.h">
       <Filter>Code</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
This wasn't working simply because the load behavior was looking in a different directory than the save behavior. In addition to fixing that, I've moved the state serialization code from AchievementSet to Achievement and added unit tests.

Previously, loading a save state didn't affect the achievement state at all. 

The corrected behavior is that the HitCounts and Delta values are restored. As a result, it is no longer possible to save before a boss, do 99% damage, create a second save, quickly load the first save to reset the HitCount flag, then load the 99% damage save to kill the boss and earn the no damage achievement. 

Conversely, the player can now use save states throughout the boss fight and revert back to a previous save before damage is taken to continue the no-damage attempt.

If the achievement definition changes, or the player attempts to modify the captured state externally, the state for that achievement will be reset instead of restored.

This corrects the save state behavior to function very similar to the hardcore behavior (achievement progress is captured with the save state), which should minimize tickets caused solely by playing in non-hardcore mode.

Note: this behavior relies on the emulator passing the name of the save state file to generate the achievement state file. For in-memory saves (rewind), the feature is still non-functional.