### PR TITLE
Demacrofied where appropriate

### DIFF
--- a/src/RA_Achievement.cpp
+++ b/src/RA_Achievement.cpp
@@ -159,7 +159,7 @@ BOOL Achievement::Test()
 
         char buffer[256];
         sprintf_s(buffer, 256, "Pause on Reset: %s", Title().c_str());
-        MessageBox(g_RAMainWnd, NativeStr(buffer).c_str(), TEXT("Paused"), MB_OK);
+        MessageBox(g_RAMainWnd, ra::NativeStr(buffer).c_str(), TEXT("Paused"), MB_OK);
 #endif
     }
 

--- a/src/RA_Achievement.cpp
+++ b/src/RA_Achievement.cpp
@@ -20,8 +20,7 @@ void _ReadStringTil(std::string& value, char nChar, const char*& pSource)
 
 //////////////////////////////////////////////////////////////////////////
 
-Achievement::Achievement(AchievementSetType nType) :
-    m_nSetType(nType), m_bPauseOnTrigger(FALSE), m_bPauseOnReset(FALSE)
+Achievement::Achievement() noexcept
 {
     Clear();
 
@@ -54,8 +53,6 @@ void Achievement::Parse(const rapidjson::Value& element)
             m_vConditions.Clear();
         }
     }
-
-    SetActive(IsCoreAchievement());	//	Activate core by default
 }
 
 #endif

--- a/src/RA_Achievement.h
+++ b/src/RA_Achievement.h
@@ -4,8 +4,6 @@
 
 #include "RA_Condition.h"
 
-
-
 //////////////////////////////////////////////////////////////////////////
 //	Achievement
 //////////////////////////////////////////////////////////////////////////
@@ -27,7 +25,7 @@ enum Achievement_DirtyFlags
 class Achievement
 {
 public:
-    Achievement(AchievementSetType nType);
+    Achievement() noexcept;
 
 public:
     void Clear();
@@ -51,8 +49,6 @@ public:
 
     inline BOOL GetPauseOnReset() const { return m_bPauseOnReset; }
     void SetPauseOnReset(BOOL bPause) { m_bPauseOnReset = bPause; }
-
-    BOOL IsCoreAchievement() const { return m_nSetType == Core; }
 
     void SetID(ra::AchievementID nID);
     inline ra::AchievementID ID() const { return m_nAchievementID; }
@@ -114,9 +110,7 @@ public:
     void ClearDirtyFlag() { m_nDirtyFlags = 0; }
 
 private:
-    /*const*/ AchievementSetType m_nSetType;
-
-    ra::AchievementID m_nAchievementID;
+    ra::AchievementID m_nAchievementID{};
     ConditionSet m_vConditions;
 
     std::string m_sTitle;
@@ -124,30 +118,28 @@ private:
     std::string m_sAuthor;
     std::string m_sBadgeImageURI;
 
-    unsigned int m_nPointValue;
-    BOOL m_bActive;
-    BOOL m_bModified;
-    BOOL m_bPauseOnTrigger;
-    BOOL m_bPauseOnReset;
+    unsigned int m_nPointValue{};
+    BOOL m_bActive{};
+    BOOL m_bModified{};
+    BOOL m_bPauseOnTrigger{};
+    BOOL m_bPauseOnReset{};
 
     //	Progress:
-    BOOL m_bProgressEnabled;	//	on/off
+    BOOL m_bProgressEnabled{};	//	on/off
 
     std::string m_sProgress;	//	How to calculate the progress so far (syntactical)
     std::string m_sProgressMax;	//	Upper limit of the progress (syntactical? value?)
     std::string m_sProgressFmt;	//	Format of the progress to be shown (currency? step?)
 
-    float m_fProgressLastShown;	//	The last shown progress
+    float m_fProgressLastShown{};	//	The last shown progress
 
-    unsigned int m_nDirtyFlags;	//	Use for rendering when editing.
+    unsigned int m_nDirtyFlags{};	//	Use for rendering when editing.
 
-    time_t m_nTimestampCreated;
-    time_t m_nTimestampModified;
+    time_t m_nTimestampCreated{};
+    time_t m_nTimestampModified{};
 
-    unsigned short m_nUpvotes;
-    unsigned short m_nDownvotes;
+    unsigned short m_nUpvotes{};
+    unsigned short m_nDownvotes{};
 };
-
-
 
 #endif // !RA_ACHIEVEMENT_H

--- a/src/RA_AchievementOverlay.cpp
+++ b/src/RA_AchievementOverlay.cpp
@@ -36,7 +36,7 @@ const char* PAGE_TITLES[] ={
     " Message Viewer "
 
 };
-static_assert(SIZEOF_ARRAY(PAGE_TITLES) == NumOverlayPages, "Must match!");
+static_assert(ra::SizeOfArray(PAGE_TITLES) == NumOverlayPages, "Must match!");
 
 }
 
@@ -539,7 +539,7 @@ void AchievementOverlay::DrawAchievementsPage(HDC hDC, int nDX, int nDY, const R
         SelectObject(hDC, g_hFontTitle);
         SetTextColor(hDC, COL_TEXT);
         std::string sTitleWithSpaces(" " + g_pCurrentGameData->GameTitle() + " ");
-        TextOut(hDC, nGameTitleX + nDX, nGameTitleY + nDY, NativeStr(sTitleWithSpaces).c_str(), sTitleWithSpaces.length());
+        TextOut(hDC, nGameTitleX + nDX, nGameTitleY + nDY, ra::NativeStr(sTitleWithSpaces).c_str(), sTitleWithSpaces.length());
     }
 
     SelectObject(hDC, g_hFontDesc);
@@ -563,7 +563,7 @@ void AchievementOverlay::DrawAchievementsPage(HDC hDC, int nDX, int nDY, const R
             sprintf_s(buffer, 256, " %u of %u won (%u/%u) ",
                 nUserCompleted, nNumberOfAchievements,
                 nUserPts, nMaxPts);
-            TextOut(hDC, nDX + nGameTitleX, nGameSubTitleY, NativeStr(buffer).c_str(), strlen(buffer));
+            TextOut(hDC, nDX + nGameTitleX, nGameSubTitleY, ra::NativeStr(buffer).c_str(), strlen(buffer));
         }
     }
 
@@ -616,12 +616,12 @@ void AchievementOverlay::DrawAchievementsPage(HDC hDC, int nDX, int nDY, const R
         if (!RA_GameIsActive())
         {
             const std::string sMsg(" No achievements present... ");
-            TextOut(hDC, nDX + nGameTitleX, nGameSubTitleY, NativeStr(sMsg).c_str(), sMsg.length());
+            TextOut(hDC, nDX + nGameTitleX, nGameSubTitleY, ra::NativeStr(sMsg).c_str(), sMsg.length());
         }
         else if (nNumberOfAchievements == 0)
         {
             const std::string sMsg(" No achievements present... ");
-            TextOut(hDC, nDX + nGameTitleX, nGameSubTitleY, NativeStr(sMsg).c_str(), sMsg.length());
+            TextOut(hDC, nDX + nGameTitleX, nGameSubTitleY, ra::NativeStr(sMsg).c_str(), sMsg.length());
         }
     }
 
@@ -695,7 +695,7 @@ void AchievementOverlay::DrawFriendsPage(HDC hDC, int nDX, _UNUSED int, const RE
             HANDLE hOldObj = SelectObject(hDC, g_hFontDesc);
 
             sprintf_s(buffer, 256, " %s (%u) ", pFriend->Username().c_str(), pFriend->GetScore());
-            TextOut(hDC, nXOffs + nFriendLeftOffsetText, nYOffs, NativeStr(buffer).c_str(), strlen(buffer));
+            TextOut(hDC, nXOffs + nFriendLeftOffsetText, nYOffs, ra::NativeStr(buffer).c_str(), strlen(buffer));
 
             SelectObject(hDC, g_hFontTiny);
             sprintf_s(buffer, 256, " %s ", pFriend->Activity().c_str());
@@ -706,7 +706,7 @@ void AchievementOverlay::DrawFriendsPage(HDC hDC, int nDX, _UNUSED int, const RE
                 nYOffs + nFriendSubtitleYOffs,
                 nDX + rcTarget.right - 40,
                 nYOffs + nFriendSubtitleYOffs + 46);
-            DrawText(hDC, NativeStr(pFriend->Activity()).c_str(), -1, &rcDest, DT_LEFT | DT_WORDBREAK);
+            DrawText(hDC, ra::NativeStr(pFriend->Activity()).c_str(), -1, &rcDest, DT_LEFT | DT_WORDBREAK);
 
             //	Restore
             SelectObject(hDC, hOldObj);
@@ -774,12 +774,12 @@ void AchievementOverlay::DrawAchievementExaminePage(HDC hDC, int nDX, _UNUSED in
     ctime_s(bufTime, 256, &tCreated);
     bufTime[strlen(bufTime) - 1] = '\0';	//	Remove pesky newline
     sprintf_s(buffer, 256, " Created: %s ", bufTime);
-    TextOut(hDC, nDX + 20, nCoreDetailsY, NativeStr(buffer).c_str(), strlen(buffer));
+    TextOut(hDC, nDX + 20, nCoreDetailsY, ra::NativeStr(buffer).c_str(), strlen(buffer));
 
     ctime_s(bufTime, 256, &tModified);
     bufTime[strlen(bufTime) - 1] = '\0';	//	Remove pesky newline
     sprintf_s(buffer, 256, " Modified: %s ", bufTime);
-    TextOut(hDC, nDX + 20, nCoreDetailsY + nCoreDetailsSpacing, NativeStr(buffer).c_str(), strlen(buffer));
+    TextOut(hDC, nDX + 20, nCoreDetailsY + nCoreDetailsSpacing, ra::NativeStr(buffer).c_str(), strlen(buffer));
 
     if (g_AchExamine.HasData())
     {
@@ -787,12 +787,12 @@ void AchievementOverlay::DrawAchievementExaminePage(HDC hDC, int nDX, _UNUSED in
             g_AchExamine.TotalWinners(),
             g_AchExamine.PossibleWinners(),
             static_cast<float>(g_AchExamine.TotalWinners() * 100) / static_cast<float>(g_AchExamine.PossibleWinners()));
-        TextOut(hDC, nDX + 20, nCoreDetailsY + (nCoreDetailsSpacing * 2), NativeStr(buffer).c_str(), strlen(buffer));
+        TextOut(hDC, nDX + 20, nCoreDetailsY + (nCoreDetailsSpacing * 2), ra::NativeStr(buffer).c_str(), strlen(buffer));
 
         if (g_AchExamine.NumRecentWinners() > 0)
         {
             sprintf_s(buffer, 256, " Recent winners: ");
-            TextOut(hDC, nDX + nRecentWinnersSubtitleX, nRecentWinnersSubtitleY, NativeStr(buffer).c_str(), strlen(buffer));
+            TextOut(hDC, nDX + nRecentWinnersSubtitleX, nRecentWinnersSubtitleY, ra::NativeStr(buffer).c_str(), strlen(buffer));
         }
 
         auto i{ 0U };
@@ -807,7 +807,7 @@ void AchievementOverlay::DrawAchievementExaminePage(HDC hDC, int nDX, _UNUSED in
                 TextOut(hDC,
                     nDX + nWonByPlayerNameX,
                     nWonByPlayerYOffs + (i*nWonByPlayerYSpacing),
-                    NativeStr(sUser).c_str(), ra::to_signed(sUser.length()));
+                    ra::NativeStr(sUser).c_str(), ra::to_signed(sUser.length()));
             }
 
             std::string sWonAt{ " " };
@@ -817,7 +817,7 @@ void AchievementOverlay::DrawAchievementExaminePage(HDC hDC, int nDX, _UNUSED in
             TextOut(hDC,
                 nDX + nWonByPlayerDateX,
                 nWonByPlayerYOffs + (i*nWonByPlayerYSpacing),
-                NativeStr(sWonAt).c_str(), ra::to_signed(sWonAt.length()));
+                ra::NativeStr(sWonAt).c_str(), ra::to_signed(sWonAt.length()));
             i++;
         }
     }
@@ -834,7 +834,7 @@ void AchievementOverlay::DrawAchievementExaminePage(HDC hDC, int nDX, _UNUSED in
             nDotCount >= 2 ? '.' : ' ',
             nDotCount >= 3 ? '.' : ' ');
 
-        TextOut(hDC, nDX + nLoadingMessageX, nLoadingMessageY, NativeStr(buffer).c_str(), strlen(buffer));
+        TextOut(hDC, nDX + nLoadingMessageX, nLoadingMessageY, ra::NativeStr(buffer).c_str(), strlen(buffer));
     }
 }
 
@@ -870,14 +870,14 @@ void AchievementOverlay::DrawNewsPage(HDC hDC, int nDX, _UNUSED int, const RECT&
         SetRect(&rcNews, nLeftAlign, nYOffset, nRightAlign, nYOffset);
 
         //	Calculate height of rect, fetch bottom for next rect:
-        DrawText(hDC, NativeStr(sTitle).c_str(), strlen(sTitle), &rcNews, DT_CALCRECT | DT_WORDBREAK);
+        DrawText(hDC, ra::NativeStr(sTitle).c_str(), strlen(sTitle), &rcNews, DT_CALCRECT | DT_WORDBREAK);
         nYOffset = rcNews.bottom;
 
         if (rcNews.bottom > nHeight)
             rcNews.bottom = nHeight;
 
         //	Draw title:
-        DrawText(hDC, NativeStr(sTitle).c_str(), strlen(sTitle), &rcNews, DT_TOP | DT_LEFT | DT_WORDBREAK);
+        DrawText(hDC, ra::NativeStr(sTitle).c_str(), strlen(sTitle), &rcNews, DT_TOP | DT_LEFT | DT_WORDBREAK);
 
         //	Offset header
         nYOffset += nHeaderGap;
@@ -887,14 +887,14 @@ void AchievementOverlay::DrawNewsPage(HDC hDC, int nDX, _UNUSED int, const RECT&
         //	Setup initial variables for the rect
         SetRect(&rcNews, nLeftAlign + nArticleIndent, nYOffset, nRightAlign - nArticleIndent, nYOffset);
         //	Calculate height of rect, fetch and inset bottom:
-        DrawText(hDC, NativeStr(sPayload).c_str(), strlen(sPayload), &rcNews, DT_CALCRECT | DT_WORDBREAK);
+        DrawText(hDC, ra::NativeStr(sPayload).c_str(), strlen(sPayload), &rcNews, DT_CALCRECT | DT_WORDBREAK);
         nYOffset = rcNews.bottom;
 
         if (rcNews.bottom > nHeight)
             rcNews.bottom = nHeight;
 
         //	Draw payload:
-        DrawText(hDC, NativeStr(sPayload).c_str(), strlen(sPayload), &rcNews, DT_TOP | DT_LEFT | DT_WORDBREAK);
+        DrawText(hDC, ra::NativeStr(sPayload).c_str(), strlen(sPayload), &rcNews, DT_TOP | DT_LEFT | DT_WORDBREAK);
 
         nYOffset += nArticleGap;
     }
@@ -973,7 +973,7 @@ void AchievementOverlay::DrawLeaderboardPage(HDC hDC, int nDX, _UNUSED int, cons
             RECT rcNews;
             SetRect(&rcNews, nLeftAlign, nYOffset, nRightAlign, nYOffset);
             //	Calculate height of rect, fetch bottom for next rect:
-            DrawText(hDC, NativeStr(sTitle).c_str(), sTitle.length(), &rcNews, DT_CALCRECT | DT_WORDBREAK);
+            DrawText(hDC, ra::NativeStr(sTitle).c_str(), sTitle.length(), &rcNews, DT_CALCRECT | DT_WORDBREAK);
             nYOffset = rcNews.bottom;
 
             if (rcNews.bottom > nHeight)
@@ -982,7 +982,7 @@ void AchievementOverlay::DrawLeaderboardPage(HDC hDC, int nDX, _UNUSED int, cons
             SetTextColor(hDC, bSelected ? COL_SELECTED : COL_TEXT);
 
             //	Draw title:
-            DrawText(hDC, NativeStr(sTitle).c_str(), sTitle.length(), &rcNews, DT_TOP | DT_LEFT | DT_WORDBREAK);
+            DrawText(hDC, ra::NativeStr(sTitle).c_str(), sTitle.length(), &rcNews, DT_TOP | DT_LEFT | DT_WORDBREAK);
 
             //	Offset header
             nYOffset += nHeaderGap;
@@ -992,7 +992,7 @@ void AchievementOverlay::DrawLeaderboardPage(HDC hDC, int nDX, _UNUSED int, cons
             //	Setup initial variables for the rect
             SetRect(&rcNews, nLeftAlign + nArticleIndent, nYOffset, nRightAlign - nArticleIndent, nYOffset);
             //	Calculate height of rect, fetch and inset bottom:
-            DrawText(hDC, NativeStr(sPayload).c_str(), sPayload.length(), &rcNews, DT_CALCRECT | DT_WORDBREAK);
+            DrawText(hDC, ra::NativeStr(sPayload).c_str(), sPayload.length(), &rcNews, DT_CALCRECT | DT_WORDBREAK);
             nYOffset = rcNews.bottom;
 
             if (rcNews.bottom > nHeight)
@@ -1001,7 +1001,7 @@ void AchievementOverlay::DrawLeaderboardPage(HDC hDC, int nDX, _UNUSED int, cons
             SetTextColor(hDC, COL_SELECTED_LOCKED);
 
             //	Draw payload:
-            DrawText(hDC, NativeStr(sPayload).c_str(), sPayload.length(), &rcNews, DT_TOP | DT_LEFT | DT_WORDBREAK);
+            DrawText(hDC, ra::NativeStr(sPayload).c_str(), sPayload.length(), &rcNews, DT_TOP | DT_LEFT | DT_WORDBREAK);
 
             nYOffset += nArticleGap;
 
@@ -1050,16 +1050,16 @@ void AchievementOverlay::DrawLeaderboardExaminePage(HDC hDC, int nDX, _UNUSED in
     if (pLB == nullptr)
     {
         const std::string sMsg(" No leaderboard found ");
-        TextOut(hDC, 120, 120, NativeStr(sMsg).c_str(), sMsg.length());
+        TextOut(hDC, 120, 120, ra::NativeStr(sMsg).c_str(), sMsg.length());
     }
     else
     {
         const std::string sTitle(" " + pLB->Title() + " ");
-        TextOut(hDC, nDX + 20, nCoreDetailsY, NativeStr(sTitle).c_str(), sTitle.length());
+        TextOut(hDC, nDX + 20, nCoreDetailsY, ra::NativeStr(sTitle).c_str(), sTitle.length());
 
         SetTextColor(hDC, COL_SELECTED_LOCKED);
         const std::string sDesc(" " + pLB->Description() + " ");
-        TextOut(hDC, nDX + 20, nCoreDetailsY + nCoreDetailsSpacing, NativeStr(sDesc).c_str(), sDesc.length());
+        TextOut(hDC, nDX + 20, nCoreDetailsY + nCoreDetailsSpacing, ra::NativeStr(sDesc).c_str(), sDesc.length());
 
         SetTextColor(hDC, COL_TEXT);
 
@@ -1083,17 +1083,17 @@ void AchievementOverlay::DrawLeaderboardExaminePage(HDC hDC, int nDX, _UNUSED in
                 TextOut(hDC,
                     nDX + nWonByPlayerRankX,
                     nLeaderboardYOffs + (i * nLeaderboardYSpacing),
-                    NativeStr(sRankText).c_str(), strlen(sRankText));
+                    ra::NativeStr(sRankText).c_str(), strlen(sRankText));
 
                 TextOut(hDC,
                     nDX + nWonByPlayerUserX,
                     nLeaderboardYOffs + (i * nLeaderboardYSpacing),
-                    NativeStr(sNameText).c_str(), strlen(sNameText));
+                    ra::NativeStr(sNameText).c_str(), strlen(sNameText));
 
                 TextOut(hDC,
                     nDX + nWonByPlayerScoreX,
                     nLeaderboardYOffs + (i * nLeaderboardYSpacing),
-                    NativeStr(sScoreText).c_str(), strlen(sScoreText));
+                    ra::NativeStr(sScoreText).c_str(), strlen(sScoreText));
             }
         }
         else
@@ -1112,7 +1112,7 @@ void AchievementOverlay::DrawLeaderboardExaminePage(HDC hDC, int nDX, _UNUSED in
                 nDotCount > 2 ? '.' : ' ',
                 nDotCount > 3 ? '.' : ' ');
 
-            TextOut(hDC, nDX + nLoadingMessageX, nLoadingMessageY, NativeStr(buffer).c_str(), strlen(buffer));
+            TextOut(hDC, nDX + nLoadingMessageX, nLoadingMessageY, ra::NativeStr(buffer).c_str(), strlen(buffer));
         }
     }
 }
@@ -1146,16 +1146,16 @@ void AchievementOverlay::Render(HDC hRealDC, RECT* rcDest) const
 
 
     g_hFontTitle = CreateFont(nFontSize1, 0, 0, 0, FW_DONTCARE, FALSE, FALSE, FALSE, DEFAULT_CHARSET, OUT_OUTLINE_PRECIS,
-        CLIP_CHARACTER_PRECIS, /*NON*/ANTIALIASED_QUALITY, VARIABLE_PITCH, NativeStr(FONT_TO_USE).c_str());
+        CLIP_CHARACTER_PRECIS, /*NON*/ANTIALIASED_QUALITY, VARIABLE_PITCH, ra::NativeStr(FONT_TO_USE).c_str());
 
     g_hFontDesc = CreateFont(nFontSize2, 0, 0, 0, FW_DONTCARE, FALSE, FALSE, FALSE, DEFAULT_CHARSET, OUT_OUTLINE_PRECIS,
-        CLIP_CHARACTER_PRECIS, /*NON*/ANTIALIASED_QUALITY, VARIABLE_PITCH, NativeStr(FONT_TO_USE).c_str());
+        CLIP_CHARACTER_PRECIS, /*NON*/ANTIALIASED_QUALITY, VARIABLE_PITCH, ra::NativeStr(FONT_TO_USE).c_str());
 
     g_hFontDesc2 = CreateFont(nFontSize3, 0, 0, 0, FW_DONTCARE, FALSE, FALSE, FALSE, DEFAULT_CHARSET, OUT_OUTLINE_PRECIS,
-        CLIP_CHARACTER_PRECIS, /*NON*/ANTIALIASED_QUALITY, VARIABLE_PITCH, NativeStr(FONT_TO_USE).c_str());
+        CLIP_CHARACTER_PRECIS, /*NON*/ANTIALIASED_QUALITY, VARIABLE_PITCH, ra::NativeStr(FONT_TO_USE).c_str());
 
     g_hFontTiny = CreateFont(nFontSize4, 0, 0, 0, FW_DONTCARE, FALSE, FALSE, FALSE, DEFAULT_CHARSET, OUT_OUTLINE_PRECIS,
-        CLIP_CHARACTER_PRECIS, /*NON*/ANTIALIASED_QUALITY, VARIABLE_PITCH, NativeStr(FONT_TO_USE).c_str());
+        CLIP_CHARACTER_PRECIS, /*NON*/ANTIALIASED_QUALITY, VARIABLE_PITCH, ra::NativeStr(FONT_TO_USE).c_str());
 
     float fPctOffScreen = (m_nTransitionState == TS_IN) ?
         (m_fTransitionTimer / PAGE_TRANSITION_IN) :
@@ -1254,7 +1254,7 @@ void AchievementOverlay::Render(HDC hRealDC, RECT* rcDest) const
     TextOut(hDC,
         nDX + nBorder,
         4 + nBorder,
-        NativeStr(buffer).c_str(), strlen(buffer));
+        ra::NativeStr(buffer).c_str(), strlen(buffer));
 
 
     //int nNextPage = (int)(m_nCurrentPage+1);
@@ -1277,10 +1277,10 @@ void AchievementOverlay::Render(HDC hRealDC, RECT* rcDest) const
 
         //	Draw control text:
         sprintf_s(buffer, 1024, " ->:%s ", "Next");
-        TextOut(hDC, nRightPx - nControlsX1, nControlsY1, NativeStr(buffer).c_str(), strlen(buffer));
+        TextOut(hDC, nRightPx - nControlsX1, nControlsY1, ra::NativeStr(buffer).c_str(), strlen(buffer));
 
         sprintf_s(buffer, 1024, " <-:%s ", "Prev");
-        TextOut(hDC, nRightPx - nControlsX1, nControlsY2, NativeStr(buffer).c_str(), strlen(buffer));
+        TextOut(hDC, nRightPx - nControlsX1, nControlsY2, ra::NativeStr(buffer).c_str(), strlen(buffer));
 
         char cBackChar = 'B';
         char cSelectChar = 'A';
@@ -1292,10 +1292,10 @@ void AchievementOverlay::Render(HDC hRealDC, RECT* rcDest) const
         }
 
         sprintf_s(buffer, 1024, " %c:%s ", cBackChar, "Back");
-        TextOut(hDC, nRightPx - nControlsX2, nControlsY1, NativeStr(buffer).c_str(), strlen(buffer));
+        TextOut(hDC, nRightPx - nControlsX2, nControlsY1, ra::NativeStr(buffer).c_str(), strlen(buffer));
 
         sprintf_s(buffer, 1024, " %c:%s ", cSelectChar, "Select");
-        TextOut(hDC, nRightPx - nControlsX2, nControlsY2, NativeStr(buffer).c_str(), strlen(buffer));
+        TextOut(hDC, nRightPx - nControlsX2, nControlsY2, ra::NativeStr(buffer).c_str(), strlen(buffer));
     }
 
     DeleteObject(g_hBrushBG);
@@ -1386,11 +1386,11 @@ void AchievementOverlay::DrawAchievement(HDC hDC, const Achievement* pAch, int n
 
     sprintf_s(buffer, 1024, " %s ", pAch->Description().c_str());
     SelectObject(hDC, g_hFontDesc2);
-    TextOut(hDC, nX + nAchLeftOffset2, nY + nAchSpacingDesc, NativeStr(buffer).c_str(), strlen(buffer));
+    TextOut(hDC, nX + nAchLeftOffset2, nY + nAchSpacingDesc, ra::NativeStr(buffer).c_str(), strlen(buffer));
 
     sprintf_s(buffer, 1024, " %s (%u Points) ", pAch->Title().c_str(), pAch->Points());
     SelectObject(hDC, g_hFontDesc);
-    TextOut(hDC, nX + nAchLeftOffset1, nY, NativeStr(buffer).c_str(), strlen(buffer));
+    TextOut(hDC, nX + nAchLeftOffset1, nY, ra::NativeStr(buffer).c_str(), strlen(buffer));
 }
 
 void AchievementOverlay::DrawUserFrame(HDC hDC, RAUser* pUser, int nX, int nY, int nW, int nH) const
@@ -1420,10 +1420,10 @@ void AchievementOverlay::DrawUserFrame(HDC hDC, RAUser* pUser, int nX, int nY, i
     SelectObject(hDC, g_hFontDesc);
 
     sprintf_s(buffer, 256, " %s ", pUser->Username().c_str());
-    TextOut(hDC, nTextX, nTextY1, NativeStr(buffer).c_str(), strlen(buffer));
+    TextOut(hDC, nTextX, nTextY1, ra::NativeStr(buffer).c_str(), strlen(buffer));
 
     sprintf_s(buffer, 256, " %u Points ", pUser->GetScore());
-    TextOut(hDC, nTextX, nTextY2, NativeStr(buffer).c_str(), strlen(buffer));
+    TextOut(hDC, nTextX, nTextY2, ra::NativeStr(buffer).c_str(), strlen(buffer));
 
     if (_RA_HardcoreModeIsActive())
     {
@@ -1431,7 +1431,7 @@ void AchievementOverlay::DrawUserFrame(HDC hDC, RAUser* pUser, int nX, int nY, i
         COLORREF nLastColorBk = SetBkColor(hDC, COL_WARNING_BG);
 
         sprintf_s(buffer, 256, " HARDCORE ");
-        TextOut(hDC, nX + 180, nY + 70, NativeStr(buffer).c_str(), strlen(buffer));
+        TextOut(hDC, nX + 180, nY + 70, ra::NativeStr(buffer).c_str(), strlen(buffer));
 
         SetTextColor(hDC, nLastColor);
         SetBkColor(hDC, nLastColorBk);

--- a/src/RA_AchievementOverlay.cpp
+++ b/src/RA_AchievementOverlay.cpp
@@ -543,7 +543,7 @@ void AchievementOverlay::DrawAchievementsPage(HDC hDC, int nDX, int nDY, const R
     }
 
     SelectObject(hDC, g_hFontDesc);
-    if (g_nActiveAchievementSet == Core)
+    if (g_nActiveAchievementSet == AchievementSet::Type::Core)
     {
         for (size_t i = 0; i < nNumberOfAchievements; ++i)
         {
@@ -1355,7 +1355,7 @@ void AchievementOverlay::DrawAchievement(HDC hDC, const Achievement* pAch, int n
 
     if (bCanLock)
     {
-        if (g_nActiveAchievementSet == Core)
+        if (g_nActiveAchievementSet == AchievementSet::Type::Core)
             bLocked = pAch->Active();
     }
 

--- a/src/RA_AchievementPopup.cpp
+++ b/src/RA_AchievementPopup.cpp
@@ -32,7 +32,7 @@ const wchar_t* MSG_SOUND[] =
     L"lbcancel.wav",
     L"message.wav",
 };
-static_assert(SIZEOF_ARRAY(MSG_SOUND) == NumMessageTypes, "Must match!");
+static_assert(ra::SizeOfArray(MSG_SOUND) == NumMessageTypes, "Must match!");
 }
 
 AchievementPopup::AchievementPopup() :
@@ -144,16 +144,16 @@ void AchievementPopup::Render(HDC hDC, RECT& rcDest)
     const std::string sSubTitle = std::string(" " + ActiveMessage().Subtitle() + " ");
 
     SelectObject(hDC, hFontTitle);
-    TextOut(hDC, nTitleX, nTitleY, NativeStr(sTitle).c_str(), sTitle.length());
+    TextOut(hDC, nTitleX, nTitleY, ra::NativeStr(sTitle).c_str(), sTitle.length());
     SIZE szTitle = { 0, 0 };
-    GetTextExtentPoint32(hDC, NativeStr(sTitle).c_str(), sTitle.length(), &szTitle);
+    GetTextExtentPoint32(hDC, ra::NativeStr(sTitle).c_str(), sTitle.length(), &szTitle);
 
     SIZE szAchievement = { 0, 0 };
     if (ActiveMessage().Subtitle().length() > 0)
     {
         SelectObject(hDC, hFontDesc);
-        TextOut(hDC, nDescX, nDescY, NativeStr(sSubTitle).c_str(), sSubTitle.length());
-        GetTextExtentPoint32(hDC, NativeStr(sSubTitle).c_str(), sSubTitle.length(), &szAchievement);
+        TextOut(hDC, nDescX, nDescY, ra::NativeStr(sSubTitle).c_str(), sSubTitle.length());
+        GetTextExtentPoint32(hDC, ra::NativeStr(sSubTitle).c_str(), sSubTitle.length(), &szAchievement);
     }
 
     HGDIOBJ hPen = CreatePen(PS_SOLID, 2, COL_POPUP_SHADOW);

--- a/src/RA_AchievementSet.cpp
+++ b/src/RA_AchievementSet.cpp
@@ -255,7 +255,7 @@ void AchievementSet::Test()
 
                 char buffer[256];
                 sprintf_s(buffer, 256, "Pause on Trigger: %s", ach.Title().c_str());
-                MessageBox(g_RAMainWnd, NativeStr(buffer).c_str(), TEXT("Paused"), MB_OK);
+                MessageBox(g_RAMainWnd, ra::NativeStr(buffer).c_str(), TEXT("Paused"), MB_OK);
             }
         }
     }

--- a/src/RA_AchievementSet.cpp
+++ b/src/RA_AchievementSet.cpp
@@ -398,7 +398,7 @@ BOOL AchievementSet::LoadFromFile(ra::GameID nGameID)
     if (!ifile.is_open())
     {
         //	Cannot open file
-        RA_LOG("Cannot open file %s\n", sFilename.c_str());
+        RA_LOG("Cannot open file %s\n", ra::Narrow(sFilename).c_str());
         char sErrMsg[2048U]{};
         strerror_s(sErrMsg, errno);
         RA_LOG("Error: %s\n", sErrMsg);

--- a/src/RA_AchievementSet.h
+++ b/src/RA_AchievementSet.h
@@ -4,7 +4,6 @@
 
 #include "RA_Achievement.h" // RA_Condition.h (RA_Defs.h)
 
-
 //////////////////////////////////////////////////////////////////////////
 //	AchievementSet
 //////////////////////////////////////////////////////////////////////////
@@ -12,29 +11,37 @@
 class AchievementSet
 {
 public:
-    AchievementSet(AchievementSetType nType) :
-        m_nSetType(nType),
-        m_bProcessingActive(TRUE)
+    enum class Type
+    {
+        Core,
+        Unofficial,
+        Local
+    };
+
+    explicit AchievementSet(_In_ Type eType) noexcept :
+        m_nSetType{ eType }
     {
         Clear();
     }
 
 public:
     static BOOL FetchFromWebBlocking(ra::GameID nGameID);
+#ifndef RA_UTEST
     static void OnRequestUnlocks(const rapidjson::Document& doc);
+#endif // !RA_UTEST
 
 public:
     void Clear();
     void Test();
     void Reset();
 
-    _Success_(return != 0)
+    _Success_(return)
     BOOL LoadFromFile(_Inout_ ra::GameID nGameID);
     BOOL SaveToFile();
 
     BOOL DeletePatchFile(ra::GameID nGameID);
 
-    std::wstring GetAchievementSetFilename(ra::GameID nGameID);
+    _NODISCARD std::wstring GetAchievementSetFilename(_In_ ra::GameID nGameID) noexcept;
 
     //	Get Achievement at offset
     Achievement& GetAchievement(size_t nIter) { return m_Achievements[nIter]; }
@@ -75,9 +82,9 @@ public:
     BOOL HasUnsavedChanges();
 
 private:
-    const AchievementSetType m_nSetType;
+    const Type m_nSetType{};
     std::vector<Achievement> m_Achievements;
-    BOOL m_bProcessingActive;
+    BOOL m_bProcessingActive{ TRUE };
 };
 
 
@@ -88,9 +95,9 @@ extern AchievementSet* g_pUnofficialAchievements;
 extern AchievementSet* g_pLocalAchievements;
 
 extern AchievementSet* g_pActiveAchievements;
-extern AchievementSetType g_nActiveAchievementSet;
+extern AchievementSet::Type g_nActiveAchievementSet;
 
-extern void RASetAchievementCollection(enum AchievementSetType Type);
+void RASetAchievementCollection(_In_ AchievementSet::Type Type) noexcept;
 
 
 #endif // !RA_ACHIEVEMENTSET_H

--- a/src/RA_Condition.cpp
+++ b/src/RA_Condition.cpp
@@ -4,13 +4,13 @@
 #include <cctype>
 
 const char* COMPARISONVARIABLESIZE_STR[] = { "Bit0", "Bit1", "Bit2", "Bit3", "Bit4", "Bit5", "Bit6", "Bit7", "Lower4", "Upper4", "8-bit", "16-bit", "32-bit" };
-static_assert(SIZEOF_ARRAY(COMPARISONVARIABLESIZE_STR) == NumComparisonVariableSizeTypes, "Must match!");
+static_assert(ra::SizeOfArray(COMPARISONVARIABLESIZE_STR) == NumComparisonVariableSizeTypes, "Must match!");
 const char* COMPARISONVARIABLETYPE_STR[] = { "Memory", "Value", "Delta", "DynVar" };
-static_assert(SIZEOF_ARRAY(COMPARISONVARIABLETYPE_STR) == NumComparisonVariableTypes, "Must match!");
+static_assert(ra::SizeOfArray(COMPARISONVARIABLETYPE_STR) == NumComparisonVariableTypes, "Must match!");
 const char* COMPARISONTYPE_STR[] = { "=", "<", "<=", ">", ">=", "!=" };
-static_assert(SIZEOF_ARRAY(COMPARISONTYPE_STR) == NumComparisonTypes, "Must match!");
+static_assert(ra::SizeOfArray(COMPARISONTYPE_STR) == NumComparisonTypes, "Must match!");
 const char* CONDITIONTYPE_STR[] = { "", "Pause If", "Reset If", "Add Source", "Sub Source", "Add Hits" };
-static_assert(SIZEOF_ARRAY(CONDITIONTYPE_STR) == Condition::NumConditionTypes, "Must match!");
+static_assert(ra::SizeOfArray(CONDITIONTYPE_STR) == Condition::NumConditionTypes, "Must match!");
 
 static ComparisonVariableSize PrefixToComparisonSize(char cPrefix)
 {

--- a/src/RA_Core.cpp
+++ b/src/RA_Core.cpp
@@ -68,6 +68,7 @@ static const unsigned int PROCESS_WAIT_TIME = 100;
 static unsigned int g_nProcessTimer = 0;
 
 BOOL APIENTRY DllMain(HMODULE hModule, DWORD dwReason, _UNUSED LPVOID)
+
 {
     if (dwReason == DLL_PROCESS_ATTACH)
         g_hThisDLLInst = hModule;
@@ -224,9 +225,9 @@ static void InitCommon(HWND hMainHWND, /*enum EmulatorID*/int nEmulatorID, const
 
     //////////////////////////////////////////////////////////////////////////
     //	Initialize All AchievementSets
-    g_pCoreAchievements = new AchievementSet(Core);
-    g_pUnofficialAchievements = new AchievementSet(Unofficial);
-    g_pLocalAchievements = new AchievementSet(Local);
+    g_pCoreAchievements = new AchievementSet(AchievementSet::Type::Core);
+    g_pUnofficialAchievements = new AchievementSet(AchievementSet::Type::Unofficial);
+    g_pLocalAchievements = new AchievementSet(AchievementSet::Type::Local);
     g_pActiveAchievements = g_pCoreAchievements;
 
     //////////////////////////////////////////////////////////////////////////

--- a/src/RA_Core.cpp
+++ b/src/RA_Core.cpp
@@ -265,9 +265,9 @@ API int CCONV _RA_Shutdown()
 {
     ra::services::ServiceLocator::Get<ra::services::IConfiguration>().Save();
 
-    SAFE_DELETE(g_pCoreAchievements);
-    SAFE_DELETE(g_pUnofficialAchievements);
-    SAFE_DELETE(g_pLocalAchievements);
+    ra::SafeDelete(g_pCoreAchievements);
+    ra::SafeDelete(g_pUnofficialAchievements);
+    ra::SafeDelete(g_pLocalAchievements);
 
     RAWeb::RA_KillHTTPThreads();
 
@@ -331,7 +331,7 @@ API bool CCONV _RA_ConfirmLoadNewRom(bool bQuittingApp)
             "If you %s you will lose these changes.\n"
             "%s", sCurrentAction, sNextAction);
 
-        nResult = MessageBox(g_RAMainWnd, NativeStr(buffer).c_str(), TEXT("Warning"), MB_ICONWARNING | MB_YESNO);
+        nResult = MessageBox(g_RAMainWnd, ra::NativeStr(buffer).c_str(), TEXT("Warning"), MB_ICONWARNING | MB_YESNO);
     }
     if (g_pUnofficialAchievements->HasUnsavedChanges())
     {
@@ -341,7 +341,7 @@ API bool CCONV _RA_ConfirmLoadNewRom(bool bQuittingApp)
             "If you %s you will lose these changes.\n"
             "%s", sCurrentAction, sNextAction);
 
-        nResult = MessageBox(g_RAMainWnd, NativeStr(buffer).c_str(), TEXT("Warning"), MB_ICONWARNING | MB_YESNO);
+        nResult = MessageBox(g_RAMainWnd, ra::NativeStr(buffer).c_str(), TEXT("Warning"), MB_ICONWARNING | MB_YESNO);
     }
     if (g_pLocalAchievements->HasUnsavedChanges())
     {
@@ -351,7 +351,7 @@ API bool CCONV _RA_ConfirmLoadNewRom(bool bQuittingApp)
             "If you %s you will lose these changes.\n"
             "%s", sCurrentAction, sNextAction);
 
-        nResult = MessageBox(g_RAMainWnd, NativeStr(buffer).c_str(), TEXT("Warning"), MB_ICONWARNING | MB_YESNO);
+        nResult = MessageBox(g_RAMainWnd, ra::NativeStr(buffer).c_str(), TEXT("Warning"), MB_ICONWARNING | MB_YESNO);
     }
 
     return(nResult == IDYES);
@@ -464,7 +464,7 @@ API int CCONV _RA_OnLoadNewRom(const BYTE* pROM, unsigned int nROMSize)
 
             std::ostringstream oss;
             oss << "Game not loaded.\nError from " << _RA_HostName() << "!";
-            MessageBox(g_RAMainWnd, NativeStr(oss.str()).c_str(), TEXT("Error returned!"), MB_OK | MB_ICONERROR);
+            MessageBox(g_RAMainWnd, ra::NativeStr(oss.str()).c_str(), TEXT("Error returned!"), MB_OK | MB_ICONERROR);
         }
     }
 
@@ -568,7 +568,7 @@ static bool RA_OfferNewRAUpdate(const char* sNewVer)
         << "Current version: " << g_sClientVersion << "\n"
         << "New version: " << sNewVer;
 
-    if (MessageBox(g_RAMainWnd, NativeStr(oss.str()).c_str(), TEXT("Update available!"), MB_YESNO | MB_ICONINFORMATION) == IDYES)
+    if (MessageBox(g_RAMainWnd, ra::NativeStr(oss.str()).c_str(), TEXT("Update available!"), MB_YESNO | MB_ICONINFORMATION) == IDYES)
     {
         //FetchBinaryFromWeb( g_sClientEXEName );
         //
@@ -601,7 +601,7 @@ static bool RA_OfferNewRAUpdate(const char* sNewVer)
         oss2 << "http://" << _RA_HostName() << "/download.php";
         ShellExecute(nullptr,
             TEXT("open"),
-            NativeStr(oss2.str()).c_str(),
+            ra::NativeStr(oss2.str()).c_str(),
             nullptr,
             nullptr,
             SW_SHOWNORMAL);
@@ -808,7 +808,7 @@ API int CCONV _RA_HandleHTTPResults()
             }
         }
 
-        SAFE_DELETE(pObj);
+        ra::SafeDelete(pObj);
         pObj = RAWeb::PopNextHttpResult();
     }
 
@@ -893,7 +893,7 @@ API void CCONV _RA_UpdateAppTitle(const char* sMessage)
     if (strcmp(_RA_HostName(), "retroachievements.org") != 0)
         sstr << " [" << _RA_HostName() << "]";
 
-    SetWindowText(g_RAMainWnd, NativeStr(sstr.str()).c_str());
+    SetWindowText(g_RAMainWnd, ra::NativeStr(sstr.str()).c_str());
 }
 
 //	##BLOCKING##
@@ -921,7 +921,7 @@ static void RA_CheckForUpdate()
                 //	Up to date
                 char buffer[1024];
                 sprintf_s(buffer, 1024, "You have the latest version of %s: 0.%02d", g_sClientEXEName, nServerVersion);
-                MessageBox(g_RAMainWnd, NativeStr(buffer).c_str(), TEXT("Up to date"), MB_OK);
+                MessageBox(g_RAMainWnd, ra::NativeStr(buffer).c_str(), TEXT("Up to date"), MB_OK);
             }
         }
         else
@@ -929,7 +929,7 @@ static void RA_CheckForUpdate()
             //	Error in download
             std::ostringstream oss;
             oss << "Unexpected response from " << _RA_HostName() << ".";
-            MessageBox(g_RAMainWnd, NativeStr(oss.str()).c_str(), TEXT("Error!"), MB_OK | MB_ICONERROR);
+            MessageBox(g_RAMainWnd, ra::NativeStr(oss.str()).c_str(), TEXT("Error!"), MB_OK | MB_ICONERROR);
         }
     }
     else
@@ -938,7 +938,7 @@ static void RA_CheckForUpdate()
         std::ostringstream oss;
         oss << "Could not connect to " << _RA_HostName() << ".\n" <<
             "Please check your connection settings or RA forums!";
-        MessageBox(g_RAMainWnd, NativeStr(oss.str()).c_str(), TEXT("Error!"), MB_OK | MB_ICONERROR);
+        MessageBox(g_RAMainWnd, ra::NativeStr(oss.str()).c_str(), TEXT("Error!"), MB_OK | MB_ICONERROR);
     }
 }
 
@@ -1160,7 +1160,7 @@ API void CCONV _RA_InvokeDialog(LPARAM nID)
                 oss << "http://" << _RA_HostName() << "/User/" << RAUsers::LocalUser().Username();
                 ShellExecute(nullptr,
                     TEXT("open"),
-                    NativeStr(oss.str()).c_str(),
+                    ra::NativeStr(oss.str()).c_str(),
                     nullptr,
                     nullptr,
                     SW_SHOWNORMAL);
@@ -1174,7 +1174,7 @@ API void CCONV _RA_InvokeDialog(LPARAM nID)
                 oss << "http://" << _RA_HostName() << "/Game/" << g_pCurrentGameData->GetGameID();
                 ShellExecute(nullptr,
                     TEXT("open"),
-                    NativeStr(oss.str()).c_str(),
+                    ra::NativeStr(oss.str()).c_str(),
                     nullptr,
                     nullptr,
                     SW_SHOWNORMAL);
@@ -1240,7 +1240,7 @@ API void CCONV _RA_InvokeDialog(LPARAM nID)
             msg += (bLeaderboardsActive ? "enabled." : "disabled.");
             msg += "\nNB. You may need to load ROM again to re-enable leaderboards.";
 
-            MessageBox(nullptr, NativeStr(msg).c_str(), TEXT("Success"), MB_OK);
+            MessageBox(nullptr, ra::NativeStr(msg).c_str(), TEXT("Success"), MB_OK);
 
             if (!bLeaderboardsActive)
                 g_PopupWindows.LeaderboardPopups().Reset();
@@ -1420,8 +1420,10 @@ void _WriteBufferToFile(const std::wstring& sFileName, const std::string& raw)
     ofile.write(raw.c_str(), ra::to_signed(raw.length()));
 }
 
-bool _ReadBufferFromFile(_Out_ std::string& buffer, const wchar_t* sFile)
+_Use_decl_annotations_
+bool _ReadBufferFromFile(std::string& buffer, const wchar_t* sFile)
 {
+    buffer = "";
     std::ifstream file(sFile);
     if (file.fail())
         return false;
@@ -1431,7 +1433,6 @@ bool _ReadBufferFromFile(_Out_ std::string& buffer, const wchar_t* sFile)
     file.seekg(0, std::ios::beg);
 
     buffer.assign((std::istreambuf_iterator<char>(file)), (std::istreambuf_iterator<char>()));
-
     return true;
 }
 

--- a/src/RA_Core.h
+++ b/src/RA_Core.h
@@ -116,7 +116,8 @@ extern bool g_bRAMTamperedWith;
 extern char* _MallocAndBulkReadFileToBuffer(const wchar_t* sFilename, long& nFileSizeOut);
 
 //  Read a file to a std::string. Returns false on error.
-extern bool _ReadBufferFromFile(_Out_ std::string& buffer, const wchar_t* sFile);
+_Success_(return)
+_NODISCARD extern bool _ReadBufferFromFile(_Out_ std::string& buffer, _In_z_ const wchar_t* sFile);
 
 //	Read file until reaching the end of the file, or the specified char.
 extern BOOL _ReadTil(const char nChar, char buffer[], unsigned int nSize, DWORD* pCharsRead, FILE* pFile);

--- a/src/RA_Defs.cpp
+++ b/src/RA_Defs.cpp
@@ -4,89 +4,11 @@
 
 namespace ra {
 
-_Use_decl_annotations_
-std::string Narrow(const std::wstring& wstr)
-{
-    return Narrow(wstr.c_str());
-}
-
-_Use_decl_annotations_
-std::string Narrow(std::wstring&& wstr) noexcept
-{
-    const auto wwstr{ std::move_if_noexcept(wstr) };
-    return Narrow(wwstr);
-}
-
-_Use_decl_annotations_
-std::string Narrow(const wchar_t* wstr)
-{
-    const auto len{ ra::to_signed(std::wcslen(wstr)) };
-
-    const auto needed{
-        ::WideCharToMultiByte(CP_UTF8, 0, wstr, len + 1, nullptr, 0, nullptr, nullptr)
-    };
-
-    std::string str(ra::to_unsigned(needed), '\000'); // allocate required space (including terminator)
-    ::WideCharToMultiByte(CP_UTF8, 0, wstr, len + 1, str.data(), ra::to_signed(str.capacity()),
-                          nullptr, nullptr);
-    str.resize(ra::to_unsigned(needed - 1)); // terminator is not actually part of the string
-    return str;
-}
-
-_Use_decl_annotations_
-std::wstring Widen(const std::string& str)
-{
-    return Widen(str.c_str());
-}
-
-_Use_decl_annotations_
-std::wstring Widen(std::string&& str) noexcept
-{
-    const auto sstr{ std::move_if_noexcept(str) };
-    return Widen(sstr);
-}
-
-_Use_decl_annotations_
-std::wstring Widen(const char* str)
-{
-    const auto len{ ra::to_signed(std::strlen(str)) };
-    const auto needed{ ::MultiByteToWideChar(CP_UTF8, 0, str, len + 1, nullptr, 0) };
-    // doesn't seem wchar_t is treated like a character type by default
-    std::wstring wstr(ra::to_unsigned(needed), L'\x0');
-    ::MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, str, len + 1, wstr.data(),
-                          ra::to_signed(wstr.capacity()));
-    wstr.resize(ra::to_unsigned(needed - 1));
-
-    return wstr;
-}
-
 std::string ByteAddressToString(ByteAddress nAddr)
 {
     std::ostringstream oss;
     oss << "0x" << std::setfill('0') << std::setw(6) << std::hex << nAddr;
     return oss.str();
-}
-
-_Use_decl_annotations_
-std::wstring Widen(const wchar_t* wstr)
-{
-    const std::wstring _wstr{ wstr };
-    return _wstr;
-}
-
-_Use_decl_annotations_ std::wstring Widen(const std::wstring& wstr) { return wstr; }
-
-_Use_decl_annotations_
-std::string Narrow(const char* str)
-{
-    const std::string _str{ str };
-    return _str;
-}
-
-_Use_decl_annotations_
-std::string Narrow(const std::string& str)
-{
-    return str;
 }
 
 } /* namespace ra */

--- a/src/RA_Defs.cpp
+++ b/src/RA_Defs.cpp
@@ -1,26 +1,12 @@
 #include "RA_Defs.h"
 
-#include <iomanip>
-
-namespace ra {
-
-std::string ByteAddressToString(ByteAddress nAddr)
-{
-    std::ostringstream oss;
-    oss << "0x" << std::setfill('0') << std::setw(6) << std::hex << nAddr;
-    return oss.str();
-}
-
-} /* namespace ra */
-
 #ifndef RA_UTEST
 extern std::wstring g_sHomeDir;
 #endif
 
 void RADebugLogNoFormat(const char* data)
 {
-    OutputDebugString(NativeStr(data).c_str());
-
+    OutputDebugString(ra::NativeStr(data).c_str());
 #ifndef RA_UTEST
     std::wstring sLogFile = g_sHomeDir + RA_LOG_FILENAME;
     FILE* pf = nullptr;
@@ -56,6 +42,6 @@ void RADebugLog(const char* format, ...)
 
 BOOL DirectoryExists(const char* sPath)
 {
-    DWORD dwAttrib = GetFileAttributes(NativeStr(sPath).c_str());
+    DWORD dwAttrib = GetFileAttributes(ra::NativeStr(sPath).c_str());
     return(dwAttrib != INVALID_FILE_ATTRIBUTES && (dwAttrib & FILE_ATTRIBUTE_DIRECTORY));
 }

--- a/src/RA_Defs.cpp
+++ b/src/RA_Defs.cpp
@@ -60,7 +60,7 @@ std::wstring Widen(const char* str)
     return wstr;
 }
 
-std::string ByteAddressToString(ra::ByteAddress nAddr)
+std::string ByteAddressToString(ByteAddress nAddr)
 {
     std::ostringstream oss;
     oss << "0x" << std::setfill('0') << std::setw(6) << std::hex << nAddr;

--- a/src/RA_Defs.h
+++ b/src/RA_Defs.h
@@ -246,7 +246,7 @@ _NODISCARD std::wstring Widen(_In_z_ const wchar_t* wstr);
 _NODISCARD std::wstring Widen(_In_ const std::wstring& wstr);
 _NODISCARD std::string Narrow(_In_z_ const char* str);
 _NODISCARD std::string Narrow(_In_ const std::string& wstr);
-_NODISCARD std::string ByteAddressToString(_In_ ra::ByteAddress nAddr);
+_NODISCARD std::string ByteAddressToString(_In_ ByteAddress nAddr);
 
 } // namespace ra
 

--- a/src/RA_Defs.h
+++ b/src/RA_Defs.h
@@ -223,33 +223,10 @@ const int SERVER_PING_DURATION = 2 * 60;
 #define UNUSED( x ) ( x );
 #endif
 
+#include "RA_StringUtils.h"
+
 namespace ra {
-
-_NODISCARD std::string Narrow(_In_ const std::wstring& wstr);
-_NODISCARD std::string Narrow(_Inout_ std::wstring&& wstr) noexcept;
-_NODISCARD std::string Narrow(_In_z_ const wchar_t* wstr);
-_NODISCARD std::wstring Widen(_In_ const std::string& str);
-_NODISCARD std::wstring Widen(_Inout_ std::string&& str) noexcept;
-_NODISCARD std::wstring Widen(_In_z_ const char* str);
-
-//	No-ops to help convert:
-_NODISCARD std::wstring Widen(_In_z_ const wchar_t* wstr);
-_NODISCARD std::wstring Widen(_In_ const std::wstring& wstr);
-_NODISCARD std::string Narrow(_In_z_ const char* str);
-_NODISCARD std::string Narrow(_In_ const std::string& wstr);
 _NODISCARD std::string ByteAddressToString(_In_ ByteAddress nAddr);
-
-} // namespace ra
-
-
-
-
-#ifdef UNICODE
-#define NativeStr(x) ra::Widen(x)
-#define NativeStrType std::wstring
-#else
-#define NativeStr(x) ra::Narrow(x)
-#define NativeStrType std::string
-#endif
+}
 
 #endif // !RA_DEFS_H

--- a/src/RA_Defs.h
+++ b/src/RA_Defs.h
@@ -200,15 +200,6 @@ public:
     }
 };
 
-enum AchievementSetType
-{
-    Core,
-    Unofficial,
-    Local,
-
-    NumAchievementSetTypes
-};
-
 extern BOOL DirectoryExists(const char* sPath);
 
 const int SERVER_PING_DURATION = 2 * 60;

--- a/src/RA_Defs.h
+++ b/src/RA_Defs.h
@@ -2,54 +2,7 @@
 #define RA_DEFS_H
 #pragma once
 
-// Windows stuff we DO need, they are commented out to show we need them, if for
-// some reason you get a compiler error put the offending NO* define here
-/*
-    #define NOCOLOR
-    #define NOCLIPBOARD - gave an error when put in the pch
-    #define NOCTLMGR
-    #define NODRAWTEXT
-    #define NOGDI
-    #define NOMB
-    #define NOMENUS
-    #define NOMSG
-    #define NONLS
-    #define NOOPENFILE
-    #define NORASTEROPS
-    #define NOSHOWWINDOW
-    #define NOTEXTMETRIC
-    #define NOUSER
-    #define NOVIRTUALKEYCODES
-    #define NOWINMESSAGES
-    #define NOWINOFFSETS
-    #define NOWINSTYLES
-*/
-
-
-// Windows stuff we don't need
-#define WIN32_LEAN_AND_MEAN
-#define NOGDICAPMASKS
-#define NOSYSMETRICS
-#define NOICONS
-#define NOKEYSTATES
-#define NOSYSCOMMANDS
-#define OEMRESOURCE
-#define NOATOM
-#define NOKERNEL
-#define NOMEMMGR
-#define NOMETAFILE
-#define NOMINMAX
-#define NOSCROLL
-#define NOSERVICE
-#define NOSOUND
-#define NOWH
-#define NOCOMM
-#define NOKANJI
-#define NOHELP
-#define NOPROFILER
-#define NODEFERWINDOWPOS
-#define NOMCX  
-
+#include "windows_nodefines.h"
 struct IUnknown;
 #include <Windows.h>
 #include <WindowsX.h>
@@ -65,8 +18,9 @@ struct IUnknown;
 #include <array> // algorithm, iterator, tuple
 #include <sstream> // string
 #include <queue> // deque, vector, algorithm
-#include "ra_utility.h"
 
+#include "ra_utility.h"
+#include "RA_StringUtils.h"
 
 #if !RA_EXPORTS
 #include <cassert> 
@@ -78,34 +32,27 @@ struct IUnknown;
 
 #include "RA_Json.h"
 
-//	RA-Only
-using namespace std::string_literals;
+using namespace std::string_literals; // u8 (UTF-8), u (UTF-16, char16_t), U (UTF-32, char32_t) prefixes and s (std::basic_string) suffix
 #endif	// RA_EXPORTS
 
-#define RA_DIR_OVERLAY					L"Overlay\\"
-#define RA_DIR_BASE						L"RACache\\"
-#define RA_DIR_DATA						RA_DIR_BASE L"Data\\"
-#define RA_DIR_BADGE					RA_DIR_BASE L"Badge\\"
-#define RA_DIR_USERPIC					RA_DIR_BASE L"UserPic\\"
-#define RA_DIR_BOOKMARKS				RA_DIR_BASE L"Bookmarks\\"
+_CONSTANT_VAR RA_KEYS_DLL{ "RA_Keys.dll" };
+_CONSTANT_VAR RA_PREFERENCES_FILENAME_PREFIX{ L"RAPrefs_" };
+_CONSTANT_VAR RA_DIR_OVERLAY{ L"Overlay\\" };
+_CONSTANT_VAR RA_DIR_BASE{ L"RACache\\" };
+_CONSTANT_VAR RA_DIR_DATA{ L"RACache\\Data\\" };
+_CONSTANT_VAR RA_DIR_BADGE{ L"RACache\\Badge\\" };
+_CONSTANT_VAR RA_DIR_USERPIC{ L"RACache\\UserPic\\" };
+_CONSTANT_VAR RA_DIR_BOOKMARKS{ L"RACache\\Bookmarks\\" };
 
-#define RA_GAME_HASH_FILENAME			RA_DIR_DATA L"gamehashlibrary.txt"
-#define RA_GAME_LIST_FILENAME			RA_DIR_DATA L"gametitles.txt"
-#define RA_MY_PROGRESS_FILENAME			RA_DIR_DATA L"myprogress.txt"
-#define RA_MY_GAME_LIBRARY_FILENAME		RA_DIR_DATA L"mygamelibrary.txt"
+_CONSTANT_VAR RA_GAME_HASH_FILENAME{ L"RACache\\Data\\gamehashlibrary.txt" };
+_CONSTANT_VAR RA_GAME_LIST_FILENAME{ L"RACache\\Data\\gametitles.txt" };
+_CONSTANT_VAR RA_MY_PROGRESS_FILENAME{ L"RACache\\Data\\myprogress.txt" };
+_CONSTANT_VAR RA_MY_GAME_LIBRARY_FILENAME{ L"RACache\\Data\\mygamelibrary.txt" };
 
-#define RA_NEWS_FILENAME				RA_DIR_DATA L"ra_news.txt"
-#define RA_TITLES_FILENAME				RA_DIR_DATA L"gametitles.txt"
-#define RA_LOG_FILENAME					RA_DIR_DATA L"RALog.txt"
+_CONSTANT_VAR RA_NEWS_FILENAME{ L"RACache\\Data\\ra_news.txt" };
+_CONSTANT_VAR RA_TITLES_FILENAME{ L"RACache\\Data\\gametitles.txt" };
+_CONSTANT_VAR RA_LOG_FILENAME{ L"RACache\\Data\\RALog.txt" };
 
-
-#define SIZEOF_ARRAY( ar )	( sizeof( ar ) / sizeof( ar[ 0 ] ) )
-#define SAFE_DELETE( x )	{ if( x != nullptr ) { delete x; x = nullptr; } }
-
-
-
-//namespace RA
-//{
 class RARect : public RECT
 {
 public:
@@ -209,24 +156,19 @@ const int SERVER_PING_DURATION = 2 * 60;
 #ifdef _DEBUG
 #ifndef RA_UTEST
 #undef ASSERT
-#define ASSERT( x ) assert( x )
+_CONSTANT_FN ASSERT(_In_ bool bExpr) noexcept { assert(bExpr); }
 #else
 #undef ASSERT
-#define ASSERT( x ) {}
+_CONSTANT_FN ASSERT(_UNUSED bool) noexcept {}
 #endif
 #else
 #undef ASSERT
-#define ASSERT( x ) {}
+_CONSTANT_FN ASSERT(_UNUSED bool) noexcept {}
 #endif
 
 #ifndef UNUSED
-#define UNUSED( x ) ( x );
+template<typename T>
+_CONSTANT_FN UNUSED(_UNUSED T) noexcept {}
 #endif
-
-#include "RA_StringUtils.h"
-
-namespace ra {
-_NODISCARD std::string ByteAddressToString(_In_ ByteAddress nAddr);
-}
 
 #endif // !RA_DEFS_H

--- a/src/RA_Dlg_AchEditor.cpp
+++ b/src/RA_Dlg_AchEditor.cpp
@@ -1919,7 +1919,7 @@ void Dlg_AchievementEditor::UpdateBadge(const std::string& sNewName)
             m_pSelectedAchievement->SetBadgeImage(sNewName);
             m_pSelectedAchievement->SetModified(TRUE);
 
-            if (g_nActiveAchievementSet == Core)
+            if (g_nActiveAchievementSet == AchievementSet::Type::Core)
             {
                 int nOffs = g_AchievementsDialog.GetSelectedAchievementIndex();
                 g_AchievementsDialog.OnEditData(nOffs, Dlg_Achievements::Modified, "Yes");

--- a/src/RA_Dlg_AchEditor.cpp
+++ b/src/RA_Dlg_AchEditor.cpp
@@ -17,7 +17,7 @@
 namespace {
 const char* COLUMN_TITLE[] = { "ID", "Flag", "Type", "Size", "Memory", "Cmp", "Type", "Size", "Mem/Val", "Hits" };
 const int COLUMN_WIDTH[] = { 30, 75, 42, 50, 72, 35, 42, 50, 72, 72 };
-static_assert(SIZEOF_ARRAY(COLUMN_TITLE) == SIZEOF_ARRAY(COLUMN_WIDTH), "Must match!");
+static_assert(ra::SizeOfArray(COLUMN_TITLE) == ra::SizeOfArray(COLUMN_WIDTH), "Must match!");
 }
 
 enum CondSubItems
@@ -114,7 +114,7 @@ void Dlg_AchievementEditor::SetupColumns(HWND hList)
     {
         col.mask = LVCF_TEXT | LVCF_WIDTH | LVCF_SUBITEM | LVCF_FMT;
         col.cx = COLUMN_WIDTH[i];
-        ra::tstring colTitle = NativeStr(COLUMN_TITLE[i]);	//	Take non-const copy
+        ra::tstring colTitle = ra::NativeStr(COLUMN_TITLE[i]);	//	Take non-const copy
         col.pszText = const_cast<LPTSTR>(colTitle.c_str());
         col.cchTextMax = 255;
         col.iSubItem = i;
@@ -153,7 +153,7 @@ const int Dlg_AchievementEditor::AddCondition(HWND hList, const Condition& Cond)
     item.cchTextMax = 256;
     item.iItem = m_nNumOccupiedRows;
     item.iSubItem = 0;
-    ra::tstring sData = NativeStr(m_lbxData[m_nNumOccupiedRows][CSI_ID]);
+    ra::tstring sData = ra::NativeStr(m_lbxData[m_nNumOccupiedRows][CSI_ID]);
     item.pszText = const_cast<LPTSTR>(sData.c_str());
     item.iItem = ListView_InsertItem(hList, &item);
 
@@ -216,7 +216,7 @@ void Dlg_AchievementEditor::UpdateCondition(HWND hList, LV_ITEM& item, const Con
     for (size_t i = 0; i < NumColumns; ++i)
     {
         item.iSubItem = i;
-        ra::tstring sData = NativeStr(m_lbxData[nRow][i]);
+        ra::tstring sData = ra::NativeStr(m_lbxData[nRow][i]);
         item.pszText = const_cast<LPTSTR>(sData.c_str());
         ListView_SetItem(hList, &item);
     }
@@ -549,7 +549,7 @@ BOOL CreateIPE(int nItem, int nSubItem)
 
             for (size_t i = 0; i < Condition::NumConditionTypes; ++i)
             {
-                ComboBox_AddString(g_hIPEEdit, NativeStr(CONDITIONTYPE_STR[i]).c_str());
+                ComboBox_AddString(g_hIPEEdit, ra::NativeStr(CONDITIONTYPE_STR[i]).c_str());
 
                 if (strcmp(g_AchievementEditorDialog.LbxDataAt(nItem, nSubItem), CONDITIONTYPE_STR[i]) == 0)
                     ComboBox_SetCurSel(g_hIPEEdit, i);
@@ -608,9 +608,9 @@ BOOL CreateIPE(int nItem, int nSubItem)
             // 			}
 
                         /*CB_ERRSPACE*/
-            ComboBox_AddString(g_hIPEEdit, NativeStr("Mem").c_str());
-            ComboBox_AddString(g_hIPEEdit, NativeStr("Delta").c_str());
-            ComboBox_AddString(g_hIPEEdit, NativeStr("Value").c_str());
+            ComboBox_AddString(g_hIPEEdit, ra::NativeStr("Mem").c_str());
+            ComboBox_AddString(g_hIPEEdit, ra::NativeStr("Delta").c_str());
+            ComboBox_AddString(g_hIPEEdit, ra::NativeStr("Value").c_str());
 
             int nSel;
             if (strcmp(g_AchievementEditorDialog.LbxDataAt(nItem, nSubItem), "Mem") == 0)
@@ -672,7 +672,7 @@ BOOL CreateIPE(int nItem, int nSubItem)
 
             for (size_t i = 0; i < NumComparisonVariableSizeTypes; ++i)
             {
-                ComboBox_AddString(g_hIPEEdit, NativeStr(COMPARISONVARIABLESIZE_STR[i]).c_str());
+                ComboBox_AddString(g_hIPEEdit, ra::NativeStr(COMPARISONVARIABLESIZE_STR[i]).c_str());
 
                 if (strcmp(g_AchievementEditorDialog.LbxDataAt(nItem, nSubItem), COMPARISONVARIABLESIZE_STR[i]) == 0)
                     ComboBox_SetCurSel(g_hIPEEdit, i);
@@ -716,7 +716,7 @@ BOOL CreateIPE(int nItem, int nSubItem)
 
             for (size_t i = 0; i < NumComparisonTypes; ++i)
             {
-                ComboBox_AddString(g_hIPEEdit, NativeStr(COMPARISONTYPE_STR[i]).c_str());
+                ComboBox_AddString(g_hIPEEdit, ra::NativeStr(COMPARISONTYPE_STR[i]).c_str());
 
                 if (strcmp(g_AchievementEditorDialog.LbxDataAt(nItem, nSubItem), COMPARISONTYPE_STR[i]) == 0)
                     ComboBox_SetCurSel(g_hIPEEdit, i);
@@ -766,7 +766,7 @@ BOOL CreateIPE(int nItem, int nSubItem)
             SendMessage(g_hIPEEdit, WM_SETFONT, (WPARAM)GetStockObject(DEFAULT_GUI_FONT), TRUE);
 
             char* pData = g_AchievementEditorDialog.LbxDataAt(nItem, nSubItem);
-            SetWindowText(g_hIPEEdit, NativeStr(pData).c_str());
+            SetWindowText(g_hIPEEdit, ra::NativeStr(pData).c_str());
 
             //	Special case, hitcounts
             if (nSubItem == CSI_HITCOUNT)
@@ -778,7 +778,7 @@ BOOL CreateIPE(int nItem, int nSubItem)
 
                     char buffer[256];
                     sprintf_s(buffer, 256, "%u", Cond.RequiredHits());
-                    SetWindowText(g_hIPEEdit, NativeStr(buffer).c_str());
+                    SetWindowText(g_hIPEEdit, ra::NativeStr(buffer).c_str());
                 }
             }
 
@@ -1132,7 +1132,7 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
                             if (GetDlgItemText(hDlg, IDC_RA_ACH_POINTS, buffer, 16))
                             {
                                 
-                                int nVal = std::stoi(NativeStr(buffer));
+                                int nVal = std::stoi(ra::NativeStr(buffer));
                                 if (nVal < 0 || nVal > 100)
                                     return FALSE;
 
@@ -1259,7 +1259,7 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
 
                             char buffer[256];
                             sprintf_s(buffer, 256, "Are you sure you wish to delete %u condition(s)?", uSelectedCount);
-                            if (MessageBox(hDlg, NativeStr(buffer).c_str(), TEXT("Warning"), MB_YESNO) == IDYES)
+                            if (MessageBox(hDlg, ra::NativeStr(buffer).c_str(), TEXT("Warning"), MB_YESNO) == IDYES)
                             {
                                 nSel = -1;
                                 std::vector<int> items;
@@ -1451,7 +1451,7 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
                             }
                             else if (ResponseData.HasMember("Error"))
                             {
-                                MessageBox(nullptr, NativeStr(ResponseData["Error"].GetString()).c_str(), TEXT("Error"), MB_OK);
+                                MessageBox(nullptr, ra::NativeStr(ResponseData["Error"].GetString()).c_str(), TEXT("Error"), MB_OK);
                             }
                             else
                             {
@@ -1615,7 +1615,7 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
                                 //	Update the text to match
                                 char buffer[16];
                                 sprintf_s(buffer, 16, "0x%06x", rCond.CompSource().RawValue());
-                                SetDlgItemText(g_MemoryDialog.GetHWND(), IDC_RA_WATCHING, NativeStr(buffer).c_str());
+                                SetDlgItemText(g_MemoryDialog.GetHWND(), IDC_RA_WATCHING, ra::NativeStr(buffer).c_str());
 
                                 //	Nudge the ComboBox to update the mem note
                                 SendMessage(g_MemoryDialog.GetHWND(), WM_COMMAND, MAKELONG(IDC_RA_WATCHING, CBN_EDITCHANGE), 0);
@@ -1631,7 +1631,7 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
                                 //	Update the text to match
                                 char buffer[16];
                                 sprintf_s(buffer, 16, "0x%06x", rCond.CompTarget().RawValue());
-                                SetDlgItemText(g_MemoryDialog.GetHWND(), IDC_RA_WATCHING, NativeStr(buffer).c_str());
+                                SetDlgItemText(g_MemoryDialog.GetHWND(), IDC_RA_WATCHING, ra::NativeStr(buffer).c_str());
 
                                 //	Nudge the ComboBox to update the mem note
                                 SendMessage(g_MemoryDialog.GetHWND(), WM_COMMAND, MAKELONG(IDC_RA_WATCHING, CBN_EDITCHANGE), 0);
@@ -1880,7 +1880,7 @@ void Dlg_AchievementEditor::GetListViewTooltip()
     else
         oss << "[no notes]";
 
-    m_sTooltip = NativeStr(oss.str());
+    m_sTooltip = ra::NativeStr(oss.str());
 }
 
 void Dlg_AchievementEditor::UpdateSelectedBadgeImage(const std::string& sBackupBadgeToUse)
@@ -2028,15 +2028,15 @@ void Dlg_AchievementEditor::LoadAchievement(Achievement* pCheevo, _UNUSED BOOL)
         CheckDlgButton(m_hAchievementEditorDlg, IDC_RA_CHK_ACH_PAUSE_ON_RESET, ActiveAchievement()->GetPauseOnReset());
 
         sprintf_s(buffer, 1024, "%u", m_pSelectedAchievement->ID());
-        SetDlgItemText(m_hAchievementEditorDlg, IDC_RA_ACH_ID, NativeStr(buffer).c_str());
+        SetDlgItemText(m_hAchievementEditorDlg, IDC_RA_ACH_ID, ra::NativeStr(buffer).c_str());
 
         sprintf_s(buffer, 1024, "%u", m_pSelectedAchievement->Points());
-        SetDlgItemText(m_hAchievementEditorDlg, IDC_RA_ACH_POINTS, NativeStr(buffer).c_str());
+        SetDlgItemText(m_hAchievementEditorDlg, IDC_RA_ACH_POINTS, ra::NativeStr(buffer).c_str());
 
-        SetDlgItemText(m_hAchievementEditorDlg, IDC_RA_ACH_TITLE, NativeStr(m_pSelectedAchievement->Title()).c_str());
-        SetDlgItemText(m_hAchievementEditorDlg, IDC_RA_ACH_DESC, NativeStr(m_pSelectedAchievement->Description()).c_str());
-        SetDlgItemText(m_hAchievementEditorDlg, IDC_RA_ACH_AUTHOR, NativeStr(m_pSelectedAchievement->Author()).c_str());
-        SetDlgItemText(m_hAchievementEditorDlg, IDC_RA_BADGENAME, NativeStr(m_pSelectedAchievement->BadgeImageURI()).c_str());
+        SetDlgItemText(m_hAchievementEditorDlg, IDC_RA_ACH_TITLE, ra::NativeStr(m_pSelectedAchievement->Title()).c_str());
+        SetDlgItemText(m_hAchievementEditorDlg, IDC_RA_ACH_DESC, ra::NativeStr(m_pSelectedAchievement->Description()).c_str());
+        SetDlgItemText(m_hAchievementEditorDlg, IDC_RA_ACH_AUTHOR, ra::NativeStr(m_pSelectedAchievement->Author()).c_str());
+        SetDlgItemText(m_hAchievementEditorDlg, IDC_RA_BADGENAME, ra::NativeStr(m_pSelectedAchievement->BadgeImageURI()).c_str());
 
         EnableWindow(GetDlgItem(m_hAchievementEditorDlg, IDC_RA_ACH_AUTHOR), FALSE);
         EnableWindow(GetDlgItem(m_hAchievementEditorDlg, IDC_RA_ACH_ID), FALSE);
@@ -2070,18 +2070,18 @@ void Dlg_AchievementEditor::LoadAchievement(Achievement* pCheevo, _UNUSED BOOL)
         m_bPopulatingAchievementEditorData = TRUE;
 
         if (pCheevo->GetDirtyFlags() & Dirty_ID)
-            SetDlgItemText(m_hAchievementEditorDlg, IDC_RA_ACH_ID, NativeStr(std::to_string(m_pSelectedAchievement->ID())).c_str());
+            SetDlgItemText(m_hAchievementEditorDlg, IDC_RA_ACH_ID, ra::NativeStr(std::to_string(m_pSelectedAchievement->ID())).c_str());
         if ((pCheevo->GetDirtyFlags() & Dirty_Points) && !bPointsSelected)
-            SetDlgItemText(m_hAchievementEditorDlg, IDC_RA_ACH_POINTS, NativeStr(std::to_string(m_pSelectedAchievement->Points())).c_str());
+            SetDlgItemText(m_hAchievementEditorDlg, IDC_RA_ACH_POINTS, ra::NativeStr(std::to_string(m_pSelectedAchievement->Points())).c_str());
         if ((pCheevo->GetDirtyFlags() & Dirty_Title) && !bTitleSelected)
-            SetDlgItemText(m_hAchievementEditorDlg, IDC_RA_ACH_TITLE, NativeStr(m_pSelectedAchievement->Title()).c_str());
+            SetDlgItemText(m_hAchievementEditorDlg, IDC_RA_ACH_TITLE, ra::NativeStr(m_pSelectedAchievement->Title()).c_str());
         if ((pCheevo->GetDirtyFlags() & Dirty_Description) && !bDescSelected)
-            SetDlgItemText(m_hAchievementEditorDlg, IDC_RA_ACH_DESC, NativeStr(m_pSelectedAchievement->Description()).c_str());
+            SetDlgItemText(m_hAchievementEditorDlg, IDC_RA_ACH_DESC, ra::NativeStr(m_pSelectedAchievement->Description()).c_str());
         if (pCheevo->GetDirtyFlags() & Dirty_Author)
-            SetDlgItemText(m_hAchievementEditorDlg, IDC_RA_ACH_AUTHOR, NativeStr(m_pSelectedAchievement->Author()).c_str());
+            SetDlgItemText(m_hAchievementEditorDlg, IDC_RA_ACH_AUTHOR, ra::NativeStr(m_pSelectedAchievement->Author()).c_str());
         if (pCheevo->GetDirtyFlags() & Dirty_Badge)
         {
-            SetDlgItemText(m_hAchievementEditorDlg, IDC_RA_BADGENAME, NativeStr(m_pSelectedAchievement->BadgeImageURI()).c_str());
+            SetDlgItemText(m_hAchievementEditorDlg, IDC_RA_BADGENAME, ra::NativeStr(m_pSelectedAchievement->BadgeImageURI()).c_str());
             UpdateBadge(m_pSelectedAchievement->BadgeImageURI());
         }
 
@@ -2213,7 +2213,7 @@ void BadgeNames::OnNewBadgeNames(const rapidjson::Document& data)
 void BadgeNames::AddNewBadgeName(const char* pStr, bool bAndSelect)
 {
     {
-        const auto nSel{ ComboBox_AddString(m_hDestComboBox, NativeStr(pStr).c_str()) };
+        const auto nSel{ ComboBox_AddString(m_hDestComboBox, ra::NativeStr(pStr).c_str()) };
         if ((nSel == CB_ERR) || (nSel == CB_ERRSPACE))
         {
             ::MessageBox(::GetActiveWindow(), _T("An error has occurred or there is insufficient space "

--- a/src/RA_Dlg_Achievement.cpp
+++ b/src/RA_Dlg_Achievement.cpp
@@ -41,11 +41,11 @@ void Dlg_Achievements::SetupColumns(HWND hList)
     for (int i = 0; i < NUM_COLS; ++i)
     {
         const char* sColTitle = nullptr;
-        if (g_nActiveAchievementSet == Core)
+        if (g_nActiveAchievementSet == AchievementSet::Type::Core)
             sColTitle = COLUMN_TITLES_CORE[i];
-        else if (g_nActiveAchievementSet == Unofficial)
+        else if (g_nActiveAchievementSet == AchievementSet::Type::Unofficial)
             sColTitle = COLUMN_TITLES_UNOFFICIAL[i];
-        else if (g_nActiveAchievementSet == Local)
+        else if (g_nActiveAchievementSet == AchievementSet::Type::Local)
             sColTitle = COLUMN_TITLES_LOCAL[i];
 
         LV_COLUMN newColumn;
@@ -157,7 +157,7 @@ size_t Dlg_Achievements::AddAchievement(HWND hList, const Achievement& Ach)
     newRow[Points] = std::to_string(Ach.Points());
     newRow[Author] = Ach.Author();
 
-    if (g_nActiveAchievementSet == Core)
+    if (g_nActiveAchievementSet == AchievementSet::Type::Core)
     {
         newRow[Achieved] = !Ach.Active() ? "Yes" : "No";
         newRow[Modified] = Ach.Modified() ? "Yes" : "No";
@@ -290,11 +290,12 @@ BOOL AttemptUploadAchievementBlocking(const Achievement& Ach, unsigned int nFlag
     return(RAWeb::DoBlockingRequest(RequestSubmitAchievementData, args, doc));
 }
 
-void Dlg_Achievements::OnClickAchievementSet(AchievementSetType nAchievementSet)
+_Use_decl_annotations_
+void Dlg_Achievements::OnClickAchievementSet(AchievementSet::Type nAchievementSet)
 {
     RASetAchievementCollection(nAchievementSet);
 
-    if (nAchievementSet == Core)
+    if (nAchievementSet == AchievementSet::Type::Core)
     {
         ShowWindow(GetDlgItem(m_hAchievementsDlg, IDC_RA_PROMOTE_ACH), FALSE);
         SetWindowText(GetDlgItem(m_hAchievementsDlg, IDC_RA_PROMOTE_ACH), TEXT("Demote from Core"));
@@ -309,7 +310,7 @@ void Dlg_Achievements::OnClickAchievementSet(AchievementSetType nAchievementSet)
         CheckDlgButton(m_hAchievementsDlg, IDC_RA_ACTIVE_UNOFFICIAL, FALSE);
         CheckDlgButton(m_hAchievementsDlg, IDC_RA_ACTIVE_LOCAL, FALSE);
     }
-    else if (nAchievementSet == Unofficial)
+    else if (nAchievementSet == AchievementSet::Type::Unofficial)
     {
         ShowWindow(GetDlgItem(m_hAchievementsDlg, IDC_RA_PROMOTE_ACH), TRUE);
         SetWindowText(GetDlgItem(m_hAchievementsDlg, IDC_RA_PROMOTE_ACH), TEXT("Promote to Core"));
@@ -324,7 +325,7 @@ void Dlg_Achievements::OnClickAchievementSet(AchievementSetType nAchievementSet)
         CheckDlgButton(m_hAchievementsDlg, IDC_RA_ACTIVE_UNOFFICIAL, TRUE);
         CheckDlgButton(m_hAchievementsDlg, IDC_RA_ACTIVE_LOCAL, FALSE);
     }
-    else if (nAchievementSet == Local)
+    else if (nAchievementSet == AchievementSet::Type::Local)
     {
         ShowWindow(GetDlgItem(m_hAchievementsDlg, IDC_RA_PROMOTE_ACH), TRUE);
         SetWindowText(GetDlgItem(m_hAchievementsDlg, IDC_RA_PROMOTE_ACH), TEXT("Promote to Unofficial"));
@@ -355,20 +356,20 @@ INT_PTR Dlg_Achievements::AchievementsProc(HWND hDlg, UINT nMsg, WPARAM wParam, 
         {
             m_hAchievementsDlg = hDlg;
 
-            SendDlgItemMessage(hDlg, IDC_RA_ACTIVE_CORE, BM_SETCHECK, (WPARAM)0, (LONG)0);
-            SendDlgItemMessage(hDlg, IDC_RA_ACTIVE_UNOFFICIAL, BM_SETCHECK, (WPARAM)0, (LONG)0);
-            SendDlgItemMessage(hDlg, IDC_RA_ACTIVE_LOCAL, BM_SETCHECK, (WPARAM)0, (LONG)0);
+            SendDlgItemMessage(hDlg, IDC_RA_ACTIVE_CORE, BM_SETCHECK, 0U, 0L);
+            SendDlgItemMessage(hDlg, IDC_RA_ACTIVE_UNOFFICIAL, BM_SETCHECK, 0U, 0L);
+            SendDlgItemMessage(hDlg, IDC_RA_ACTIVE_LOCAL, BM_SETCHECK, 0U, 0L);
 
             switch (g_nActiveAchievementSet)
             {
-                case Core:
-                    SendDlgItemMessage(hDlg, IDC_RA_ACTIVE_CORE, BM_SETCHECK, (WPARAM)1, (LONG)0);
+                case AchievementSet::Type::Core:
+                    SendDlgItemMessage(hDlg, IDC_RA_ACTIVE_CORE, BM_SETCHECK, 1U, 0L);
                     break;
-                case Unofficial:
-                    SendDlgItemMessage(hDlg, IDC_RA_ACTIVE_UNOFFICIAL, BM_SETCHECK, (WPARAM)1, (LONG)0);
+                case AchievementSet::Type::Unofficial:
+                    SendDlgItemMessage(hDlg, IDC_RA_ACTIVE_UNOFFICIAL, BM_SETCHECK, 1U, 0L);
                     break;
-                case Local:
-                    SendDlgItemMessage(hDlg, IDC_RA_ACTIVE_LOCAL, BM_SETCHECK, (WPARAM)1, (LONG)0);
+                case AchievementSet::Type::Local:
+                    SendDlgItemMessage(hDlg, IDC_RA_ACTIVE_LOCAL, BM_SETCHECK, 1U, 0L);
                     break;
                 default:
                     ASSERT(!"Unknown achievement set!");
@@ -380,7 +381,7 @@ INT_PTR Dlg_Achievements::AchievementsProc(HWND hDlg, UINT nMsg, WPARAM wParam, 
             CheckDlgButton(hDlg, IDC_RA_CHKACHPROCESSINGACTIVE, g_pActiveAchievements->ProcessingActive());
 
             //	Click the core 
-            OnClickAchievementSet(Core);
+            OnClickAchievementSet(AchievementSet::Type::Core);
 
             RestoreWindowPosition(hDlg, "Achievements", false, true);
         }
@@ -390,15 +391,15 @@ INT_PTR Dlg_Achievements::AchievementsProc(HWND hDlg, UINT nMsg, WPARAM wParam, 
             switch (LOWORD(wParam))
             {
                 case IDC_RA_ACTIVE_CORE:
-                    OnClickAchievementSet(Core);
+                    OnClickAchievementSet(AchievementSet::Type::Core);
                     return TRUE;
 
                 case IDC_RA_ACTIVE_UNOFFICIAL:
-                    OnClickAchievementSet(Unofficial);
+                    OnClickAchievementSet(AchievementSet::Type::Unofficial);
                     return TRUE;
 
                 case IDC_RA_ACTIVE_LOCAL:
-                    OnClickAchievementSet(Local);
+                    OnClickAchievementSet(AchievementSet::Type::Local);
                     return TRUE;
 
                 case IDCLOSE:
@@ -413,12 +414,12 @@ INT_PTR Dlg_Achievements::AchievementsProc(HWND hDlg, UINT nMsg, WPARAM wParam, 
                     }
                     else
                     {
-                        if (g_nActiveAchievementSet == Local)
+                        if (g_nActiveAchievementSet == AchievementSet::Type::Local)
                         {
                             // Promote from Local to Unofficial is just a commit to Unofficial
                             CommitAchievements(hDlg);
                         }
-                        else if (g_nActiveAchievementSet == Unofficial)
+                        else if (g_nActiveAchievementSet == AchievementSet::Type::Unofficial)
                         {
                             HWND hList = GetDlgItem(hDlg, IDC_RA_LISTACHIEVEMENTS);
                             int nSel = ListView_GetNextItem(hList, -1, LVNI_SELECTED);
@@ -439,7 +440,7 @@ INT_PTR Dlg_Achievements::AchievementsProc(HWND hDlg, UINT nMsg, WPARAM wParam, 
                                 const Achievement& selectedAch = g_pActiveAchievements->GetAchievement(nSel);
 
                                 unsigned int nFlags = 1 << 0;	//	Active achievements! : 1
-                                if (g_nActiveAchievementSet == Unofficial)
+                                if (g_nActiveAchievementSet == AchievementSet::Type::Unofficial)
                                     nFlags |= 1 << 1;			//	Official achievements: 3
 
 
@@ -491,7 +492,7 @@ INT_PTR Dlg_Achievements::AchievementsProc(HWND hDlg, UINT nMsg, WPARAM wParam, 
                     if (!RA_GameIsActive())
                         break;
 
-                    if (g_nActiveAchievementSet == Local)
+                    if (g_nActiveAchievementSet == AchievementSet::Type::Local)
                     {
                         if (MessageBox(hDlg,
                             TEXT("Are you sure that you want to reload achievements from disk?\n")
@@ -613,7 +614,7 @@ INT_PTR Dlg_Achievements::AchievementsProc(HWND hDlg, UINT nMsg, WPARAM wParam, 
                     sprintf_s(buffer, 256, "%s (copy)", NewClone.Title().c_str());
                     NewClone.SetTitle(buffer);
 
-                    OnClickAchievementSet(Local);
+                    OnClickAchievementSet(AchievementSet::Type::Local);
 
                     ListView_SetItemState(hList, g_pLocalAchievements->NumAchievements() - 1, LVIS_FOCUSED | LVIS_SELECTED, ra::to_unsigned(-1));
                     ListView_EnsureVisible(hList, g_pLocalAchievements->NumAchievements() - 1, FALSE);
@@ -671,7 +672,7 @@ INT_PTR Dlg_Achievements::AchievementsProc(HWND hDlg, UINT nMsg, WPARAM wParam, 
                     if (!RA_GameIsActive())
                         break;
 
-                    if (g_nActiveAchievementSet == Local)
+                    if (g_nActiveAchievementSet == AchievementSet::Type::Local)
                     {
                         // Local save is to disk
                         if (g_pActiveAchievements->SaveToFile())
@@ -738,7 +739,7 @@ INT_PTR Dlg_Achievements::AchievementsProc(HWND hDlg, UINT nMsg, WPARAM wParam, 
                                     assert(nIndex < g_pActiveAchievements->NumAchievements());
                                     if (nIndex < g_pActiveAchievements->NumAchievements())
                                     {
-                                        if (g_nActiveAchievementSet == Core)
+                                        if (g_nActiveAchievementSet == AchievementSet::Type::Core)
                                             OnEditData(nIndex, Dlg_Achievements::Achieved, "Yes");
                                         else
                                             OnEditData(nIndex, Dlg_Achievements::Active, "No");
@@ -784,7 +785,7 @@ INT_PTR Dlg_Achievements::AchievementsProc(HWND hDlg, UINT nMsg, WPARAM wParam, 
                         if (!Cheevo.Active())
                         {
                             const TCHAR* sMessage = TEXT("Temporarily reset 'achieved' state of this achievement?");
-                            if (g_nActiveAchievementSet != Core)
+                            if (g_nActiveAchievementSet != AchievementSet::Type::Core)
                                 sMessage = TEXT("Activate this achievement?");
 
                             if (MessageBox(hDlg, sMessage, TEXT("Activate Achievement"), MB_YESNO) == IDYES)
@@ -796,7 +797,7 @@ INT_PTR Dlg_Achievements::AchievementsProc(HWND hDlg, UINT nMsg, WPARAM wParam, 
                                 ASSERT(nIndex < g_pActiveAchievements->NumAchievements());
                                 if (nIndex < g_pActiveAchievements->NumAchievements())
                                 {
-                                    if (g_nActiveAchievementSet == Core)
+                                    if (g_nActiveAchievementSet == AchievementSet::Type::Core)
                                         OnEditData(nIndex, Dlg_Achievements::Achieved, "No");
                                     else
                                         OnEditData(nIndex, Dlg_Achievements::Active, "Yes");
@@ -805,7 +806,7 @@ INT_PTR Dlg_Achievements::AchievementsProc(HWND hDlg, UINT nMsg, WPARAM wParam, 
                                 //	Also needs to reinject text into IDC_RA_LISTACHIEVEMENTS
                             }
                         }
-                        else if (g_nActiveAchievementSet != Core)
+                        else if (g_nActiveAchievementSet != AchievementSet::Type::Core)
                         {
                             if (MessageBox(hDlg, TEXT("Deactivate this achievement?"), TEXT("Deactivate Achievement"), MB_YESNO) == IDYES)
                             {
@@ -846,7 +847,7 @@ INT_PTR Dlg_Achievements::AchievementsProc(HWND hDlg, UINT nMsg, WPARAM wParam, 
                                 Cheevo.Reset();
                                 Cheevo.SetActive(true);
 
-                                if (g_nActiveAchievementSet == Core)
+                                if (g_nActiveAchievementSet == AchievementSet::Type::Core)
                                     OnEditData(nIndex, Dlg_Achievements::Achieved, "No");
                                 else
                                     OnEditData(nIndex, Dlg_Achievements::Active, "Yes");
@@ -973,14 +974,14 @@ INT_PTR Dlg_Achievements::CommitAchievements(HWND hDlg)
         {
             Achievement& NextAch = g_pActiveAchievements->GetAchievement(nLbxItemsChecked[i]);
 
-            BOOL bMovedFromUserToUnofficial = (g_nActiveAchievementSet == Local);
+            BOOL bMovedFromUserToUnofficial = (g_nActiveAchievementSet == AchievementSet::Type::Local);
 
             unsigned int nFlags = 1 << 0;	//	Active achievements! : 1
-            if (g_nActiveAchievementSet == Core)
+            if (g_nActiveAchievementSet == AchievementSet::Type::Core)
                 nFlags |= 1 << 1;			//	Core: 3
-            else if (g_nActiveAchievementSet == Unofficial)
+            else if (g_nActiveAchievementSet == AchievementSet::Type::Unofficial)
                 nFlags |= 1 << 2;			//	Retain at Unofficial: 5
-            else if (g_nActiveAchievementSet == Local)
+            else if (g_nActiveAchievementSet == AchievementSet::Type::Local)
                 nFlags |= 1 << 2;			//	Promote to Unofficial: 5
 
             rapidjson::Document response;
@@ -1018,7 +1019,7 @@ INT_PTR Dlg_Achievements::CommitAchievements(HWND hDlg)
                         ASSERT(nIndex < g_pActiveAchievements->NumAchievements());
                         if (nIndex < g_pActiveAchievements->NumAchievements())
                         {
-                            if (g_nActiveAchievementSet == Core)
+                            if (g_nActiveAchievementSet == AchievementSet::Type::Core)
                                 OnEditData(nIndex, Dlg_Achievements::Modified, "No");
                         }
 
@@ -1062,7 +1063,7 @@ void Dlg_Achievements::UpdateSelectedAchievementButtons(const Achievement* Cheev
     {
         EnableWindow(GetDlgItem(m_hAchievementsDlg, IDC_RA_RESET_ACH), FALSE);
         EnableWindow(GetDlgItem(m_hAchievementsDlg, IDC_RA_REVERTSELECTED), FALSE);
-        EnableWindow(GetDlgItem(m_hAchievementsDlg, IDC_RA_COMMIT_ACH), g_nActiveAchievementSet == Local);
+        EnableWindow(GetDlgItem(m_hAchievementsDlg, IDC_RA_COMMIT_ACH), g_nActiveAchievementSet == AchievementSet::Type::Local);
         EnableWindow(GetDlgItem(m_hAchievementsDlg, IDC_RA_CLONE_ACH), FALSE);
         EnableWindow(GetDlgItem(m_hAchievementsDlg, IDC_RA_DEL_ACH), FALSE);
         EnableWindow(GetDlgItem(m_hAchievementsDlg, IDC_RA_PROMOTE_ACH), FALSE);
@@ -1070,12 +1071,12 @@ void Dlg_Achievements::UpdateSelectedAchievementButtons(const Achievement* Cheev
     else
     {
         EnableWindow(GetDlgItem(m_hAchievementsDlg, IDC_RA_REVERTSELECTED), Cheevo->Modified());
-        EnableWindow(GetDlgItem(m_hAchievementsDlg, IDC_RA_COMMIT_ACH), g_nActiveAchievementSet == Local ? TRUE : Cheevo->Modified());
+        EnableWindow(GetDlgItem(m_hAchievementsDlg, IDC_RA_COMMIT_ACH), g_nActiveAchievementSet == AchievementSet::Type::Local ? TRUE : Cheevo->Modified());
         EnableWindow(GetDlgItem(m_hAchievementsDlg, IDC_RA_CLONE_ACH), TRUE);
-        EnableWindow(GetDlgItem(m_hAchievementsDlg, IDC_RA_DEL_ACH), g_nActiveAchievementSet == Local);
+        EnableWindow(GetDlgItem(m_hAchievementsDlg, IDC_RA_DEL_ACH), g_nActiveAchievementSet == AchievementSet::Type::Local);
         EnableWindow(GetDlgItem(m_hAchievementsDlg, IDC_RA_PROMOTE_ACH), TRUE);
 
-        if (g_nActiveAchievementSet != Core)
+        if (g_nActiveAchievementSet != AchievementSet::Type::Core)
         {
             EnableWindow(GetDlgItem(m_hAchievementsDlg, IDC_RA_RESET_ACH), TRUE);
             SetWindowText(GetDlgItem(m_hAchievementsDlg, IDC_RA_RESET_ACH), Cheevo->Active() ? TEXT("Deactivate Selected") : TEXT("Activate Selected"));
@@ -1116,7 +1117,7 @@ void Dlg_Achievements::OnLoad_NewRom(ra::GameID nGameID)
         if (nGameID != 0)
         {
             EnableWindow(GetDlgItem(m_hAchievementsDlg, IDC_RA_DOWNLOAD_ACH), TRUE);
-            EnableWindow(GetDlgItem(m_hAchievementsDlg, IDC_RA_ADD_ACH), g_nActiveAchievementSet == Local);
+            EnableWindow(GetDlgItem(m_hAchievementsDlg, IDC_RA_ADD_ACH), g_nActiveAchievementSet == AchievementSet::Type::Local);
             EnableWindow(GetDlgItem(m_hAchievementsDlg, IDC_RA_ACTIVATE_ALL_ACH), TRUE);
             EnableWindow(GetDlgItem(m_hAchievementsDlg, IDC_RA_PROMOTE_ACH), TRUE);
         }
@@ -1133,7 +1134,7 @@ void Dlg_Achievements::OnGet_Achievement(const Achievement& ach)
 {
     size_t nIndex = g_pActiveAchievements->GetAchievementIndex(ach);
 
-    if (g_nActiveAchievementSet == Core)
+    if (g_nActiveAchievementSet == AchievementSet::Type::Core)
         OnEditData(nIndex, Achieved, "Yes");
     else
         OnEditData(nIndex, Active, "No");
@@ -1151,7 +1152,7 @@ void Dlg_Achievements::OnEditAchievement(const Achievement& ach)
 
         SetDlgItemText(m_hAchievementsDlg, IDC_RA_POINT_TOTAL, NativeStr(std::to_string(g_pActiveAchievements->PointTotal())).c_str());
 
-        if (g_nActiveAchievementSet == Core)
+        if (g_nActiveAchievementSet == AchievementSet::Type::Core)
             OnEditData(nIndex, Dlg_Achievements::Modified, "Yes");
 
         // Achievement stays active after edit, so this print is unnecessary.
@@ -1168,7 +1169,7 @@ void Dlg_Achievements::ReloadLBXData(int nOffset)
     //const char* g_sColTitlesUnofficial[]  = { "ID", "Title", "Author", "Active", "Votes" };
 
     Achievement& Ach = g_pActiveAchievements->GetAchievement(nOffset);
-    if (g_nActiveAchievementSet == Core)
+    if (g_nActiveAchievementSet == AchievementSet::Type::Core)
     {
         OnEditData(nOffset, Dlg_Achievements::Title, Ach.Title());
         OnEditData(nOffset, Dlg_Achievements::Author, Ach.Author());

--- a/src/RA_Dlg_Achievement.cpp
+++ b/src/RA_Dlg_Achievement.cpp
@@ -19,7 +19,7 @@ const char* COLUMN_TITLES_UNOFFICIAL[] = { "ID", "Title", "Points", "Author", "A
 const char* COLUMN_TITLES_LOCAL[] = { "ID", "Title", "Points", "Author", "Active",	"Votes" };
 const int COLUMN_SIZE[] = { 45, 200, 45, 80, 65, 65 };
 
-const int NUM_COLS = SIZEOF_ARRAY(COLUMN_SIZE);
+const int NUM_COLS = ra::SizeOfArray(COLUMN_SIZE);
 
 int iSelect = -1;
 
@@ -40,7 +40,7 @@ void Dlg_Achievements::SetupColumns(HWND hList)
 
     for (int i = 0; i < NUM_COLS; ++i)
     {
-        const char* sColTitle = nullptr;
+        const char* sColTitle{""};
         if (g_nActiveAchievementSet == AchievementSet::Type::Core)
             sColTitle = COLUMN_TITLES_CORE[i];
         else if (g_nActiveAchievementSet == AchievementSet::Type::Unofficial)
@@ -55,7 +55,7 @@ void Dlg_Achievements::SetupColumns(HWND hList)
         if (i == (NUM_COLS - 1))
             newColumn.fmt |= LVCFMT_FILL;
         newColumn.cx = COLUMN_SIZE[i];
-        ra::tstring sColTitleStr = NativeStr(sColTitle);	//	Take a copy
+        ra::tstring sColTitleStr = ra::NativeStr(sColTitle);	//	Take a copy
         newColumn.pszText = const_cast<LPTSTR>(sColTitleStr.c_str());
         newColumn.cchTextMax = 255;
         newColumn.iSubItem = i;
@@ -138,8 +138,8 @@ void Dlg_Achievements::RemoveAchievement(HWND hList, int nIter)
 
     char buffer[16];
     sprintf_s(buffer, 16, " %u", g_pActiveAchievements->NumAchievements());
-    SetDlgItemText(m_hAchievementsDlg, IDC_RA_NUMACH, NativeStr(buffer).c_str());
-    SetDlgItemText(m_hAchievementsDlg, IDC_RA_POINT_TOTAL, NativeStr(std::to_string(g_pActiveAchievements->PointTotal())).c_str());
+    SetDlgItemText(m_hAchievementsDlg, IDC_RA_NUMACH, ra::NativeStr(buffer).c_str());
+    SetDlgItemText(m_hAchievementsDlg, IDC_RA_POINT_TOTAL, ra::NativeStr(std::to_string(g_pActiveAchievements->PointTotal())).c_str());
 
     UpdateSelectedAchievementButtons(nullptr);
 
@@ -181,7 +181,7 @@ size_t Dlg_Achievements::AddAchievement(HWND hList, const Achievement& Ach)
     {
         //	Cache this (stack) to ensure it lives until after ListView_*Item
         //	SD: Is this necessary?
-        ra::tstring sTextData = NativeStr(m_lbxData.back()[item.iSubItem]);
+        ra::tstring sTextData = ra::NativeStr(m_lbxData.back()[item.iSubItem]);
         item.pszText = const_cast<LPTSTR>((LPCTSTR)sTextData.c_str());
 
         if (item.iSubItem == 0)
@@ -204,26 +204,26 @@ BOOL LocalValidateAchievementsBeforeCommit(int nLbxItems[1])
         if (Ach.Title().length() < 2)
         {
             sprintf_s(buffer, 2048, "Achievement title too short:\n%s\nMust be greater than 2 characters.", Ach.Title().c_str());
-            MessageBox(nullptr, NativeStr(buffer).c_str(), TEXT("Error!"), MB_OK);
+            MessageBox(nullptr, ra::NativeStr(buffer).c_str(), TEXT("Error!"), MB_OK);
             return FALSE;
         }
         if (Ach.Title().length() > 63)
         {
             sprintf_s(buffer, 2048, "Achievement title too long:\n%s\nMust be fewer than 80 characters.", Ach.Title().c_str());
-            MessageBox(nullptr, NativeStr(buffer).c_str(), TEXT("Error!"), MB_OK);
+            MessageBox(nullptr, ra::NativeStr(buffer).c_str(), TEXT("Error!"), MB_OK);
             return FALSE;
         }
 
         if (Ach.Description().length() < 2)
         {
             sprintf_s(buffer, 2048, "Achievement description too short:\n%s\nMust be greater than 2 characters.", Ach.Description().c_str());
-            MessageBox(nullptr, NativeStr(buffer).c_str(), TEXT("Error!"), MB_OK);
+            MessageBox(nullptr, ra::NativeStr(buffer).c_str(), TEXT("Error!"), MB_OK);
             return FALSE;
         }
         if (Ach.Description().length() > 255)
         {
             sprintf_s(buffer, 2048, "Achievement description too long:\n%s\nMust be fewer than 255 characters.", Ach.Description().c_str());
-            MessageBox(nullptr, NativeStr(buffer).c_str(), TEXT("Error!"), MB_OK);
+            MessageBox(nullptr, ra::NativeStr(buffer).c_str(), TEXT("Error!"), MB_OK);
             return FALSE;
         }
 
@@ -235,7 +235,7 @@ BOOL LocalValidateAchievementsBeforeCommit(int nLbxItems[1])
                 std::string str{ "Achievement title contains an illegal character: " };
                 str += cNextChar;
                 str += "\nPlease remove and try again";
-                MessageBox(nullptr, NativeStr(str).c_str(), TEXT("Error!"), MB_OK | MB_ICONERROR);
+                MessageBox(nullptr, ra::NativeStr(str).c_str(), TEXT("Error!"), MB_OK | MB_ICONERROR);
                 return FALSE;
             }
             if (Ach.Description().find_first_of(cNextChar) != std::string::npos)
@@ -243,7 +243,7 @@ BOOL LocalValidateAchievementsBeforeCommit(int nLbxItems[1])
                 std::string str{ "Achievement description contains an illegal character: " };
                 str += cNextChar;
                 str += "\nPlease remove and try again";
-                MessageBox(nullptr, NativeStr(str).c_str(), TEXT("Error!"), MB_OK);
+                MessageBox(nullptr, ra::NativeStr(str).c_str(), TEXT("Error!"), MB_OK);
                 return FALSE;
             }
         }
@@ -341,7 +341,7 @@ void Dlg_Achievements::OnClickAchievementSet(AchievementSet::Type nAchievementSe
         CheckDlgButton(m_hAchievementsDlg, IDC_RA_ACTIVE_LOCAL, TRUE);
     }
 
-    SetDlgItemText(m_hAchievementsDlg, IDC_RA_POINT_TOTAL, NativeStr(std::to_string(g_pActiveAchievements->PointTotal())).c_str());
+    SetDlgItemText(m_hAchievementsDlg, IDC_RA_POINT_TOTAL, ra::NativeStr(std::to_string(g_pActiveAchievements->PointTotal())).c_str());
 
     CheckDlgButton(m_hAchievementsDlg, IDC_RA_CHKACHPROCESSINGACTIVE, g_pActiveAchievements->ProcessingActive());
     OnLoad_NewRom(g_pCurrentGameData->GetGameID()); // assert: calls UpdateSelectedAchievementButtons
@@ -468,7 +468,7 @@ INT_PTR Dlg_Achievements::AchievementsProc(HWND hDlg, UINT nMsg, WPARAM wParam, 
                                     else
                                     {
                                         MessageBox(hDlg,
-                                            NativeStr(std::string("Error in upload: response from server:") + std::string(response["Error"].GetString())).c_str(),
+                                            ra::NativeStr(std::string("Error in upload: response from server:") + std::string(response["Error"].GetString())).c_str(),
                                             TEXT("Error in upload!"), MB_OK);
                                     }
                                 }
@@ -519,7 +519,7 @@ INT_PTR Dlg_Achievements::AchievementsProc(HWND hDlg, UINT nMsg, WPARAM wParam, 
                         std::ostringstream oss;
                         oss << "Are you sure that you want to download fresh achievements from " << _RA_HostName() << "?\n" <<
                             "This will overwrite any changes that you have made with fresh achievements from the server";
-                        if (MessageBox(hDlg, NativeStr(oss.str()).c_str(), TEXT("Refresh from Server"), MB_YESNO | MB_ICONWARNING) == IDYES)
+                        if (MessageBox(hDlg, ra::NativeStr(oss.str()).c_str(), TEXT("Refresh from Server"), MB_YESNO | MB_ICONWARNING) == IDYES)
                         {
                             ra::GameID nGameID = g_pCurrentGameData->GetGameID();
                             if (nGameID != 0)
@@ -581,7 +581,7 @@ INT_PTR Dlg_Achievements::AchievementsProc(HWND hDlg, UINT nMsg, WPARAM wParam, 
 
                     char buffer[16];
                     sprintf_s(buffer, 16, " %u", g_pActiveAchievements->NumAchievements());
-                    SetDlgItemText(m_hAchievementsDlg, IDC_RA_NUMACH, NativeStr(buffer).c_str());
+                    SetDlgItemText(m_hAchievementsDlg, IDC_RA_NUMACH, ra::NativeStr(buffer).c_str());
 
                     Cheevo.SetModified(TRUE);
                     UpdateSelectedAchievementButtons(&Cheevo);
@@ -621,8 +621,8 @@ INT_PTR Dlg_Achievements::AchievementsProc(HWND hDlg, UINT nMsg, WPARAM wParam, 
 
                     char buffer2[16];
                     sprintf_s(buffer2, 16, " %u", g_pActiveAchievements->NumAchievements());
-                    SetDlgItemText(m_hAchievementsDlg, IDC_RA_NUMACH, NativeStr(buffer2).c_str());
-                    SetDlgItemText(m_hAchievementsDlg, IDC_RA_POINT_TOTAL, NativeStr(std::to_string(g_pActiveAchievements->PointTotal())).c_str());
+                    SetDlgItemText(m_hAchievementsDlg, IDC_RA_NUMACH, ra::NativeStr(buffer2).c_str());
+                    SetDlgItemText(m_hAchievementsDlg, IDC_RA_POINT_TOTAL, ra::NativeStr(std::to_string(g_pActiveAchievements->PointTotal())).c_str());
 
                     NewClone.SetModified(TRUE);
                     UpdateSelectedAchievementButtons(&NewClone);
@@ -662,7 +662,7 @@ INT_PTR Dlg_Achievements::AchievementsProc(HWND hDlg, UINT nMsg, WPARAM wParam, 
                             oss << "This achievement exists on " << _RA_HostName() << ".\n\n"
                                 << "*Removing it will affect other games*\n\n"
                                 << "Are you absolutely sure you want to delete this?";
-                            MessageBox(hDlg, NativeStr(oss.str()).c_str(), TEXT("Confirm Delete"), MB_YESNO | MB_ICONWARNING);
+                            MessageBox(hDlg, ra::NativeStr(oss.str()).c_str(), TEXT("Confirm Delete"), MB_YESNO | MB_ICONWARNING);
                         }
                     }
                 }
@@ -968,7 +968,7 @@ INT_PTR Dlg_Achievements::CommitAchievements(HWND hDlg)
 
     BOOL bErrorsEncountered = FALSE;
 
-    if (MessageBox(hDlg, NativeStr(message).c_str(), NativeStr(title).c_str(), MB_YESNO | MB_ICONWARNING) == IDYES)
+    if (MessageBox(hDlg, ra::NativeStr(message).c_str(), ra::NativeStr(title).c_str(), MB_YESNO | MB_ICONWARNING) == IDYES)
     {
         for (size_t i = 0; i < nNumChecked; ++i)
         {
@@ -1033,7 +1033,7 @@ INT_PTR Dlg_Achievements::CommitAchievements(HWND hDlg)
                 {
                     char buffer[1024];
                     sprintf_s(buffer, 1024, "Error!!\n%s", std::string(response["Error"].GetString()).c_str());
-                    MessageBox(hDlg, NativeStr(buffer).c_str(), TEXT("Error!"), MB_OK);
+                    MessageBox(hDlg, ra::NativeStr(buffer).c_str(), TEXT("Error!"), MB_OK);
                     bErrorsEncountered = TRUE;
                 }
             }
@@ -1047,7 +1047,7 @@ INT_PTR Dlg_Achievements::CommitAchievements(HWND hDlg)
         {
             char buffer[512];
             sprintf_s(buffer, 512, "Successfully uploaded data for %u achievements!", nNumChecked);
-            MessageBox(hDlg, NativeStr(buffer).c_str(), TEXT("Success!"), MB_OK);
+            MessageBox(hDlg, ra::NativeStr(buffer).c_str(), TEXT("Success!"), MB_OK);
 
             RECT rcBounds;
             GetClientRect(hList, &rcBounds);
@@ -1112,7 +1112,7 @@ void Dlg_Achievements::OnLoad_NewRom(ra::GameID nGameID)
 
         TCHAR buffer[256];
         _stprintf_s(buffer, 256, _T(" %u"), nGameID);
-        SetDlgItemText(m_hAchievementsDlg, IDC_RA_GAMEHASH, NativeStr(buffer).c_str());
+        SetDlgItemText(m_hAchievementsDlg, IDC_RA_GAMEHASH, ra::NativeStr(buffer).c_str());
 
         if (nGameID != 0)
         {
@@ -1123,8 +1123,8 @@ void Dlg_Achievements::OnLoad_NewRom(ra::GameID nGameID)
         }
 
         _stprintf_s(buffer, _T(" %u"), g_pActiveAchievements->NumAchievements());
-        SetDlgItemText(m_hAchievementsDlg, IDC_RA_NUMACH, NativeStr(buffer).c_str());
-        SetDlgItemText(m_hAchievementsDlg, IDC_RA_POINT_TOTAL, NativeStr(std::to_string(g_pActiveAchievements->PointTotal())).c_str());
+        SetDlgItemText(m_hAchievementsDlg, IDC_RA_NUMACH, ra::NativeStr(buffer).c_str());
+        SetDlgItemText(m_hAchievementsDlg, IDC_RA_POINT_TOTAL, ra::NativeStr(std::to_string(g_pActiveAchievements->PointTotal())).c_str());
     }
 
     UpdateSelectedAchievementButtons(nullptr);
@@ -1150,7 +1150,7 @@ void Dlg_Achievements::OnEditAchievement(const Achievement& ach)
     {
         OnEditData(nIndex, Dlg_Achievements::Points, std::to_string(ach.Points()));
 
-        SetDlgItemText(m_hAchievementsDlg, IDC_RA_POINT_TOTAL, NativeStr(std::to_string(g_pActiveAchievements->PointTotal())).c_str());
+        SetDlgItemText(m_hAchievementsDlg, IDC_RA_POINT_TOTAL, ra::NativeStr(std::to_string(g_pActiveAchievements->PointTotal())).c_str());
 
         if (g_nActiveAchievementSet == AchievementSet::Type::Core)
             OnEditData(nIndex, Dlg_Achievements::Modified, "Yes");
@@ -1208,7 +1208,7 @@ void Dlg_Achievements::OnEditData(size_t nItem, Column nColumn, const std::strin
         item.iItem = nItem;
         item.iSubItem = nColumn;
         item.cchTextMax = 256;
-        ra::tstring sStr = NativeStr(m_lbxData[nItem][nColumn]);	//	scoped cache
+        ra::tstring sStr = ra::NativeStr(m_lbxData[nItem][nColumn]);	//	scoped cache
         item.pszText = sStr.data();
         if (ListView_SetItem(hList, &item) == FALSE)
         {

--- a/src/RA_Dlg_Achievement.h
+++ b/src/RA_Dlg_Achievement.h
@@ -2,7 +2,7 @@
 #define RA_DLG_ACHIEVEMENT_H
 #pragma once
 
-#include "RA_Achievement.h"
+#include "RA_AchievementSet.h"
 
 const int MAX_TEXT_ITEM_SIZE = 80;
 
@@ -42,7 +42,7 @@ public:
     void ReloadLBXData(int nOffset);
     void OnEditData(size_t nItem, Column nColumn, const std::string& sNewData);
     void OnEditAchievement(const Achievement& ach);
-    void OnClickAchievementSet(AchievementSetType nAchievementSet);
+    void OnClickAchievementSet(_In_ AchievementSet::Type nAchievementSet);
 
     inline std::string& LbxDataAt(size_t nRow, Column nCol) { return(m_lbxData[nRow])[nCol]; }
 

--- a/src/RA_Dlg_AchievementsReporter.cpp
+++ b/src/RA_Dlg_AchievementsReporter.cpp
@@ -12,7 +12,7 @@ namespace {
 
 const char* COL_TITLE[] = { "", "Title", "Description", "Author", "Achieved?" };
 const int COL_SIZE[] = { 19, 105, 205, 75, 62 };
-static_assert(SIZEOF_ARRAY(COL_TITLE) == SIZEOF_ARRAY(COL_SIZE), "Must match!");
+static_assert(ra::SizeOfArray(COL_TITLE) == ra::SizeOfArray(COL_SIZE), "Must match!");
 
 const char* PROBLEM_STR[] = { "Unknown", "Triggers at wrong time", "Didn't trigger at all" };
 
@@ -34,17 +34,17 @@ void Dlg_AchievementsReporter::SetupColumns(HWND hList)
     LV_COLUMN col;
     ZeroMemory(&col, sizeof(col));
 
-    for (size_t i = 0; i < SIZEOF_ARRAY(COL_TITLE); ++i)
+    for (size_t i = 0; i < ra::SizeOfArray(COL_TITLE); ++i)
     {
         col.mask = LVCF_TEXT | LVCF_WIDTH | LVCF_SUBITEM | LVCF_FMT;
         col.cx = COL_SIZE[i];
         col.cchTextMax = 255;
-        ra::tstring str = NativeStr(COL_TITLE[i]);	//	Hold the temporary object
+        ra::tstring str = ra::NativeStr(COL_TITLE[i]);	//	Hold the temporary object
         col.pszText = str.data();
         col.iSubItem = i;
 
         col.fmt = LVCFMT_LEFT | LVCFMT_FIXED_WIDTH;
-        if (i == SIZEOF_ARRAY(COL_TITLE) - 1)	//If the last element: fill to the end
+        if (i == ra::SizeOfArray(COL_TITLE) - 1)	//If the last element: fill to the end
             col.fmt |= LVCFMT_FILL;
 
         ListView_InsertColumn(hList, i, reinterpret_cast<LPARAM>(&col));
@@ -90,7 +90,7 @@ int Dlg_AchievementsReporter::AddAchievementToListBox(HWND hList, const Achievem
     for (size_t i = 0; i < NumReporterColumns; ++i)
     {
         item.iSubItem = i;
-        ra::tstring sStr = NativeStr(ms_lbxData[ms_nNumOccupiedRows][i]);	//Scoped cache
+        ra::tstring sStr = ra::NativeStr(ms_lbxData[ms_nNumOccupiedRows][i]);	//Scoped cache
         item.pszText = sStr.data();
 
         if (i == 0)
@@ -118,7 +118,7 @@ INT_PTR CALLBACK Dlg_AchievementsReporter::AchievementsReporterProc(HWND hDlg, U
                 AddAchievementToListBox(hList, &g_pActiveAchievements->GetAchievement(i));
 
             ListView_SetExtendedListViewStyle(hList, LVS_EX_CHECKBOXES | LVS_EX_HEADERDRAGDROP);
-            SetDlgItemText(hDlg, IDC_RA_BROKENACH_BUGREPORTER, NativeStr(RAUsers::LocalUser().Username()).c_str());
+            SetDlgItemText(hDlg, IDC_RA_BROKENACH_BUGREPORTER, ra::NativeStr(RAUsers::LocalUser().Username()).c_str());
         }
         return FALSE;
 
@@ -192,7 +192,7 @@ INT_PTR CALLBACK Dlg_AchievementsReporter::AchievementsReporterProc(HWND hDlg, U
                         g_sCurrentROMMD5.c_str(),
                         sBugReportComment.c_str());
 
-                    if (MessageBox(nullptr, NativeStr(sBugReportInFull).c_str(), TEXT("Summary"), MB_YESNO) == IDNO)
+                    if (MessageBox(nullptr, ra::NativeStr(sBugReportInFull).c_str(), TEXT("Summary"), MB_YESNO) == IDNO)
                         return FALSE;
 
                     PostArgs args;
@@ -219,7 +219,7 @@ INT_PTR CALLBACK Dlg_AchievementsReporter::AchievementsReporterProc(HWND hDlg, U
                                 "\n"
                                 "Thanks again!");
 
-                            MessageBox(hDlg, NativeStr(buffer).c_str(), TEXT("Success!"), MB_OK);
+                            MessageBox(hDlg, ra::NativeStr(buffer).c_str(), TEXT("Success!"), MB_OK);
                             EndDialog(hDlg, TRUE);
                             return TRUE;
                         }
@@ -232,7 +232,7 @@ INT_PTR CALLBACK Dlg_AchievementsReporter::AchievementsReporterProc(HWND hDlg, U
                                 "Response From Server:\n"
                                 "\n"
                                 "Error code: %d", doc.GetParseError());
-                            MessageBox(hDlg, NativeStr(buffer).c_str(), TEXT("Error from server!"), MB_OK);
+                            MessageBox(hDlg, ra::NativeStr(buffer).c_str(), TEXT("Error from server!"), MB_OK);
                             return FALSE;
                         }
                     }

--- a/src/RA_Dlg_GameTitle.cpp
+++ b/src/RA_Dlg_GameTitle.cpp
@@ -26,14 +26,14 @@ INT_PTR Dlg_GameTitle::GameTitleProc(HWND hDlg, UINT uMsg, WPARAM wParam, _UNUSE
         {
             const HWND hKnownGamesCbo = GetDlgItem(hDlg, IDC_RA_KNOWNGAMES);
             std::string sGameTitleTidy = Dlg_GameTitle::CleanRomName(g_GameTitleDialog.m_sEstimatedGameTitle);
-            SetDlgItemText(hDlg, IDC_RA_GAMETITLE, NativeStr(sGameTitleTidy).c_str());
+            SetDlgItemText(hDlg, IDC_RA_GAMETITLE, ra::NativeStr(sGameTitleTidy).c_str());
 
             //	Load in the checksum
-            SetDlgItemText(hDlg, IDC_RA_CHECKSUM, NativeStr(g_GameTitleDialog.m_sMD5).c_str());
+            SetDlgItemText(hDlg, IDC_RA_CHECKSUM, ra::NativeStr(g_GameTitleDialog.m_sMD5).c_str());
 
             //	Populate the dropdown
             //	***Do blocking fetch of all game titles.***
-            int nSel = ComboBox_AddString(hKnownGamesCbo, NativeStr("<New Title>").c_str());
+            int nSel = ComboBox_AddString(hKnownGamesCbo, ra::NativeStr("<New Title>").c_str());
             ComboBox_SetCurSel(hKnownGamesCbo, nSel);
 
             PostArgs args;
@@ -69,7 +69,7 @@ INT_PTR Dlg_GameTitle::GameTitleProc(HWND hDlg, UINT uMsg, WPARAM wParam, _UNUSE
                     {
                         const std::string& sTitle = iter->first;
 
-                        nSel = ComboBox_AddString(hKnownGamesCbo, NativeStr(sTitle).c_str());
+                        nSel = ComboBox_AddString(hKnownGamesCbo, ra::NativeStr(sTitle).c_str());
 
                         //	Attempt to find this game and select it by default: case insensitive comparison
                         if (sGameTitleTidy.compare(sTitle) == 0)
@@ -107,7 +107,7 @@ INT_PTR Dlg_GameTitle::GameTitleProc(HWND hDlg, UINT uMsg, WPARAM wParam, _UNUSE
                     else
                     {
                         //	Existing title
-                        ASSERT(m_aGameTitles.find(std::string(sSelectedTitle)) != m_aGameTitles.end());
+                        ASSERT(m_aGameTitles.find(ra::Narrow(sSelectedTitle)) != m_aGameTitles.end());
                         nGameID = m_aGameTitles[std::string(ra::Narrow(sSelectedTitle))];
                     }
 
@@ -143,7 +143,7 @@ INT_PTR Dlg_GameTitle::GameTitleProc(HWND hDlg, UINT uMsg, WPARAM wParam, _UNUSE
                         {
                             //Error given
                             MessageBox(hDlg,
-                                NativeStr(std::string("Could not add new title: ") + std::string(doc["Error"].GetString())).c_str(),
+                                ra::NativeStr(std::string("Could not add new title: ") + std::string(doc["Error"].GetString())).c_str(),
                                 TEXT("Errors encountered"),
                                 MB_OK);
                         }

--- a/src/RA_Dlg_Login.cpp
+++ b/src/RA_Dlg_Login.cpp
@@ -17,7 +17,7 @@ INT_PTR CALLBACK RA_Dlg_Login::RA_Dlg_LoginProc(HWND hDlg, UINT uMsg, WPARAM wPa
     {
         case WM_INITDIALOG:
 
-            SetDlgItemText(hDlg, IDC_RA_USERNAME, NativeStr(RAUsers::LocalUser().Username()).c_str());
+            SetDlgItemText(hDlg, IDC_RA_USERNAME, ra::NativeStr(RAUsers::LocalUser().Username()).c_str());
             if (RAUsers::LocalUser().Username().length() > 2)
             {
                 HWND hPass = GetDlgItem(hDlg, IDC_RA_PASSWORD);
@@ -80,7 +80,7 @@ INT_PTR CALLBACK RA_Dlg_Login::RA_Dlg_LoginProc(HWND hDlg, UINT uMsg, WPARAM wPa
                             sResponseTitle = "Error logging in!";
                         }
 
-                        MessageBox(hDlg, NativeStr(sResponse).c_str(), NativeStr(sResponseTitle).c_str(), MB_OK);
+                        MessageBox(hDlg, ra::NativeStr(sResponse).c_str(), ra::NativeStr(sResponseTitle).c_str(), MB_OK);
 
                         //	If we are now logged in
                         if (RAUsers::LocalUser().IsLoggedIn())
@@ -95,7 +95,7 @@ INT_PTR CALLBACK RA_Dlg_Login::RA_Dlg_LoginProc(HWND hDlg, UINT uMsg, WPARAM wPa
                     {
                         if (!doc.HasParseError() && doc.HasMember("Error"))
                         {
-                            MessageBox(hDlg, NativeStr(std::string("Server error: ") + std::string(doc["Error"].GetString())).c_str(), TEXT("Error!"), MB_OK);
+                            MessageBox(hDlg, ra::NativeStr(std::string("Server error: ") + std::string(doc["Error"].GetString())).c_str(), TEXT("Error!"), MB_OK);
                         }
                         else
                         {

--- a/src/RA_Dlg_MemBookmark.cpp
+++ b/src/RA_Dlg_MemBookmark.cpp
@@ -935,7 +935,7 @@ BOOL Dlg_MemBookmark::EditLabel(int nItem, int nSubItem)
     };
 
     SendMessage(g_hIPEEditBM, WM_SETFONT, (WPARAM)GetStockObject(DEFAULT_GUI_FONT), TRUE);
-    SetWindowText(g_hIPEEditBM, NativeStr(m_vBookmarks[nItem]->Description()).c_str());
+    SetWindowText(g_hIPEEditBM, ra::NativeStr(m_vBookmarks[nItem]->Description()).c_str());
 
     SendMessage(g_hIPEEditBM, EM_SETSEL, 0, -1);
     SetFocus(g_hIPEEditBM);

--- a/src/RA_Dlg_MemBookmark.cpp
+++ b/src/RA_Dlg_MemBookmark.cpp
@@ -20,25 +20,20 @@ HWND g_hIPEEditBM;
 int nSelItemBM;
 int nSelSubItemBM;
 
-namespace {
-const char* COLUMN_TITLE[] ={ "Description", "Address", "Value", "Prev.", "Changes" };
-const int COLUMN_WIDTH[] ={ 112, 64, 64, 64, 54 };
-static_assert(SIZEOF_ARRAY(COLUMN_TITLE) == SIZEOF_ARRAY(COLUMN_WIDTH), "Must match!");
-}
+namespace ra {
 
+using ColumnTitles = std::array<LPCTSTR, 5>;
+using ColumnWidths = std::array<int, 5>;
+
+inline constexpr ColumnTitles COLUMN_TITLE{ _T("Description"), _T("Address"), _T("Value"), _T("Prev."), _T("Changes") };
+inline constexpr ColumnWidths COLUMN_WIDTH{ 112, 64, 64, 64, 54 };
 inline constexpr std::array<COMDLG_FILTERSPEC, 1> c_rgFileTypes{ {L"Text Document (*.txt)", L"*.txt"} };
 
+static_assert(is_same_size_v<ColumnTitles, ColumnWidths>);
 
-enum BookmarkSubItems
-{
-    CSI_DESC,
-    CSI_ADDRESS,
-    CSI_VALUE,
-    CSI_PREVIOUS,
-    CSI_CHANGES,
+} // namespace ra
 
-    NumColumns
-};
+
 
 INT_PTR CALLBACK Dlg_MemBookmark::s_MemBookmarkDialogProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
@@ -225,12 +220,13 @@ INT_PTR Dlg_MemBookmark::MemBookmarkDialogProc(HWND hDlg, UINT uMsg, WPARAM wPar
                         rcCol.left = rcCol.right;
                         rcCol.right += lvc.cx;
 
-                        switch (i)
+                        const auto eSubItem{ ra::itoe<SubItems>(i) };
+                        switch (eSubItem)
                         {
-                            case CSI_ADDRESS:
+                            case SubItems::Address:
                                 swprintf_s(buffer, 512, L"%06x", m_vBookmarks[pdis->itemID]->Address());
                                 break;
-                            case CSI_VALUE:
+                            case SubItems::Value:
                                 if (m_vBookmarks[pdis->itemID]->Decimal())
                                     swprintf_s(buffer, 512, L"%u", m_vBookmarks[pdis->itemID]->Value());
                                 else
@@ -243,7 +239,7 @@ INT_PTR Dlg_MemBookmark::MemBookmarkDialogProc(HWND hDlg, UINT uMsg, WPARAM wPar
                                     }
                                 }
                                 break;
-                            case CSI_PREVIOUS:
+                            case SubItems::Previous:
                                 if (m_vBookmarks[pdis->itemID]->Decimal())
                                     swprintf_s(buffer, 512, L"%u", m_vBookmarks[pdis->itemID]->Previous());
                                 else
@@ -256,7 +252,7 @@ INT_PTR Dlg_MemBookmark::MemBookmarkDialogProc(HWND hDlg, UINT uMsg, WPARAM wPar
                                     }
                                 }
                                 break;
-                            case CSI_CHANGES:
+                            case SubItems::Changes:
                                 swprintf_s(buffer, 512, L"%u", m_vBookmarks[pdis->itemID]->Count());
                                 break;
                             default:
@@ -318,14 +314,15 @@ INT_PTR Dlg_MemBookmark::MemBookmarkDialogProc(HWND hDlg, UINT uMsg, WPARAM wPar
 
                         LPNMITEMACTIVATE pOnClick = (LPNMITEMACTIVATE)lParam;
 
-                        if (pOnClick->iItem != -1 && pOnClick->iSubItem == CSI_DESC)
+                        using namespace ra::rel_ops;
+                        if ((pOnClick->iItem != -1) && (pOnClick->iSubItem == SubItems::Desc))
                         {
                             nSelItemBM = pOnClick->iItem;
                             nSelSubItemBM = pOnClick->iSubItem;
 
                             EditLabel(pOnClick->iItem, pOnClick->iSubItem);
                         }
-                        else if (pOnClick->iItem != -1 && pOnClick->iSubItem == CSI_ADDRESS)
+                        else if ((pOnClick->iItem != -1) && (pOnClick->iSubItem == SubItems::Address))
                         {
                             g_MemoryDialog.SetWatchingAddress(m_vBookmarks[pOnClick->iItem]->Address());
                             MemoryViewerControl::setAddress((m_vBookmarks[pOnClick->iItem]->Address() &
@@ -539,30 +536,32 @@ void Dlg_MemBookmark::SetupColumns(HWND hList)
     //	Remove all data.
     ListView_DeleteAllItems(hList);
 
-    LV_COLUMN col;
-    ZeroMemory(&col, sizeof(col));
-
-    for (size_t i = 0; i < NumColumns; ++i)
+    auto idx{ 0 };
+    for (auto& sColTitle : ra::COLUMN_TITLE)
     {
-        col.mask = LVCF_TEXT | LVCF_WIDTH | LVCF_SUBITEM | LVCF_FMT;
-        col.cx = COLUMN_WIDTH[i];
-        ra::tstring colTitle = NativeStr(COLUMN_TITLE[i]).c_str();
-        col.pszText = const_cast<LPTSTR>(colTitle.c_str());
-        col.cchTextMax = 255;
-        col.iSubItem = i;
+        ra::tstring tszText{ sColTitle };
+        LV_COLUMN col
+        {
+            col.mask       = LVCF_TEXT | LVCF_WIDTH | LVCF_SUBITEM | LVCF_FMT,
+            col.fmt        = LVCFMT_CENTER | LVCFMT_FIXED_WIDTH,
+            col.cx         = ra::COLUMN_WIDTH.at(idx),
+            col.pszText    = tszText.data(),
+            col.cchTextMax = 255,
+            col.iSubItem   = idx
+        };
 
-        col.fmt = LVCFMT_CENTER | LVCFMT_FIXED_WIDTH;
-        if (i == NumColumns - 1)
+        if (idx == (ra::COLUMN_TITLE.size() - 1))
             col.fmt |= LVCFMT_FILL;
 
-        ListView_InsertColumn(hList, i, (LPARAM)&col);
+        ListView_InsertColumn(hList, idx, &col);
+        idx++;
     }
-
     m_nNumOccupiedRows = 0;
 
-    BOOL bSuccess = ListView_SetExtendedListViewStyle(hList, LVS_EX_FULLROWSELECT | LVS_EX_GRIDLINES | LVS_EX_DOUBLEBUFFER);
-    bSuccess = ListView_EnableGroupView(hList, FALSE);
-
+#if _WIN32_WINNT >= _WIN32_WINNT_LONGHORN
+    if (ListView_SetExtendedListViewStyle(hList, LVS_EX_FULLROWSELECT | LVS_EX_GRIDLINES | LVS_EX_DOUBLEBUFFER) != 0UL)
+        ::MessageBox(::GetActiveWindow(), _T("The styles specified could not be set."), _T("Error!"), MB_OK | MB_ICONERROR);
+#endif // _WIN32_WINNT >= _WIN32_WINNT_LONGHORN
 }
 
 void Dlg_MemBookmark::AddAddress()
@@ -707,7 +706,7 @@ void Dlg_MemBookmark::ExportJSON()
     HRESULT hr;
     if (SUCCEEDED(hr = CoCreateInstance(CLSID_FileSaveDialog, nullptr, CLSCTX_ALL, IID_IFileSaveDialog, reinterpret_cast<void**>(&pDlg))))
     {
-        if (SUCCEEDED(hr = pDlg->SetFileTypes(c_rgFileTypes.size(), &c_rgFileTypes.front())))
+        if (SUCCEEDED(hr = pDlg->SetFileTypes(ra::c_rgFileTypes.size(), &ra::c_rgFileTypes.front())))
         {
             std::ostringstream oss;
             oss << g_pCurrentGameData->GetGameID() << "-Bookmarks.txt";
@@ -728,7 +727,7 @@ void Dlg_MemBookmark::ExportJSON()
                         {
                             if (SUCCEEDED(hr = pDlg->GetResult(&pItem.p)))
                             {
-                                LPWSTR pStr = nullptr;
+                                LPWSTR pStr{ nullptr };
                                 if (SUCCEEDED(hr = pItem->GetDisplayName(SIGDN_FILESYSPATH, &pStr)))
                                 {
                                     rapidjson::Document doc;
@@ -835,14 +834,14 @@ std::wstring Dlg_MemBookmark::ImportDialog()
     HRESULT hr;
     if (SUCCEEDED(hr = CoCreateInstance(CLSID_FileOpenDialog, nullptr, CLSCTX_ALL, IID_IFileOpenDialog, reinterpret_cast<void**>(&pDlg))))
     {
-        if (SUCCEEDED(hr = pDlg->SetFileTypes(c_rgFileTypes.size(), &c_rgFileTypes.front())))
+        if (SUCCEEDED(hr = pDlg->SetFileTypes(ra::c_rgFileTypes.size(), &ra::c_rgFileTypes.front())))
         {
             if (SUCCEEDED(hr = pDlg->Show(nullptr)))
             {
                 CComPtr<IShellItem> pItem;
                 if (SUCCEEDED(hr = pDlg->GetResult(&pItem)))
                 {
-                    LPWSTR pStr = nullptr;
+                    LPWSTR pStr{ nullptr };
                     if (SUCCEEDED(hr = pItem->GetDisplayName(SIGDN_FILESYSPATH, &pStr)))
                     {
                         str = pStr;

--- a/src/RA_Dlg_MemBookmark.cpp
+++ b/src/RA_Dlg_MemBookmark.cpp
@@ -550,7 +550,7 @@ void Dlg_MemBookmark::SetupColumns(HWND hList)
             col.iSubItem   = idx
         };
 
-        if (idx == (ra::COLUMN_TITLE.size() - 1))
+        if (idx == (ra::to_signed(ra::COLUMN_TITLE.size()) - 1))
             col.fmt |= LVCFMT_FILL;
 
         ListView_InsertColumn(hList, idx, &col);

--- a/src/RA_Dlg_MemBookmark.h
+++ b/src/RA_Dlg_MemBookmark.h
@@ -41,9 +41,16 @@ private:
 
 class Dlg_MemBookmark
 {
+    enum class SubItems
+    {
+        Desc,
+        Address,
+        Value,
+        Previous,
+        Changes
+    };
+
 public:
-    //Dlg_MemBookmark();
-    //~Dlg_MemBookmark();
 
     static INT_PTR CALLBACK s_MemBookmarkDialogProc(HWND, UINT, WPARAM, LPARAM);
     INT_PTR MemBookmarkDialogProc(HWND, UINT, WPARAM, LPARAM);

--- a/src/RA_Dlg_Memory.cpp
+++ b/src/RA_Dlg_Memory.cpp
@@ -589,7 +589,7 @@ void MemoryViewerControl::RenderMemViewer(HWND hTarget)
     r.right = rect.right - 3;
 
     //	Draw header:
-    DrawText(hMemDC, NativeStr(sHeader).c_str(), strlen(sHeader), &r, DT_TOP | DT_LEFT | DT_NOPREFIX);
+    DrawText(hMemDC, ra::NativeStr(sHeader).c_str(), strlen(sHeader), &r, DT_TOP | DT_LEFT | DT_NOPREFIX);
 
     //	Adjust for header:
     r.top += m_szFontSize.cy;
@@ -639,7 +639,7 @@ void MemoryViewerControl::RenderMemViewer(HWND hTarget)
                         break;
                 }
 
-                DrawText(hMemDC, NativeStr(bufferNative).c_str(), ptr - bufferNative, &r, DT_TOP | DT_LEFT | DT_NOPREFIX);
+                DrawText(hMemDC, ra::NativeStr(bufferNative).c_str(), ptr - bufferNative, &r, DT_TOP | DT_LEFT | DT_NOPREFIX);
 
                 if ((ra::to_signed(m_nWatchedAddress) & ~0x0F) == addr)
                 {
@@ -714,7 +714,7 @@ void MemoryViewerControl::RenderMemViewer(HWND hTarget)
                             }
 
                             r.left = 3 + (ptr - bufferNative) * m_szFontSize.cx;
-                            DrawText(hMemDC, NativeStr(ptr).c_str(), stride, &r, DT_TOP | DT_LEFT | DT_NOPREFIX);
+                            DrawText(hMemDC, ra::NativeStr(ptr).c_str(), stride, &r, DT_TOP | DT_LEFT | DT_NOPREFIX);
                         }
 
                         notes >>= 1;
@@ -804,7 +804,7 @@ INT_PTR Dlg_Memory::MemoryProc(HWND hDlg, UINT nMsg, WPARAM wParam, LPARAM lPara
             EnableWindow(GetDlgItem(hDlg, IDC_RA_TESTVAL), FALSE);
 
             for (size_t i = 0; i < NumComparisonTypes; ++i)
-                ComboBox_AddString(GetDlgItem(hDlg, IDC_RA_CBO_CMPTYPE), NativeStr(COMPARISONTYPE_STR[i]).c_str());
+                ComboBox_AddString(GetDlgItem(hDlg, IDC_RA_CBO_CMPTYPE), ra::NativeStr(COMPARISONTYPE_STR[i]).c_str());
 
             ComboBox_SetCurSel(GetDlgItem(hDlg, IDC_RA_CBO_CMPTYPE), 0);
 
@@ -884,9 +884,9 @@ INT_PTR Dlg_Memory::MemoryProc(HWND hDlg, UINT nMsg, WPARAM wParam, LPARAM lPara
                         {
                             const std::string& sFirstLine = m_SearchResults[m_nPage].m_results.Summary();
                             if (sFirstLine.empty())
-                                _stprintf_s(buffer, sizeof(buffer), _T("%s"), "Invalid Range");
+                                _stprintf_s(buffer, sizeof(buffer), _T("%s"), _T("Invalid Range"));
                             else
-                                _stprintf_s(buffer, sizeof(buffer), _T("%s"), sFirstLine.c_str());
+                                _stprintf_s(buffer, sizeof(buffer), _T("%s"), ra::NativeStr(sFirstLine).c_str());
                         }
                         else
                         {
@@ -918,7 +918,7 @@ INT_PTR Dlg_Memory::MemoryProc(HWND hDlg, UINT nMsg, WPARAM wParam, LPARAM lPara
                         {
                             std::ostringstream oss;
                             oss << "   (" << pSavedNote->Note() << ")";
-                            _tcscat_s(buffer, NativeStr(oss.str()).c_str());
+                            _tcscat_s(buffer, ra::NativeStr(oss.str()).c_str());
                         }
 
                         COLORREF color;
@@ -978,7 +978,7 @@ INT_PTR Dlg_Memory::MemoryProc(HWND hDlg, UINT nMsg, WPARAM wParam, LPARAM lPara
                             if (!m_SearchResults[m_nPage].m_results.GetMatchingAddress(nSelect - 2, result))
                                 break;
 
-                            ComboBox_SetText(GetDlgItem(hDlg, IDC_RA_WATCHING), NativeStr(ra::ByteAddressToString(result.nAddress)).c_str());
+                            ComboBox_SetText(GetDlgItem(hDlg, IDC_RA_WATCHING), ra::NativeStr(ra::ByteAddressToString(result.nAddress)).c_str());
 
                             const CodeNotes::CodeNoteObj* pSavedNote = m_CodeNotes.FindCodeNote(result.nAddress);
                             if ((pSavedNote != nullptr) && (pSavedNote->Note().length() > 0))
@@ -1222,7 +1222,7 @@ INT_PTR Dlg_Memory::MemoryProc(HWND hDlg, UINT nMsg, WPARAM wParam, LPARAM lPara
                         //	Doesn't yet exist: add it newly!
                         m_CodeNotes.Add(nAddr, RAUsers::LocalUser().Username(), sNewNote);
                         const std::string sAddress = ra::ByteAddressToString(nAddr);
-                        ComboBox_AddString(hMemWatch, NativeStr(sAddress).c_str());
+                        ComboBox_AddString(hMemWatch, ra::NativeStr(sAddress).c_str());
                     }
 
                     return FALSE;
@@ -1241,7 +1241,7 @@ INT_PTR Dlg_Memory::MemoryProc(HWND hDlg, UINT nMsg, WPARAM wParam, LPARAM lPara
 
                     SetDlgItemText(hDlg, IDC_RA_MEMSAVENOTE, TEXT(""));
 
-                    int nIndex = ComboBox_FindString(hMemWatch, -1, NativeStr(sAddress).c_str());
+                    int nIndex = ComboBox_FindString(hMemWatch, -1, ra::NativeStr(sAddress).c_str());
                     if (nIndex != CB_ERR)
                         ComboBox_DeleteString(hMemWatch, nIndex);
 
@@ -1258,7 +1258,7 @@ INT_PTR Dlg_Memory::MemoryProc(HWND hDlg, UINT nMsg, WPARAM wParam, LPARAM lPara
                         oss << "http://" << _RA_HostName() << "/codenotes.php?g=" << g_pCurrentGameData->GetGameID();
                         ShellExecute(nullptr,
                             _T("open"),
-                            NativeStr(oss.str()).c_str(),
+                            ra::NativeStr(oss.str()).c_str(),
                             nullptr,
                             nullptr,
                             SW_SHOWNORMAL);
@@ -1460,7 +1460,7 @@ void Dlg_Memory::RepopulateMemNotesFromFile()
         while (iter != m_CodeNotes.EndOfNotes())
         {
             const std::string sAddr = ra::ByteAddressToString(iter->first);
-            ComboBox_AddString(hMemWatch, NativeStr(sAddr).c_str());
+            ComboBox_AddString(hMemWatch, ra::NativeStr(sAddr).c_str());
             iter++;
         }
 
@@ -1595,7 +1595,7 @@ void Dlg_Memory::SetWatchingAddress(unsigned int nAddr)
 
     char buffer[32];
     sprintf_s(buffer, 32, "0x%06x", nAddr);
-    SetDlgItemText(g_MemoryDialog.GetHWND(), IDC_RA_WATCHING, NativeStr(buffer).c_str());
+    SetDlgItemText(g_MemoryDialog.GetHWND(), IDC_RA_WATCHING, ra::NativeStr(buffer).c_str());
     UpdateBits();
 
     OnWatchingMemChange();
@@ -1621,7 +1621,7 @@ void Dlg_Memory::AddBank(size_t nBankID)
         return;
 
     HWND hMemBanks = GetDlgItem(m_hWnd, IDC_RA_MEMBANK);
-    int nIndex = ComboBox_AddString(hMemBanks, NativeStr(std::to_string(nBankID)).c_str());
+    int nIndex = ComboBox_AddString(hMemBanks, ra::NativeStr(std::to_string(nBankID)).c_str());
     if (nIndex != CB_ERR)
     {
         ComboBox_SetItemData(hMemBanks, nIndex, nBankID);

--- a/src/RA_Dlg_RomChecksum.cpp
+++ b/src/RA_Dlg_RomChecksum.cpp
@@ -14,7 +14,7 @@ INT_PTR CALLBACK RA_Dlg_RomChecksum::RA_Dlg_RomChecksumProc(HWND hDlg, UINT nMsg
     switch (nMsg)
     {
         case WM_INITDIALOG:
-            SetDlgItemText(hDlg, IDC_RA_ROMCHECKSUMTEXT, NativeStr(std::string("ROM Checksum: ") + g_sCurrentROMMD5).c_str());
+            SetDlgItemText(hDlg, IDC_RA_ROMCHECKSUMTEXT, ra::NativeStr(std::string("ROM Checksum: ") + g_sCurrentROMMD5).c_str());
             return FALSE;
 
         case WM_COMMAND:

--- a/src/RA_Integration.vcxproj
+++ b/src/RA_Integration.vcxproj
@@ -124,6 +124,7 @@
     <ClInclude Include="services\TextReader.hh" />
     <ClInclude Include="services\TextWriter.hh" />
     <ClInclude Include="ui\WindowViewModelBase.hh" />
+    <ClInclude Include="windows_nodefines.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="RA_Shared.rc" />
@@ -207,11 +208,15 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <TargetName>RA_Integration</TargetName>
+    <CodeAnalysisRuleSet>NativeRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <RunCodeAnalysis>false</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugUnicode|Win32'">
     <OutDir>..\bin\$(Configuration)\</OutDir>
     <IntDir>..\obj\$(Configuration)\</IntDir>
     <TargetName>RA_Integration</TargetName>
+    <CodeAnalysisRuleSet>NativeRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <RunCodeAnalysis>false</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <OutDir>..\bin\$(Configuration)\</OutDir>
@@ -220,6 +225,8 @@
     <LibraryPath>C:\Program Files\Microsoft DirectX SDK %28June 2010%29\Lib\x86;$(LibraryPath)</LibraryPath>
     <LinkIncremental>false</LinkIncremental>
     <TargetName>RA_Integration</TargetName>
+    <CodeAnalysisRuleSet>NativeRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <RunCodeAnalysis>false</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseWithDebug|Win32'">
     <OutDir>..\bin\$(Configuration)\</OutDir>
@@ -228,6 +235,8 @@
     <LibraryPath>C:\Program Files\Microsoft DirectX SDK %28June 2010%29\Lib\x86;$(LibraryPath)</LibraryPath>
     <LinkIncremental>false</LinkIncremental>
     <TargetName>RA_Integration</TargetName>
+    <CodeAnalysisRuleSet>NativeRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <RunCodeAnalysis>false</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseUnicode|Win32'">
     <OutDir>..\bin\$(Configuration)\</OutDir>
@@ -236,6 +245,8 @@
     <LibraryPath>C:\Program Files\Microsoft DirectX SDK %28June 2010%29\Lib\x86;$(LibraryPath)</LibraryPath>
     <LinkIncremental>false</LinkIncremental>
     <TargetName>RA_Integration</TargetName>
+    <CodeAnalysisRuleSet>NativeRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <RunCodeAnalysis>false</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseWithDebugUnicode|Win32'">
     <OutDir>..\bin\$(Configuration)\</OutDir>
@@ -244,6 +255,8 @@
     <LibraryPath>C:\Program Files\Microsoft DirectX SDK %28June 2010%29\Lib\x86;$(LibraryPath)</LibraryPath>
     <LinkIncremental>false</LinkIncremental>
     <TargetName>RA_Integration</TargetName>
+    <CodeAnalysisRuleSet>NativeRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <RunCodeAnalysis>false</RunCodeAnalysis>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -257,6 +270,7 @@
       <ControlFlowGuard>false</ControlFlowGuard>
       <ShowIncludes>false</ShowIncludes>
       <ConformanceMode>true</ConformanceMode>
+      <EnablePREfast>false</EnablePREfast>
     </ClCompile>
     <Link>
       <AdditionalDependencies>windowscodecs.lib;winmm.lib;Winhttp.lib;comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -283,6 +297,8 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DisableSpecificWarnings>4091</DisableSpecificWarnings>
       <ConformanceMode>true</ConformanceMode>
+      <EnablePREfast>false</EnablePREfast>
+      <ControlFlowGuard>false</ControlFlowGuard>
     </ClCompile>
     <Link>
       <AdditionalDependencies>windowscodecs.lib;winmm.lib;Winhttp.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -310,6 +326,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DisableSpecificWarnings>4091</DisableSpecificWarnings>
       <ConformanceMode>true</ConformanceMode>
+      <EnablePREfast>false</EnablePREfast>
     </ClCompile>
     <Link>
       <AdditionalDependencies>windowscodecs.lib;winmm.lib;Winhttp.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -335,6 +352,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DisableSpecificWarnings>4091</DisableSpecificWarnings>
       <ConformanceMode>true</ConformanceMode>
+      <EnablePREfast>false</EnablePREfast>
     </ClCompile>
     <Link>
       <AdditionalDependencies>windowscodecs.lib;winmm.lib;Winhttp.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -358,6 +376,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DisableSpecificWarnings>4091</DisableSpecificWarnings>
       <ConformanceMode>true</ConformanceMode>
+      <EnablePREfast>false</EnablePREfast>
     </ClCompile>
     <Link>
       <AdditionalDependencies>windowscodecs.lib;winmm.lib;Winhttp.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -384,6 +403,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DisableSpecificWarnings>4091</DisableSpecificWarnings>
       <ConformanceMode>true</ConformanceMode>
+      <EnablePREfast>false</EnablePREfast>
     </ClCompile>
     <Link>
       <AdditionalDependencies>windowscodecs.lib;winmm.lib;Winhttp.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/src/RA_Integration.vcxproj
+++ b/src/RA_Integration.vcxproj
@@ -50,6 +50,7 @@
     <ClCompile Include="RA_httpthread.cpp" />
     <ClCompile Include="RA_ImageFactory.cpp" />
     <ClCompile Include="RA_Interface.cpp" />
+    <ClCompile Include="RA_Json.cpp" />
     <ClCompile Include="RA_Leaderboard.cpp" />
     <ClCompile Include="RA_LeaderboardPopup.cpp" />
     <ClCompile Include="RA_md5factory.cpp" />
@@ -58,9 +59,11 @@
     <ClCompile Include="RA_PopupWindows.cpp" />
     <ClCompile Include="RA_ProgressPopup.cpp" />
     <ClCompile Include="RA_RichPresence.cpp" />
+    <ClCompile Include="RA_StringUtils.cpp" />
     <ClCompile Include="RA_User.cpp" />
     <ClCompile Include="services\impl\JsonFileConfiguration.cpp" />
     <ClCompile Include="services\impl\LeaderboardManager.cpp" />
+    <ClCompile Include="services\impl\WindowsFileSystem.cpp" />
     <ClCompile Include="services\Initialization.cpp" />
     <ClCompile Include="services\ImageRepository.cpp" />
     <ClCompile Include="services\SearchResults.cpp" />
@@ -102,15 +105,24 @@
     <ClInclude Include="RA_ProgressPopup.h" />
     <ClInclude Include="RA_Resource.h" />
     <ClInclude Include="RA_RichPresence.h" />
+    <ClInclude Include="RA_StringUtils.h" />
     <ClInclude Include="RA_User.h" />
     <ClInclude Include="services\IConfiguration.hh" />
+    <ClInclude Include="services\IFileSystem.hh" />
     <ClInclude Include="services\ILeaderboardManager.hh" />
+    <ClInclude Include="services\impl\FileTextReader.hh" />
+    <ClInclude Include="services\impl\FileTextWriter.hh" />
     <ClInclude Include="services\impl\JsonFileConfiguration.hh" />
     <ClInclude Include="services\impl\LeaderboardManager.hh" />
+    <ClInclude Include="services\impl\StringTextReader.hh" />
+    <ClInclude Include="services\impl\StringTextWriter.hh" />
+    <ClInclude Include="services\impl\WindowsFileSystem.hh" />
     <ClInclude Include="services\Initialization.hh" />
     <ClInclude Include="services\ServiceLocator.hh" />
     <ClInclude Include="services\ImageRepository.h" />
     <ClInclude Include="services\SearchResults.h" />
+    <ClInclude Include="services\TextReader.hh" />
+    <ClInclude Include="services\TextWriter.hh" />
     <ClInclude Include="ui\WindowViewModelBase.hh" />
   </ItemGroup>
   <ItemGroup>

--- a/src/RA_Integration.vcxproj.filters
+++ b/src/RA_Integration.vcxproj.filters
@@ -314,6 +314,9 @@
     <ClInclude Include="services\TextReader.hh">
       <Filter>Services</Filter>
     </ClInclude>
+    <ClInclude Include="windows_nodefines.h">
+      <Filter>Helpers</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="RA_Shared.rc">

--- a/src/RA_Integration.vcxproj.filters
+++ b/src/RA_Integration.vcxproj.filters
@@ -120,9 +120,6 @@
     <ClCompile Include="services\SearchResults.cpp">
       <Filter>Services</Filter>
     </ClCompile>
-    <ClCompile Include="RA_LeaderboardManager.cpp">
-      <Filter>Services</Filter>
-    </ClCompile>
     <ClCompile Include="RA_MemValue.cpp">
       <Filter>Data</Filter>
     </ClCompile>
@@ -136,6 +133,15 @@
       <Filter>Services</Filter>
     </ClCompile>
     <ClCompile Include="services\ImageRepository.cpp">
+      <Filter>Services</Filter>
+    </ClCompile>
+    <ClCompile Include="services\impl\WindowsFileSystem.cpp">
+      <Filter>Services\Impl</Filter>
+    </ClCompile>
+    <ClCompile Include="RA_StringUtils.cpp">
+      <Filter>Services</Filter>
+    </ClCompile>
+    <ClCompile Include="RA_Json.cpp">
       <Filter>Services</Filter>
     </ClCompile>
   </ItemGroup>
@@ -272,9 +278,6 @@
     <ClInclude Include="services\SearchResults.h">
       <Filter>Services</Filter>
     </ClInclude>
-    <ClInclude Include="RA_LeaderboardManager.h">
-      <Filter>Services</Filter>
-    </ClInclude>
     <ClInclude Include="RA_MemValue.h">
       <Filter>Data</Filter>
     </ClInclude>
@@ -282,6 +285,33 @@
       <Filter>Helpers</Filter>
     </ClInclude>
     <ClInclude Include="services\ImageRepository.h">
+      <Filter>Services</Filter>
+    </ClInclude>
+    <ClInclude Include="services\IFileSystem.hh">
+      <Filter>Services</Filter>
+    </ClInclude>
+    <ClInclude Include="services\impl\WindowsFileSystem.hh">
+      <Filter>Services\Impl</Filter>
+    </ClInclude>
+    <ClInclude Include="RA_StringUtils.h">
+      <Filter>Services</Filter>
+    </ClInclude>
+    <ClInclude Include="services\impl\StringTextReader.hh">
+      <Filter>Services\Impl</Filter>
+    </ClInclude>
+    <ClInclude Include="services\impl\StringTextWriter.hh">
+      <Filter>Services\Impl</Filter>
+    </ClInclude>
+    <ClInclude Include="services\impl\FileTextWriter.hh">
+      <Filter>Services\Impl</Filter>
+    </ClInclude>
+    <ClInclude Include="services\impl\FileTextReader.hh">
+      <Filter>Services\Impl</Filter>
+    </ClInclude>
+    <ClInclude Include="services\TextWriter.hh">
+      <Filter>Services</Filter>
+    </ClInclude>
+    <ClInclude Include="services\TextReader.hh">
       <Filter>Services</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/RA_Interface.cpp
+++ b/src/RA_Interface.cpp
@@ -361,7 +361,7 @@ static std::wstring GetIntegrationPath()
     DWORD iIndex = GetModuleFileNameW(0, sBuffer, 2048);
     while (iIndex > 0 && sBuffer[iIndex - 1] != '\\' && sBuffer[iIndex - 1] != '/')
         --iIndex;
-    wcscpy(&sBuffer[iIndex], L"RA_Integration.dll");
+    wcscpy_s(&sBuffer[iIndex], sizeof(sBuffer)/sizeof(sBuffer[0]) - iIndex, L"RA_Integration.dll");
 
     return std::wstring(sBuffer);
 }
@@ -378,7 +378,7 @@ static void WriteBufferToFile(const std::wstring& sFile, const char* sBuffer, in
     else
     {
         wchar_t sErrBuffer[2048];
-        _wcserror_s(sErrBuffer, nErr);
+        _wcserror_s(sErrBuffer, sizeof(sErrBuffer)/sizeof(sErrBuffer[0]), nErr);
 
         std::wstring sErrMsg = L"Unable to write " + sFile + L"\n" + sErrBuffer;
         MessageBoxW(nullptr, sErrMsg.c_str(), L"Error", MB_OK | MB_ICONERROR);

--- a/src/RA_Json.cpp
+++ b/src/RA_Json.cpp
@@ -1,0 +1,78 @@
+#include "RA_Json.h"
+
+#include "services\impl\FileTextReader.hh"
+#include "services\impl\FileTextWriter.hh"
+#include "services\impl\StringTextReader.hh"
+#include "services\impl\StringTextWriter.hh"
+
+#include <fstream>
+
+void _WriteBufferToFile(const std::wstring& sFileName, const rapidjson::Document& doc)
+{
+    std::ofstream ofile{ sFileName };
+    if (!ofile.is_open())
+        return;
+
+    rapidjson::OStreamWrapper osw{ ofile };
+    rapidjson::Writer<rapidjson::OStreamWrapper> writer{ osw };
+    doc.Accept(writer);
+}
+
+bool LoadDocument(_Out_ rapidjson::Document& doc, ra::services::TextReader& reader)
+{
+    auto* pFileTextReader = dynamic_cast<ra::services::impl::FileTextReader*>(&reader);
+    if (pFileTextReader != nullptr)
+    {
+        auto& iFile = pFileTextReader->GetFStream();
+        if (!iFile.is_open())
+            return false;
+
+        rapidjson::IStreamWrapper iStreamWrapper(iFile);
+        doc.ParseStream(iStreamWrapper);
+    }
+    else
+    {
+        auto* pStringTextReader = dynamic_cast<ra::services::impl::StringTextReader*>(&reader);
+        if (pStringTextReader != nullptr)
+        {
+            doc.Parse(pStringTextReader->GetString());
+        }
+        else
+        {
+            assert(!"Unsupported TextReader");
+            return false;
+        }
+    }
+
+    return !doc.HasParseError();
+}
+
+bool SaveDocument(_In_ const rapidjson::Document& doc, ra::services::TextWriter& writer)
+{
+    auto* pFileTextWriter = dynamic_cast<ra::services::impl::FileTextWriter*>(&writer);
+    if (pFileTextWriter != nullptr)
+    {
+        auto& oFile = pFileTextWriter->GetFStream();
+        if (!oFile.is_open())
+            return false;
+
+        rapidjson::OStreamWrapper oStreamWrapper(oFile);
+        rapidjson::Writer<rapidjson::OStreamWrapper> oStreamWriter(oStreamWrapper);
+        return doc.Accept(oStreamWriter);
+    }
+
+    auto* pStringTextWriter = dynamic_cast<ra::services::impl::StringTextWriter*>(&writer);
+    if (pStringTextWriter != nullptr)
+    {
+        rapidjson::StringBuffer oStringBuffer;
+        rapidjson::Writer<rapidjson::StringBuffer> oStreamWriter(oStringBuffer);
+        if (!doc.Accept(oStreamWriter))
+            return false;
+
+        pStringTextWriter->GetString().assign(oStringBuffer.GetString());
+        return true;
+    }
+
+    assert(!"Unsupported TextWriter");
+    return false;
+}

--- a/src/RA_Json.h
+++ b/src/RA_Json.h
@@ -2,6 +2,9 @@
 #define RA_JSON_H
 #pragma once
 
+#include "services\TextReader.hh"
+#include "services\TextWriter.hh"
+
 #define RAPIDJSON_HAS_STDSTRING 1
 #define RAPIDJSON_NOMEMBERITERATORCLASS 1
 
@@ -11,6 +14,9 @@
 #include <rapidjson\ostreamwrapper.h>
 #include <rapidjson\error\en.h>
 
-extern void _WriteBufferToFile(const std::wstring& sFileName, const rapidjson::Document& doc);
+void _WriteBufferToFile(const std::wstring& sFileName, const rapidjson::Document& doc);
+
+bool LoadDocument(_Out_ rapidjson::Document& doc, ra::services::TextReader& reader);
+bool SaveDocument(_In_ const rapidjson::Document& doc, ra::services::TextWriter& writer);
 
 #endif // !RA_JSON_H

--- a/src/RA_LeaderboardManager.cpp
+++ b/src/RA_LeaderboardManager.cpp
@@ -1,0 +1,171 @@
+#include "RA_LeaderboardManager.h"
+#include "RA_MemManager.h"
+#include "RA_PopupWindows.h"
+#include "RA_md5factory.h"
+#include "RA_httpthread.h"
+
+#include <ctime>
+
+RA_LeaderboardManager g_LeaderboardManager;
+
+RA_Leaderboard* RA_LeaderboardManager::FindLB(ra::LeaderboardID nID)
+{
+    std::vector<RA_Leaderboard>::iterator iter = m_Leaderboards.begin();
+    while (iter != m_Leaderboards.end())
+    {
+        if ((*iter).ID() == nID)
+            return &(*iter);
+
+        iter++;
+    }
+
+    return nullptr;
+}
+
+void RA_LeaderboardManager::ActivateLeaderboard(const RA_Leaderboard& lb) const
+{
+    if (g_bLBDisplayNotification)
+    {
+        g_PopupWindows.AchievementPopups().AddMessage(
+            MessagePopup("Challenge Available: " + lb.Title(),
+            lb.Description(),
+            PopupLeaderboardInfo));
+    }
+
+    g_PopupWindows.LeaderboardPopups().Activate(lb.ID());
+}
+
+void RA_LeaderboardManager::DeactivateLeaderboard(const RA_Leaderboard& lb) const
+{
+    g_PopupWindows.LeaderboardPopups().Deactivate(lb.ID());
+
+    if (g_bLBDisplayNotification)
+    {
+        g_PopupWindows.AchievementPopups().AddMessage(
+            MessagePopup("Leaderboard attempt cancelled!",
+            lb.Title(),
+            PopupLeaderboardCancel));
+    }
+}
+
+void RA_LeaderboardManager::SubmitLeaderboardEntry(const RA_Leaderboard& lb, unsigned int nValue) const
+{
+    g_PopupWindows.LeaderboardPopups().Deactivate(lb.ID());
+
+    if (g_bRAMTamperedWith)
+    {
+        g_PopupWindows.AchievementPopups().AddMessage(
+            MessagePopup("Not posting to leaderboard: memory tamper detected!",
+            "Reset game to reenable posting.",
+            PopupInfo));
+    }
+    else if (!g_bHardcoreModeActive)
+    {
+        g_PopupWindows.AchievementPopups().AddMessage(
+            MessagePopup("Leaderboard submission post cancelled.",
+            "Enable Hardcore Mode to enable posting.",
+            PopupInfo));
+    }
+    else
+    {
+        char sValidationSig[50];
+        sprintf_s(sValidationSig, 50, "%u%s%u", lb.ID(), RAUsers::LocalUser().Username().c_str(), lb.ID());
+        std::string sValidationMD5 = RAGenerateMD5(sValidationSig);
+
+        PostArgs args;
+        args['u'] = RAUsers::LocalUser().Username();
+        args['t'] = RAUsers::LocalUser().Token();
+        args['i'] = std::to_string(lb.ID());
+        args['v'] = sValidationMD5;
+        args['s'] = std::to_string(nValue);
+
+        RAWeb::CreateThreadedHTTPRequest(RequestSubmitLeaderboardEntry, args);
+    }
+}
+
+void RA_LeaderboardManager::OnSubmitEntry(const rapidjson::Document& doc)
+{
+    if (!doc.HasMember("Response"))
+    {
+        ASSERT(!"Cannot process this LB Response!");
+        return;
+    }
+
+    const auto& Response{ doc["Response"] };
+    const auto& LBData{ Response["LBData"] };
+
+    const auto nLBID{ static_cast<ra::LeaderboardID>(LBData["LeaderboardID"].GetUint()) };
+    const auto nGameID{ static_cast<ra::GameID>(LBData["GameID"].GetUint()) };
+    const auto bLowerIsBetter{ LBData["LowerIsBetter"].GetUint() == 1U };
+
+    auto pLB{ g_LeaderboardManager.FindLB(nLBID) };
+
+    const auto nSubmittedScore{ Response["Score"].GetInt() };
+    const auto nBestScore{ Response["BestScore"].GetInt() };
+    pLB->ClearRankInfo();
+
+    RA_LOG("LB Data, Top Entries:\n");
+    const auto& TopEntries{ Response["TopEntries"] };
+    for (auto& NextEntry : TopEntries.GetArray())
+    {
+        const auto nRank{ NextEntry["Rank"].GetUint() };
+        const std::string& sUser{ NextEntry["User"].GetString() };
+        const auto nUserScore{ NextEntry["Score"].GetInt() };
+        auto nSubmitted{ static_cast<std::time_t>(ra::to_signed(NextEntry["DateSubmitted"].GetUint())) };
+
+        {
+            std::ostringstream oss;
+            oss << "(" << nRank << ") " << sUser << ": " << pLB->FormatScore(nUserScore);
+            auto str{ oss.str() };
+            RA_LOG("%s", str.c_str());
+        }
+
+        pLB->SubmitRankInfo(nRank, sUser, nUserScore, nSubmitted);
+    }
+
+    pLB->SortRankInfo();
+#pragma region TBD
+    //char sTestData[ 4096 ];
+    //sprintf_s( sTestData, 4096, "Leaderboard for %s (%s)\n\n", pLB->Title().c_str(), pLB->Description().c_str() );
+    //for( size_t i = 0; i < pLB->GetRankInfoCount(); ++i )
+    //{
+    //	const LB_Entry& NextScore = pLB->GetRankInfo( i );
+
+    //	std::string sScoreFormatted = pLB->FormatScore( NextScore.m_nScore );
+
+    //	char bufferMessage[ 512 ];
+    //	sprintf_s( bufferMessage, 512, "%02d: %s - %s\n", NextScore.m_nRank, NextScore.m_sUsername, sScoreFormatted.c_str() );
+    //	strcat_s( sTestData, 4096, bufferMessage );
+    //}  
+#pragma endregion
+    g_PopupWindows.LeaderboardPopups().ShowScoreboard(pLB->ID());
+}
+
+void RA_LeaderboardManager::AddLeaderboard(const RA_Leaderboard& lb)
+{
+    if (g_bLeaderboardsActive)	//	If not, simply ignore them.
+        m_Leaderboards.push_back(lb);
+}
+
+void RA_LeaderboardManager::Test()
+{
+    if (g_bLeaderboardsActive)
+    {
+        std::vector<RA_Leaderboard>::iterator iter = m_Leaderboards.begin();
+        while (iter != m_Leaderboards.end())
+        {
+            (*iter).Test();
+            iter++;
+        }
+    }
+}
+
+void RA_LeaderboardManager::Reset()
+{
+    std::vector<RA_Leaderboard>::iterator iter = m_Leaderboards.begin();
+    while (iter != m_Leaderboards.end())
+    {
+        (*iter).Reset();
+        iter++;
+    }
+}

--- a/src/RA_LeaderboardManager.h
+++ b/src/RA_LeaderboardManager.h
@@ -1,0 +1,41 @@
+#ifndef RA_LEADERBOARD_MANAGER_H
+#define RA_LEADERBOARD_MANAGER_H
+#pragma once
+
+#include "RA_Leaderboard.h"
+
+#ifndef RAPIDJSON_DOCUMENT_H_
+#include <rapidjson/document.h>
+#endif /* !RAPIDJSON_DOCUMENT_H_ */
+
+#ifndef _VECTOR_
+#include <vector>
+#endif /* !_VECTOR_ */
+
+class RA_LeaderboardManager
+{
+public:
+    static void OnSubmitEntry(const rapidjson::Document& doc);
+
+public:
+    void Reset();
+
+    void AddLeaderboard(const RA_Leaderboard& lb);
+    void Test();
+    void Clear() { m_Leaderboards.clear(); }
+    size_t Count() const { return m_Leaderboards.size(); }
+    inline RA_Leaderboard& GetLB(size_t iter) { return m_Leaderboards[iter]; }
+
+    RA_Leaderboard* FindLB(ra::LeaderboardID nID);
+
+    void ActivateLeaderboard(const RA_Leaderboard& lb) const;
+    void DeactivateLeaderboard(const RA_Leaderboard& lb) const;
+    void SubmitLeaderboardEntry(const RA_Leaderboard& lb, unsigned int nValue) const;
+
+private:
+    std::vector<RA_Leaderboard> m_Leaderboards;
+};
+
+extern RA_LeaderboardManager g_LeaderboardManager;
+
+#endif /* !RA_LEADERBOARD_MANAGER_H */

--- a/src/RA_LeaderboardPopup.cpp
+++ b/src/RA_LeaderboardPopup.cpp
@@ -170,15 +170,15 @@ void LeaderboardPopup::Render(HDC hDC, RECT& rcDest)
 
     HFONT hFontTitle = CreateFont(FONT_SIZE_TITLE, 0, 0, 0, FW_NORMAL, FALSE, FALSE, FALSE,
         DEFAULT_CHARSET, OUT_DEFAULT_PRECIS, CLIP_CHARACTER_PRECIS, ANTIALIASED_QUALITY,/*NONANTIALIASED_QUALITY,*/
-        DEFAULT_PITCH, NativeStr(FONT_TO_USE).c_str());
+        DEFAULT_PITCH, ra::NativeStr(FONT_TO_USE).c_str());
 
     HFONT hFontDesc = CreateFont(FONT_SIZE_SUBTITLE, 0, 0, 0, FW_NORMAL, FALSE, FALSE, FALSE,
         DEFAULT_CHARSET, OUT_DEFAULT_PRECIS, CLIP_CHARACTER_PRECIS, ANTIALIASED_QUALITY,/*NONANTIALIASED_QUALITY,*/
-        DEFAULT_PITCH, NativeStr(FONT_TO_USE).c_str());
+        DEFAULT_PITCH, ra::NativeStr(FONT_TO_USE).c_str());
 
     HFONT hFontText = CreateFont(FONT_SIZE_TEXT, 0, 0, 0, FW_NORMAL, FALSE, FALSE, FALSE,
         DEFAULT_CHARSET, OUT_DEFAULT_PRECIS, CLIP_CHARACTER_PRECIS, ANTIALIASED_QUALITY,/*NONANTIALIASED_QUALITY,*/
-        DEFAULT_PITCH, NativeStr(FONT_TO_USE).c_str());
+        DEFAULT_PITCH, ra::NativeStr(FONT_TO_USE).c_str());
 
 
     const int nWidth = rcDest.right - rcDest.left;
@@ -238,7 +238,7 @@ void LeaderboardPopup::Render(HDC hDC, RECT& rcDest)
                     std::string sScoreSoFar = std::string(" ") + pLB->FormatScore(static_cast<int>(pLB->GetCurrentValueProgress())) + std::string(" ");
 
                     SIZE szProgress;
-                    GetTextExtentPoint32(hDC, NativeStr(sScoreSoFar).c_str(), sScoreSoFar.length(), &szProgress);
+                    GetTextExtentPoint32(hDC, ra::NativeStr(sScoreSoFar).c_str(), sScoreSoFar.length(), &szProgress);
 
                     HGDIOBJ hBkup = SelectObject(hDC, hPen);
 
@@ -248,7 +248,7 @@ void LeaderboardPopup::Render(HDC hDC, RECT& rcDest)
 
                     RECT rcProgress;
                     SetRect(&rcProgress, 0, 0, nWidth - 8, nHeight - 8 + nProgressYOffs);
-                    DrawText(hDC, NativeStr(sScoreSoFar).c_str(), sScoreSoFar.length(), &rcProgress, DT_BOTTOM | DT_RIGHT | DT_SINGLELINE);
+                    DrawText(hDC, ra::NativeStr(sScoreSoFar).c_str(), sScoreSoFar.length(), &rcProgress, DT_BOTTOM | DT_RIGHT | DT_SINGLELINE);
 
                     SelectObject(hDC, hBkup);
                     nProgressYOffs -= 26;
@@ -271,7 +271,7 @@ void LeaderboardPopup::Render(HDC hDC, RECT& rcDest)
                 char buffer[1024];
                 sprintf_s(buffer, 1024, " Results: %s ", pLB->Title().c_str());
                 RECT rcTitle = { nScoreboardX + 2, nScoreboardY + 2, nRightLim - 2, nHeight - 8 };
-                DrawText(hDC, NativeStr(buffer).c_str(), strlen(buffer), &rcTitle, DT_TOP | DT_LEFT | DT_SINGLELINE);
+                DrawText(hDC, ra::NativeStr(buffer).c_str(), strlen(buffer), &rcTitle, DT_TOP | DT_LEFT | DT_SINGLELINE);
 
                 //	Show scoreboard
                 RECT rcScoreboard = { nScoreboardX + 2, nScoreboardY + 32, nRightLim - 2, nHeight - 16 };
@@ -293,13 +293,13 @@ void LeaderboardPopup::Render(HDC hDC, RECT& rcDest)
                     ra::tstring str;
                     {
                         std::basic_ostringstream<TCHAR> oss;
-                        oss << " " << lbInfo.m_nRank << " " << lbInfo.m_sUsername << " ";
+                        oss << " " << lbInfo.m_nRank << " " << ra::NativeStr(lbInfo.m_sUsername) << " ";
                         str = oss.str();
                     }
                     DrawText(hDC, str.c_str(), ra::to_signed(str.length()), &rcScoreboard, DT_TOP | DT_LEFT | DT_SINGLELINE);
 
                     std::string sScore(" " + pLB->FormatScore(lbInfo.m_nScore) + " ");
-                    DrawText(hDC, NativeStr(sScore).c_str(), sScore.length(), &rcScoreboard, DT_TOP | DT_RIGHT | DT_SINGLELINE);
+                    DrawText(hDC, ra::NativeStr(sScore).c_str(), sScore.length(), &rcScoreboard, DT_TOP | DT_RIGHT | DT_SINGLELINE);
 
                     rcScoreboard.top += 24;
 

--- a/src/RA_Log.h
+++ b/src/RA_Log.h
@@ -5,6 +5,6 @@
 extern void RADebugLogNoFormat(const char* data);
 extern void RADebugLog(const char* sFormat, ...);
 
-#define RA_LOG RADebugLog
+inline constexpr auto& RA_LOG{ RADebugLog };
 
 #endif // !RA_LOG_H

--- a/src/RA_ProgressPopup.cpp
+++ b/src/RA_ProgressPopup.cpp
@@ -144,11 +144,11 @@ void ProgressPopup::Render(HDC hDC, RECT& rcDest)
 
     HFONT hFontTitle = CreateFont(FONT_SIZE_MAIN, 0, 0, 0, FW_NORMAL, FALSE, FALSE, FALSE,
         DEFAULT_CHARSET, OUT_DEFAULT_PRECIS, CLIP_CHARACTER_PRECIS, ANTIALIASED_QUALITY,/*NONANTIALIASED_QUALITY,*/
-        DEFAULT_PITCH, NativeStr(FONT_TO_USE).c_str());
+        DEFAULT_PITCH, ra::NativeStr(FONT_TO_USE).c_str());
 
     HFONT hFontDesc = CreateFont(FONT_SIZE_SUBTITLE, 0, 0, 0, FW_NORMAL, FALSE, FALSE, FALSE,
         DEFAULT_CHARSET, OUT_DEFAULT_PRECIS, CLIP_CHARACTER_PRECIS, ANTIALIASED_QUALITY,/*NONANTIALIASED_QUALITY,*/
-        DEFAULT_PITCH, NativeStr(FONT_TO_USE).c_str());
+        DEFAULT_PITCH, ra::NativeStr(FONT_TO_USE).c_str());
 
 
     int nTitleX = 10;
@@ -173,12 +173,12 @@ void ProgressPopup::Render(HDC hDC, RECT& rcDest)
     SIZE szTitle, szAchievement;
 
     SelectObject(hDC, hFontTitle);
-    TextOut(hDC, nTitleX, nTitleY, NativeStr(GetTitle()).c_str(), strlen(GetTitle()));
-    GetTextExtentPoint32(hDC, NativeStr(GetTitle()).c_str(), strlen(GetTitle()), &szTitle);
+    TextOut(hDC, nTitleX, nTitleY, ra::NativeStr(GetTitle()).c_str(), strlen(GetTitle()));
+    GetTextExtentPoint32(hDC, ra::NativeStr(GetTitle()).c_str(), strlen(GetTitle()), &szTitle);
 
     SelectObject(hDC, hFontDesc);
-    TextOut(hDC, nDescX, nDescY, NativeStr(GetDesc()).c_str(), strlen(GetDesc()));
-    GetTextExtentPoint32(hDC, NativeStr(GetDesc()).c_str(), strlen(GetDesc()), &szAchievement);
+    TextOut(hDC, nDescX, nDescY, ra::NativeStr(GetDesc()).c_str(), strlen(GetDesc()));
+    GetTextExtentPoint32(hDC, ra::NativeStr(GetDesc()).c_str(), strlen(GetDesc()), &szAchievement);
 
     HGDIOBJ hPen = CreatePen(PS_SOLID, 2, RGB(0, 0, 0));
     SelectObject(hDC, hPen);

--- a/src/RA_ProgressPopup.h
+++ b/src/RA_ProgressPopup.h
@@ -6,14 +6,14 @@
 //	Graphic to display an progress towards an achievement
 
 
-#define OVERLAY_MESSAGE_QUEUE_SIZE (5)
+_CONSTANT_VAR OVERLAY_MESSAGE_QUEUE_SIZE{ 5 };
 
 class ProgressPopup
 {
 public:
     ProgressPopup();
 
-    void Update(ControllerInput input, float fDelta, BOOL bFullScreen, BOOL bPaused);
+    void Update(_UNUSED ControllerInput, float fDelta, _UNUSED BOOL, BOOL bPaused);
     void Render(HDC hDC, RECT& rcDest);
 
     void AddMessage(const char* sTitle, const char* sMessage, int nMessageType = 0, HBITMAP hImage = nullptr);

--- a/src/RA_StringUtils.cpp
+++ b/src/RA_StringUtils.cpp
@@ -1,0 +1,106 @@
+#include "RA_StringUtils.h"
+
+#include <iomanip>
+
+#define WIN32_LEAN_AND_MEAN
+struct IUnknown;
+#include <Windows.h>
+
+// has to be after Windows.h for LPTSTR definition
+#include "ra_utility.h"
+
+namespace ra {
+
+_Use_decl_annotations_
+std::string Narrow(const std::wstring& wstr)
+{
+    return Narrow(wstr.c_str());
+}
+
+_Use_decl_annotations_
+std::string Narrow(std::wstring&& wstr) noexcept
+{
+    const auto wwstr{ std::move_if_noexcept(wstr) };
+    return Narrow(wwstr);
+}
+
+_Use_decl_annotations_
+std::string Narrow(const wchar_t* wstr)
+{
+    const auto len{ ra::to_signed(std::wcslen(wstr)) };
+
+    const auto needed{
+        ::WideCharToMultiByte(CP_UTF8, 0, wstr, len + 1, nullptr, 0, nullptr, nullptr)
+    };
+
+    std::string str(ra::to_unsigned(needed), '\000'); // allocate required space (including terminator)
+    ::WideCharToMultiByte(CP_UTF8, 0, wstr, len + 1, str.data(), ra::to_signed(str.capacity()),
+                          nullptr, nullptr);
+    str.resize(ra::to_unsigned(needed - 1)); // terminator is not actually part of the string
+    return str;
+}
+
+_Use_decl_annotations_
+std::wstring Widen(const std::string& str)
+{
+    return Widen(str.c_str());
+}
+
+_Use_decl_annotations_
+std::wstring Widen(std::string&& str) noexcept
+{
+    const auto sstr{ std::move_if_noexcept(str) };
+    return Widen(sstr);
+}
+
+_Use_decl_annotations_
+std::wstring Widen(const char* str)
+{
+    const auto len{ ra::to_signed(std::strlen(str)) };
+    const auto needed{ ::MultiByteToWideChar(CP_UTF8, 0, str, len + 1, nullptr, 0) };
+    // doesn't seem wchar_t is treated like a character type by default
+    std::wstring wstr(ra::to_unsigned(needed), L'\x0');
+    ::MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, str, len + 1, wstr.data(),
+                          ra::to_signed(wstr.capacity()));
+    wstr.resize(ra::to_unsigned(needed - 1));
+
+    return wstr;
+}
+
+_Use_decl_annotations_
+std::wstring Widen(const wchar_t* wstr)
+{
+    const std::wstring _wstr{ wstr };
+    return _wstr;
+}
+
+_Use_decl_annotations_ std::wstring Widen(const std::wstring& wstr) { return wstr; }
+
+_Use_decl_annotations_
+std::string Narrow(const char* str)
+{
+    const std::string _str{ str };
+    return _str;
+}
+
+_Use_decl_annotations_
+std::string Narrow(const std::string& str)
+{
+    return str;
+}
+
+std::string& TrimLineEnding(std::string& str) noexcept
+{
+    auto nIndex = str.length();
+    if (nIndex > 0 && str[nIndex - 1] == '\n')
+        nIndex--;
+    if (nIndex > 0 && str[nIndex - 1] == '\r')
+        nIndex--;
+
+    if (nIndex != str.length())
+        str.resize(nIndex);
+
+    return str;
+}
+
+} /* namespace ra */

--- a/src/RA_StringUtils.cpp
+++ b/src/RA_StringUtils.cpp
@@ -1,13 +1,12 @@
 #include "RA_StringUtils.h"
 
-#include <iomanip>
-
-#define WIN32_LEAN_AND_MEAN
+#include "windows_nodefines.h"
 struct IUnknown;
 #include <Windows.h>
 
-// has to be after Windows.h for LPTSTR definition
-#include "ra_utility.h"
+#include <iomanip>
+#include <sstream>
+
 
 namespace ra {
 
@@ -74,6 +73,20 @@ std::wstring Widen(const wchar_t* wstr)
     return _wstr;
 }
 
+_Use_decl_annotations_
+std::wstring Widen(std::wstring&& wstr) noexcept
+{
+    const auto _wstr{ std::move_if_noexcept(wstr) };
+    return Widen(_wstr);
+}
+
+_Use_decl_annotations_
+std::string Narrow(std::string&& str) noexcept
+{
+    auto move_str{ std::move_if_noexcept(str) };
+    return Narrow(move_str);
+}
+
 _Use_decl_annotations_ std::wstring Widen(const std::wstring& wstr) { return wstr; }
 
 _Use_decl_annotations_
@@ -89,6 +102,7 @@ std::string Narrow(const std::string& str)
     return str;
 }
 
+_Use_decl_annotations_
 std::string& TrimLineEnding(std::string& str) noexcept
 {
     auto nIndex = str.length();
@@ -101,6 +115,14 @@ std::string& TrimLineEnding(std::string& str) noexcept
         str.resize(nIndex);
 
     return str;
+}
+
+_Use_decl_annotations_
+std::string ByteAddressToString(ByteAddress nAddr)
+{
+    std::ostringstream oss;
+    oss << "0x" << std::setfill('0') << std::setw(6) << std::hex << nAddr;
+    return oss.str();
 }
 
 } /* namespace ra */

--- a/src/RA_StringUtils.h
+++ b/src/RA_StringUtils.h
@@ -2,7 +2,7 @@
 #define RA_STRINGUTILS_H
 #pragma once
 
-#include "ra_fwd.h"
+#include "ra_utility.h" // "redefinitions"
 
 #include <string>
 
@@ -18,23 +18,56 @@ _NODISCARD std::wstring Widen(_In_z_ const char* str);
 //	No-ops to help convert:
 _NODISCARD std::wstring Widen(_In_z_ const wchar_t* wstr);
 _NODISCARD std::wstring Widen(_In_ const std::wstring& wstr);
+_NODISCARD std::wstring Widen(_Inout_ std::wstring&& wstr) noexcept;
 _NODISCARD std::string Narrow(_In_z_ const char* str);
 _NODISCARD std::string Narrow(_In_ const std::string& wstr);
+_NODISCARD std::string Narrow(_Inout_ std::string&& wstr) noexcept;
 
-/// <summary>
-/// Removes one "\r", "\n", or "\r\n" from the end of a string.
-/// </summary>
+/// <summary>Removes one "\r", "\n", or "\r\n" from the end of a string.</summary>
 /// <returns>Reference to <paramref name="str" /> for chaining.</returns>
-std::string& TrimLineEnding(_Inout_ std::string& str) noexcept;
+_NODISCARD std::string& TrimLineEnding(_Inout_ std::string& str) noexcept;
+_NODISCARD std::string ByteAddressToString(_In_ ByteAddress nAddr);
+
+template<typename CharT, class = std::enable_if_t<is_char_v<CharT>>>
+_NODISCARD inline auto NativeStr(_In_ const CharT* str)
+{
+    static_assert(!std::is_same_v<CharT, unsigned char>, "Conversion for unsigned strings is currently unsupported!");
+#if _MBCS
+    return Narrow(str);
+#elif _UNICODE
+    return Widen(str);
+#else
+#error Unknown character set detected! Only MultiByte and Unicode are supported!
+#endif // _MBCS
+}
+
+template<typename CharT, class = std::enable_if_t<is_char_v<CharT>>>
+_NODISCARD inline auto NativeStr(_In_ const std::basic_string<CharT>& str)
+{
+    static_assert(!std::is_same_v<CharT, unsigned char>, "Conversion for unsigned strings is currently unsupported!");
+#if _MBCS
+    return Narrow(str);
+#elif _UNICODE
+    return Widen(str);
+#else
+#error Unknown character set detected! Only MultiByte and Unicode are supported!
+#endif // _MBCS
+}
+
+template<typename CharT, class = std::enable_if_t<is_char_v<CharT>>>
+_NODISCARD inline auto NativeStr(_In_ std::basic_string<CharT>&& str) noexcept
+{
+    static_assert(!std::is_same_v<CharT, unsigned char>, "Conversion for unsigned strings is currently unsupported!");
+#if _MBCS
+    return Narrow(std::forward<std::basic_string<CharT>>(str));
+#elif _UNICODE
+    return Widen(std::forward<std::basic_string<CharT>>(str));
+#else
+#error Unknown character set detected! Only MultiByte and Unicode are supported!
+#endif // _MBCS
+}
 
 } // namespace ra
 
-#ifdef UNICODE
-#define NativeStr(x) ra::Widen(x)
-#define NativeStrType std::wstring
-#else
-#define NativeStr(x) ra::Narrow(x)
-#define NativeStrType std::string
-#endif
 
 #endif // !RA_STRINGUTILS_H

--- a/src/RA_StringUtils.h
+++ b/src/RA_StringUtils.h
@@ -1,0 +1,40 @@
+#ifndef RA_STRINGUTILS_H
+#define RA_STRINGUTILS_H
+#pragma once
+
+#include "ra_fwd.h"
+
+#include <string>
+
+namespace ra {
+
+_NODISCARD std::string Narrow(_In_ const std::wstring& wstr);
+_NODISCARD std::string Narrow(_Inout_ std::wstring&& wstr) noexcept;
+_NODISCARD std::string Narrow(_In_z_ const wchar_t* wstr);
+_NODISCARD std::wstring Widen(_In_ const std::string& str);
+_NODISCARD std::wstring Widen(_Inout_ std::string&& str) noexcept;
+_NODISCARD std::wstring Widen(_In_z_ const char* str);
+
+//	No-ops to help convert:
+_NODISCARD std::wstring Widen(_In_z_ const wchar_t* wstr);
+_NODISCARD std::wstring Widen(_In_ const std::wstring& wstr);
+_NODISCARD std::string Narrow(_In_z_ const char* str);
+_NODISCARD std::string Narrow(_In_ const std::string& wstr);
+
+/// <summary>
+/// Removes one "\r", "\n", or "\r\n" from the end of a string.
+/// </summary>
+/// <returns>Reference to <paramref name="str" /> for chaining.</returns>
+std::string& TrimLineEnding(_Inout_ std::string& str) noexcept;
+
+} // namespace ra
+
+#ifdef UNICODE
+#define NativeStr(x) ra::Widen(x)
+#define NativeStrType std::wstring
+#else
+#define NativeStr(x) ra::Narrow(x)
+#define NativeStrType std::string
+#endif
+
+#endif // !RA_STRINGUTILS_H

--- a/src/RA_User.cpp
+++ b/src/RA_User.cpp
@@ -109,7 +109,7 @@ void LocalRAUser::HandleSilentLoginResponse(rapidjson::Document& doc)
     }
     else if (doc.HasMember("Error"))
     {
-        MessageBox(nullptr, NativeStr(doc["Error"].GetString()).c_str(), TEXT("Login Failed"), MB_OK);
+        MessageBox(nullptr, ra::NativeStr(doc["Error"].GetString()).c_str(), TEXT("Login Failed"), MB_OK);
     }
     else
     {

--- a/src/RA_httpthread.cpp
+++ b/src/RA_httpthread.cpp
@@ -814,7 +814,7 @@ DWORD RAWeb::HTTPWorkerThread(LPVOID lpParameter)
                                 args['m'] = "Developing Achievements";
                             else if (_RA_HardcoreModeIsActive())
                                 args['m'] = "Inspecting Memory in Hardcore mode";
-                            else if (g_nActiveAchievementSet == Core)
+                            else if (g_nActiveAchievementSet == AchievementSet::Type::Core)
                                 args['m'] = "Fixing Achievements";
 
                         else

--- a/src/RA_httpthread.cpp
+++ b/src/RA_httpthread.cpp
@@ -53,7 +53,7 @@ const char* RequestTypeToString[] =
 
     "STOP_THREAD",
 };
-static_assert(SIZEOF_ARRAY(RequestTypeToString) == NumRequestTypes, "Must match up!");
+static_assert(ra::SizeOfArray(RequestTypeToString) == NumRequestTypes, "Must match up!");
 
 const char* RequestTypeToPost[] =
 {
@@ -88,19 +88,19 @@ const char* RequestTypeToPost[] =
 
     "_stopthread_",         //  STOP_THREAD
 };
-static_assert(SIZEOF_ARRAY(RequestTypeToPost) == NumRequestTypes, "Must match up!");
+static_assert(ra::SizeOfArray(RequestTypeToPost) == NumRequestTypes, "Must match up!");
 
 const char* UploadTypeToString[] =
 {
     "RequestUploadBadgeImage",
 };
-static_assert(SIZEOF_ARRAY(UploadTypeToString) == NumUploadTypes, "Must match up!");
+static_assert(ra::SizeOfArray(UploadTypeToString) == NumUploadTypes, "Must match up!");
 
 const char* UploadTypeToPost[] =
 {
     "uploadbadgeimage",
 };
-static_assert(SIZEOF_ARRAY(UploadTypeToPost) == NumUploadTypes, "Must match up!");
+static_assert(ra::SizeOfArray(UploadTypeToPost) == NumUploadTypes, "Must match up!");
 
 //  No game-specific code here please!
 
@@ -787,7 +787,7 @@ DWORD RAWeb::HTTPWorkerThread(LPVOID lpParameter)
             {
                 //  Take ownership and delete(): we caused the 'pop' earlier, so we have responsibility to
                 //   either pass to LastHttpResults, or deal with it here.
-                SAFE_DELETE(pObj);
+                ra::SafeDelete(pObj);
             }
         }
 
@@ -928,7 +928,7 @@ void HttpResults::Clear()
         {
             RequestObject* pObj = m_aRequests.front();
             m_aRequests.pop_front();
-            SAFE_DELETE(pObj);
+            ra::SafeDelete(pObj);
         }
     }
     ReleaseMutex(RAWeb::Mutex());

--- a/src/ra_fwd.h
+++ b/src/ra_fwd.h
@@ -43,12 +43,23 @@ using LPVOID = void*;
 #endif // !_WINDEF_
 
 #ifndef _WINNT_
-using HANDLE = void*;
+using HANDLE  = void*;
+using LPTSTR  = TCHAR*;
+using LPCTSTR = const TCHAR*;
 #endif // !_WINNT_
 
 namespace ra {
 
-using tstring = std::basic_string<TCHAR>;
+#if _MBCS
+using NativeStrType = std::string;
+#elif _UNICODE
+using NativeStrType = std::wstring;
+#else
+#error Unknown character set detected! Only MultiByte and Unicode are supported!
+#endif // _MBCS
+
+using Native_CStrType = NativeStrType::const_pointer;
+using tstring         = NativeStrType;
 
 using ARGB          = DWORD;
 using ByteAddress   = std::size_t;

--- a/src/ra_fwd.h
+++ b/src/ra_fwd.h
@@ -2,12 +2,12 @@
 #define RA_FWD_H
 #pragma once
 
-// Forward declaring namespace std caused problems
+/* Forward declaring namespace std caused problems */
 #include <xstring>
 
-// Maybe an extra check just in-case
 #define _NORETURN            [[noreturn]]
 
+/* Maybe an extra check just in-case */
 #if _HAS_CXX17
 #define _DEPRECATED          [[deprecated]]
 #define _DEPRECATEDR(reason) [[deprecated(reason)]]
@@ -33,9 +33,9 @@ using TCHAR = char;
 using TCHAR = wchar_t;
 #else 
 #error Unknown character set detected, only MultiByte and Unicode are supported!
-#endif // _MBCS
+#endif /* _MBCS */
 #define _TCHAR_DEFINED
-#endif // !_TCHAR_DEFINED
+#endif /* !_TCHAR_DEFINED */
 
 #ifndef _WINDEF_
 using DWORD  = unsigned long;

--- a/src/ra_type_traits.h
+++ b/src/ra_type_traits.h
@@ -19,7 +19,6 @@
 #endif // !_CONSTANT_FN
 
 namespace ra {
-
 namespace detail {
 
 /// <summary>
@@ -29,87 +28,80 @@ namespace detail {
 /// <typeparam name="CharT">A type to be evaluated.</typeparam>
 /// <remarks><c>char16_t</c> and <c>char32_t</c> are not considered valid by this type_trait.</remarks>
 template<typename CharT>
-struct is_char : std::bool_constant<(std::_Is_character<CharT>::value || std::is_same_v<CharT, wchar_t>)> {};
+struct _NODISCARD is_char :
+    std::bool_constant<(std::_Is_character<CharT>::value || std::is_same_v<CharT, wchar_t>)>
+{
+};
 
 /// <summary>
 ///   This should only be used to compare the sizes of data types and not objects.
 /// </summary>
-template<typename T, typename U>
-struct is_same_size : std::bool_constant<sizeof(T) == sizeof(U)> {};
-
+template<typename T, typename U> struct _NODISCARD is_same_size : std::bool_constant<sizeof(T) == sizeof(U)> {};
 } // namespace detail
 
-template<typename CharacterType> _NODISCARD _CONSTANT_VAR 
+template<typename CharacterType> _CONSTANT_VAR
 is_char_v{ detail::is_char<CharacterType>::value };
 
-
-template<typename ValueType, typename TestType> _NODISCARD _CONSTANT_VAR
+template<typename ValueType, typename TestType> _CONSTANT_VAR
 is_same_size_v{ detail::is_same_size<ValueType, TestType>::value };
 
 namespace detail {
-
 template<typename EqualityComparable, class = std::void_t<>>
-struct is_equality_comparable : std::false_type {};
+struct _NODISCARD is_equality_comparable : std::false_type {};
 
 template<typename EqualityComparable>
-struct is_equality_comparable<EqualityComparable, std::enable_if_t<std::is_convertible_v<
-	decltype(std::declval<EqualityComparable&>() == std::declval<EqualityComparable&>()), bool>>> :
-	std::true_type {};
+struct _NODISCARD is_equality_comparable<EqualityComparable, std::enable_if_t<std::is_convertible_v<
+    decltype(std::declval<EqualityComparable&>() == std::declval<EqualityComparable&>()), bool>>> :
+    std::true_type {};
 
 template<typename EqualityComparable>
-struct is_nothrow_equality_comparable :
-	std::bool_constant<noexcept(is_equality_comparable<EqualityComparable>::value)>
+struct _NODISCARD is_nothrow_equality_comparable :
+    std::bool_constant<noexcept(is_equality_comparable<EqualityComparable>::value)>
 {
 };
 
 template<typename LessThanComparable, class = std::void_t<>>
-struct is_lessthan_comparable : std::false_type {};
+struct _NODISCARD is_lessthan_comparable : std::false_type {};
 
 template<typename LessThanComparable>
-struct is_lessthan_comparable<LessThanComparable, std::enable_if_t<std::is_convertible_v<
+struct _NODISCARD is_lessthan_comparable<LessThanComparable, std::enable_if_t<std::is_convertible_v<
     decltype(std::declval<LessThanComparable&>() < std::declval<LessThanComparable&>()), bool>>> :
     std::true_type {};
 
 template<typename LessThanComparable>
-struct is_nothrow_lessthan_comparable :
+struct _NODISCARD is_nothrow_lessthan_comparable :
     std::bool_constant<noexcept(is_lessthan_comparable<LessThanComparable>::value)>
 {
 };
 
 template<typename Comparable>
-struct is_comparable :
+struct _NODISCARD is_comparable :
     std::bool_constant<(is_equality_comparable<Comparable>::value && is_lessthan_comparable<Comparable>::value)>
 {
 };
 
 template<typename Comparable>
-struct is_nothrow_comparable :
-    std::bool_constant<noexcept(is_comparable<Comparable>::value)>
-{
-};
+struct _NODISCARD is_nothrow_comparable : std::bool_constant<noexcept(is_comparable<Comparable>::value)> {};
+} // namespace detail
 
-} // namespace detail 
-
-template<typename EqualityComparable> _NODISCARD _CONSTANT_VAR
+template<typename EqualityComparable> _CONSTANT_VAR
 is_equality_comparable_v{ detail::is_equality_comparable<EqualityComparable>::value };
 
-template<typename EqualityComparable> _NODISCARD _CONSTANT_VAR
+template<typename EqualityComparable> _CONSTANT_VAR
 is_nothrow_equality_comparable_v{ detail::is_nothrow_equality_comparable<EqualityComparable>::value };
 
-template<typename LessThanComparable> _NODISCARD _CONSTANT_VAR
+template<typename LessThanComparable> _CONSTANT_VAR
 is_lessthan_comparable_v{ detail::is_lessthan_comparable<LessThanComparable>::value };
 
-template<typename LessThanComparable> _NODISCARD _CONSTANT_VAR
+template<typename LessThanComparable> _CONSTANT_VAR
 is_nothrow_lessthan_comparable_v{ detail::is_nothrow_lessthan_comparable<LessThanComparable>::value };
 
-template<typename Comparable> _NODISCARD _CONSTANT_VAR
+template<typename Comparable> _CONSTANT_VAR
 is_comparable_v{ detail::is_comparable<Comparable>::value };
 
-template<typename Comparable> _NODISCARD _CONSTANT_VAR
+template<typename Comparable> _CONSTANT_VAR
 is_nothrow_comparable_v{ detail::is_nothrow_comparable<Comparable>::value };
 
 } // namespace ra
-
-
 
 #endif // !RA_TYPE_TRAITS_H

--- a/src/ra_type_traits.h
+++ b/src/ra_type_traits.h
@@ -82,6 +82,25 @@ struct _NODISCARD is_comparable :
 
 template<typename Comparable>
 struct _NODISCARD is_nothrow_comparable : std::bool_constant<noexcept(is_comparable<Comparable>::value)> {};
+template<typename T, typename C, class = std::void_t<>>
+struct is_equality_comparable_with :
+    std::false_type
+{
+};
+
+template<typename T, typename C>
+struct is_equality_comparable_with<T, C, std::enable_if_t<std::is_convertible_v<
+    decltype(std::declval<T&>() == std::declval<C&>()), bool>>> :
+    std::true_type
+{
+};
+
+template<typename T, typename C>
+struct is_nothrow_equality_comparable_with :
+    std::bool_constant<noexcept(is_equality_comparable_with<T, C>::value)>
+{
+};
+
 } // namespace detail
 
 template<typename EqualityComparable> _CONSTANT_VAR
@@ -101,6 +120,38 @@ is_comparable_v{ detail::is_comparable<Comparable>::value };
 
 template<typename Comparable> _CONSTANT_VAR
 is_nothrow_comparable_v{ detail::is_nothrow_comparable<Comparable>::value };
+
+template<typename EqualityComparable, typename TestComparable> _NODISCARD _CONSTANT_VAR
+is_equality_comparable_with_v{ detail::is_equality_comparable_with<EqualityComparable, TestComparable>::value };
+
+template<typename EqualityComparable, typename TestComparable> _NODISCARD _CONSTANT_VAR
+is_nothrow_equality_comparable_with_v{ detail::is_nothrow_equality_comparable_with<EqualityComparable, TestComparable>::value };
+
+namespace detail {
+
+// Based off of the NullablePointer named requirement
+template<typename T, class = std::void_t<>>
+struct _NODISCARD is_nullable_pointer : std::false_type{};
+
+template<typename T>
+struct is_nullable_pointer<T, std::enable_if_t<
+    is_nothrow_equality_comparable<T>::value &&
+    std::is_nothrow_default_constructible_v<T> &&
+    std::is_nothrow_copy_constructible_v<T> &&
+    std::is_nothrow_copy_assignable_v<T> &&
+    std::is_nothrow_destructible_v<T> &&
+    std::is_nothrow_constructible_v<T, std::nullptr_t> &&
+    std::is_nothrow_assignable_v<T&, std::nullptr_t> &&
+    std::is_nothrow_constructible_v<T&&, std::nullptr_t> &&
+    std::is_same_v<decltype(std::declval<T&>() = nullptr), T&> &&
+    is_nothrow_equality_comparable_with<T, std::nullptr_t>::value &&
+    is_nothrow_equality_comparable_with<std::nullptr_t, T>::value
+>> : std::true_type{};
+
+} // namespace detail
+
+template<typename NullablePointer> _CONSTANT_VAR
+is_nullable_pointer_v{ detail::is_nullable_pointer<NullablePointer>::value };
 
 } // namespace ra
 

--- a/src/ra_utility.h
+++ b/src/ra_utility.h
@@ -103,6 +103,9 @@ filesize(std::basic_string<CharT>&& filename) noexcept
     return file.tellg();
 } // end function filesize
 
+using LPCTSTR = const TCHAR*;
+using LPTSTR = TCHAR*;
+
 // More functions to be Unicode compatible w/o sacrificing MBCS
 _EXTERN_C
 /* A wrapper for converting a string to an unsigned long depending on the character set specified */

--- a/src/ra_utility.h
+++ b/src/ra_utility.h
@@ -9,9 +9,7 @@
     For most of these functions you won't have to specify the template argument as it will be auto-deduced unless
     stated otherwise.
 */
-
 namespace ra {
-
 template<typename SignedType, class = std::enable_if_t<std::is_signed_v<SignedType>>> _NODISCARD _CONSTANT_FN
 to_unsigned(_In_ SignedType st) noexcept { return static_cast<std::make_unsigned_t<SignedType>>(st); }
 
@@ -53,19 +51,32 @@ _NODISCARD _CONSTANT_FN ftoi(_In_ FloatingPoint fp) noexcept { return std::lroun
 template<typename FloatingPoint, class = std::enable_if_t<std::is_floating_point_v<FloatingPoint>>>
 _NODISCARD _CONSTANT_FN ftou(_In_ FloatingPoint fp) noexcept { return to_unsigned(std::lround(fp)); }
 
-template<typename Arithmetic, class = std::enable_if_t<std::is_arithmetic_v<Arithmetic>>> _NODISCARD _CONSTANT_FN
-sqr(_In_ Arithmetic a) noexcept { return std::pow(a, 2); }
+template<typename Arithmetic, class = std::enable_if_t<std::is_arithmetic_v<Arithmetic>>>
+_NODISCARD _CONSTANT_FN sqr(_In_ Arithmetic a) noexcept { return std::pow(a, 2); }
 
 template<typename Enum, typename = std::enable_if_t<std::is_enum_v<Enum>>> _NODISCARD _CONSTANT_VAR
 etoi(_In_ Enum e) noexcept { return static_cast<std::underlying_type_t<Enum>>(e); }
 
-// function alias template for etoi (EnumToIntegral)
-template<typename Enum> _NODISCARD _CONSTANT_VAR to_integral{ etoi<Enum> };
+template<
+    typename Enum,
+    typename Integral = std::underlying_type_t<Enum>,
+    typename = std::enable_if_t<
+    std::is_enum_v<Enum> &&
+    std::is_integral_v<Integral> &&
+    std::is_convertible_v<Integral, std::underlying_type_t<Enum>>>
+> _NODISCARD _CONSTANT_VAR
+itoe(_In_ Integral i) noexcept { return static_cast<Enum>(i); }
+
+// function alias templates for etoi (EnumToIntegral) and itoe (IntegralToEnum)
+template<typename Enum> _CONSTANT_VAR to_integral{ etoi<Enum> };
+template<typename Enum, typename Integral = std::underlying_type_t<Enum>>
+_CONSTANT_VAR to_enum{ itoe<Enum, Integral> };
 
 /// <summary>Calculates the size of any standard fstream.</summary>
 /// <param name="filename">The filename.</param>
 /// <typeparam name="CharT">
-///   The character type, it should be auto deduced if valid. Otherwise you'll get an intellisense error.
+///   The character type, it should be auto deduced if valid. Otherwise you'll
+///   get an intellisense error.
 /// </typeparam>
 /// <returns>The size of the file stream.</returns>
 template<typename CharT, class = std::enable_if_t<is_char_v<CharT>>> _NODISCARD _CONSTANT_FN

--- a/src/services/IConfiguration.hh
+++ b/src/services/IConfiguration.hh
@@ -20,8 +20,11 @@ enum class Feature
     PreferDecimal,
 };
 
-class IConfiguration {
+class IConfiguration
+{
 public:
+    virtual ~IConfiguration() noexcept = default;
+
     virtual const std::string& GetUsername() const = 0;
     virtual void SetUsername(const std::string& sValue) = 0;
     virtual const std::string& GetApiToken() const = 0;

--- a/src/services/IFileSystem.hh
+++ b/src/services/IFileSystem.hh
@@ -1,0 +1,54 @@
+#ifndef RA_SERVICES_IFILESYSTEM
+#define RA_SERVICES_IFILESYSTEM
+#pragma once
+
+#include "services/TextReader.hh"
+#include "services/TextWriter.hh"
+
+#include <string>
+#include <memory>
+
+// nuke WinAPI #defines - anything including this file should be using these functions
+#undef CreateDirectory 
+
+namespace ra {
+namespace services {
+
+class IFileSystem
+{
+public:
+    virtual ~IFileSystem() noexcept = default;
+
+    /// <summary>
+    /// Gets the base directory of the running executable.
+    /// </summary>
+    virtual const std::wstring& BaseDirectory() const = 0;
+
+    /// <summary>
+    /// Determines if the specified directory exists.
+    /// </summary>
+    virtual bool DirectoryExists(const std::wstring& sDirectory) const = 0;
+
+    /// <summary>
+    /// Creates the specified directory.
+    /// </summary>
+    /// <returns><c>true</c> if successful, <c>false</c> if not.</returns>
+    virtual bool CreateDirectory(const std::wstring& sDirectory) const = 0;
+
+    /// <summary>
+    /// Opens the specified file.
+    /// </summary>
+    /// <returns>Pointer to a <see cref="TextReader"/> for reading the contents of the file. nullptr if the file was not found.</returns>
+    virtual std::unique_ptr<TextReader> OpenTextFile(const std::wstring& sPath) const = 0;
+
+    /// <summary>
+    /// Creates the specified file.
+    /// </summary>
+    /// <returns>Pointer to a <see cref="TextWriter"/> for writing the contents of the file. nullptr if the file could not be created.</returns>
+    virtual std::unique_ptr<TextWriter> CreateTextFile(const std::wstring& sPath) const = 0;
+};
+
+} // namespace services
+} // namespace ra
+
+#endif // !RA_SERVICES_IFILESYSTEM

--- a/src/services/ILeaderboardManager.hh
+++ b/src/services/ILeaderboardManager.hh
@@ -10,6 +10,8 @@ namespace services {
 class ILeaderboardManager
 {
 public:
+    virtual ~ILeaderboardManager() noexcept = default;
+
     virtual void Test() = 0;
     virtual void Reset() = 0;
 

--- a/src/services/Initialization.cpp
+++ b/src/services/Initialization.cpp
@@ -3,13 +3,17 @@
 #include "services\ServiceLocator.hh"
 #include "services\impl\JsonFileConfiguration.hh"
 #include "services\impl\LeaderboardManager.hh"
+#include "services\impl\WindowsFileSystem.hh"
 
 namespace ra {
 namespace services {
 
-void Initialization::RegisterServices(const std::wstring& sHomeDir, const std::string& sClientName)
+void Initialization::RegisterServices(const std::string& sClientName)
 {
-    std::wstring sFilename = sHomeDir + L"RAPrefs_" + ra::Widen(sClientName) + L".cfg";
+    auto* pFileSystem = new ra::services::impl::WindowsFileSystem();
+    ra::services::ServiceLocator::Provide<ra::services::IFileSystem>(pFileSystem);
+
+    std::wstring sFilename = pFileSystem->BaseDirectory() + L"RAPrefs_" + ra::Widen(sClientName) + L".cfg";
     auto* pConfiguration = new ra::services::impl::JsonFileConfiguration();
     pConfiguration->Load(sFilename);
     ra::services::ServiceLocator::Provide<ra::services::IConfiguration>(pConfiguration);

--- a/src/services/Initialization.hh
+++ b/src/services/Initialization.hh
@@ -10,7 +10,7 @@ namespace services {
 class Initialization
 {
 public:
-    static void RegisterServices(const std::wstring& sHomeDir, const std::string& sClientName);
+    static void RegisterServices(const std::string& sClientName);
 };
 
 } // namespace services

--- a/src/services/ServiceLocator.hh
+++ b/src/services/ServiceLocator.hh
@@ -38,7 +38,7 @@ public:
     {
         return Service<TClass>::Get();
     }
-    
+
     /// <summary>
     /// Registers a service implementation for an interface
     /// </summary>
@@ -51,7 +51,7 @@ public:
     {
         Service<TClass>::s_pInstance.reset(pInstance);
     }
-    
+
     /// <summary>
     /// Provides a temporary implementation of an interface for the duration of the scope of the ServiceOverride.
     /// The original implementation will be restored when the <see cref="ServiceOverride"/> goes out of scope.
@@ -88,25 +88,25 @@ public:
 
             Service<TClass>::s_pInstance.reset(m_pPrevious);
         }
-        
+
     private:
         TClass* m_pPrevious;
         bool m_bDestroy;
     };
-    
+
 private:
     template <class TClass>
     class Service
     {
     public:
-        static TClass& Get() 
+        static TClass& Get()
         {
             if (s_pInstance == nullptr)
                 ThrowNoServiceProvidedException();
 
             return *s_pInstance.get();
         }
-        
+
         static std::unique_ptr<TClass> s_pInstance;
 
     private:

--- a/src/services/TextReader.hh
+++ b/src/services/TextReader.hh
@@ -1,0 +1,33 @@
+#ifndef RA_SERVICES_TEXTREADER
+#define RA_SERVICES_TEXTREADER
+#pragma once
+
+#include <string>
+
+namespace ra {
+namespace services {
+
+class TextReader
+{
+public:
+    virtual ~TextReader() noexcept = default;
+
+    /// <summary>
+    /// Reads the next line from the input.
+    /// </summary>
+    /// <param name="sLine">The string to read the next line into.</param>
+    /// <returns><c>true</c> if a line was read, <c>false</c> if the end of the input was reached.</returns>
+    virtual bool GetLine(_Out_ std::string& sLine) = 0;
+
+    /// <summary>
+    /// Reads the next line from the input.
+    /// </summary>
+    /// <param name="sLine">The string to read the next line into.</param>
+    /// <returns><c>true</c> if a line was read, <c>false</c> if the end of the input was reached.</returns>
+    virtual bool GetLine(_Out_ std::wstring& sLine) = 0;
+};
+
+} // namespace services
+} // namespace ra
+
+#endif // !RA_SERVICES_TEXTREADER

--- a/src/services/TextWriter.hh
+++ b/src/services/TextWriter.hh
@@ -1,0 +1,31 @@
+#ifndef RA_SERVICES_TEXTWRITER
+#define RA_SERVICES_TEXTWRITER
+#pragma once
+
+#include <string>
+
+namespace ra {
+namespace services {
+
+class TextWriter
+{
+public:
+    virtual ~TextWriter() noexcept = default;
+
+    /// <summary>
+    /// Writes text to the output.
+    /// </summary>
+    /// <param name="sText">The string to write.</param>
+    virtual void Write(_In_ const std::string& sText) = 0;
+
+    /// <summary>
+    /// Writes text to the output.
+    /// </summary>
+    /// <param name="sText">The string to write.</param>
+    virtual void Write(_In_ const std::wstring& sText) = 0;
+};
+
+} // namespace services
+} // namespace ra
+
+#endif // !RA_SERVICES_TEXTWRITER

--- a/src/services/impl/FileTextReader.hh
+++ b/src/services/impl/FileTextReader.hh
@@ -1,0 +1,52 @@
+#ifndef RA_SERVICES_FILETEXTREADER
+#define RA_SERVICES_FILETEXTREADER
+#pragma once
+
+#include "services\TextReader.hh"
+
+#include "RA_StringUtils.h"
+
+#include <fstream>
+
+namespace ra {
+namespace services {
+namespace impl {
+
+class FileTextReader : public ra::services::TextReader
+{
+public:
+    explicit FileTextReader(const std::wstring& sFilename) noexcept
+        : m_iStream(sFilename)
+    {
+    }
+
+    bool GetLine(_Out_ std::string& sLine) override
+    {
+        if (!std::getline(m_iStream, sLine))
+            return false;
+
+        ra::TrimLineEnding(sLine);
+        return true;
+    }
+
+    bool GetLine(_Out_ std::wstring& sLine) override
+    {
+        std::string sNarrowLine;
+        if (!std::getline(m_iStream, sNarrowLine))
+            return false;
+
+        sLine = ra::Widen(ra::TrimLineEnding(sNarrowLine));
+        return true;
+    }
+
+    std::ifstream& GetFStream() { return m_iStream; }
+
+private:
+    std::ifstream m_iStream;
+};
+
+} // namespace impl
+} // namespace services
+} // namespace ra
+
+#endif // !RA_SERVICES_FILETEXTREADER

--- a/src/services/impl/FileTextWriter.hh
+++ b/src/services/impl/FileTextWriter.hh
@@ -1,0 +1,49 @@
+#ifndef RA_SERVICES_FILETEXTWRITER
+#define RA_SERVICES_FILETEXTWRITER
+#pragma once
+
+#include "services\TextWriter.hh"
+
+#include "RA_StringUtils.h"
+#include "ra_utility.h"
+
+#include <fstream>
+
+namespace ra {
+namespace services {
+namespace impl {
+
+class FileTextWriter : public ra::services::TextWriter
+{
+public:
+    explicit FileTextWriter(const std::wstring& sFilename) noexcept
+        : m_oStream(sFilename, std::ios::binary)
+    {
+    }
+
+    void Write(_In_ const std::string& sText) override
+    {
+        if (m_oStream.is_open())
+            m_oStream.write(sText.c_str(), ra::to_signed(sText.length()));
+    }
+
+    void Write(_In_ const std::wstring& sText) override
+    {
+        if (m_oStream.is_open())
+        {
+            std::string sNarrowText = ra::Narrow(sText);
+            m_oStream.write(sNarrowText.c_str(), ra::to_signed(sNarrowText.length()));
+        }
+    }
+
+    std::ofstream& GetFStream() { return m_oStream; }
+
+private:
+    std::ofstream m_oStream;
+};
+
+} // namespace impl
+} // namespace services
+} // namespace ra
+
+#endif // !RA_SERVICES_FILETEXTWRITER

--- a/src/services/impl/StringTextReader.hh
+++ b/src/services/impl/StringTextReader.hh
@@ -1,0 +1,52 @@
+#ifndef RA_SERVICES_STRINGTEXTREADER
+#define RA_SERVICES_STRINGTEXTREADER
+#pragma once
+
+#include "services\TextReader.hh"
+
+#include "RA_StringUtils.h"
+
+#include <sstream>
+
+namespace ra {
+namespace services {
+namespace impl {
+
+class StringTextReader : public ra::services::TextReader
+{
+public:
+    explicit StringTextReader(const std::string& sInput) noexcept
+        : m_iStream(sInput)
+    {
+    }
+
+    bool GetLine(_Out_ std::string& sLine) override
+    {
+        if (!std::getline(m_iStream, sLine))
+            return false;
+
+        ra::TrimLineEnding(sLine);
+        return true;
+    }
+
+    bool GetLine(_Out_ std::wstring& sLine) override
+    {
+        std::string sNarrowLine;
+        if (!std::getline(m_iStream, sNarrowLine))
+            return false;
+
+        sLine = ra::Widen(ra::TrimLineEnding(sNarrowLine));
+        return true;
+    }
+
+    std::string GetString() { return m_iStream.str(); }
+
+private:
+    std::istringstream m_iStream;
+};
+
+} // namespace impl
+} // namespace services
+} // namespace ra
+
+#endif // !RA_SERVICES_STRINGTEXTREADER

--- a/src/services/impl/StringTextWriter.hh
+++ b/src/services/impl/StringTextWriter.hh
@@ -1,0 +1,47 @@
+#ifndef RA_SERVICES_STRINGTEXTWRITER
+#define RA_SERVICES_STRINGTEXTWRITER
+#pragma once
+
+#include "services\TextWriter.hh"
+
+#include "RA_StringUtils.h"
+
+namespace ra {
+namespace services {
+namespace impl {
+
+class StringTextWriter : public ra::services::TextWriter
+{
+public:
+    StringTextWriter() noexcept
+        : StringTextWriter(m_sBuffer)
+    {
+    }
+
+    explicit StringTextWriter(std::string& sOutput) noexcept
+        : m_sOutput(sOutput)
+    {
+    }
+
+    void Write(_In_ const std::string& sText) override
+    {
+        m_sOutput.append(sText);
+    }
+
+    void Write(_In_ const std::wstring& sText) override
+    {
+        m_sOutput.append(ra::Narrow(sText));
+    }
+
+    std::string& GetString() { return m_sOutput; }
+
+private:
+    std::string& m_sOutput;
+    std::string m_sBuffer;
+};
+
+} // namespace impl
+} // namespace services
+} // namespace ra
+
+#endif // !RA_SERVICES_STRINGTEXTWRITER

--- a/src/services/impl/WindowsFileSystem.cpp
+++ b/src/services/impl/WindowsFileSystem.cpp
@@ -1,0 +1,71 @@
+#include "WindowsFileSystem.hh"
+
+#include "RA_Log.h"
+#include "RA_StringUtils.h"
+
+#include "services\impl\FileTextReader.hh"
+#include "services\impl\FileTextWriter.hh"
+
+#include <fstream>
+
+#define WIN32_LEAN_AND_MEAN
+struct IUnknown;
+#include <Windows.h>
+#include <Shlwapi.h>
+#undef CreateDirectory
+
+namespace ra {
+namespace services {
+namespace impl {
+
+WindowsFileSystem::WindowsFileSystem() noexcept
+{
+    // determine the home directory from the executable's path
+    wchar_t sBuffer[MAX_PATH];
+    GetModuleFileNameW(0, sBuffer, MAX_PATH);
+    PathRemoveFileSpecW(sBuffer);
+    m_sBaseDirectory = sBuffer;
+    if (m_sBaseDirectory.back() != '\\')
+        m_sBaseDirectory.push_back('\\');
+
+    RA_LOG("BaseDirectory: %s", ra::Narrow(m_sBaseDirectory).c_str());
+}
+
+bool WindowsFileSystem::DirectoryExists(const std::wstring& sDirectory) const
+{
+    DWORD nAttrib = GetFileAttributesW(sDirectory.c_str());
+    return (nAttrib != INVALID_FILE_ATTRIBUTES);
+}
+
+bool WindowsFileSystem::CreateDirectory(const std::wstring& sDirectory) const
+{
+    return static_cast<bool>(CreateDirectoryW(sDirectory.c_str(), nullptr));
+}
+
+std::unique_ptr<TextReader> WindowsFileSystem::OpenTextFile(const std::wstring& sPath) const
+{
+    auto pReader = std::make_unique<FileTextReader>(sPath);
+    if (!pReader->GetFStream().is_open())
+    {
+        RA_LOG("Failed to open \"%s\": %d", ra::Narrow(sPath).c_str(), errno);
+        return std::unique_ptr<TextReader>();
+    }
+
+    return std::unique_ptr<TextReader>(pReader.release());
+}
+
+std::unique_ptr<TextWriter> WindowsFileSystem::CreateTextFile(const std::wstring& sPath) const
+{
+    auto pWriter = std::make_unique<FileTextWriter>(sPath);
+    if (!pWriter->GetFStream().is_open())
+    {
+        RA_LOG("Failed to create \"%s\": %d", ra::Narrow(sPath).c_str(), errno);
+        return std::unique_ptr<TextWriter>();
+    }
+
+    return std::unique_ptr<TextWriter>(pWriter.release());
+}
+
+} // namespace impl
+} // namespace services
+} // namespace ra

--- a/src/services/impl/WindowsFileSystem.hh
+++ b/src/services/impl/WindowsFileSystem.hh
@@ -1,0 +1,31 @@
+#ifndef RA_SERVICES_WIN32_FILESYSTEM_HH
+#define RA_SERVICES_WIN32_FILESYSTEM_HH
+#pragma once
+
+#include "services\IFileSystem.hh"
+
+namespace ra {
+namespace services {
+namespace impl {
+
+class WindowsFileSystem : public IFileSystem
+{
+public:
+    WindowsFileSystem() noexcept;
+
+    const std::wstring& BaseDirectory() const override { return m_sBaseDirectory; }
+    bool DirectoryExists(const std::wstring& sDirectory) const override;
+    bool CreateDirectory(const std::wstring& sDirectory) const override;
+    std::unique_ptr<TextReader> OpenTextFile(const std::wstring& sPath) const override;
+    std::unique_ptr<TextWriter> CreateTextFile(const std::wstring& sPath) const override;
+
+private:
+
+    std::wstring m_sBaseDirectory;
+};
+
+} // namespace impl
+} // namespace services
+} // namespace ra
+
+#endif // !RA_SERVICES_WIN32_FILESYSTEM_HH

--- a/src/windows_nodefines.h
+++ b/src/windows_nodefines.h
@@ -1,0 +1,52 @@
+#ifndef WINDOWS_NODEFINES_H
+#define WINDOWS_NODEFINES_H
+#pragma once
+
+// Windows stuff we DO need, they are commented out to show we need them, if for
+// some reason you get a compiler error put the offending NO* define here
+/*
+    #define NOCOLOR
+    #define NOCLIPBOARD - gave an error when put in the pch
+    #define NOCTLMGR
+    #define NODRAWTEXT
+    #define NOGDI
+    #define NOMB
+    #define NOMENUS
+    #define NOMSG
+    #define NONLS
+    #define NOOPENFILE
+    #define NORASTEROPS
+    #define NOSHOWWINDOW
+    #define NOTEXTMETRIC
+    #define NOUSER
+    #define NOVIRTUALKEYCODES
+    #define NOWINMESSAGES
+    #define NOWINOFFSETS
+    #define NOWINSTYLES
+*/
+
+// Windows stuff we don't need
+#define WIN32_LEAN_AND_MEAN
+#define NOGDICAPMASKS
+#define NOSYSMETRICS
+#define NOICONS
+#define NOKEYSTATES
+#define NOSYSCOMMANDS
+#define OEMRESOURCE
+#define NOATOM
+#define NOKERNEL
+#define NOMEMMGR
+#define NOMETAFILE
+#define NOMINMAX
+#define NOSCROLL
+#define NOSERVICE
+#define NOSOUND
+#define NOWH
+#define NOCOMM
+#define NOKANJI
+#define NOHELP
+#define NOPROFILER
+#define NODEFERWINDOWPOS
+#define NOMCX
+
+#endif // !WINDOWS_NODEFINES_H

--- a/tests/RA_Achievement_Tests.cpp
+++ b/tests/RA_Achievement_Tests.cpp
@@ -14,15 +14,14 @@ TEST_CLASS(RA_Achievement_Tests)
 public:
     TEST_METHOD(TestStateEmpty)
     {
-        Achievement ach(AchievementSetType::Local);
-        std::string sState = ach.CreateStateString("user1");
+        std::string sState = Achievement{}.CreateStateString("user1");
 
         Assert::AreEqual(std::string("0:0:a9bf5b6918bb43ec1d430f09d6606fbd:d41d8cd98f00b204e9800998ecf8427e:"), sState);
     }
 
     TEST_METHOD(TestStateSimple)
     {
-        Achievement ach(AchievementSetType::Local);
+        Achievement ach;
         ach.SetID(12345);
         ach.ParseLine("12345:0xh1234=6");
         ach.GetCondition(0, 0).OverrideCurrentHits(4);
@@ -55,7 +54,7 @@ public:
 
     TEST_METHOD(TestStateDelta)
     {
-        Achievement ach(AchievementSetType::Local);
+        Achievement ach;
         ach.SetID(12345);
         ach.ParseLine("12345:0xh1234=d0x1234");
         ach.GetCondition(0, 0).OverrideCurrentHits(4);
@@ -77,7 +76,7 @@ public:
 
     TEST_METHOD(TestStateMultipleConditions)
     {
-        Achievement ach(AchievementSetType::Local);
+        Achievement ach;
         ach.SetID(12345);
         ach.ParseLine("12345:0xh1234=6.1._0xh2345!=d0xh2345_R:0xh3456=7");
         ach.GetCondition(0, 0).OverrideCurrentHits(1);
@@ -107,7 +106,7 @@ public:
 
     TEST_METHOD(TestStateMultipleGroups)
     {
-        Achievement ach(AchievementSetType::Local);
+        Achievement ach;
         ach.SetID(12345);
         ach.ParseLine("12345:0xh1234=6.1._0xh2345!=d0xh2345SR:0xh3456=7S0xh4567=0xh5678");
         ach.GetCondition(0, 0).OverrideCurrentHits(1);
@@ -142,7 +141,7 @@ public:
 
     TEST_METHOD(TestStateMultipleAchievements)
     {
-        Achievement ach(AchievementSetType::Local);
+        Achievement ach;
         ach.SetID(12345);
         ach.ParseLine("12345:0xh1234=6.1._0xh2345!=d0xh2345_R:0xh3456=7");
         ach.GetCondition(0, 0).OverrideCurrentHits(1);
@@ -176,7 +175,7 @@ public:
 
     TEST_METHOD(TestStateAchievementModified)
     {
-        Achievement ach(AchievementSetType::Local);
+        Achievement ach;
         ach.SetID(12345);
         ach.ParseLine("12345:0xh1234=6");
         ach.GetCondition(0, 0).OverrideCurrentHits(4);

--- a/tests/RA_Defs_Tests.cpp
+++ b/tests/RA_Defs_Tests.cpp
@@ -1,0 +1,50 @@
+#include "CppUnitTest.h"
+
+#include "RA_Defs.h"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace ra {
+namespace data {
+namespace tests {
+
+TEST_CLASS(RA_Defs_Tests)
+{
+public:
+    TEST_METHOD(TestNarrow)
+    {
+        // ASCII
+        Assert::AreEqual(std::string("Test"), Narrow("Test"));
+        Assert::AreEqual(std::string("Test"), Narrow(L"Test"));
+        Assert::AreEqual(std::string("Test"), Narrow(std::string("Test")));
+        Assert::AreEqual(std::string("Test"), Narrow(std::wstring(L"Test")));
+
+        // U+1F30F - EARTH GLOBE ASIA-AUSTRALIA
+        Assert::AreEqual(std::string("\xF0\x9F\x8C\x8F"), Narrow("\xF0\x9F\x8C\x8F"));
+        Assert::AreEqual(std::string("\xF0\x9F\x8C\x8F"), Narrow(L"\xD83C\xDF0F"));
+        Assert::AreEqual(std::string("\xF0\x9F\x8C\x8F"), Narrow(std::string("\xF0\x9F\x8C\x8F")));
+        Assert::AreEqual(std::string("\xF0\x9F\x8C\x8F"), Narrow(std::wstring(L"\xD83C\xDF0F")));
+    }
+
+    TEST_METHOD(TestWiden)
+    {
+        // ASCII
+        Assert::AreEqual(std::wstring(L"Test"), Widen("Test"));
+        Assert::AreEqual(std::wstring(L"Test"), Widen(L"Test"));
+        Assert::AreEqual(std::wstring(L"Test"), Widen(std::string("Test")));
+        Assert::AreEqual(std::wstring(L"Test"), Widen(std::wstring(L"Test")));
+
+        // U+1F30F - EARTH GLOBE ASIA-AUSTRALIA
+        Assert::AreEqual(std::wstring(L"\xD83C\xDF0F"), Widen("\xF0\x9F\x8C\x8F"));
+        Assert::AreEqual(std::wstring(L"\xD83C\xDF0F"), Widen(L"\xD83C\xDF0F"));
+        Assert::AreEqual(std::wstring(L"\xD83C\xDF0F"), Widen(std::string("\xF0\x9F\x8C\x8F")));
+        Assert::AreEqual(std::wstring(L"\xD83C\xDF0F"), Widen(std::wstring(L"\xD83C\xDF0F")));
+
+        // invalid UTF-8 replaced with placeholder U+FFFD
+        Assert::AreEqual(std::wstring(L"T\xFFFDst"), Widen("T\xA9st")); // should be \xC3\xA9
+    }
+};
+
+} // namespace tests
+} // namespace data
+} // namespace ra

--- a/tests/RA_Integration.Tests.vcxproj
+++ b/tests/RA_Integration.Tests.vcxproj
@@ -65,7 +65,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>$(MSBuildProjectDirectory)\..;$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(RA_IncludePath);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;RA_UTEST;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -97,7 +97,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <AdditionalIncludeDirectories>$(MSBuildProjectDirectory)\..;$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(RA_IncludePath);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;RA_UTEST;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -131,16 +131,24 @@
   <ItemGroup>
     <ClCompile Include="..\src\md5.c" />
     <ClCompile Include="..\src\RA_Achievement.cpp" />
+    <ClCompile Include="..\src\RA_Json.cpp" />
     <ClCompile Include="..\src\RA_md5factory.cpp" />
     <ClCompile Include="..\src\RA_RichPresence.cpp" />
+    <ClCompile Include="..\src\RA_StringUtils.cpp" />
+    <ClCompile Include="..\src\services\impl\JsonFileConfiguration.cpp" />
     <ClCompile Include="..\src\services\SearchResults.cpp" />
     <ClCompile Include="RA_Achievement_Tests.cpp" />
     <ClCompile Include="RA_RichPresence_Tests.cpp" />
-    <ClCompile Include="SearchResults_Tests.cpp" />
+    <ClCompile Include="RA_StringUtils_Tests.cpp" />
+    <ClCompile Include="services\JsonFileConfiguration_Tests.cpp" />
+    <ClCompile Include="services\SearchResults_Tests.cpp" />
+    <ClCompile Include="services\StringTextReader_Tests.cpp" />
+    <ClCompile Include="services\StringTextWriter_Tests.cpp" />
     <ClInclude Include="..\src\md5.h" />
     <ClInclude Include="..\src\RA_Achievement.h" />
     <ClInclude Include="..\src\RA_Condition.h" />
     <ClInclude Include="..\src\RA_Defs.h" />
+    <ClInclude Include="..\src\RA_Json.h" />
     <ClInclude Include="..\src\RA_Leaderboard.h" />
     <ClInclude Include="..\src\RA_md5factory.h" />
     <ClInclude Include="..\src\RA_MemManager.h" />
@@ -149,12 +157,14 @@
     <ClCompile Include="..\src\RA_Leaderboard.cpp" />
     <ClCompile Include="..\src\RA_MemManager.cpp" />
     <ClInclude Include="..\src\RA_MemValue.h" />
+    <ClInclude Include="..\src\RA_StringUtils.h" />
+    <ClInclude Include="..\src\services\impl\JsonFileConfiguration.hh" />
+    <ClInclude Include="mocks\MockFileSystem.hh" />
     <ClInclude Include="RA_UnitTestHelpers.h" />
     <ClCompile Include="..\src\RA_MemValue.cpp" />
     <ClCompile Include="RA_CompVariable_Tests.cpp" />
     <ClCompile Include="RA_ConditionSet_Tests.cpp" />
     <ClCompile Include="RA_Condition_Tests.cpp" />
-    <ClCompile Include="RA_Defs_Tests.cpp" />
     <ClCompile Include="RA_Leaderboard_Tests.cpp" />
     <ClCompile Include="RA_MemValue_Tests.cpp" />
     <ClCompile Include="RA_UnitTestHelpers.cpp" />

--- a/tests/RA_Integration.Tests.vcxproj.filters
+++ b/tests/RA_Integration.Tests.vcxproj.filters
@@ -7,6 +7,12 @@
     <Filter Include="Code">
       <UniqueIdentifier>{c09a9464-e27a-4721-8467-626c7f5e3ab0}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Tests\Services">
+      <UniqueIdentifier>{d2101e8f-5483-4eec-89f5-8f8fc586b0b9}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Tests\Mocks">
+      <UniqueIdentifier>{4623f02c-7135-4cd4-ada2-36fa4b29520c}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\src\RA_Condition.cpp">
@@ -39,9 +45,6 @@
     <ClCompile Include="RA_Leaderboard_Tests.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
-    <ClCompile Include="SearchResults_Tests.cpp">
-      <Filter>Tests</Filter>
-    </ClCompile>
     <ClCompile Include="..\src\services\SearchResults.cpp">
       <Filter>Code</Filter>
     </ClCompile>
@@ -63,6 +66,30 @@
     <ClCompile Include="..\src\RA_md5factory.cpp">
       <Filter>Code</Filter>
     </ClCompile>
+    <ClCompile Include="RA_StringUtils_Tests.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\RA_StringUtils.cpp">
+      <Filter>Code</Filter>
+    </ClCompile>
+    <ClCompile Include="services\SearchResults_Tests.cpp">
+      <Filter>Tests\Services</Filter>
+    </ClCompile>
+    <ClCompile Include="services\StringTextReader_Tests.cpp">
+      <Filter>Tests\Services</Filter>
+    </ClCompile>
+    <ClCompile Include="services\StringTextWriter_Tests.cpp">
+      <Filter>Tests\Services</Filter>
+    </ClCompile>
+    <ClCompile Include="services\JsonFileConfiguration_Tests.cpp">
+      <Filter>Tests\Services</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\services\impl\JsonFileConfiguration.cpp">
+      <Filter>Code</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\RA_Json.cpp">
+      <Filter>Code</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="RA_Condition_Tests.cpp">
@@ -80,9 +107,6 @@
     <ClInclude Include="RA_UnitTestHelpers.h">
       <Filter>Tests</Filter>
     </ClInclude>
-    <ClCompile Include="RA_Defs_Tests.cpp">
-      <Filter>Tests</Filter>
-    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\src\RA_MemValue.h">
@@ -98,6 +122,18 @@
       <Filter>Code</Filter>
     </ClInclude>
     <ClInclude Include="..\src\RA_md5factory.h">
+      <Filter>Code</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\RA_StringUtils.h">
+      <Filter>Code</Filter>
+    </ClInclude>
+    <ClInclude Include="mocks\MockFileSystem.hh">
+      <Filter>Tests\Mocks</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\services\impl\JsonFileConfiguration.hh">
+      <Filter>Code</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\RA_Json.h">
       <Filter>Code</Filter>
     </ClInclude>
   </ItemGroup>

--- a/tests/RA_StringUtils_Tests.cpp
+++ b/tests/RA_StringUtils_Tests.cpp
@@ -8,7 +8,7 @@ namespace ra {
 namespace data {
 namespace tests {
 
-TEST_CLASS(RA_Defs_Tests)
+TEST_CLASS(RA_StringUtils_Tests)
 {
 public:
     TEST_METHOD(TestNarrow)
@@ -42,6 +42,16 @@ public:
 
         // invalid UTF-8 replaced with placeholder U+FFFD
         Assert::AreEqual(std::wstring(L"T\xFFFDst"), Widen("T\xA9st")); // should be \xC3\xA9
+    }
+
+    TEST_METHOD(TestTrimLineEnding)
+    {
+        Assert::AreEqual(std::string("test"), TrimLineEnding(std::string("test")));
+        Assert::AreEqual(std::string("test"), TrimLineEnding(std::string("test\r")));
+        Assert::AreEqual(std::string("test"), TrimLineEnding(std::string("test\n")));
+        Assert::AreEqual(std::string("test"), TrimLineEnding(std::string("test\r\n")));
+        Assert::AreEqual(std::string("test\n"), TrimLineEnding(std::string("test\n\n")));
+        Assert::AreEqual(std::string("test\r\n"), TrimLineEnding(std::string("test\r\n\r\n")));
     }
 };
 

--- a/tests/RA_UnitTestHelpers.cpp
+++ b/tests/RA_UnitTestHelpers.cpp
@@ -2,6 +2,8 @@
 
 #include "RA_MemManager.h"
 
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
 static unsigned char* g_pMemoryBuffer;
 static size_t g_nMemorySize;
 
@@ -26,4 +28,13 @@ void InitializeMemory(unsigned char* pMemory, size_t nMemorySize)
 
     g_MemManager.ClearMemoryBanks();
     g_MemManager.AddMemoryBank(0, ReadMemory, SetMemory, nMemorySize);
+}
+
+void AssertContains(const std::string& sHaystack, const std::string& sNeedle)
+{
+    if (sHaystack.find(sNeedle) == std::string::npos)
+    {
+        std::wstring sError = L"\"" + ra::Widen(sNeedle) + L"\" not found in \"" + ra::Widen(sHaystack) + L"\"";
+        Assert::Fail(sError.c_str());
+    }
 }

--- a/tests/RA_UnitTestHelpers.h
+++ b/tests/RA_UnitTestHelpers.h
@@ -44,3 +44,5 @@ template<> static std::wstring ToString<MemValue::Format>(const MemValue::Format
 
 // Loads memory into the MemoryManager
 void InitializeMemory(unsigned char* pMemory, size_t szMemorySize);
+
+void AssertContains(const std::string& sHaystack, const std::string& sNeedle);

--- a/tests/SearchResults_Tests.cpp
+++ b/tests/SearchResults_Tests.cpp
@@ -673,8 +673,7 @@ public:
 
     TEST_METHOD(TestInitializeFromMemoryEightBitLargeMemory)
     {
-        std::unique_ptr<unsigned char> memory;
-        memory.reset(new unsigned char[BIG_BLOCK_SIZE]);
+        auto memory = std::make_unique<unsigned char[]>(BIG_BLOCK_SIZE);
         for (unsigned int i = 0; i < BIG_BLOCK_SIZE; ++i)
             memory.get()[i] = (i % 256);
         InitializeMemory(memory.get(), BIG_BLOCK_SIZE);
@@ -708,8 +707,7 @@ public:
 
     TEST_METHOD(TestInitializeFromMemorySixteenBitLargeMemory)
     {
-        std::unique_ptr<unsigned char> memory;
-        memory.reset(new unsigned char[BIG_BLOCK_SIZE]);
+        auto memory = std::make_unique<unsigned char[]>(BIG_BLOCK_SIZE);
         for (unsigned int i = 0; i < BIG_BLOCK_SIZE; ++i)
             memory.get()[i] = (i % 256);
         InitializeMemory(memory.get(), BIG_BLOCK_SIZE);

--- a/tests/SearchResults_Tests.cpp
+++ b/tests/SearchResults_Tests.cpp
@@ -1,0 +1,747 @@
+#include "CppUnitTest.h"
+
+#include "services\SearchResults.h"
+#include "RA_UnitTestHelpers.h"
+
+#include <memory>
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace ra {
+namespace services {
+namespace tests {
+
+const unsigned int MAX_BLOCK_SIZE = 256 * 1024; // assert: matches value in SearchResults.cpp
+const unsigned int BIG_BLOCK_SIZE = MAX_BLOCK_SIZE + MAX_BLOCK_SIZE + (MAX_BLOCK_SIZE / 2);
+
+TEST_CLASS(SearchResults_Tests)
+{
+public:
+    TEST_METHOD(TestEmpty)
+    {
+        SearchResults results;
+        Assert::AreEqual(0U, results.MatchingAddressCount());
+        Assert::AreEqual(std::string(""), results.Summary());
+
+        SearchResults::Result result;
+        Assert::IsFalse(results.GetMatchingAddress(0, result));
+    }
+
+    TEST_METHOD(TestInitializeFromMemoryEightBit)
+    {
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        SearchResults results;
+        results.Initialize(1U, 3U, ComparisonVariableSize::EightBit);
+
+        Assert::AreEqual(3U, results.MatchingAddressCount());
+        Assert::AreEqual(std::string("Cleared: (8-bit) mode. Aware of 3 RAM locations."), results.Summary());
+
+        Assert::IsFalse(results.ContainsAddress(0U));
+        Assert::IsTrue(results.ContainsAddress(1U));
+        Assert::IsTrue(results.ContainsAddress(2U));
+        Assert::IsTrue(results.ContainsAddress(3U));
+        Assert::IsFalse(results.ContainsAddress(4U));
+
+        SearchResults::Result result;
+        Assert::IsTrue(results.GetMatchingAddress(0U, result));
+        Assert::AreEqual(1U, result.nAddress);
+        Assert::AreEqual(ComparisonVariableSize::EightBit, result.nSize);
+        Assert::AreEqual(0x12U, result.nValue);
+
+        Assert::IsTrue(results.GetMatchingAddress(1U, result));
+        Assert::AreEqual(2U, result.nAddress);
+        Assert::AreEqual(ComparisonVariableSize::EightBit, result.nSize);
+        Assert::AreEqual(0x34U, result.nValue);
+
+        Assert::IsTrue(results.GetMatchingAddress(2U, result));
+        Assert::AreEqual(3U, result.nAddress);
+        Assert::AreEqual(ComparisonVariableSize::EightBit, result.nSize);
+        Assert::AreEqual(0xABU, result.nValue);
+    }
+
+    TEST_METHOD(TestInitializeFromMemorySixteenBit)
+    {
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        SearchResults results;
+        results.Initialize(1U, 3U, ComparisonVariableSize::SixteenBit);
+
+        Assert::AreEqual(2U, results.MatchingAddressCount());
+        Assert::AreEqual(std::string("Cleared: (16-bit) mode. Aware of 2 RAM locations."), results.Summary());
+
+        Assert::IsFalse(results.ContainsAddress(0U));
+        Assert::IsTrue(results.ContainsAddress(1U));
+        Assert::IsTrue(results.ContainsAddress(2U));
+        Assert::IsFalse(results.ContainsAddress(3U));
+
+        SearchResults::Result result;
+        Assert::IsTrue(results.GetMatchingAddress(0U, result));
+        Assert::AreEqual(1U, result.nAddress);
+        Assert::AreEqual(ComparisonVariableSize::SixteenBit, result.nSize);
+        Assert::AreEqual(0x3412U, result.nValue);
+
+        Assert::IsTrue(results.GetMatchingAddress(1U, result));
+        Assert::AreEqual(2U, result.nAddress);
+        Assert::AreEqual(ComparisonVariableSize::SixteenBit, result.nSize);
+        Assert::AreEqual(0xAB34U, result.nValue);
+    }
+
+    TEST_METHOD(TestInitializeFromMemoryThirtyTwoBit)
+    {
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56, 0xCD };
+        InitializeMemory(memory, 6);
+
+        SearchResults results;
+        results.Initialize(1U, 4U, ComparisonVariableSize::ThirtyTwoBit);
+
+        Assert::AreEqual(1U, results.MatchingAddressCount());
+        Assert::AreEqual(std::string("Cleared: (32-bit) mode. Aware of 1 RAM locations."), results.Summary());
+
+        Assert::IsFalse(results.ContainsAddress(0U));
+        Assert::IsTrue(results.ContainsAddress(1U));
+        Assert::IsFalse(results.ContainsAddress(2U));
+
+        SearchResults::Result result;
+        Assert::IsTrue(results.GetMatchingAddress(0U, result));
+        Assert::AreEqual(1U, result.nAddress);
+        Assert::AreEqual(ComparisonVariableSize::ThirtyTwoBit, result.nSize);
+        Assert::AreEqual(0x56AB3412U, result.nValue);
+    }
+
+    TEST_METHOD(TestInitializeFromMemoryUpperNibble)
+    {
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        SearchResults results;
+        results.Initialize(1U, 3U, ComparisonVariableSize::Nibble_Upper);
+
+        Assert::AreEqual(6U, results.MatchingAddressCount());
+        Assert::AreEqual(std::string("Cleared: (Lower4) mode. Aware of 6 RAM locations."), results.Summary());
+
+        Assert::IsFalse(results.ContainsAddress(0U));
+        Assert::IsTrue(results.ContainsAddress(1U));
+        Assert::IsTrue(results.ContainsAddress(2U));
+        Assert::IsTrue(results.ContainsAddress(3U));
+        Assert::IsFalse(results.ContainsAddress(4U));
+
+        // lower nibble always returned first
+        SearchResults::Result result;
+        Assert::IsTrue(results.GetMatchingAddress(0U, result));
+        Assert::AreEqual(1U, result.nAddress);
+        Assert::AreEqual(ComparisonVariableSize::Nibble_Lower, result.nSize);
+        Assert::AreEqual(0x2U, result.nValue);
+
+        Assert::IsTrue(results.GetMatchingAddress(1U, result));
+        Assert::AreEqual(1U, result.nAddress);
+        Assert::AreEqual(ComparisonVariableSize::Nibble_Upper, result.nSize);
+        Assert::AreEqual(0x1U, result.nValue);
+
+        Assert::IsTrue(results.GetMatchingAddress(2U, result));
+        Assert::AreEqual(2U, result.nAddress);
+        Assert::AreEqual(ComparisonVariableSize::Nibble_Lower, result.nSize);
+        Assert::AreEqual(0x4U, result.nValue);
+
+        Assert::IsTrue(results.GetMatchingAddress(3U, result));
+        Assert::AreEqual(2U, result.nAddress);
+        Assert::AreEqual(ComparisonVariableSize::Nibble_Upper, result.nSize);
+        Assert::AreEqual(0x3U, result.nValue);
+
+        Assert::IsTrue(results.GetMatchingAddress(4U, result));
+        Assert::AreEqual(3U, result.nAddress);
+        Assert::AreEqual(ComparisonVariableSize::Nibble_Lower, result.nSize);
+        Assert::AreEqual(0xBU, result.nValue);
+
+        Assert::IsTrue(results.GetMatchingAddress(5U, result));
+        Assert::AreEqual(3U, result.nAddress);
+        Assert::AreEqual(ComparisonVariableSize::Nibble_Upper, result.nSize);
+        Assert::AreEqual(0xAU, result.nValue);
+    }
+
+    TEST_METHOD(TestInitializeFromMemoryLowerNibble)
+    {
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        SearchResults results;
+        results.Initialize(1U, 3U, ComparisonVariableSize::Nibble_Lower); // should behave identical to Nibble_Upper
+
+        Assert::AreEqual(6U, results.MatchingAddressCount());
+        Assert::AreEqual(std::string("Cleared: (Lower4) mode. Aware of 6 RAM locations."), results.Summary());
+
+        Assert::IsFalse(results.ContainsAddress(0U));
+        Assert::IsTrue(results.ContainsAddress(1U));
+        Assert::IsTrue(results.ContainsAddress(2U));
+        Assert::IsTrue(results.ContainsAddress(3U));
+        Assert::IsFalse(results.ContainsAddress(4U));
+
+        // lower nibble always returned first
+        SearchResults::Result result;
+        Assert::IsTrue(results.GetMatchingAddress(0U, result));
+        Assert::AreEqual(1U, result.nAddress);
+        Assert::AreEqual(ComparisonVariableSize::Nibble_Lower, result.nSize);
+        Assert::AreEqual(0x2U, result.nValue);
+
+        Assert::IsTrue(results.GetMatchingAddress(1U, result));
+        Assert::AreEqual(1U, result.nAddress);
+        Assert::AreEqual(ComparisonVariableSize::Nibble_Upper, result.nSize);
+        Assert::AreEqual(0x1U, result.nValue);
+
+        Assert::IsTrue(results.GetMatchingAddress(2U, result));
+        Assert::AreEqual(2U, result.nAddress);
+        Assert::AreEqual(ComparisonVariableSize::Nibble_Lower, result.nSize);
+        Assert::AreEqual(0x4U, result.nValue);
+
+        Assert::IsTrue(results.GetMatchingAddress(3U, result));
+        Assert::AreEqual(2U, result.nAddress);
+        Assert::AreEqual(ComparisonVariableSize::Nibble_Upper, result.nSize);
+        Assert::AreEqual(0x3U, result.nValue);
+
+        Assert::IsTrue(results.GetMatchingAddress(4U, result));
+        Assert::AreEqual(3U, result.nAddress);
+        Assert::AreEqual(ComparisonVariableSize::Nibble_Lower, result.nSize);
+        Assert::AreEqual(0xBU, result.nValue);
+
+        Assert::IsTrue(results.GetMatchingAddress(5U, result));
+        Assert::AreEqual(3U, result.nAddress);
+        Assert::AreEqual(ComparisonVariableSize::Nibble_Upper, result.nSize);
+        Assert::AreEqual(0xAU, result.nValue);
+    }
+
+    TEST_METHOD(TestInitializeFromMemorySixteenBitBounded)
+    {
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        SearchResults results;
+        results.Initialize(1U, 8U, ComparisonVariableSize::SixteenBit);
+
+        Assert::AreEqual(3U, results.MatchingAddressCount());
+        Assert::AreEqual(std::string("Cleared: (16-bit) mode. Aware of 3 RAM locations."), results.Summary());
+
+        Assert::IsFalse(results.ContainsAddress(0U));
+        Assert::IsTrue(results.ContainsAddress(1U));
+        Assert::IsTrue(results.ContainsAddress(2U));
+        Assert::IsTrue(results.ContainsAddress(3U));
+        Assert::IsFalse(results.ContainsAddress(4U));
+
+        SearchResults::Result result;
+        Assert::IsTrue(results.GetMatchingAddress(0U, result));
+        Assert::AreEqual(1U, result.nAddress);
+        Assert::AreEqual(ComparisonVariableSize::SixteenBit, result.nSize);
+        Assert::AreEqual(0x3412U, result.nValue);
+
+        Assert::IsTrue(results.GetMatchingAddress(1U, result));
+        Assert::AreEqual(2U, result.nAddress);
+        Assert::AreEqual(ComparisonVariableSize::SixteenBit, result.nSize);
+        Assert::AreEqual(0xAB34U, result.nValue);
+
+        Assert::IsTrue(results.GetMatchingAddress(2U, result));
+        Assert::AreEqual(3U, result.nAddress);
+        Assert::AreEqual(ComparisonVariableSize::SixteenBit, result.nSize);
+        Assert::AreEqual(0x56ABU, result.nValue);
+    }
+
+    TEST_METHOD(TestInitializeFromResultsEightBitEqualsConstant)
+    {
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        SearchResults results1;
+        results1.Initialize(1U, 3U, ComparisonVariableSize::EightBit);
+        Assert::AreEqual(3U, results1.MatchingAddressCount());
+
+        SearchResults results;
+        results.Initialize(results1, ComparisonType::Equals, 0xABU);
+        Assert::AreEqual(std::string("Filtering for EQUAL 171..."), results.Summary());
+
+        Assert::AreEqual(1U, results.MatchingAddressCount());
+        Assert::IsFalse(results.ContainsAddress(0U));
+        Assert::IsFalse(results.ContainsAddress(1U));
+        Assert::IsFalse(results.ContainsAddress(2U));
+        Assert::IsTrue(results.ContainsAddress(3U));
+        Assert::IsFalse(results.ContainsAddress(4U));
+
+        SearchResults::Result result;
+        Assert::IsTrue(results.GetMatchingAddress(0U, result));
+        Assert::AreEqual(3U, result.nAddress);
+        Assert::AreEqual(ComparisonVariableSize::EightBit, result.nSize);
+        Assert::AreEqual(0xABU, result.nValue);
+    }
+
+    TEST_METHOD(TestInitializeFromResultsEightBitNotEqualsConstant)
+    {
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        SearchResults results1;
+        results1.Initialize(1U, 3U, ComparisonVariableSize::EightBit);
+        Assert::AreEqual(3U, results1.MatchingAddressCount());
+
+        SearchResults results;
+        results.Initialize(results1, ComparisonType::NotEqualTo, 0xABU);
+        Assert::AreEqual(std::string("Filtering for NOT EQUAL 171..."), results.Summary());
+
+        Assert::AreEqual(2U, results.MatchingAddressCount());
+        Assert::IsFalse(results.ContainsAddress(0U));
+        Assert::IsTrue(results.ContainsAddress(1U));
+        Assert::IsTrue(results.ContainsAddress(2U));
+        Assert::IsFalse(results.ContainsAddress(3U));
+        Assert::IsFalse(results.ContainsAddress(4U));
+
+        SearchResults::Result result;
+        Assert::IsTrue(results.GetMatchingAddress(0U, result));
+        Assert::AreEqual(1U, result.nAddress);
+        Assert::AreEqual(ComparisonVariableSize::EightBit, result.nSize);
+        Assert::AreEqual(0x12U, result.nValue);
+
+        Assert::IsTrue(results.GetMatchingAddress(1U, result));
+        Assert::AreEqual(2U, result.nAddress);
+        Assert::AreEqual(ComparisonVariableSize::EightBit, result.nSize);
+        Assert::AreEqual(0x34U, result.nValue);
+    }
+
+    TEST_METHOD(TestInitializeFromResultsEightBitNotEqualsConstantGap)
+    {
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        SearchResults results1;
+        results1.Initialize(1U, 3U, ComparisonVariableSize::EightBit);
+        Assert::AreEqual(3U, results1.MatchingAddressCount());
+
+        SearchResults results;
+        results.Initialize(results1, ComparisonType::NotEqualTo, 0x34U);
+        Assert::AreEqual(std::string("Filtering for NOT EQUAL 52..."), results.Summary());
+
+        Assert::AreEqual(2U, results.MatchingAddressCount());
+        Assert::IsFalse(results.ContainsAddress(0U));
+        Assert::IsTrue(results.ContainsAddress(1U));
+        Assert::IsFalse(results.ContainsAddress(2U));
+        Assert::IsTrue(results.ContainsAddress(3U));
+        Assert::IsFalse(results.ContainsAddress(4U));
+
+        SearchResults::Result result;
+        Assert::IsTrue(results.GetMatchingAddress(0U, result));
+        Assert::AreEqual(1U, result.nAddress);
+        Assert::AreEqual(ComparisonVariableSize::EightBit, result.nSize);
+        Assert::AreEqual(0x12U, result.nValue);
+
+        Assert::IsTrue(results.GetMatchingAddress(1U, result));
+        Assert::AreEqual(3U, result.nAddress);
+        Assert::AreEqual(ComparisonVariableSize::EightBit, result.nSize);
+        Assert::AreEqual(0xABU, result.nValue);
+    }
+
+    TEST_METHOD(TestInitializeFromResultsEightBitGreaterThanConstant)
+    {
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        SearchResults results1;
+        results1.Initialize(1U, 3U, ComparisonVariableSize::EightBit);
+        Assert::AreEqual(3U, results1.MatchingAddressCount());
+
+        SearchResults results;
+        results.Initialize(results1, ComparisonType::GreaterThan, 0x34U);
+        Assert::AreEqual(std::string("Filtering for GREATER THAN 52..."), results.Summary());
+
+        Assert::AreEqual(1U, results.MatchingAddressCount());
+        Assert::IsFalse(results.ContainsAddress(0U));
+        Assert::IsFalse(results.ContainsAddress(1U));
+        Assert::IsFalse(results.ContainsAddress(2U));
+        Assert::IsTrue(results.ContainsAddress(3U));
+        Assert::IsFalse(results.ContainsAddress(4U));
+
+        SearchResults::Result result;
+        Assert::IsTrue(results.GetMatchingAddress(0U, result));
+        Assert::AreEqual(3U, result.nAddress);
+        Assert::AreEqual(ComparisonVariableSize::EightBit, result.nSize);
+        Assert::AreEqual(0xABU, result.nValue);
+    }
+
+    TEST_METHOD(TestInitializeFromResultsEightBitGreaterThanOrEqualConstant)
+    {
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        SearchResults results1;
+        results1.Initialize(1U, 3U, ComparisonVariableSize::EightBit);
+        Assert::AreEqual(3U, results1.MatchingAddressCount());
+
+        SearchResults results;
+        results.Initialize(results1, ComparisonType::GreaterThanOrEqual, 0x34U);
+        Assert::AreEqual(std::string("Filtering for GREATER THAN/EQUAL 52..."), results.Summary());
+
+        Assert::AreEqual(2U, results.MatchingAddressCount());
+        Assert::IsFalse(results.ContainsAddress(0U));
+        Assert::IsFalse(results.ContainsAddress(1U));
+        Assert::IsTrue(results.ContainsAddress(2U));
+        Assert::IsTrue(results.ContainsAddress(3U));
+        Assert::IsFalse(results.ContainsAddress(4U));
+
+        SearchResults::Result result;
+        Assert::IsTrue(results.GetMatchingAddress(0U, result));
+        Assert::AreEqual(2U, result.nAddress);
+        Assert::AreEqual(ComparisonVariableSize::EightBit, result.nSize);
+        Assert::AreEqual(0x34U, result.nValue);
+
+        Assert::IsTrue(results.GetMatchingAddress(1U, result));
+        Assert::AreEqual(3U, result.nAddress);
+        Assert::AreEqual(ComparisonVariableSize::EightBit, result.nSize);
+        Assert::AreEqual(0xABU, result.nValue);
+    }
+
+    TEST_METHOD(TestInitializeFromResultsEightBitLessThanConstant)
+    {
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        SearchResults results1;
+        results1.Initialize(1U, 3U, ComparisonVariableSize::EightBit);
+        Assert::AreEqual(3U, results1.MatchingAddressCount());
+
+        SearchResults results;
+        results.Initialize(results1, ComparisonType::LessThan, 0x34U);
+        Assert::AreEqual(std::string("Filtering for LESS THAN 52..."), results.Summary());
+
+        Assert::AreEqual(1U, results.MatchingAddressCount());
+        Assert::IsFalse(results.ContainsAddress(0U));
+        Assert::IsTrue(results.ContainsAddress(1U));
+        Assert::IsFalse(results.ContainsAddress(2U));
+        Assert::IsFalse(results.ContainsAddress(3U));
+        Assert::IsFalse(results.ContainsAddress(4U));
+
+        SearchResults::Result result;
+        Assert::IsTrue(results.GetMatchingAddress(0U, result));
+        Assert::AreEqual(1U, result.nAddress);
+        Assert::AreEqual(ComparisonVariableSize::EightBit, result.nSize);
+        Assert::AreEqual(0x12U, result.nValue);
+    }
+
+    TEST_METHOD(TestInitializeFromResultsEightBitLessThanOrEqualConstant)
+    {
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        SearchResults results1;
+        results1.Initialize(1U, 3U, ComparisonVariableSize::EightBit);
+        Assert::AreEqual(3U, results1.MatchingAddressCount());
+
+        SearchResults results;
+        results.Initialize(results1, ComparisonType::LessThanOrEqual, 0x34U);
+        Assert::AreEqual(std::string("Filtering for LESS THAN/EQUAL 52..."), results.Summary());
+
+        Assert::AreEqual(2U, results.MatchingAddressCount());
+        Assert::IsFalse(results.ContainsAddress(0U));
+        Assert::IsTrue(results.ContainsAddress(1U));
+        Assert::IsTrue(results.ContainsAddress(2U));
+        Assert::IsFalse(results.ContainsAddress(3U));
+        Assert::IsFalse(results.ContainsAddress(4U));
+
+        SearchResults::Result result;
+        Assert::IsTrue(results.GetMatchingAddress(0U, result));
+        Assert::AreEqual(1U, result.nAddress);
+        Assert::AreEqual(ComparisonVariableSize::EightBit, result.nSize);
+        Assert::AreEqual(0x12U, result.nValue);
+
+        Assert::IsTrue(results.GetMatchingAddress(1U, result));
+        Assert::AreEqual(2U, result.nAddress);
+        Assert::AreEqual(ComparisonVariableSize::EightBit, result.nSize);
+        Assert::AreEqual(0x34U, result.nValue);
+    }
+
+    TEST_METHOD(TestInitializeFromResultsEightBitEqualsConstantModified)
+    {
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        SearchResults results1;
+        results1.Initialize(1U, 3U, ComparisonVariableSize::EightBit);
+        Assert::AreEqual(3U, results1.MatchingAddressCount());
+
+        // swap bytes 1 and 3, match should be found at address 1, not address 3
+        memory[1] = 0xAB;
+        memory[3] = 0x12;
+        SearchResults results;
+        results.Initialize(results1, ComparisonType::Equals, 0xABU);
+        Assert::AreEqual(std::string("Filtering for EQUAL 171..."), results.Summary());
+
+        Assert::AreEqual(1U, results.MatchingAddressCount());
+        Assert::IsFalse(results.ContainsAddress(0U));
+        Assert::IsTrue(results.ContainsAddress(1U));
+        Assert::IsFalse(results.ContainsAddress(2U));
+        Assert::IsFalse(results.ContainsAddress(3U));
+        Assert::IsFalse(results.ContainsAddress(4U));
+
+        SearchResults::Result result;
+        Assert::IsTrue(results.GetMatchingAddress(0U, result));
+        Assert::AreEqual(1U, result.nAddress);
+        Assert::AreEqual(ComparisonVariableSize::EightBit, result.nSize);
+        Assert::AreEqual(0xABU, result.nValue);
+    }
+
+    TEST_METHOD(TestInitializeFromResultsEightBitNotEqualsPrevious)
+    {
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        SearchResults results1;
+        results1.Initialize(1U, 3U, ComparisonVariableSize::EightBit);
+        Assert::AreEqual(3U, results1.MatchingAddressCount());
+
+        memory[1] = 0x14;
+        memory[2] = 0x55;
+        SearchResults results;
+        results.Initialize(results1, ComparisonType::NotEqualTo);
+        Assert::AreEqual(std::string("Filtering for NOT EQUAL last known value..."), results.Summary());
+
+        Assert::AreEqual(2U, results.MatchingAddressCount());
+        Assert::IsFalse(results.ContainsAddress(0U));
+        Assert::IsTrue(results.ContainsAddress(1U));
+        Assert::IsTrue(results.ContainsAddress(2U));
+        Assert::IsFalse(results.ContainsAddress(3U));
+        Assert::IsFalse(results.ContainsAddress(4U));
+
+        SearchResults::Result result;
+        Assert::IsTrue(results.GetMatchingAddress(0U, result));
+        Assert::AreEqual(1U, result.nAddress);
+        Assert::AreEqual(ComparisonVariableSize::EightBit, result.nSize);
+        Assert::AreEqual(0x14U, result.nValue);
+
+        Assert::IsTrue(results.GetMatchingAddress(1U, result));
+        Assert::AreEqual(2U, result.nAddress);
+        Assert::AreEqual(ComparisonVariableSize::EightBit, result.nSize);
+        Assert::AreEqual(0x55U, result.nValue);
+    }
+
+    TEST_METHOD(TestInitializeFromResultsSixteenBitNotEqualPrevious)
+    {
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        SearchResults results1;
+        results1.Initialize(1U, 4U, ComparisonVariableSize::SixteenBit);
+        Assert::AreEqual(3U, results1.MatchingAddressCount());
+
+        memory[2] = 0x55;
+        SearchResults results;
+        results.Initialize(results1, ComparisonType::NotEqualTo);
+        Assert::AreEqual(std::string("Filtering for NOT EQUAL last known value..."), results.Summary());
+
+        Assert::AreEqual(2U, results.MatchingAddressCount());
+        Assert::IsFalse(results.ContainsAddress(0U));
+        Assert::IsTrue(results.ContainsAddress(1U));
+        Assert::IsTrue(results.ContainsAddress(2U));
+        Assert::IsFalse(results.ContainsAddress(3U));
+
+        SearchResults::Result result;
+        Assert::IsTrue(results.GetMatchingAddress(0U, result));
+        Assert::AreEqual(1U, result.nAddress);
+        Assert::AreEqual(ComparisonVariableSize::SixteenBit, result.nSize);
+        Assert::AreEqual(0x5512U, result.nValue);
+
+        Assert::IsTrue(results.GetMatchingAddress(1U, result));
+        Assert::AreEqual(2U, result.nAddress);
+        Assert::AreEqual(ComparisonVariableSize::SixteenBit, result.nSize);
+        Assert::AreEqual(0xAB55U, result.nValue);
+    }
+
+    TEST_METHOD(TestInitializeFromResultsFourBitNotEqualsPrevious)
+    {
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        SearchResults results1;
+        results1.Initialize(1U, 3U, ComparisonVariableSize::Nibble_Lower);
+        Assert::AreEqual(6U, results1.MatchingAddressCount());
+
+        memory[1] = 0x14;
+        memory[2] = 0x55;
+        SearchResults results;
+        results.Initialize(results1, ComparisonType::NotEqualTo);
+        Assert::AreEqual(std::string("Filtering for NOT EQUAL last known value..."), results.Summary());
+
+        Assert::AreEqual(3U, results.MatchingAddressCount());
+        Assert::IsFalse(results.ContainsAddress(0U));
+        Assert::IsTrue(results.ContainsAddress(1U));
+        Assert::IsTrue(results.ContainsAddress(2U));
+        Assert::IsFalse(results.ContainsAddress(3U));
+        Assert::IsFalse(results.ContainsAddress(4U));
+
+        SearchResults::Result result;
+        Assert::IsTrue(results.GetMatchingAddress(0U, result));
+        Assert::AreEqual(1U, result.nAddress);
+        Assert::AreEqual(ComparisonVariableSize::Nibble_Lower, result.nSize);
+        Assert::AreEqual(4U, result.nValue);
+
+        Assert::IsTrue(results.GetMatchingAddress(1U, result));
+        Assert::AreEqual(2U, result.nAddress);
+        Assert::AreEqual(ComparisonVariableSize::Nibble_Lower, result.nSize);
+        Assert::AreEqual(5U, result.nValue);
+
+        Assert::IsTrue(results.GetMatchingAddress(2U, result));
+        Assert::AreEqual(2U, result.nAddress);
+        Assert::AreEqual(ComparisonVariableSize::Nibble_Upper, result.nSize);
+        Assert::AreEqual(5U, result.nValue);
+    }
+
+    TEST_METHOD(TestExcludeAddressEightBit)
+    {
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        SearchResults results1;
+        results1.Initialize(1U, 3U, ComparisonVariableSize::EightBit);
+        Assert::AreEqual(3U, results1.MatchingAddressCount());
+
+        // exclude doesn't do anything to unfiltered results
+        results1.ExcludeAddress(1U);
+        Assert::AreEqual(3U, results1.MatchingAddressCount());
+
+        memory[1] = 0x14;
+        memory[2] = 0x55;
+        SearchResults results;
+        results.Initialize(results1, ComparisonType::NotEqualTo);
+        Assert::AreEqual(std::string("Filtering for NOT EQUAL last known value..."), results.Summary());
+
+        Assert::AreEqual(2U, results.MatchingAddressCount());
+        Assert::IsFalse(results.ContainsAddress(0U));
+        Assert::IsTrue(results.ContainsAddress(1U));
+        Assert::IsTrue(results.ContainsAddress(2U));
+        Assert::IsFalse(results.ContainsAddress(3U));
+        Assert::IsFalse(results.ContainsAddress(4U));
+
+        results.ExcludeAddress(1U);
+        Assert::AreEqual(1U, results.MatchingAddressCount());
+        Assert::IsFalse(results.ContainsAddress(0U));
+        Assert::IsFalse(results.ContainsAddress(1U));
+        Assert::IsTrue(results.ContainsAddress(2U));
+        Assert::IsFalse(results.ContainsAddress(3U));
+        Assert::IsFalse(results.ContainsAddress(4U));
+
+        SearchResults::Result result;
+        Assert::IsTrue(results.GetMatchingAddress(0U, result));
+        Assert::AreEqual(2U, result.nAddress);
+        Assert::AreEqual(ComparisonVariableSize::EightBit, result.nSize);
+        Assert::AreEqual(0x55U, result.nValue);
+    }
+
+    TEST_METHOD(TestExcludeMatchingAddressEightBit)
+    {
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        SearchResults results1;
+        results1.Initialize(1U, 3U, ComparisonVariableSize::EightBit);
+        Assert::AreEqual(3U, results1.MatchingAddressCount());
+
+        // exclude doesn't do anything to unfiltered results
+        results1.ExcludeMatchingAddress(0U);
+        Assert::AreEqual(3U, results1.MatchingAddressCount());
+
+        memory[1] = 0x14;
+        memory[2] = 0x55;
+        SearchResults results;
+        results.Initialize(results1, ComparisonType::NotEqualTo);
+        Assert::AreEqual(std::string("Filtering for NOT EQUAL last known value..."), results.Summary());
+
+        Assert::AreEqual(2U, results.MatchingAddressCount());
+        Assert::IsFalse(results.ContainsAddress(0U));
+        Assert::IsTrue(results.ContainsAddress(1U));
+        Assert::IsTrue(results.ContainsAddress(2U));
+        Assert::IsFalse(results.ContainsAddress(3U));
+        Assert::IsFalse(results.ContainsAddress(4U));
+
+        results.ExcludeMatchingAddress(0U);
+        Assert::AreEqual(1U, results.MatchingAddressCount());
+        Assert::IsFalse(results.ContainsAddress(0U));
+        Assert::IsFalse(results.ContainsAddress(1U));
+        Assert::IsTrue(results.ContainsAddress(2U));
+        Assert::IsFalse(results.ContainsAddress(3U));
+        Assert::IsFalse(results.ContainsAddress(4U));
+
+        SearchResults::Result result;
+        Assert::IsTrue(results.GetMatchingAddress(0U, result));
+        Assert::AreEqual(2U, result.nAddress);
+        Assert::AreEqual(ComparisonVariableSize::EightBit, result.nSize);
+        Assert::AreEqual(0x55U, result.nValue);
+    }
+
+    TEST_METHOD(TestInitializeFromMemoryEightBitLargeMemory)
+    {
+        std::unique_ptr<unsigned char> memory;
+        memory.reset(new unsigned char[BIG_BLOCK_SIZE]);
+        for (unsigned int i = 0; i < BIG_BLOCK_SIZE; ++i)
+            memory.get()[i] = (i % 256);
+        InitializeMemory(memory.get(), BIG_BLOCK_SIZE);
+
+        SearchResults results;
+        results.Initialize(0U, BIG_BLOCK_SIZE, ComparisonVariableSize::EightBit);
+
+        Assert::AreEqual(BIG_BLOCK_SIZE, results.MatchingAddressCount());
+        Assert::IsTrue(results.ContainsAddress(0U));
+        Assert::IsTrue(results.ContainsAddress(MAX_BLOCK_SIZE - 1));
+        Assert::IsTrue(results.ContainsAddress(MAX_BLOCK_SIZE));
+        Assert::IsTrue(results.ContainsAddress(BIG_BLOCK_SIZE - 1));
+        Assert::IsFalse(results.ContainsAddress(BIG_BLOCK_SIZE));
+
+        SearchResults::Result result;
+        Assert::IsTrue(results.GetMatchingAddress(MAX_BLOCK_SIZE - 1, result));
+        Assert::AreEqual(MAX_BLOCK_SIZE - 1, result.nAddress);
+        Assert::AreEqual(ComparisonVariableSize::EightBit, result.nSize);
+        Assert::AreEqual(0xFFU, result.nValue);
+
+        Assert::IsTrue(results.GetMatchingAddress(MAX_BLOCK_SIZE, result));
+        Assert::AreEqual(MAX_BLOCK_SIZE, result.nAddress);
+        Assert::AreEqual(ComparisonVariableSize::EightBit, result.nSize);
+        Assert::AreEqual(0x00U, result.nValue);
+
+        Assert::IsTrue(results.GetMatchingAddress(BIG_BLOCK_SIZE - 1, result));
+        Assert::AreEqual(BIG_BLOCK_SIZE - 1, result.nAddress);
+        Assert::AreEqual(ComparisonVariableSize::EightBit, result.nSize);
+        Assert::AreEqual(0xFFU, result.nValue);
+    }
+
+    TEST_METHOD(TestInitializeFromMemorySixteenBitLargeMemory)
+    {
+        std::unique_ptr<unsigned char> memory;
+        memory.reset(new unsigned char[BIG_BLOCK_SIZE]);
+        for (unsigned int i = 0; i < BIG_BLOCK_SIZE; ++i)
+            memory.get()[i] = (i % 256);
+        InitializeMemory(memory.get(), BIG_BLOCK_SIZE);
+
+        SearchResults results;
+        results.Initialize(0U, BIG_BLOCK_SIZE, ComparisonVariableSize::SixteenBit);
+
+        Assert::AreEqual(BIG_BLOCK_SIZE - 1, results.MatchingAddressCount());
+        Assert::IsTrue(results.ContainsAddress(0U));
+        Assert::IsTrue(results.ContainsAddress(MAX_BLOCK_SIZE - 1));
+        Assert::IsTrue(results.ContainsAddress(MAX_BLOCK_SIZE));
+        Assert::IsTrue(results.ContainsAddress(BIG_BLOCK_SIZE - 2));
+        Assert::IsFalse(results.ContainsAddress(BIG_BLOCK_SIZE - 1));
+
+        SearchResults::Result result;
+        Assert::IsTrue(results.GetMatchingAddress(MAX_BLOCK_SIZE - 1, result));
+        Assert::AreEqual(MAX_BLOCK_SIZE - 1, result.nAddress);
+        Assert::AreEqual(ComparisonVariableSize::SixteenBit, result.nSize);
+        Assert::AreEqual(0x00FFU, result.nValue);
+
+        Assert::IsTrue(results.GetMatchingAddress(MAX_BLOCK_SIZE, result));
+        Assert::AreEqual(MAX_BLOCK_SIZE, result.nAddress);
+        Assert::AreEqual(ComparisonVariableSize::SixteenBit, result.nSize);
+        Assert::AreEqual(0x0100U, result.nValue);
+
+        Assert::IsTrue(results.GetMatchingAddress(BIG_BLOCK_SIZE - 2, result));
+        Assert::AreEqual(BIG_BLOCK_SIZE - 2, result.nAddress);
+        Assert::AreEqual(ComparisonVariableSize::SixteenBit, result.nSize);
+        Assert::AreEqual(0xFFFEU, result.nValue);
+    }
+};
+
+} // namespace tests
+} // namespace services
+} // namespace ra

--- a/tests/base.props
+++ b/tests/base.props
@@ -5,7 +5,8 @@
     <RA_DIR>$(SolutionDir)</RA_DIR>
     <RapidJSON_IncludeDir>$(RA_DIR)rapidjson/include/</RapidJSON_IncludeDir>
     <RA_SourceDir>$(RA_DIR)src/</RA_SourceDir>
-    <RA_IncludePath>$(RA_DIR);$(RA_SourceDir);$(RapidJSON_IncludeDir)</RA_IncludePath>
+    <MSTest_IncludePath>$(VCInstallDir)UnitTest\include\</MSTest_IncludePath>
+    <RA_IncludePath>$(RA_DIR);$(RA_SourceDir);$(RapidJSON_IncludeDir);$(MSTest_IncludePath)</RA_IncludePath>
   </PropertyGroup>
   <PropertyGroup>
     <OutDir>$(SolutionDir)bin\$(Configuration)\</OutDir>
@@ -22,8 +23,7 @@
       <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <CompileAs>CompileAsCpp</CompileAs>
-      <AdditionalIncludeDirectories>
-      </AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(RA_IncludePath)</AdditionalIncludeDirectories>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <PostBuildEvent>

--- a/tests/mocks/MockFileSystem.hh
+++ b/tests/mocks/MockFileSystem.hh
@@ -1,0 +1,84 @@
+#ifndef RA_SERVICES_MOCK_FILESYSTEM_HH
+#define RA_SERVICES_MOCK_FILESYSTEM_HH
+#pragma once
+
+#include "services\IFileSystem.hh"
+#include "services\ServiceLocator.hh"
+#include "services\impl\StringTextReader.hh"
+#include "services\impl\StringTextWriter.hh"
+
+#include <map>
+
+namespace ra {
+namespace services {
+namespace mocks {
+
+class MockFileSystem : public IFileSystem
+{
+public:
+    MockFileSystem() noexcept 
+        : m_Override(this)
+    {
+    }
+
+    const std::wstring& BaseDirectory() const override { return m_sBaseDirectory; }
+    void SetBaseDirectory(const std::wstring& sBaseDirectory)
+    {
+        m_sBaseDirectory = sBaseDirectory;
+    }
+
+    bool DirectoryExists(const std::wstring& sDirectory) const override
+    {
+        assert(!"not implemented");
+        return false;
+    }
+
+    bool CreateDirectory(const std::wstring& sDirectory) const override
+    {
+        assert(!"not implemented");
+        return false;
+    }
+
+    void MockFile(const std::wstring& sPath, const std::string& sContents)
+    {
+        m_mFileContents[sPath] = sContents;
+    }
+
+    std::string& GetFileContents(const std::wstring& sPath)
+    {
+        auto pIter = m_mFileContents.find(sPath);
+        if (pIter != m_mFileContents.end())
+            return pIter->second;
+
+        static std::string sEmpty;
+        return sEmpty;
+    }
+
+    std::unique_ptr<TextReader> OpenTextFile(const std::wstring& sPath) const override
+    {
+        auto pIter = m_mFileContents.find(sPath);
+        if (pIter == m_mFileContents.end())
+            return std::unique_ptr<TextReader>();
+
+        auto pReader = std::make_unique<ra::services::impl::StringTextReader>(pIter->second);
+        return std::unique_ptr<TextReader>(pReader.release());
+    }
+
+    std::unique_ptr<TextWriter> CreateTextFile(const std::wstring& sPath) const override
+    {
+        std::string& sContents = m_mFileContents[sPath];
+        auto pWriter = std::make_unique<ra::services::impl::StringTextWriter>(sContents);
+        return std::unique_ptr<TextWriter>(pWriter.release());
+    }
+
+private:
+    ra::services::ServiceLocator::ServiceOverride<ra::services::IFileSystem> m_Override;
+    std::wstring m_sBaseDirectory = L".\\";
+    mutable std::map<std::wstring, std::string> m_mFileContents;
+};
+
+} // namespace mocks
+} // namespace services
+} // namespace ra
+
+#endif // !RA_SERVICES_MOCK_FILESYSTEM_HH

--- a/tests/services/JsonFileConfiguration_Tests.cpp
+++ b/tests/services/JsonFileConfiguration_Tests.cpp
@@ -1,0 +1,150 @@
+#include "CppUnitTest.h"
+
+#include "services\impl\JsonFileConfiguration.hh"
+
+#include "tests\RA_UnitTestHelpers.h"
+#include "tests\mocks\MockFileSystem.hh"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace ra {
+namespace services {
+namespace impl {
+namespace tests {
+
+TEST_CLASS(JsonFileConfiguration_Tests)
+{
+private:
+    std::wstring sFilename = L"prefs.json";
+
+public:
+    TEST_METHOD(TestUsername)
+    {
+        ra::services::mocks::MockFileSystem fileSystem;
+
+        // default
+        JsonFileConfiguration config;
+        Assert::AreEqual(std::string(""), config.GetUsername());
+
+        // no file
+        Assert::IsFalse(config.Load(sFilename));
+        Assert::AreEqual(std::string(""), config.GetUsername());
+
+        // no value provided
+        fileSystem.MockFile(sFilename, "{}");
+        Assert::IsTrue(config.Load(sFilename));
+        Assert::AreEqual(std::string(""), config.GetUsername());
+
+        // value provided
+        fileSystem.MockFile(sFilename, "{\"Username\":\"User\"}");
+        Assert::IsTrue(config.Load(sFilename));
+        Assert::AreEqual(std::string("User"), config.GetUsername());
+
+        // provide value
+        config.SetUsername("User2");
+        Assert::AreEqual(std::string("User2"), config.GetUsername());
+
+        // persist value
+        config.Save();
+        AssertContains(fileSystem.GetFileContents(sFilename), "\"Username\":\"User2\"");
+    }
+
+    TEST_METHOD(TestToken)
+    {
+        ra::services::mocks::MockFileSystem fileSystem;
+
+        // default
+        JsonFileConfiguration config;
+        Assert::AreEqual(std::string(""), config.GetApiToken());
+
+        // no file
+        Assert::IsFalse(config.Load(sFilename));
+        Assert::AreEqual(std::string(""), config.GetApiToken());
+
+        // no value provided
+        fileSystem.MockFile(sFilename, "{}");
+        Assert::IsTrue(config.Load(sFilename));
+        Assert::AreEqual(std::string(""), config.GetApiToken());
+
+        // value provided
+        fileSystem.MockFile(sFilename, "{\"Token\":\"API_TOKEN\"}");
+        Assert::IsTrue(config.Load(sFilename));
+        Assert::AreEqual(std::string("API_TOKEN"), config.GetApiToken());
+
+        // provide value
+        config.SetApiToken("TOKEN");
+        Assert::AreEqual(std::string("TOKEN"), config.GetApiToken());
+
+        // persist value
+        config.Save();
+        AssertContains(fileSystem.GetFileContents(sFilename), "\"Token\":\"TOKEN\"");
+    }
+
+    void TestFeature(ra::services::Feature nFeature, const std::string& sJsonKey, bool bDefault)
+    {
+        ra::services::mocks::MockFileSystem fileSystem;
+
+        // uninitialized
+        JsonFileConfiguration config;
+        Assert::IsFalse(config.IsFeatureEnabled(nFeature), L"default");
+
+        // no file
+        Assert::IsFalse(config.Load(sFilename));
+        Assert::AreEqual(bDefault, config.IsFeatureEnabled(nFeature), L"no file");
+
+        // no value provided
+        fileSystem.MockFile(sFilename, "{}");
+        Assert::IsTrue(config.Load(sFilename));
+        Assert::AreEqual(bDefault, config.IsFeatureEnabled(nFeature), L"empty file");
+
+        // value provided
+        std::string sJson = "{\"" + sJsonKey + "\":" + (bDefault ? "false" : "true") + "}";
+        fileSystem.MockFile(sFilename, sJson);
+        Assert::IsTrue(config.Load(sFilename));
+        Assert::AreEqual(!bDefault, config.IsFeatureEnabled(nFeature), L"value provided");
+
+        // provide value
+        config.SetFeatureEnabled(nFeature, bDefault);
+        Assert::AreEqual(bDefault, config.IsFeatureEnabled(nFeature), L"value set");
+
+        // persist value
+        config.Save();
+        sJson = "\"" + sJsonKey + "\":" + (bDefault ? "true" : "false");
+        AssertContains(fileSystem.GetFileContents(sFilename), sJson);
+    }
+
+    TEST_METHOD(TestHardcore)
+    {
+        TestFeature(ra::services::Feature::Hardcore, "Hardcore Active", true);
+    }
+
+    TEST_METHOD(TestLeaderboardsActive)
+    {
+        TestFeature(ra::services::Feature::Leaderboards, "Leaderboards Active", true);
+    }
+
+    TEST_METHOD(TestLeaderboardNotificationDisplay)
+    {
+        TestFeature(ra::services::Feature::LeaderboardNotifications, "Leaderboard Notification Display", true);
+    }
+
+    TEST_METHOD(TestLeaderboardCounterDisplay)
+    {
+        TestFeature(ra::services::Feature::LeaderboardCounters, "Leaderboard Counter Display", true);
+    }
+
+    TEST_METHOD(TestLeaderboardsScoreboardDisplay)
+    {
+        TestFeature(ra::services::Feature::LeaderboardScoreboards, "Leaderboard Scoreboard Display", true);
+    }
+
+    TEST_METHOD(TestPreferDecimal)
+    {
+        TestFeature(ra::services::Feature::PreferDecimal, "Prefer Decimal", false);
+    }
+};
+
+} // namespace tests
+} // namespace impl
+} // namespace services
+} // namespace ra

--- a/tests/services/SearchResults_Tests.cpp
+++ b/tests/services/SearchResults_Tests.cpp
@@ -1,7 +1,7 @@
 #include "CppUnitTest.h"
 
 #include "services\SearchResults.h"
-#include "RA_UnitTestHelpers.h"
+#include "tests\RA_UnitTestHelpers.h"
 
 #include <memory>
 

--- a/tests/services/StringTextReader_Tests.cpp
+++ b/tests/services/StringTextReader_Tests.cpp
@@ -1,0 +1,69 @@
+#include "CppUnitTest.h"
+
+#include "services\impl\StringTextReader.hh"
+#include "tests\RA_UnitTestHelpers.h"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace ra {
+namespace services {
+namespace impl {
+namespace tests {
+
+TEST_CLASS(StringTextReader_Tests)
+{
+public:
+    TEST_METHOD(TestEmpty)
+    {
+        StringTextReader reader(std::string(""));
+        std::string sLine;
+        Assert::IsFalse(reader.GetLine(sLine));
+    }
+
+    TEST_METHOD(TestOneLine)
+    {
+        StringTextReader reader(std::string("test"));
+        std::string sLine;
+        Assert::IsTrue(reader.GetLine(sLine));
+        Assert::AreEqual(std::string("test"), sLine);
+        Assert::IsFalse(reader.GetLine(sLine));
+    }
+
+    TEST_METHOD(TestOneLineWithLineEnding)
+    {
+        StringTextReader reader(std::string("test\r\n"));
+        std::string sLine;
+        Assert::IsTrue(reader.GetLine(sLine));
+        Assert::AreEqual(std::string("test"), sLine);
+        Assert::IsFalse(reader.GetLine(sLine));
+    }
+
+    TEST_METHOD(TestTwoLines)
+    {
+        StringTextReader reader(std::string("test\r\ntwo"));
+        std::string sLine;
+        Assert::IsTrue(reader.GetLine(sLine));
+        Assert::AreEqual(std::string("test"), sLine);
+        Assert::IsTrue(reader.GetLine(sLine));
+        Assert::AreEqual(std::string("two"), sLine);
+        Assert::IsFalse(reader.GetLine(sLine));
+    }
+
+    TEST_METHOD(TestThreeLinesEmptyMiddle)
+    {
+        StringTextReader reader(std::string("test\r\n\r\ntwo"));
+        std::string sLine;
+        Assert::IsTrue(reader.GetLine(sLine));
+        Assert::AreEqual(std::string("test"), sLine);
+        Assert::IsTrue(reader.GetLine(sLine));
+        Assert::AreEqual(std::string(""), sLine);
+        Assert::IsTrue(reader.GetLine(sLine));
+        Assert::AreEqual(std::string("two"), sLine);
+        Assert::IsFalse(reader.GetLine(sLine));
+    }
+};
+
+} // namespace tests
+} // namespace impl
+} // namespace services
+} // namespace ra

--- a/tests/services/StringTextWriter_Tests.cpp
+++ b/tests/services/StringTextWriter_Tests.cpp
@@ -1,0 +1,34 @@
+#include "CppUnitTest.h"
+
+#include "services\impl\StringTextWriter.hh"
+#include "tests\RA_UnitTestHelpers.h"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace ra {
+namespace services {
+namespace impl {
+namespace tests {
+
+TEST_CLASS(StringTextWriter_Tests)
+{
+public:
+    TEST_METHOD(TestEmpty)
+    {
+        StringTextWriter writer;
+        Assert::AreEqual(std::string(""), writer.GetString());
+    }
+
+    TEST_METHOD(TestWriteLine)
+    {
+        StringTextWriter writer;
+        writer.Write(std::string("Test"));
+        writer.Write(std::string("1\n"));
+        Assert::AreEqual(std::string("Test1\n"), writer.GetString());
+    }
+};
+
+} // namespace tests
+} // namespace impl
+} // namespace services
+} // namespace ra


### PR DESCRIPTION
I was looking back at earlier PRs and felt like the demacrofication felt proper now. The other PR was off-track and felt making a new one would be more efficient.

The other one had `715 additions and 357 deletions`. 
This one has `429 additions and 282 deletions`, which most are just prefixing `ra` everywhere (RA_AchievementOverlay.cpp is one of them).

Some other stuff changed as well, stuff around it that should were unchanged.

A test to see if a pointer satisfied the `NullablePointer` named requirement made for `ra::SafeDelete`; it was in the form of a `type_trait `(data contracts may happen in C++20, but it is a good learning experience).

There will be review comments explaining the above more specifically and other things that were too important to ignore.