### PR TITLE
Ensure conditional display string order is retained

### DIFF
--- a/src/RA_RichPresence.cpp
+++ b/src/RA_RichPresence.cpp
@@ -181,7 +181,7 @@ void RA_RichPresenceInterpreter::ParseFromString(const char* sRichPresence)
     m_vLookups.clear();
     m_vDisplayStrings.clear();
 
-    std::map<std::string, std::string> mDisplayStrings;
+    std::vector<std::pair<std::string, std::string>> mDisplayStrings;
     std::string sDisplayString;
 
     std::map<std::string, MemValue::Format> mFormats;
@@ -249,7 +249,7 @@ void RA_RichPresenceInterpreter::ParseFromString(const char* sRichPresence)
                         std::string sCondition(sLine, 1, nIndex - 1);
                         std::string sDisplay(sLine, nIndex + 1);
 
-                        mDisplayStrings[sCondition] = sDisplay;
+                        mDisplayStrings.emplace_back(sCondition, sDisplay);
                         continue;
                     }
                 }
@@ -262,7 +262,7 @@ void RA_RichPresenceInterpreter::ParseFromString(const char* sRichPresence)
 
     if (!sDisplayString.empty())
     {
-        for (std::map<std::string, std::string>::const_iterator iter = mDisplayStrings.begin(); iter != mDisplayStrings.end(); ++iter)
+        for (std::vector<std::pair<std::string, std::string>>::const_iterator iter = mDisplayStrings.begin(); iter != mDisplayStrings.end(); ++iter)
         {
             auto& displayString = m_vDisplayStrings.emplace_back(iter->first);
             displayString.InitializeParts(iter->second, mFormats, m_vLookups);

--- a/tests/RA_RichPresence_Tests.cpp
+++ b/tests/RA_RichPresence_Tests.cpp
@@ -271,6 +271,51 @@ public:
         Assert::AreEqual("Near Zero", rp.GetRichPresenceString().c_str());
     }
 
+    TEST_METHOD(TestConditionalDisplayCommonPrefix)
+    {
+        // ensures order matters
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        RA_RichPresenceInterpreter rp;
+        rp.ParseFromString("Display:\n?0xH0000=0_0xH0001=18?First\n?0xH0000=0?Second\nThird");
+
+        Assert::AreEqual("First", rp.GetRichPresenceString().c_str());
+
+        memory[1] = 1;
+        Assert::AreEqual("Second", rp.GetRichPresenceString().c_str());
+
+        memory[0] = 1;
+        Assert::AreEqual("Third", rp.GetRichPresenceString().c_str());
+
+        memory[0] = 0;
+        memory[1] = 18;
+        rp.ParseFromString("Display:\n?0xH0000=0?First\n?0xH0000=0_0xH0001=18?Second\nThird");
+
+        Assert::AreEqual("First", rp.GetRichPresenceString().c_str());
+
+        memory[1] = 1;
+        Assert::AreEqual("First", rp.GetRichPresenceString().c_str());
+
+        memory[0] = 1;
+        Assert::AreEqual("Third", rp.GetRichPresenceString().c_str());
+    }
+
+    TEST_METHOD(TestConditionalDisplayDuplicatedCondition)
+    {
+        // ensures order matters
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        RA_RichPresenceInterpreter rp;
+        rp.ParseFromString("Display:\n?0xH0000=0?First\n?0xH0000=0?Second\nThird");
+
+        Assert::AreEqual("First", rp.GetRichPresenceString().c_str());
+
+        memory[0] = 1;
+        Assert::AreEqual("Third", rp.GetRichPresenceString().c_str());
+    }
+
     TEST_METHOD(TestConditionalDisplayInvalid)
     {
         // invalid condition is ignored


### PR DESCRIPTION
Fixes a bug introduced by #80 