### PR TITLE
URL-escape password before sending login request

### DIFF
--- a/src/RA_Dlg_Login.cpp
+++ b/src/RA_Dlg_Login.cpp
@@ -5,6 +5,11 @@
 #include "RA_httpthread.h"
 #include "RA_PopupWindows.h"
 
+#include <cctype>
+#include <iomanip>
+#include <sstream>
+#include <string>
+
 //static 
 BOOL RA_Dlg_Login::DoModalLogin()
 {
@@ -46,9 +51,32 @@ INT_PTR CALLBACK RA_Dlg_Login::RA_Dlg_LoginProc(HWND hDlg, UINT uMsg, WPARAM wPa
                         return TRUE;
                     }
 
+
+                    //URL-escape password so it gets sent to the server properly
+                    //https://stackoverflow.com/questions/154536/encode-decode-urls-in-c
+                    std::ostringstream escaped;
+                    escaped.fill('0');
+                    escaped << std::hex;
+
+                    const std::string &value = ra::Narrow(sPassEntry);
+                    for (std::string::const_iterator i = value.begin(), n = value.end(); i != n; ++i) {
+                        std::string::value_type c = (*i);
+
+                        // Keep alphanumeric and other accepted characters intact
+                        if (isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~') {
+                            escaped << c;
+                            continue;
+                        }
+
+                        // Any other characters are percent-encoded
+                        escaped << std::uppercase;
+                        escaped << '%' << std::setw(2) << int((unsigned char)c);
+                        escaped << std::nouppercase;
+                    }
+
                     PostArgs args;
                     args['u'] = ra::Narrow(sUserEntry);
-                    args['p'] = ra::Narrow(sPassEntry);		//	Plaintext password(!)
+                    args['p'] = escaped.str(); //Plaintext password(!)
 
                     rapidjson::Document doc;
                     if (RAWeb::DoBlockingRequest(RequestLogin, args, doc))


### PR DESCRIPTION
Fixes #114 

Basically just iterates through the password string and replaces it with a percent-encoded character if a non-valid character is found. Previously, if a password had any special characters outside of the range of valid URL characters, the login would just fail.