### PR TITLE
support for auto-updating patch releases

### DIFF
--- a/MakeBuildVer.bat
+++ b/MakeBuildVer.bat
@@ -25,15 +25,11 @@ if %DIFF_FILE_SIZE% GTR 0 (
 
 git rev-parse --abbrev-ref HEAD > Temp.txt
 set /p ACTIVE_BRANCH=<Temp.txt
-if "%ACTIVE_BRANCH%"=="master" (
-    echo RAIntegration Tag: %ACTIVE_TAG% [%VERSION_MINOR%]
-    echo #define RA_INTEGRATION_VERSION "0.%VERSION_MINOR%" > RA_BuildVer.h
-) else (
-    echo RAIntegration Tag 0.999 - Not on Master Branch!
-    echo #define RA_INTEGRATION_VERSION "0.999" > RA_BuildVer.h
+if not "%ACTIVE_BRANCH%"=="master" (
     set VERSION_PRODUCT=%VERSION_PRODUCT%-%ACTIVE_BRANCH%
 )
 
+echo #define RA_INTEGRATION_VERSION "%VERSION_MAJOR%.%VERSION_MINOR%.%VERSION_REVISION%.%VERSION_MODIFIED%" > RA_BuildVer.h
 echo #define RA_INTEGRATION_VERSION_MAJOR %VERSION_MAJOR% >> RA_BuildVer.h
 echo #define RA_INTEGRATION_VERSION_MINOR %VERSION_MINOR% >> RA_BuildVer.h
 echo #define RA_INTEGRATION_VERSION_REVISION %VERSION_REVISION% >> RA_BuildVer.h


### PR DESCRIPTION
* Removes the 0.999 version previously used to circumvent the auto-updater for branch development.
* Allows for patch and revision versions to supersede the server version. "0.74.2.0" > "0.74.0.1" > "0.74.0.0".
* Allows for the server to specify a patch version as the latest version and have players with the base version download the patch.

The auto-update functionality will be compiled into the emulators. If a patch is released for an emulator that doesn't support auto-updating patches, the user will not get the patch. i.e. If server version is "0.74.2" and client version is "0.74.0", the _old_ auto-updater will only match the "0.74" part of the version and assume the dll is up-to-date. As patch releases are aimed as fixing bugs and not adding new features, this behavior is acceptable. Players should upgrade to the newer versions of the emulators anyway.

The only difference in behavior is that once a new release is published/tagged, branches have to merge master to pick up the new tag. As a branch inherently has more commits than master, the branch version will always be newer than the published version as long as the minor version is kept up to date by merging master.
