### PR TITLE
use executable path as home directory for sound files

### DIFF
--- a/src/RA_AchievementOverlay.cpp
+++ b/src/RA_AchievementOverlay.cpp
@@ -130,7 +130,7 @@ void AchievementOverlay::Initialize(HINSTANCE hInst)
 
     m_LatestNews.clear();
 
-    m_hOverlayBackground.ChangeReference(ra::services::ImageType::Local, RA_OVERLAY_BG_FILENAME);
+    m_hOverlayBackground.ChangeReference(ra::services::ImageType::Local, RA_DIR_OVERLAY "overlayBG.png");
     m_hUserImage.ChangeReference(ra::services::ImageType::UserPic, RAUsers::LocalUser().Username());
 }
 

--- a/src/RA_AchievementPopup.cpp
+++ b/src/RA_AchievementPopup.cpp
@@ -22,15 +22,15 @@ const float APPEAR_AT = 0.8f;
 const float FADEOUT_AT = 4.2f;
 const float FINISH_AT = 5.0f;
 
-const TCHAR* MSG_SOUND[] =
+const char* MSG_SOUND[] =
 {
-    _T("./Overlay/login.wav"),
-    _T("./Overlay/info.wav"),
-    _T("./Overlay/unlock.wav"),
-    _T("./Overlay/acherror.wav"),
-    _T("./Overlay/lb.wav"),
-    _T("./Overlay/lbcancel.wav"),
-    _T("./Overlay/message.wav"),
+    "login.wav",
+    "info.wav",
+    "unlock.wav",
+    "acherror.wav",
+    "lb.wav",
+    "lbcancel.wav",
+    "message.wav",
 };
 static_assert(SIZEOF_ARRAY(MSG_SOUND) == NumMessageTypes, "Must match!");
 }
@@ -43,7 +43,8 @@ AchievementPopup::AchievementPopup() :
 void AchievementPopup::PlayAudio()
 {
     ASSERT(MessagesPresent());	//	ActiveMessage() dereferences!
-    PlaySound(MSG_SOUND[ActiveMessage().Type()], nullptr, SND_FILENAME | SND_ASYNC);
+    std::string sSoundPath = g_sHomeDir + RA_DIR_OVERLAY + MSG_SOUND[ActiveMessage().Type()];
+    PlaySoundA(sSoundPath.c_str(), nullptr, SND_FILENAME | SND_ASYNC);
 }
 
 void AchievementPopup::AddMessage(const MessagePopup& msg)

--- a/src/RA_Defs.h
+++ b/src/RA_Defs.h
@@ -152,7 +152,6 @@ using namespace std::string_literals;
 #define RA_MY_PROGRESS_FILENAME			RA_DIR_DATA##"myprogress.txt"
 #define RA_MY_GAME_LIBRARY_FILENAME		RA_DIR_DATA##"mygamelibrary.txt"
 
-#define RA_OVERLAY_BG_FILENAME			RA_DIR_OVERLAY##"overlayBG.png"
 #define RA_NEWS_FILENAME				RA_DIR_DATA##"ra_news.txt"
 #define RA_TITLES_FILENAME				RA_DIR_DATA##"gametitles.txt"
 #define RA_LOG_FILENAME					RA_DIR_DATA##"RALog.txt"


### PR DESCRIPTION
Extension of #85. Sound files were not being opened using fopen and were missed.

Reported by Redwykelz, who explained that he was using a desktop shortcut to launch the emulator. I was not able to directly recreate this way, but by modifying the shortcut to point to a different "Start In" directory, the problem occurred.

