### PR TITLE
allow unicode characters in file paths

### DIFF
--- a/src/RA_AchievementOverlay.cpp
+++ b/src/RA_AchievementOverlay.cpp
@@ -130,7 +130,7 @@ void AchievementOverlay::Initialize(HINSTANCE hInst)
 
     m_LatestNews.clear();
 
-    m_hOverlayBackground.ChangeReference(ra::services::ImageType::Local, RA_DIR_OVERLAY "overlayBG.png");
+    m_hOverlayBackground.ChangeReference(ra::services::ImageType::Local, "Overlay\\overlayBG.png");
     m_hUserImage.ChangeReference(ra::services::ImageType::UserPic, RAUsers::LocalUser().Username());
 }
 
@@ -1506,9 +1506,9 @@ void AchievementOverlay::InstallNewsArticlesFromFile()
 {
     m_LatestNews.clear();
 
-    std::string sNewsFile = g_sHomeDir + RA_NEWS_FILENAME;
+    std::wstring sNewsFile = g_sHomeDir + RA_NEWS_FILENAME;
     FILE* pf = nullptr;
-    fopen_s(&pf, sNewsFile.c_str(), "rb");
+    _wfopen_s(&pf, sNewsFile.c_str(), L"rb");
     if (pf != nullptr)
     {
         Document doc;

--- a/src/RA_AchievementPopup.cpp
+++ b/src/RA_AchievementPopup.cpp
@@ -22,15 +22,15 @@ const float APPEAR_AT = 0.8f;
 const float FADEOUT_AT = 4.2f;
 const float FINISH_AT = 5.0f;
 
-const char* MSG_SOUND[] =
+const wchar_t* MSG_SOUND[] =
 {
-    "login.wav",
-    "info.wav",
-    "unlock.wav",
-    "acherror.wav",
-    "lb.wav",
-    "lbcancel.wav",
-    "message.wav",
+    L"login.wav",
+    L"info.wav",
+    L"unlock.wav",
+    L"acherror.wav",
+    L"lb.wav",
+    L"lbcancel.wav",
+    L"message.wav",
 };
 static_assert(SIZEOF_ARRAY(MSG_SOUND) == NumMessageTypes, "Must match!");
 }
@@ -43,8 +43,8 @@ AchievementPopup::AchievementPopup() :
 void AchievementPopup::PlayAudio()
 {
     ASSERT(MessagesPresent());	//	ActiveMessage() dereferences!
-    std::string sSoundPath = g_sHomeDir + RA_DIR_OVERLAY + MSG_SOUND[ActiveMessage().Type()];
-    PlaySoundA(sSoundPath.c_str(), nullptr, SND_FILENAME | SND_ASYNC);
+    std::wstring sSoundPath = g_sHomeDir + RA_DIR_OVERLAY + MSG_SOUND[ActiveMessage().Type()];
+    PlaySoundW(sSoundPath.c_str(), nullptr, SND_FILENAME | SND_ASYNC);
 }
 
 void AchievementPopup::AddMessage(const MessagePopup& msg)

--- a/src/RA_AchievementSet.cpp
+++ b/src/RA_AchievementSet.cpp
@@ -603,10 +603,9 @@ void AchievementSet::SaveProgress(const char* sSaveStateFilename)
     if (sSaveStateFilename == nullptr)
         return;
 
-    char buffer[4096];
-    sprintf_s(buffer, 4096, "%s.rap", sSaveStateFilename);
+    std::wstring sAchievementStateFile = ra::Widen(sSaveStateFilename) + L".rap";
     FILE* pf = nullptr;
-    fopen_s(&pf, buffer, "w");
+    _wfopen_s(&pf, sAchievementStateFile.c_str(), L"w");
     if (pf == nullptr)
     {
         ASSERT(!"Could not save progress!");

--- a/src/RA_AchievementSet.cpp
+++ b/src/RA_AchievementSet.cpp
@@ -29,18 +29,18 @@ void RASetAchievementCollection(AchievementSetType Type)
     g_pActiveAchievements = *ACH_SETS[Type];
 }
 
-std::string AchievementSet::GetAchievementSetFilename(ra::GameID nGameID)
+std::wstring AchievementSet::GetAchievementSetFilename(ra::GameID nGameID)
 {
     switch (m_nSetType)
     {
         case Core:
-            return g_sHomeDir + RA_DIR_DATA + std::to_string(nGameID) + ".txt";
+            return g_sHomeDir + RA_DIR_DATA + std::to_wstring(nGameID) + L".txt";
         case Unofficial:
-            return g_sHomeDir + RA_DIR_DATA + std::to_string(nGameID) + ".txt";	// Same as Core
+            return g_sHomeDir + RA_DIR_DATA + std::to_wstring(nGameID) + L".txt";	// Same as Core
         case Local:
-            return g_sHomeDir + RA_DIR_DATA + std::to_string(nGameID) + "-User.txt";
+            return g_sHomeDir + RA_DIR_DATA + std::to_wstring(nGameID) + L"-User.txt";
         default:
-            return "";
+            return L"";
     }
 }
 
@@ -59,8 +59,8 @@ BOOL AchievementSet::DeletePatchFile(ra::GameID nGameID)
     }
 
     //	Remove the text file
-    std::string sFilename = GetAchievementSetFilename(nGameID);
-    return RemoveFileIfExists(g_sHomeDir + "\\" + sFilename);
+    std::wstring sFilename = GetAchievementSetFilename(nGameID);
+    return RemoveFileIfExists(g_sHomeDir + L"\\" + sFilename);
 }
 
 //static 
@@ -267,9 +267,9 @@ BOOL AchievementSet::SaveToFile()
     char sMem[2048];
     unsigned int i = 0;
 
-    const std::string sFilename = GetAchievementSetFilename(g_pCurrentGameData->GetGameID());
+    const std::wstring sFilename = GetAchievementSetFilename(g_pCurrentGameData->GetGameID());
 
-    fopen_s(&pFile, sFilename.c_str(), "w");
+    _wfopen_s(&pFile, sFilename.c_str(), L"w");
     if (pFile != nullptr)
     {
         sprintf_s(sNextLine, 2048, "0.030\n");						//	Min ver
@@ -399,7 +399,7 @@ BOOL AchievementSet::FetchFromWebBlocking(ra::GameID nGameID)
     {
         const Value& PatchData = doc["PatchData"];
         FILE* pf = nullptr;
-        fopen_s(&pf, std::string(g_sHomeDir + RA_DIR_DATA + std::to_string(nGameID) + ".txt").c_str(), "wb");
+        _wfopen_s(&pf, std::wstring(g_sHomeDir + RA_DIR_DATA + std::to_wstring(nGameID) + L".txt").c_str(), L"wb");
         if (pf != nullptr)
         {
             FileStream fs(pf);
@@ -435,10 +435,10 @@ BOOL AchievementSet::LoadFromFile(ra::GameID nGameID)
         return TRUE;
     }
 
-    const std::string sFilename = GetAchievementSetFilename(nGameID);
+    const std::wstring sFilename = GetAchievementSetFilename(nGameID);
 
     FILE* pFile = nullptr;
-    errno_t nErr = fopen_s(&pFile, sFilename.c_str(), "r");
+    errno_t nErr = _wfopen_s(&pFile, sFilename.c_str(), L"r");
     if (pFile != nullptr)
     {
         //	Store this: we are now assuming this is the correct checksum if we have a file for it
@@ -502,7 +502,7 @@ BOOL AchievementSet::LoadFromFile(ra::GameID nGameID)
                 ra::GameID nGameID = g_pCurrentGameData->GetGameID();
 
                 //	Rich Presence
-                _WriteBufferToFile(g_sHomeDir + RA_DIR_DATA + std::to_string(nGameID) + "-Rich.txt", g_pCurrentGameData->RichPresencePatch());
+                _WriteBufferToFile(g_sHomeDir + RA_DIR_DATA + std::to_wstring(nGameID) + L"-Rich.txt", g_pCurrentGameData->RichPresencePatch());
                 g_RichPresenceInterpreter.ParseFromString(g_pCurrentGameData->RichPresencePatch().c_str());
 
                 const Value& AchievementsData = doc["Achievements"];
@@ -628,7 +628,6 @@ void AchievementSet::SaveProgress(const char* sSaveStateFilename)
 
 void AchievementSet::LoadProgress(const char* sLoadStateFilename)
 {
-    char buffer[4096];
     long nFileSize;
 
     if (!RAUsers::LocalUser().IsLoggedIn())
@@ -637,9 +636,9 @@ void AchievementSet::LoadProgress(const char* sLoadStateFilename)
     if (sLoadStateFilename == nullptr)
         return;
 
-    sprintf_s(buffer, sizeof(buffer), "%s.rap", sLoadStateFilename);
+    std::wstring sAchievementStateFile = ra::Widen(sLoadStateFilename) + L".rap";
 
-    char* pRawFile = _MallocAndBulkReadFileToBuffer(buffer, nFileSize);
+    char* pRawFile = _MallocAndBulkReadFileToBuffer(sAchievementStateFile.c_str(), nFileSize);
     if (pRawFile != nullptr)
     {
         const char* pIter = pRawFile;

--- a/src/RA_AchievementSet.h
+++ b/src/RA_AchievementSet.h
@@ -34,7 +34,7 @@ public:
 
     BOOL DeletePatchFile(ra::GameID nGameID);
 
-    std::string GetAchievementSetFilename(ra::GameID nGameID);
+    std::wstring GetAchievementSetFilename(ra::GameID nGameID);
 
     //	Get Achievement at offset
     Achievement& GetAchievement(size_t nIter) { return m_Achievements[nIter]; }

--- a/src/RA_CodeNotes.cpp
+++ b/src/RA_CodeNotes.cpp
@@ -12,12 +12,12 @@ void CodeNotes::Clear()
     m_CodeNotes.clear();
 }
 
-size_t CodeNotes::Load(const std::string& sFile)
+size_t CodeNotes::Load(const std::wstring& sFile)
 {
     Clear();
 
     FILE* pf = nullptr;
-    if (fopen_s(&pf, sFile.c_str(), "rb") == 0)
+    if (_wfopen_s(&pf, sFile.c_str(), L"rb") == 0)
     {
         Document doc;
         doc.ParseStream(FileStream(pf));
@@ -50,7 +50,7 @@ size_t CodeNotes::Load(const std::string& sFile)
     return m_CodeNotes.size();
 }
 
-BOOL CodeNotes::Save(const std::string& sFile)
+BOOL CodeNotes::Save(const std::wstring& sFile)
 {
     return FALSE;
     //	All saving should be cloud-based!
@@ -73,7 +73,7 @@ void CodeNotes::OnCodeNotesResponse(Document& doc)
     //	Persist then reload
     const ra::GameID nGameID = doc["GameID"].GetUint();
 
-    _WriteBufferToFile(g_sHomeDir + std::string(RA_DIR_DATA) + std::to_string(nGameID) + "-Notes2.txt", doc);
+    _WriteBufferToFile(g_sHomeDir + RA_DIR_DATA + std::to_wstring(nGameID) + L"-Notes2.txt", doc);
 
     g_MemoryDialog.RepopulateMemNotesFromFile();
 }

--- a/src/RA_CodeNotes.h
+++ b/src/RA_CodeNotes.h
@@ -29,8 +29,8 @@ public:
 public:
     void Clear();
 
-    BOOL Save(const std::string& sFile);
-    size_t Load(const std::string& sFile);
+    BOOL Save(const std::wstring& sFile);
+    size_t Load(const std::wstring& sFile);
 
     BOOL ReloadFromWeb(ra::GameID nID);
     static void OnCodeNotesResponse(Document& doc);

--- a/src/RA_Core.h
+++ b/src/RA_Core.h
@@ -105,7 +105,7 @@ extern "C" {
 
 //	Non-exposed:
 extern std::string g_sKnownRAVersion;
-extern std::string g_sHomeDir;
+extern std::wstring g_sHomeDir;
 extern std::string g_sROMDirLocation;
 extern std::string g_sCurrentROMMD5;
 
@@ -127,10 +127,10 @@ extern bool g_bPreferDecimalVal;
 extern unsigned int g_nNumHTTPThreads;
 
 //	Read a file to a malloc'd buffer. Returns nullptr on error. Owner MUST free() buffer if not nullptr.
-extern char* _MallocAndBulkReadFileToBuffer(const char* sFilename, long& nFileSizeOut);
+extern char* _MallocAndBulkReadFileToBuffer(const wchar_t* sFilename, long& nFileSizeOut);
 
 //  Read a file to a std::string. Returns false on error.
-extern bool _ReadBufferFromFile(_Out_ std::string& buffer, const char* sFile);
+extern bool _ReadBufferFromFile(_Out_ std::string& buffer, const wchar_t* sFile);
 
 //	Read file until reaching the end of the file, or the specified char.
 extern BOOL _ReadTil(const char nChar, char buffer[], unsigned int nSize, DWORD* pCharsRead, FILE* pFile);
@@ -140,8 +140,8 @@ extern char* _ReadStringTil(char nChar, char*& pOffsetInOut, BOOL bTerminate);
 extern void  _ReadStringTil(std::string& sValue, char nChar, const char*& pOffsetInOut);
 
 //	Write out the buffer to a file
-extern void _WriteBufferToFile(const std::string& sFileName, const std::string& sString);
-extern void _WriteBufferToFile(const std::string& sFileName, const Document& doc);
+extern void _WriteBufferToFile(const std::wstring& sFileName, const std::string& sString);
+extern void _WriteBufferToFile(const std::wstring& sFileName, const Document& doc);
 
 //	Fetch various interim txt/data files
 extern void _FetchGameHashLibraryFromWeb();
@@ -149,14 +149,14 @@ extern void _FetchGameTitlesFromWeb();
 extern void _FetchMyProgressFromWeb();
 
 
-extern BOOL _FileExists(const std::string& sFileName);
+extern BOOL _FileExists(const std::wstring& sFileName);
 
 extern std::string _TimeStampToString(time_t nTime);
 
 
 extern std::string GetFolderFromDialog();
 
-extern BOOL RemoveFileIfExists(const std::string& sFilePath);
+extern BOOL RemoveFileIfExists(const std::wstring& sFilePath);
 
 BOOL CanCausePause();
 

--- a/src/RA_Defs.cpp
+++ b/src/RA_Defs.cpp
@@ -53,7 +53,7 @@ _Use_decl_annotations_ std::wstring Widen(std::string&& str) noexcept
 _Use_decl_annotations_ std::wstring Widen(const char* str)
 {
     auto len{ ra::to_signed(std::strlen(str)) };
-    auto needed{::MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, str, len + 1, nullptr, 0)};
+    auto needed{::MultiByteToWideChar(CP_UTF8, 0, str, len + 1, nullptr, 0)};
     // doesn't seem wchar_t is treated like a character type by default
     std::wstring wstr(ra::to_unsigned(needed), L'\x0'); 
     ::MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, str, len + 1, wstr.data(),
@@ -97,7 +97,7 @@ _Use_decl_annotations_ std::string Narrow(const std::string& str)
 } // namespace ra
 
 #ifndef RA_UTEST
-extern std::string g_sHomeDir;
+extern std::wstring g_sHomeDir;
 #endif
 
 void RADebugLogNoFormat(const char* data)
@@ -105,9 +105,9 @@ void RADebugLogNoFormat(const char* data)
     OutputDebugString(NativeStr(data).c_str());
 
 #ifndef RA_UTEST
-    std::string sLogFile = g_sHomeDir + RA_LOG_FILENAME;
+    std::wstring sLogFile = g_sHomeDir + RA_LOG_FILENAME;
     FILE* pf = nullptr;
-    if (fopen_s(&pf, sLogFile.c_str(), "a") == 0)
+    if (_wfopen_s(&pf, sLogFile.c_str(), L"a") == 0)
     {
         fwrite(data, sizeof(char), strlen(data), pf);
         fclose(pf);

--- a/src/RA_Defs.h
+++ b/src/RA_Defs.h
@@ -138,23 +138,23 @@ using namespace std::string_literals;
 #define _CONSTANT_FN  _CONSTANT_VAR
 
 #define RA_KEYS_DLL						"RA_Keys.dll"
-#define RA_PREFERENCES_FILENAME_PREFIX	"RAPrefs_"
+#define RA_PREFERENCES_FILENAME_PREFIX	L"RAPrefs_"
 
-#define RA_DIR_OVERLAY					"Overlay\\"
-#define RA_DIR_BASE						"RACache\\"
-#define RA_DIR_DATA						RA_DIR_BASE##"Data\\"
-#define RA_DIR_BADGE					RA_DIR_BASE##"Badge\\"
-#define RA_DIR_USERPIC					RA_DIR_BASE##"UserPic\\"
-#define RA_DIR_BOOKMARKS				RA_DIR_BASE##"Bookmarks\\"
+#define RA_DIR_OVERLAY					L"Overlay\\"
+#define RA_DIR_BASE						L"RACache\\"
+#define RA_DIR_DATA						RA_DIR_BASE L"Data\\"
+#define RA_DIR_BADGE					RA_DIR_BASE L"Badge\\"
+#define RA_DIR_USERPIC					RA_DIR_BASE L"UserPic\\"
+#define RA_DIR_BOOKMARKS				RA_DIR_BASE L"Bookmarks\\"
 
-#define RA_GAME_HASH_FILENAME			RA_DIR_DATA##"gamehashlibrary.txt"
-#define RA_GAME_LIST_FILENAME			RA_DIR_DATA##"gametitles.txt"
-#define RA_MY_PROGRESS_FILENAME			RA_DIR_DATA##"myprogress.txt"
-#define RA_MY_GAME_LIBRARY_FILENAME		RA_DIR_DATA##"mygamelibrary.txt"
+#define RA_GAME_HASH_FILENAME			RA_DIR_DATA L"gamehashlibrary.txt"
+#define RA_GAME_LIST_FILENAME			RA_DIR_DATA L"gametitles.txt"
+#define RA_MY_PROGRESS_FILENAME			RA_DIR_DATA L"myprogress.txt"
+#define RA_MY_GAME_LIBRARY_FILENAME		RA_DIR_DATA L"mygamelibrary.txt"
 
-#define RA_NEWS_FILENAME				RA_DIR_DATA##"ra_news.txt"
-#define RA_TITLES_FILENAME				RA_DIR_DATA##"gametitles.txt"
-#define RA_LOG_FILENAME					RA_DIR_DATA##"RALog.txt"
+#define RA_NEWS_FILENAME				RA_DIR_DATA L"ra_news.txt"
+#define RA_TITLES_FILENAME				RA_DIR_DATA L"gametitles.txt"
+#define RA_LOG_FILENAME					RA_DIR_DATA L"RALog.txt"
 
 
 #define SIZEOF_ARRAY( ar )	( sizeof( ar ) / sizeof( ar[ 0 ] ) )

--- a/src/RA_Dlg_GameLibrary.cpp
+++ b/src/RA_Dlg_GameLibrary.cpp
@@ -91,9 +91,9 @@ Dlg_GameLibrary::~Dlg_GameLibrary()
 
 void ParseGameHashLibraryFromFile(std::map<std::string, ra::GameID>& GameHashLibraryOut)
 {
-    std::string sGameHashFile = g_sHomeDir + RA_GAME_HASH_FILENAME;
+    std::wstring sGameHashFile = g_sHomeDir + RA_GAME_HASH_FILENAME;
     FILE* pf = nullptr;
-    fopen_s(&pf, sGameHashFile.c_str(), "rb");
+    _wfopen_s(&pf, sGameHashFile.c_str(), L"rb");
     if (pf != nullptr)
     {
         Document doc;
@@ -120,9 +120,9 @@ void ParseGameHashLibraryFromFile(std::map<std::string, ra::GameID>& GameHashLib
 
 void ParseGameTitlesFromFile(std::map<ra::GameID, std::string>& GameTitlesListOut)
 {
-    std::string sTitlesFile = g_sHomeDir + RA_TITLES_FILENAME;
+    std::wstring sTitlesFile = g_sHomeDir + RA_TITLES_FILENAME;
     FILE* pf = nullptr;
-    fopen_s(&pf, sTitlesFile.c_str(), "rb");
+    _wfopen_s(&pf, sTitlesFile.c_str(), L"rb");
     if (pf != nullptr)
     {
         Document doc;
@@ -148,9 +148,9 @@ void ParseGameTitlesFromFile(std::map<ra::GameID, std::string>& GameTitlesListOu
 
 void ParseMyProgressFromFile(std::map<ra::GameID, std::string>& GameProgressOut)
 {
-    std::string sProgressFile = g_sHomeDir + RA_TITLES_FILENAME;
+    std::wstring sProgressFile = g_sHomeDir + RA_TITLES_FILENAME;
     FILE* pf = nullptr;
-    fopen_s(&pf, sProgressFile.c_str(), "rb");
+    _wfopen_s(&pf, sProgressFile.c_str(), L"rb");
     if (pf != nullptr)
     {
         Document doc;
@@ -469,11 +469,11 @@ BOOL Dlg_GameLibrary::LaunchSelected()
 
 void Dlg_GameLibrary::LoadAll()
 {
-    std::string sMyGameLibraryFile = g_sHomeDir + RA_MY_GAME_LIBRARY_FILENAME;
+    std::wstring sMyGameLibraryFile = g_sHomeDir + RA_MY_GAME_LIBRARY_FILENAME;
     
     mtx.lock();
     FILE* pLoadIn = nullptr;
-    fopen_s(&pLoadIn, sMyGameLibraryFile.c_str(), "rb");
+    _wfopen_s(&pLoadIn, sMyGameLibraryFile.c_str(), L"rb");
     if (pLoadIn != nullptr)
     {
         DWORD nCharsRead1 = 0;
@@ -513,11 +513,11 @@ void Dlg_GameLibrary::LoadAll()
 
 void Dlg_GameLibrary::SaveAll()
 {
-    std::string sMyGameLibraryFile = g_sHomeDir + RA_MY_GAME_LIBRARY_FILENAME;
+    std::wstring sMyGameLibraryFile = g_sHomeDir + RA_MY_GAME_LIBRARY_FILENAME;
 
     mtx.lock();
     FILE* pf = nullptr;
-    fopen_s(&pf, sMyGameLibraryFile.c_str(), "wb");
+    _wfopen_s(&pf, sMyGameLibraryFile.c_str(), L"wb");
     if (pf != nullptr)
     {
         std::map<std::string, std::string>::iterator iter = Results.begin();

--- a/src/RA_Dlg_MemBookmark.cpp
+++ b/src/RA_Dlg_MemBookmark.cpp
@@ -119,7 +119,7 @@ INT_PTR Dlg_MemBookmark::MemBookmarkDialogProc(HWND hDlg, UINT uMsg, WPARAM wPar
             // Auto-import bookmark file when opening dialog
             if (g_pCurrentGameData->GetGameID() != 0)
             {
-                std::string file = RA_DIR_BOOKMARKS + std::to_string(g_pCurrentGameData->GetGameID()) + "-Bookmarks.txt";
+                std::wstring file = RA_DIR_BOOKMARKS + std::to_wstring(g_pCurrentGameData->GetGameID()) + L"-Bookmarks.txt";
                 ImportFromFile(file);
             }
 
@@ -440,7 +440,7 @@ INT_PTR Dlg_MemBookmark::MemBookmarkDialogProc(HWND hDlg, UINT uMsg, WPARAM wPar
                 }
                 case IDC_RA_LOADBOOKMARK:
                 {
-                    std::string file = ImportDialog();
+                    std::wstring file = ImportDialog();
                     if (file.length() > 0)
                         ImportFromFile(file);
                     return TRUE;
@@ -699,7 +699,7 @@ void Dlg_MemBookmark::ExportJSON()
         return;
     }
 
-    std::string defaultDir = g_sHomeDir + RA_DIR_BOOKMARKS;
+    std::wstring defaultDir = g_sHomeDir + RA_DIR_BOOKMARKS;
 
     CComPtr<IFileSaveDialog> pDlg;
 
@@ -715,7 +715,7 @@ void Dlg_MemBookmark::ExportJSON()
             if (SUCCEEDED(hr = pDlg->SetFileName(ra::Widen(defaultFileName).c_str())))
             {
                 PIDLIST_ABSOLUTE pidl{ nullptr };
-                if (SUCCEEDED(hr = SHParseDisplayName(ra::Widen(defaultDir).c_str(), nullptr, &pidl, SFGAO_FOLDER, nullptr)))
+                if (SUCCEEDED(hr = SHParseDisplayName(defaultDir.c_str(), nullptr, &pidl, SFGAO_FOLDER, nullptr)))
                 {
                     CComPtr<IShellItem> pItem;
                     SHCreateShellItem(nullptr, nullptr, pidl, &pItem);
@@ -753,7 +753,7 @@ void Dlg_MemBookmark::ExportJSON()
                                     }
                                     doc.AddMember("Bookmarks", bookmarks, allocator);
 
-                                    _WriteBufferToFile(ra::Narrow(pStr), doc);
+                                    _WriteBufferToFile(pStr, doc);
                                     CoTaskMemFree(static_cast<LPVOID>(pStr));
                                     pStr = nullptr;
                                 }
@@ -770,10 +770,10 @@ void Dlg_MemBookmark::ExportJSON()
     }
 }
 
-void Dlg_MemBookmark::ImportFromFile(std::string sFilename)
+void Dlg_MemBookmark::ImportFromFile(std::wstring sFilename)
 {
     FILE* pFile = nullptr;
-    errno_t nErr = fopen_s(&pFile, sFilename.c_str(), "r");
+    errno_t nErr = _wfopen_s(&pFile, sFilename.c_str(), L"r");
     if (pFile != nullptr)
     {
         Document doc;
@@ -819,9 +819,9 @@ void Dlg_MemBookmark::ImportFromFile(std::string sFilename)
     }
 }
 
-std::string Dlg_MemBookmark::ImportDialog()
+std::wstring Dlg_MemBookmark::ImportDialog()
 {
-    std::string str;
+    std::wstring str;
 
     if (g_pCurrentGameData->GetGameID() == 0)
     {
@@ -844,7 +844,7 @@ std::string Dlg_MemBookmark::ImportDialog()
                     LPWSTR pStr = nullptr;
                     if (SUCCEEDED(hr = pItem->GetDisplayName(SIGDN_FILESYSPATH, &pStr)))
                     {
-                        str = ra::Narrow(pStr);
+                        str = pStr;
                         CoTaskMemFree(static_cast<LPVOID>(pStr));
                         pStr = nullptr;
                     }
@@ -865,7 +865,7 @@ void Dlg_MemBookmark::OnLoad_NewRom()
     {
         ClearAllBookmarks();
 
-        std::string file = RA_DIR_BOOKMARKS + std::to_string(g_pCurrentGameData->GetGameID()) + "-Bookmarks.txt";
+        std::wstring file = RA_DIR_BOOKMARKS + std::to_wstring(g_pCurrentGameData->GetGameID()) + L"-Bookmarks.txt";
         ImportFromFile(file);
     }
 }

--- a/src/RA_Dlg_MemBookmark.h
+++ b/src/RA_Dlg_MemBookmark.h
@@ -70,9 +70,9 @@ private:
     unsigned int GetMemory(unsigned int nAddr, int type);
 
     void ExportJSON();
-    void ImportFromFile(std::string filename);
+    void ImportFromFile(std::wstring filename);
     void GenerateResizes(HWND hDlg);
-    std::string ImportDialog();
+    std::wstring ImportDialog();
 
     void AddBookmarkMap(MemBookmark* bookmark)
     {

--- a/src/RA_Dlg_Memory.cpp
+++ b/src/RA_Dlg_Memory.cpp
@@ -1443,7 +1443,7 @@ void Dlg_Memory::RepopulateMemNotesFromFile()
     ra::GameID nGameID = g_pCurrentGameData->GetGameID();
     if (nGameID != 0)
     {
-        std::string sNotesFilename = g_sHomeDir + RA_DIR_DATA + std::to_string(nGameID) + "-Notes2.txt";
+        std::wstring sNotesFilename = g_sHomeDir + RA_DIR_DATA + std::to_wstring(nGameID) + L"-Notes2.txt";
         nSize = m_CodeNotes.Load(sNotesFilename);
     }
 

--- a/src/services/ImageRepository.cpp
+++ b/src/services/ImageRepository.cpp
@@ -123,20 +123,20 @@ ImageRepository::~ImageRepository()
     g_bImageRepositoryValid = false;
 }
 
-std::string ImageRepository::GetFilename(ImageType nType, const std::string& sName)
+std::wstring ImageRepository::GetFilename(ImageType nType, const std::string& sName)
 {
-    std::string sFilename = g_sHomeDir;
+    std::wstring sFilename = g_sHomeDir;
 
     switch (nType)
     {
         case ImageType::Badge:
-            sFilename += RA_DIR_BADGE + sName + ".png";
+            sFilename += RA_DIR_BADGE + ra::Widen(sName) + L".png";
             break;
         case ImageType::UserPic:
-            sFilename += RA_DIR_USERPIC + sName + ".png";
+            sFilename += RA_DIR_USERPIC + ra::Widen(sName) + L".png";
             break;
         case ImageType::Local:
-            sFilename += sName;
+            sFilename += ra::Widen(sName);
             break;
         default:
             ASSERT(!"Unsupported image type");
@@ -151,7 +151,7 @@ void ImageRepository::FetchImage(ImageType nType, const std::string& sName)
     if (sName.empty())
         return;
 
-    std::string sFilename = GetFilename(nType, sName);
+    std::wstring sFilename = GetFilename(nType, sName);
     if (_FileExists(sFilename))
         return;
 
@@ -320,7 +320,7 @@ static HRESULT CreateDIBFromBitmapSource(_In_ IWICBitmapSource *pToRenderBitmapS
     return hr;
 }
 
-HBITMAP ImageRepository::LoadLocalPNG(const std::string& sFilename, size_t nWidth, size_t nHeight)
+HBITMAP ImageRepository::LoadLocalPNG(const std::wstring& sFilename, size_t nWidth, size_t nHeight)
 {
     if (g_pIWICFactory == nullptr)
         return nullptr;
@@ -405,7 +405,7 @@ HBITMAP ImageRepository::GetImage(ImageType nType, const std::string& sName, boo
     if (sName.empty())
         return nullptr;
 
-    std::string sFilename = GetFilename(nType, sName);
+    std::wstring sFilename = GetFilename(nType, sName);
     if (!_FileExists(sFilename))
     {
         FetchImage(nType, sName);

--- a/src/services/ImageRepository.h
+++ b/src/services/ImageRepository.h
@@ -92,8 +92,8 @@ public:
     void ReleaseReference(ImageType nType, const std::string& sName);
 
 private:
-    static std::string GetFilename(ImageType nType, const std::string& sName);
-    static HBITMAP LoadLocalPNG(const std::string& sFilename, size_t nWidth, size_t nHeight);
+    static std::wstring GetFilename(ImageType nType, const std::string& sName);
+    static HBITMAP LoadLocalPNG(const std::wstring& sFilename, size_t nWidth, size_t nHeight);
 
     friend class ImageReference;
     HBITMAP DefaultImage(ImageType nType);

--- a/tests/RA_Defs_Tests.cpp
+++ b/tests/RA_Defs_Tests.cpp
@@ -39,6 +39,9 @@ public:
         Assert::AreEqual(std::wstring(L"\xD83C\xDF0F"), Widen(L"\xD83C\xDF0F"));
         Assert::AreEqual(std::wstring(L"\xD83C\xDF0F"), Widen(std::string("\xF0\x9F\x8C\x8F")));
         Assert::AreEqual(std::wstring(L"\xD83C\xDF0F"), Widen(std::wstring(L"\xD83C\xDF0F")));
+
+        // invalid UTF-8 replaced with placeholder U+FFFD
+        Assert::AreEqual(std::wstring(L"T\xFFFDst"), Widen("T\xA9st")); // should be \xC3\xA9
     }
 };
 


### PR DESCRIPTION
Changes made for #85 were not working if the executable path had non-ASCII characters in it. 

Problem identified by realgex . see http://retroachievements.org/viewtopic.php?t=7237
Also worked with darlanfagunes to come to the conclusion that he was having the same problem.
Wayne121 was also having the same issue. Both darlanfagunes and Wayne121 tested a DLL built off this branch and verified it fixed their issue (at least well enough to get into their games).

This PR changes all file path references to use wstring (16-bit characters).

It also ensures that if `ra::Widen` is called with a non-UTF8 string it doesn't throw an exception. This is what was causing the crash. The non-ASCII character was not valid UTF8, so attempting to Widen it to load the user's image failed.