### PR TITLE
More error details when auto-update fails

### DIFF
--- a/src/RA_Interface.cpp
+++ b/src/RA_Interface.cpp
@@ -258,13 +258,21 @@ static BOOL DoBlockingHttpGet(const char* sHostName, const char* sRequestedPage,
         WINHTTP_NO_PROXY_BYPASS, 0);
 
     // Specify an HTTP server.
-    if (hSession != nullptr)
+    if (hSession == nullptr)
+    {
+        *pStatusCode = GetLastError();
+    }
+    else
     {
         mbstowcs_s(&nTemp, wBuffer, sizeof(wBuffer) / sizeof(wBuffer[0]), sHostName, strlen(sHostName) + 1);
         hConnect = WinHttpConnect(hSession, wBuffer, INTERNET_DEFAULT_HTTP_PORT, 0);
 
         // Create an HTTP Request handle.
-        if (hConnect != nullptr)
+        if (hConnect == nullptr)
+        {
+            *pStatusCode = GetLastError();
+        }
+        else
         {
             mbstowcs_s(&nTemp, wBuffer, sizeof(wBuffer)/sizeof(wBuffer[0]), sRequestedPage, strlen(sRequestedPage) + 1);
 
@@ -277,7 +285,11 @@ static BOOL DoBlockingHttpGet(const char* sHostName, const char* sRequestedPage,
                 0);
 
             // Send a Request.
-            if (hRequest != nullptr)
+            if (hRequest == nullptr)
+            {
+                *pStatusCode = GetLastError();
+            }
+            else
             {
                 bResults = WinHttpSendRequest(hRequest,
                     L"Content-Type: application/x-www-form-urlencoded",
@@ -287,7 +299,11 @@ static BOOL DoBlockingHttpGet(const char* sHostName, const char* sRequestedPage,
                     0,
                     0);
 
-                if (WinHttpReceiveResponse(hRequest, nullptr))
+                if (!WinHttpReceiveResponse(hRequest, nullptr))
+                {
+                    *pStatusCode = GetLastError();
+                }
+                else
                 {
                     DWORD dwSize = sizeof(DWORD);
                     WinHttpQueryHeaders(hRequest, WINHTTP_QUERY_STATUS_CODE | WINHTTP_QUERY_FLAG_NUMBER, WINHTTP_HEADER_NAME_BY_INDEX, pStatusCode, &dwSize, WINHTTP_NO_HEADER_INDEX);

--- a/src/RA_Interface.cpp
+++ b/src/RA_Interface.cpp
@@ -364,7 +364,8 @@ static std::wstring GetIntegrationPath()
 
 static void WriteBufferToFile(const std::wstring& sFile, const char* sBuffer, int nBytes)
 {
-    FILE* pf = _wfopen(sFile.c_str(), L"wb");
+    FILE* pf;
+    errno_t nErr = _wfopen_s(&pf, sFile.c_str(), L"wb");
     if (pf != nullptr)
     {
         fwrite(sBuffer, 1, nBytes, pf);
@@ -372,7 +373,11 @@ static void WriteBufferToFile(const std::wstring& sFile, const char* sBuffer, in
     }
     else
     {
-        MessageBoxW(nullptr, L"Problems writing file!", sFile.c_str(), MB_OK);
+        wchar_t sErrBuffer[2048];
+        _wcserror_s(sErrBuffer, nErr);
+
+        std::wstring sErrMsg = L"Unable to write " + sFile + L"\n" + sErrBuffer;
+        MessageBoxW(nullptr, sErrMsg.c_str(), L"Error", MB_OK | MB_ICONERROR);
     }
 }
 


### PR DESCRIPTION
These changes are not consumed by the toolkit. The modified file is compiled into each emulator separately.