### PR TITLE
Track per-game playtime (locally)

### DIFF
--- a/src/RA_AchievementOverlay.cpp
+++ b/src/RA_AchievementOverlay.cpp
@@ -530,7 +530,7 @@ void AchievementOverlay::DrawAchievementsPage(HDC hDC, int nDX, int nDY, const R
 
     SelectFont(hDC, g_hFontDesc);
     SetTextColor(hDC, COL_TEXT_LOCKED);
-    TextOutA(hDC, nDX + nGameTitleX, nGameSubTitleY, sSubtitle.c_str(), sSubtitle.length());
+    TextOutA(hDC, nDX + nGameTitleX + 8, nGameSubTitleY, sSubtitle.c_str(), sSubtitle.length());
 
     const int nAchievementsToDraw = ((rcTarget.bottom - rcTarget.top) - 160) / nAchSpacing;
     if (nAchievementsToDraw > 0 && nNumberOfAchievements > 0)

--- a/src/RA_Integration.vcxproj
+++ b/src/RA_Integration.vcxproj
@@ -70,6 +70,7 @@
     <ClCompile Include="api\impl\ConnectedServer.cpp" />
     <ClCompile Include="api\impl\DisconnectedServer.cpp" />
     <ClCompile Include="api\impl\OfflineServer.cpp" />
+    <ClCompile Include="data\SessionTracker.cpp" />
     <ClCompile Include="md5.c" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='DebugUnicode|Win32'">Create</PrecompiledHeader>
@@ -146,7 +147,10 @@
     <ClInclude Include="api\IServer.hh" />
     <ClInclude Include="api\Login.hh" />
     <ClInclude Include="api\Logout.hh" />
+    <ClInclude Include="api\Ping.hh" />
+    <ClInclude Include="api\StartSession.hh" />
     <ClInclude Include="data\GameContext.hh" />
+    <ClInclude Include="data\SessionTracker.hh" />
     <ClInclude Include="Exports.hh" />
     <ClInclude Include="md5.h" />
     <ClInclude Include="pch.h" />

--- a/src/RA_Integration.vcxproj.filters
+++ b/src/RA_Integration.vcxproj.filters
@@ -324,6 +324,9 @@
     <ClCompile Include="ui\drawing\gdi\ImageRepository.cpp">
       <Filter>UI\Drawing\GDI</Filter>
     </ClCompile>
+    <ClCompile Include="data\SessionTracker.cpp">
+      <Filter>Data</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="md5.h">
@@ -628,6 +631,15 @@
     </ClInclude>
     <ClInclude Include="ui\drawing\gdi\ResourceRepository.hh">
       <Filter>UI\Drawing\GDI</Filter>
+    </ClInclude>
+    <ClInclude Include="data\SessionTracker.hh">
+      <Filter>Data</Filter>
+    </ClInclude>
+    <ClInclude Include="api\StartSession.hh">
+      <Filter>API</Filter>
+    </ClInclude>
+    <ClInclude Include="api\Ping.hh">
+      <Filter>API</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/RA_User.cpp
+++ b/src/RA_User.cpp
@@ -17,6 +17,7 @@
 #include "api\Login.hh"
 
 #include "data\GameContext.hh"
+#include "data\SessionTracker.hh"
 
 #include "services\IConfiguration.hh"
 #include "services\ServiceLocator.hh"
@@ -153,6 +154,9 @@ void LocalRAUser::ProcessSuccessfulLogin(const std::string& sUser, const std::st
     g_AchievementEditorDialog.OnLoad_NewRom();
     g_AchievementOverlay.OnLoad_NewRom();
 
+    auto& pSessionTracker = ra::services::ServiceLocator::GetMutable<ra::data::SessionTracker>();
+    pSessionTracker.Initialize(sUser);
+
     RA_RebuildMenu();
     _RA_UpdateAppTitle();
 }
@@ -213,31 +217,6 @@ RAUser* LocalRAUser::AddFriend(const std::string& sUser, unsigned int nScore)
         m_aFriends.push_back(pUser);
 
     return pUser;
-}
-
-void LocalRAUser::PostActivity(ActivityType nActivityType)
-{
-    switch (nActivityType)
-    {
-        case PlayerStartedPlaying:
-        {
-            const auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::GameContext>();
-
-            PostArgs args;
-            args['u'] = Username();
-            args['t'] = Token();
-            args['a'] = std::to_string(nActivityType);
-            args['m'] = std::to_string(pGameContext.GameId());
-
-            RAWeb::CreateThreadedHTTPRequest(RequestPostActivity, args);
-            break;
-        }
-
-        default:
-            //	unhandled
-            ASSERT(!"User isn't designed to handle posting this activity!");
-            break;
-    }
 }
 
 void LocalRAUser::Clear()

--- a/src/RA_User.h
+++ b/src/RA_User.h
@@ -18,16 +18,6 @@ typedef struct
 
 class RequestObject;
 
-enum ActivityType
-{
-    ActivityTypeUnknown = 0,	//	DO NOT USE
-    PlayerEarnedAchievement,	//	DO NOT USE: handled at PHP level
-    PlayerLoggedIn,				//	DO NOT USE: handled at PHP level
-    PlayerStartedPlaying,
-    UserUploadedAchievement,
-    UserModifiedAchievement,
-};
-
 
 class RAUser
 {
@@ -59,7 +49,6 @@ public:
     void AttemptLogin(bool bBlocking);
 
     void AttemptSilentLogin();
-    void HandleSilentLoginResponse(rapidjson::Document& doc);
 
     void ProcessSuccessfulLogin(const std::string& sUser, const std::string& sToken, unsigned int nPoints, unsigned int nMessages, BOOL bRememberLogin);
     void Logout();
@@ -77,8 +66,6 @@ public:
     const std::string& Token() const { return m_sToken; }
 
     BOOL IsLoggedIn() const { return m_bIsLoggedIn; }
-
-    void PostActivity(ActivityType nActivityType);
 
     void Clear();
 

--- a/src/RA_httpthread.cpp
+++ b/src/RA_httpthread.cpp
@@ -36,8 +36,6 @@ const char* RequestTypeToString[] =
     "RequestAllProgress",
     "RequestGameID",
 
-    "RequestPing",
-    "RequestPostActivity",
     "RequestSubmitAwardAchievement",
     "RequestSubmitCodeNote",
     "RequestSubmitLeaderboardEntry",
@@ -65,8 +63,6 @@ const char* RequestTypeToPost[] =
     "allprogress",
     "gameid",
 
-    "ping",
-    "postactivity",
     "awardachievement",
     "submitcodenote",
     "submitlbentry",
@@ -97,8 +93,6 @@ HttpResults RAWeb::ms_LastHttpResults;
 time_t RAWeb::ms_tSendNextKeepAliveAt = time(nullptr);
 
 std::wstring RAWeb::m_sUserAgent = ra::Widen("RetroAchievements Toolkit " RA_INTEGRATION_VERSION_PRODUCT);
-
-const int SERVER_PING_FREQUENCY = 2 * 60; // seconds between server pings
 
 BOOL RequestObject::ParseResponseToJSON(rapidjson::Document& rDocOut)
 {
@@ -394,73 +388,6 @@ void RAWeb::CreateThreadedHTTPRequest(RequestType nType, const PostArgs& PostDat
 
         pObj->SetResponse(sResponse);
         ms_LastHttpResults.PushItem(pObj);
-    });
-}
-
-//////////////////////////////////////////////////////////////////////////
-
-static void DoSendKeepAlive(unsigned int nGameId)
-{
-    if (!RAUsers::LocalUser().IsLoggedIn())
-        return;
-
-    const auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::GameContext>();
-    if (pGameContext.GameId() != nGameId)
-        return;
-
-    // schedule the next ping
-    ra::services::ServiceLocator::GetMutable<ra::services::IThreadPool>().ScheduleAsync(std::chrono::seconds(SERVER_PING_FREQUENCY), [nGameId]()
-    {
-        DoSendKeepAlive(nGameId);
-    });
-
-    PostArgs args;
-    args['u'] = RAUsers::LocalUser().Username();
-    args['t'] = RAUsers::LocalUser().Token();
-    args['g'] = std::to_string(pGameContext.GameId());
-
-    if (RA_GameIsActive())
-    {
-        if (g_MemoryDialog.IsActive() || g_AchievementEditorDialog.IsActive() || g_MemBookmarkDialog.IsActive())
-        {
-            if (!g_pActiveAchievements || g_pActiveAchievements->NumAchievements() == 0)
-                args['m'] = "Developing Achievements";
-            else if (_RA_HardcoreModeIsActive())
-                args['m'] = "Inspecting Memory in Hardcore mode";
-            else if (g_nActiveAchievementSet == AchievementSet::Type::Core)
-                args['m'] = "Fixing Achievements";
-            else
-                args['m'] = "Developing Achievements";
-        }
-        else
-        {
-            const auto sRPResponse = pGameContext.GetRichPresenceDisplayString();
-            if (pGameContext.HasRichPresence() && !sRPResponse.empty())
-                args['m'] = ra::Narrow(sRPResponse);
-            else if (g_pActiveAchievements && g_pActiveAchievements->NumAchievements() > 0)
-                args['m'] = "Earning Achievements";
-            else
-                args['m'] = "Playing " + ra::Narrow(pGameContext.GameTitle());
-        }
-    }
-
-    //  Scott: Temporarily removed; Ping and RP are merged at current
-    //   and if we don't constantly poll the server, the players are dropped
-    //   from 'currently playing'.
-    //if (args['m'] != PrevArgs['m'] || args['g'] != PrevArgs['g'])
-    {
-        std::string sResponse;
-        RAWeb::DoBlockingRequest(RequestPing, args, sResponse);
-    }
-}
-
-void RAWeb::StartKeepAlive()
-{
-    const auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::GameContext>();
-    int nGameId = pGameContext.GameId();
-    ra::services::ServiceLocator::GetMutable<ra::services::IThreadPool>().ScheduleAsync(std::chrono::seconds(SERVER_PING_FREQUENCY), [nGameId]()
-    {
-        DoSendKeepAlive(nGameId);
     });
 }
 

--- a/src/RA_httpthread.h
+++ b/src/RA_httpthread.h
@@ -34,8 +34,6 @@ enum RequestType
     RequestGameID,
 
     //	Submit
-    RequestPing,
-    RequestPostActivity,
     RequestSubmitAwardAchievement,
     RequestSubmitCodeNote,
     RequestSubmitLeaderboardEntry,
@@ -111,8 +109,6 @@ public:
     static BOOL DoBlockingRequest(RequestType nType, const PostArgs& PostData, std::string& ResponseOut);
 
     static BOOL DoBlockingImageUpload(UploadType nType, const std::string& sFilename, rapidjson::Document& ResponseOut);
-
-    static void StartKeepAlive();
 
     static HANDLE Mutex() { return ms_hHTTPMutex; }
     static RequestObject* PopNextHttpResult() { return ms_LastHttpResults.PopNextItem(); }

--- a/src/api/ApiCall.cpp
+++ b/src/api/ApiCall.cpp
@@ -22,5 +22,15 @@ Logout::Response Logout::Request::Call() const noexcept
     return Server().Logout(*this);
 }
 
+StartSession::Response StartSession::Request::Call() const noexcept
+{
+    return Server().StartSession(*this);
+}
+
+Ping::Response Ping::Request::Call() const noexcept
+{
+    return Server().Ping(*this);
+}
+
 } // namespace api
 } // namespace ra

--- a/src/api/IServer.hh
+++ b/src/api/IServer.hh
@@ -4,6 +4,8 @@
 
 #include "api/Login.hh"
 #include "api/Logout.hh"
+#include "api/Ping.hh"
+#include "api/StartSession.hh"
 
 namespace ra {
 namespace api {
@@ -17,6 +19,8 @@ public:
 
     virtual Login::Response Login(const Login::Request& request) noexcept = 0;
     virtual Logout::Response Logout(const Logout::Request& request) noexcept = 0;
+    virtual StartSession::Response StartSession(const StartSession::Request& request) noexcept = 0;
+    virtual Ping::Response Ping(const Ping::Request& request) noexcept = 0;
 
 protected:
     IServer() noexcept = default;

--- a/src/api/Ping.hh
+++ b/src/api/Ping.hh
@@ -19,7 +19,7 @@ public:
     struct Request : ApiRequestBase
     {
         unsigned int GameId;
-        std::wstring RichPresence;
+        std::wstring CurrentActivity;
 
         using Callback = std::function<void(const Response& response)>;
 

--- a/src/api/Ping.hh
+++ b/src/api/Ping.hh
@@ -1,0 +1,38 @@
+#ifndef RA_API_PING_HH
+#define RA_API_PING_HH
+#pragma once
+
+#include "ApiCall.hh"
+
+namespace ra {
+namespace api {
+
+class Ping
+{
+public:
+    static constexpr const char* const Name() noexcept { return "Ping"; }
+
+    struct Response : ApiResponseBase
+    {
+    };
+
+    struct Request : ApiRequestBase
+    {
+        unsigned int GameId;
+        std::wstring RichPresence;
+
+        using Callback = std::function<void(const Response& response)>;
+
+        Response Call() const noexcept;
+
+        void CallAsync(Callback&& callback) const
+        {
+            ApiRequestBase::CallAsync<Request, Callback>(*this, std::move(callback));
+        }
+    };
+};
+
+} // namespace api
+} // namespace ra
+
+#endif // !RA_API_PING_HH

--- a/src/api/StartSession.hh
+++ b/src/api/StartSession.hh
@@ -1,0 +1,37 @@
+#ifndef RA_API_START_SESSION_HH
+#define RA_API_START_SESSION_HH
+#pragma once
+
+#include "ApiCall.hh"
+
+namespace ra {
+namespace api {
+
+class StartSession
+{
+public:
+    static constexpr const char* const Name() noexcept { return "StartSession"; }
+
+    struct Response : ApiResponseBase
+    {
+    };
+
+    struct Request : ApiRequestBase
+    {
+        unsigned int GameId{ 0U };
+
+        using Callback = std::function<void(const Response& response)>;
+
+        Response Call() const noexcept;
+
+        void CallAsync(Callback&& callback) const
+        {
+            ApiRequestBase::CallAsync<Request, Callback>(*this, std::move(callback));
+        }
+    };
+};
+
+} // namespace api
+} // namespace ra
+
+#endif // !RA_API_START_SESSION_HH

--- a/src/api/impl/ConnectedServer.cpp
+++ b/src/api/impl/ConnectedServer.cpp
@@ -32,16 +32,12 @@ _NODISCARD static bool GetJson(_In_ const char* sApiName, _In_ const ra::service
 {
     if (HandleHttpError(httpResponse, pResponse))
     {
-        pDocument.Clear();
-
         RA_LOG_ERR("-- %s: %s", sApiName, pResponse.ErrorMessage.c_str());
         return false;
     }
 
     if (httpResponse.Content().empty())
     {
-        pDocument.Clear();
-
         RA_LOG_ERR("-- %s: Empty JSON response", sApiName);
         pResponse.Result = ApiResult::Failed;
         pResponse.ErrorMessage = "Empty JSON response";
@@ -209,8 +205,8 @@ Ping::Response ConnectedServer::Ping(_UNUSED const Ping::Request& request) noexc
     std::string sPostData;
 
     AppendUrlParam(sPostData, "g", std::to_string(request.GameId));
-    if (!request.RichPresence.empty())
-        AppendUrlParam(sPostData, "m", ra::Narrow(request.RichPresence));
+    if (!request.CurrentActivity.empty())
+        AppendUrlParam(sPostData, "m", ra::Narrow(request.CurrentActivity));
 
     if (DoRequest(m_sHost, Ping::Name(), "ping", sPostData, response, document))
         response.Result = ApiResult::Success;

--- a/src/api/impl/ConnectedServer.cpp
+++ b/src/api/impl/ConnectedServer.cpp
@@ -32,12 +32,16 @@ _NODISCARD static bool GetJson(_In_ const char* sApiName, _In_ const ra::service
 {
     if (HandleHttpError(httpResponse, pResponse))
     {
+        pDocument.SetArray();
+
         RA_LOG_ERR("-- %s: %s", sApiName, pResponse.ErrorMessage.c_str());
         return false;
     }
 
     if (httpResponse.Content().empty())
     {
+        pDocument.SetArray();
+
         RA_LOG_ERR("-- %s: Empty JSON response", sApiName);
         pResponse.Result = ApiResult::Failed;
         pResponse.ErrorMessage = "Empty JSON response";

--- a/src/api/impl/ConnectedServer.cpp
+++ b/src/api/impl/ConnectedServer.cpp
@@ -3,6 +3,8 @@
 #include "DisconnectedServer.hh"
 #include "RA_Defs.h"
 
+#include "RA_User.h"
+
 #include "services\Http.hh"
 #include "services\ServiceLocator.hh"
 
@@ -152,6 +154,67 @@ Logout::Response ConnectedServer::Logout(_UNUSED const Logout::Request& request)
 
     Logout::Response response;
     response.Result = ApiResult::Success;
+    return std::move(response);
+}
+
+static bool DoRequest(const std::string& sHost, const char* sApiName, const char* sRequestName, const std::string& sInputParams, ApiResponseBase& pResponse, rapidjson::Document& document)
+{
+    std::string sPostData;
+
+#ifndef RA_UTEST
+    AppendUrlParam(sPostData, "u", RAUsers::LocalUser().Username());
+    AppendUrlParam(sPostData, "t", RAUsers::LocalUser().Token());
+#endif
+    AppendUrlParam(sPostData, "r", sRequestName);
+    if (!sInputParams.empty())
+    {
+        sPostData.push_back('&');
+        sPostData.append(sInputParams);
+    }
+    RA_LOG_INFO("%s Request: %s", sApiName, sPostData.c_str());
+
+    ra::services::Http::Request httpRequest(sHost + "/dorequest.php");
+    httpRequest.SetPostData(sPostData);
+
+    const auto httpResponse = httpRequest.Call();
+    return GetJson(sApiName, httpResponse, pResponse, document);
+}
+
+StartSession::Response ConnectedServer::StartSession(_UNUSED const StartSession::Request& request) noexcept
+{
+    StartSession::Response response;
+    rapidjson::Document document;
+    std::string sPostData;
+
+    // activity type enum (only 3 is used )
+    // 1 = earned achievement - handled by awardachievement
+    // 2 = logged in - handled by login
+    // 3 = started playing
+    // 4 = uploaded achievement - handled by uploadachievement
+    // 5 = modified achievmeent - handled by uploadachievement
+    AppendUrlParam(sPostData, "a", "3");
+
+    AppendUrlParam(sPostData, "m", std::to_string(request.GameId));
+
+    if (DoRequest(m_sHost, StartSession::Name(), "postactivity", sPostData, response, document))
+        response.Result = ApiResult::Success;
+
+    return std::move(response);
+}
+
+Ping::Response ConnectedServer::Ping(_UNUSED const Ping::Request& request) noexcept
+{
+    Ping::Response response;
+    rapidjson::Document document;
+    std::string sPostData;
+
+    AppendUrlParam(sPostData, "g", std::to_string(request.GameId));
+    if (!request.RichPresence.empty())
+        AppendUrlParam(sPostData, "m", ra::Narrow(request.RichPresence));
+
+    if (DoRequest(m_sHost, Ping::Name(), "ping", sPostData, response, document))
+        response.Result = ApiResult::Success;
+
     return std::move(response);
 }
 

--- a/src/api/impl/ConnectedServer.hh
+++ b/src/api/impl/ConnectedServer.hh
@@ -15,6 +15,8 @@ public:
 
     Login::Response Login(const Login::Request& request) noexcept override;
     Logout::Response Logout(_UNUSED const Logout::Request& request) noexcept override;
+    StartSession::Response StartSession(_UNUSED const StartSession::Request& request) noexcept override;
+    Ping::Response Ping(_UNUSED const Ping::Request& request) noexcept override;
 
 private:
     const std::string m_sHost;

--- a/src/api/impl/ServerBase.hh
+++ b/src/api/impl/ServerBase.hh
@@ -25,6 +25,16 @@ public:
         return UnsupportedApi<Logout::Response>(Logout::Name());
     }
 
+    StartSession::Response StartSession(_UNUSED const StartSession::Request& request) noexcept override
+    {
+        return UnsupportedApi<StartSession::Response>(StartSession::Name());
+    }
+
+    Ping::Response Ping(_UNUSED const Ping::Request& request) noexcept override
+    {
+        return UnsupportedApi<Ping::Response>(Ping::Name());
+    }
+
 protected:
     template<typename TResponse>
     inline typename TResponse UnsupportedApi(const char* const apiName) const noexcept

--- a/src/data/GameContext.hh
+++ b/src/data/GameContext.hh
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "RA_RichPresence.h"
+#include "RA_AchievementSet.h"
 
 #include <string>
 
@@ -43,7 +44,31 @@ public:
     /// Sets the game hash.
     /// </summary>
     void SetGameHash(const std::string& sGameHash) { m_sGameHash = sGameHash; }
+        
+    /// <summary>
+    /// Gets which achievements are active.
+    /// </summary>
+    virtual AchievementSet::Type ActiveAchievementType() const 
+    {
+#ifdef RA_UTEST
+        return AchievementSet::Type::Core;
+#else
+        return g_nActiveAchievementSet; 
+#endif
+    }
     
+    /// <summary>
+    /// Determines if any achievements are currently active.
+    /// </summary>
+    virtual bool HasActiveAchievements() const 
+    {
+#ifdef RA_UTEST
+        return false;
+#else
+        return g_pActiveAchievements && g_pActiveAchievements->NumAchievements() > 0; 
+#endif
+    }
+
     /// <summary>
     /// Gets whether or not the loaded game has a rich presence script.
     /// </summary>

--- a/src/data/SessionTracker.cpp
+++ b/src/data/SessionTracker.cpp
@@ -1,0 +1,218 @@
+#include "SessionTracker.hh"
+
+#include "Exports.hh"
+#include "RA_Dlg_AchEditor.h"
+#include "RA_Dlg_MemBookmark.h"
+#include "RA_Dlg_Memory.h"
+#include "RA_Log.h"
+#include "RA_md5factory.h"
+#include "RA_StringUtils.h"
+
+#include "api\Ping.hh"
+#include "api\StartSession.hh"
+
+#include "data\GameContext.hh"
+
+#include "services\IClock.hh"
+#include "services\IFileSystem.hh"
+#include "services\ILocalStorage.hh"
+#include "services\IThreadPool.hh"
+
+namespace ra {
+namespace data {
+
+const int SERVER_PING_FREQUENCY = 2 * 60; // seconds between server pings
+
+void SessionTracker::Initialize(const std::string& sUsername)
+{
+    m_sUsername = ra::Widen(sUsername);
+
+    auto& pLocalStorage = ra::services::ServiceLocator::GetMutable<ra::services::ILocalStorage>();
+    auto pStatsFile = pLocalStorage.ReadText(ra::services::StorageItemType::SessionStats, m_sUsername);
+
+    if (pStatsFile != nullptr)
+    {
+        // line format: <gameid>:<sessionstart>:<sessionlength>:<checksum>
+        std::string sLine;
+        while (pStatsFile->GetLine(sLine))
+        {
+            auto nIndex = sLine.find(':');
+            if (nIndex != std::string::npos)
+            {
+                auto nGameId = strtoul(sLine.c_str(), nullptr, 10);
+
+                auto nIndex2 = sLine.find(':', ++nIndex);
+                if (nIndex2 != std::string::npos)
+                {
+                    auto nSessionStart = strtoul(&sLine[nIndex], nullptr, 10);
+
+                    nIndex = sLine.find(':', ++nIndex2);
+                    if (nIndex != std::string::npos)
+                    {
+                        auto nSessionLength = strtoul(&sLine[nIndex2], nullptr, 10);
+
+                        auto md5 = RAGenerateMD5(reinterpret_cast<const unsigned char*>(sLine.c_str()), nIndex);
+                        if (sLine[nIndex + 1] == md5.front() && sLine[nIndex + 2] == md5.back())
+                        {
+                            auto pIter = m_vGameStats.begin();
+                            while (pIter != m_vGameStats.end() && pIter->GameId != nGameId)
+                                ++pIter;
+
+                            if (pIter == m_vGameStats.end())
+                            {
+                                m_vGameStats.emplace_back();
+                                pIter = m_vGameStats.end() - 1;
+                                pIter->GameId = nGameId;
+                            }
+
+                            pIter->LastSessionStart = std::chrono::system_clock::from_time_t(nSessionStart);
+                            pIter->TotalPlaytime += std::chrono::seconds(nSessionLength);
+                        }
+                    }
+                }
+            }
+        }
+
+        m_nFileWritePosition = pStatsFile->GetPosition();
+    }
+}
+
+void SessionTracker::BeginSession(unsigned int nGameId)
+{
+    if (m_nCurrentGameId != 0)
+        EndSession();
+
+    RA_LOG_INFO("Starting new session for game %u", nGameId);
+
+    m_nCurrentGameId = nGameId;
+
+    const auto& pClock = ra::services::ServiceLocator::Get<ra::services::IClock>();
+    m_tpSessionStart = pClock.UpTime();
+    m_tSessionStart = std::chrono::system_clock::to_time_t(pClock.Now());
+    m_tSessionDuration = std::chrono::seconds(0);
+
+    ra::api::StartSession::Request request;
+    request.GameId = nGameId;
+    request.CallAsync([](const ra::api::StartSession::Response&) {});
+
+    auto& pThreadPool = ra::services::ServiceLocator::GetMutable<ra::services::IThreadPool>();
+    pThreadPool.ScheduleAsync(std::chrono::seconds(5), [this, tSessionStart = m_tSessionStart]() { UpdateSession(tSessionStart); });
+}
+
+void SessionTracker::EndSession()
+{
+    RA_LOG_INFO("Ending session for game %u (%zu seconds)", m_nCurrentGameId, m_tSessionDuration.count());
+    if (m_nCurrentGameId != 0)
+        m_nFileWritePosition = WriteSessionStats();
+
+    m_nCurrentGameId = 0;
+    m_tSessionStart = 0;
+    m_tSessionDuration = std::chrono::seconds(0);
+}
+
+void SessionTracker::UpdateSession(time_t tSessionStart)
+{
+    // make sure we're still tracking the same game
+    if (tSessionStart != m_tSessionStart)
+        return;
+
+    // ping the server (this also updates the player's current activity string)
+    ra::api::Ping::Request request;
+    request.GameId = m_nCurrentGameId;
+    request.RichPresence = GetRichPresence();
+    request.CallAsync([](const ra::api::Ping::Response&) {});
+
+    // update session duration
+    const auto& pClock = ra::services::ServiceLocator::Get<ra::services::IClock>();
+    m_tSessionDuration = std::chrono::duration_cast<std::chrono::seconds>(pClock.UpTime() - m_tpSessionStart);
+
+    // ignore sessions less than one minute
+    if (m_tSessionDuration > std::chrono::seconds(5))
+        WriteSessionStats();
+
+    // schedule next ping
+    auto& pThreadPool = ra::services::ServiceLocator::GetMutable<ra::services::IThreadPool>();
+    pThreadPool.ScheduleAsync(std::chrono::seconds(5), [this, tSessionStart]() { UpdateSession(tSessionStart); });
+}
+
+long SessionTracker::WriteSessionStats() const
+{
+    auto& pLocalStorage = ra::services::ServiceLocator::GetMutable<ra::services::ILocalStorage>();
+    auto pStatsFile = pLocalStorage.AppendText(ra::services::StorageItemType::SessionStats, m_sUsername);
+
+    auto nSessionDuration = static_cast<unsigned int>(m_tSessionDuration.count());
+    auto sLine = ra::StringPrintf("%u:%ld:%u:", m_nCurrentGameId, static_cast<long>(m_tSessionStart), nSessionDuration);
+    const auto sMD5 = RAGenerateMD5(sLine);
+    sLine.push_back(sMD5.front());
+    sLine.push_back(sMD5.back());
+
+    pStatsFile->SetPosition(m_nFileWritePosition);
+    pStatsFile->WriteLine(sLine);
+
+    return pStatsFile->GetPosition();
+}
+
+std::chrono::seconds SessionTracker::GetTotalPlaytime(unsigned int nGameId) const
+{
+    std::chrono::seconds tPlaytime(0);
+
+    // get the current session duration
+    if (m_nCurrentGameId == nGameId)
+    {
+        const auto& pClock = ra::services::ServiceLocator::Get<ra::services::IClock>();
+        auto tSessionDuration = std::chrono::duration_cast<std::chrono::seconds>(pClock.UpTime() - m_tpSessionStart);
+
+        tPlaytime += tSessionDuration;
+    }
+
+    // add any prior session durations
+    for (const auto& pGameStats : m_vGameStats)
+    {
+        if (pGameStats.GameId == nGameId)
+        {
+            tPlaytime += pGameStats.TotalPlaytime;
+            break;
+        }
+    }
+
+    return tPlaytime;
+}
+
+bool SessionTracker::IsInspectingMemory() const
+{
+    return (g_MemoryDialog.IsActive() || g_AchievementEditorDialog.IsActive() || g_MemBookmarkDialog.IsActive());
+}
+
+std::wstring SessionTracker::GetRichPresence() const
+{
+    const auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::GameContext>();
+
+    if (IsInspectingMemory())
+    {
+        if (!pGameContext.HasActiveAchievements())
+            return L"Developing Achievements";
+
+        if (_RA_HardcoreModeIsActive())
+            return L"Inspecting Memory in Hardcore mode";
+
+        if (pGameContext.ActiveAchievementType() == AchievementSet::Type::Core)
+            return L"Fixing Achievements";
+
+        return L"Developing Achievements";
+    }
+
+    if (pGameContext.HasRichPresence())
+    {
+        const auto sRPResponse = pGameContext.GetRichPresenceDisplayString();
+        if (!sRPResponse.empty())
+            return sRPResponse;
+    }
+
+    if (pGameContext.HasActiveAchievements())
+        return L"Earning Achievements";
+
+    return L"Playing " + pGameContext.GameTitle();
+}
+
+} // namespace data
+} // namespace ra

--- a/src/data/SessionTracker.hh
+++ b/src/data/SessionTracker.hh
@@ -39,7 +39,7 @@ public:
 
 protected:
     void UpdateSession(time_t tSessionStart);
-    long WriteSessionStats() const;
+    long WriteSessionStats(std::chrono::seconds tSessionDuration) const;
     std::wstring GetRichPresence() const;
 
     virtual bool IsInspectingMemory() const;
@@ -48,7 +48,6 @@ private:
     unsigned int m_nCurrentGameId = 0;
     std::chrono::steady_clock::time_point m_tpSessionStart{};
     time_t m_tSessionStart{};
-    std::chrono::seconds m_tSessionDuration{ 0 };
 
     struct GameStats
     {

--- a/src/data/SessionTracker.hh
+++ b/src/data/SessionTracker.hh
@@ -1,0 +1,69 @@
+#ifndef RA_DATA_SESSIONTRACKER_HH
+#define RA_DATA_SESSIONTRACKER_HH
+#pragma once
+
+#include <string>
+
+namespace ra {
+namespace data {
+
+class SessionTracker
+{
+public:
+    SessionTracker() noexcept = default;
+    virtual ~SessionTracker() noexcept = default;
+    SessionTracker(const SessionTracker&) noexcept = delete;
+    SessionTracker& operator=(const SessionTracker&) noexcept = delete;
+    SessionTracker(SessionTracker&&) noexcept = delete;
+    SessionTracker& operator=(SessionTracker&&) noexcept = delete;
+    
+    /// <summary>
+    /// Initializes the session data for the specified user.
+    /// </summary>
+    void Initialize(const std::string& sUsername);
+
+    /// <summary>
+    /// Begins a new session for the specified game.
+    /// </summary>
+    void BeginSession(unsigned int nGameId);
+    
+    /// <summary>
+    /// Ends the current session.
+    /// </summary>
+    void EndSession();
+    
+    /// <summary>
+    /// Gets the total captured playtime for the specified game.
+    /// </summary>
+    std::chrono::seconds GetTotalPlaytime(unsigned int nGameId) const;
+
+protected:
+    void UpdateSession(time_t tSessionStart);
+    long WriteSessionStats() const;
+    std::wstring GetRichPresence() const;
+
+    virtual bool IsInspectingMemory() const;
+
+private:
+    unsigned int m_nCurrentGameId = 0;
+    std::chrono::steady_clock::time_point m_tpSessionStart{};
+    time_t m_tSessionStart{};
+    std::chrono::seconds m_tSessionDuration{ 0 };
+
+    struct GameStats
+    {
+        unsigned int GameId;
+        std::chrono::seconds TotalPlaytime;
+        std::chrono::system_clock::time_point LastSessionStart;
+    };
+
+    std::vector<GameStats> m_vGameStats;
+
+    std::wstring m_sUsername;
+    long m_nFileWritePosition{};
+};
+
+} // namespace data
+} // namespace ra
+
+#endif // !RA_DATA_SESSIONTRACKER_HH

--- a/src/data/SessionTracker.hh
+++ b/src/data/SessionTracker.hh
@@ -40,11 +40,14 @@ public:
 protected:
     void UpdateSession(time_t tSessionStart);
     long WriteSessionStats(std::chrono::seconds tSessionDuration) const;
-    std::wstring GetRichPresence() const;
+    std::wstring GetCurrentActivity() const;
 
     virtual bool IsInspectingMemory() const;
 
 private:
+    void AddSession(unsigned int nGameId, time_t tSessionStart, std::chrono::seconds tSessionDuration);
+    void SortSessions();
+
     unsigned int m_nCurrentGameId = 0;
     std::chrono::steady_clock::time_point m_tpSessionStart{};
     time_t m_tSessionStart{};

--- a/src/services/ILocalStorage.hh
+++ b/src/services/ILocalStorage.hh
@@ -17,6 +17,7 @@ enum class StorageItemType
     UserAchievements,
     Badge,
     UserPic,
+    SessionStats,
 };
 
 class ILocalStorage
@@ -41,6 +42,14 @@ public:
     ///   <see cref="TextWriter" /> for writing the data, <c>nullptr</c> if the data cannot be written.
     /// </returns>
     virtual std::unique_ptr<TextWriter> WriteText(StorageItemType nType, const std::wstring& sKey) = 0;
+
+    /// <summary>
+    ///   Begins appending stored data for the specified <paramref name="nType" /> and <paramref name="sKey" />.
+    /// </summary>
+    /// <returns>
+    ///   <see cref="TextWriter" /> for writing the data, <c>nullptr</c> if the data cannot be written.
+    /// </returns>
+    virtual std::unique_ptr<TextWriter> AppendText(StorageItemType nType, const std::wstring& sKey) = 0;
 
 protected:
     ILocalStorage() noexcept = default;

--- a/src/services/Initialization.cpp
+++ b/src/services/Initialization.cpp
@@ -3,6 +3,7 @@
 #include "api\impl\DisconnectedServer.hh"
 
 #include "data\GameContext.hh"
+#include "data\SessionTracker.hh"
 
 #include "services\ServiceLocator.hh"
 #include "services\impl\Clock.hh"
@@ -89,6 +90,9 @@ void Initialization::RegisterServices(const std::string& sClientName)
 
     auto* pGameContext = new ra::data::GameContext();
     ra::services::ServiceLocator::Provide<ra::data::GameContext>(pGameContext);
+
+    auto* pSessionTracker = new ra::data::SessionTracker();
+    ra::services::ServiceLocator::Provide<ra::data::SessionTracker>(pSessionTracker);
 
     auto* pLeaderboardManager = new ra::services::impl::LeaderboardManager(*pConfiguration);
     ra::services::ServiceLocator::Provide<ra::services::ILeaderboardManager>(pLeaderboardManager);

--- a/src/services/TextReader.hh
+++ b/src/services/TextReader.hh
@@ -27,6 +27,11 @@ public:
     /// <param name="sLine">The string to read the next line into.</param>
     /// <returns><c>true</c> if a line was read, <c>false</c> if the end of the input was reached.</returns>
     virtual bool GetLine(_Out_ std::wstring& sLine) = 0;
+    
+    /// <summary>
+    /// Gets the current read offset within the input.
+    /// </summary>
+    virtual long GetPosition() const = 0;
 
 protected:
     TextReader() noexcept = default;

--- a/src/services/TextWriter.hh
+++ b/src/services/TextWriter.hh
@@ -51,6 +51,18 @@ public:
         Write(sText);
         WriteLine();
     }
+
+    /// <summary>
+    /// Gets the current write offset within the output.
+    /// </summary>
+    virtual long GetPosition() const = 0;
+    
+    /// <summary>
+    /// Sets the current write offset within the output.
+    /// </summary>
+    /// <param name="nNewPosition">The n new position.</param>
+    virtual void SetPosition(long nNewPosition) = 0;
+
 protected:
     TextWriter() noexcept = default;
 };

--- a/src/services/impl/FileLocalStorage.cpp
+++ b/src/services/impl/FileLocalStorage.cpp
@@ -105,6 +105,12 @@ std::wstring FileLocalStorage::GetPath(StorageItemType nType, const std::wstring
             sPath.append(L".png");
             break;
 
+        case StorageItemType::SessionStats:
+            sPath.append(RA_DIR_BASE);
+            sPath.append(sKey);
+            sPath.append(L"-history.txt");
+            break;
+
         default:
             assert(!"unhandled StorageItemType");
             sPath.append(RA_DIR_DATA);
@@ -124,6 +130,11 @@ std::unique_ptr<TextReader> FileLocalStorage::ReadText(StorageItemType nType, co
 std::unique_ptr<TextWriter> FileLocalStorage::WriteText(StorageItemType nType, const std::wstring& sKey)
 {
     return m_pFileSystem.CreateTextFile(GetPath(nType, sKey));
+}
+
+std::unique_ptr<TextWriter> FileLocalStorage::AppendText(StorageItemType nType, const std::wstring& sKey)
+{
+    return m_pFileSystem.AppendTextFile(GetPath(nType, sKey));
 }
 
 } // namespace impl

--- a/src/services/impl/FileLocalStorage.hh
+++ b/src/services/impl/FileLocalStorage.hh
@@ -16,6 +16,7 @@ public:
 
     std::unique_ptr<TextReader> ReadText(StorageItemType nType, const std::wstring& sKey) override;
     std::unique_ptr<TextWriter> WriteText(StorageItemType nType, const std::wstring& sKey) override;
+    std::unique_ptr<TextWriter> AppendText(StorageItemType nType, const std::wstring& sKey) override;
 
     std::wstring GetPath(StorageItemType nType, const std::wstring& sKey) const;
 

--- a/src/services/impl/FileTextReader.hh
+++ b/src/services/impl/FileTextReader.hh
@@ -37,6 +37,23 @@ public:
         return true;
     }
 
+    long GetPosition() const override
+    {
+        auto& iStream = const_cast<std::ifstream&>(m_iStream);
+
+        if (!m_iStream.good())
+        {
+            // if we've set the eof flag, tellg() will return -1 unless we reset it
+            if (m_iStream.eof())
+            {
+                iStream.clear();
+                iStream.seekg(0, m_iStream.end);
+            }
+        }
+
+        return static_cast<size_t>(const_cast<std::ifstream&>(m_iStream).tellg());
+    }
+
     std::ifstream& GetFStream() { return m_iStream; }
 
 private:

--- a/src/services/impl/FileTextWriter.hh
+++ b/src/services/impl/FileTextWriter.hh
@@ -40,6 +40,17 @@ public:
             m_oStream.write("\r\n", 2);
     }
 
+    long GetPosition() const override
+    {
+        return static_cast<long>(const_cast<std::ofstream&>(m_oStream).tellp());
+    }
+
+    void SetPosition(long nNewPosition) override
+    {
+        assert(nNewPosition >= 0);
+        m_oStream.seekp(static_cast<std::streampos>(nNewPosition));
+    }
+
     std::ofstream& GetFStream() { return m_oStream; }
 
 private:

--- a/src/services/impl/StringTextReader.hh
+++ b/src/services/impl/StringTextReader.hh
@@ -40,7 +40,19 @@ public:
 
     long GetPosition() const override
     {
-        return static_cast<long>(const_cast<std::istringstream&>(m_iStream).tellg());
+        auto& iStream = const_cast<std::istringstream&>(m_iStream);
+
+        if (!m_iStream.good())
+        {
+            // if we've set the eof flag, tellg() will return -1 unless we reset it
+            if (m_iStream.eof())
+            {
+                iStream.clear();
+                iStream.seekg(0, m_iStream.end);
+            }
+        }
+
+        return static_cast<long>(iStream.tellg());
     }
 
     std::string GetString() { return m_iStream.str(); }

--- a/src/services/impl/StringTextReader.hh
+++ b/src/services/impl/StringTextReader.hh
@@ -38,6 +38,11 @@ public:
         return true;
     }
 
+    long GetPosition() const override
+    {
+        return static_cast<long>(const_cast<std::istringstream&>(m_iStream).tellg());
+    }
+
     std::string GetString() { return m_iStream.str(); }
 
 private:

--- a/src/services/impl/StringTextWriter.hh
+++ b/src/services/impl/StringTextWriter.hh
@@ -21,21 +21,42 @@ public:
     explicit StringTextWriter(std::string& sOutput) noexcept
         : m_sOutput(sOutput)
     {
+        m_nWritePosition = sOutput.length();
     }
 
     void Write(_In_ const std::string& sText) override
     {
-        m_sOutput.append(sText);
+        if (m_nWritePosition < m_sOutput.length())
+        {
+            m_sOutput.replace(m_nWritePosition, sText.length(), sText.c_str());
+            m_nWritePosition += sText.length();
+        }
+        else
+        {
+            m_sOutput.append(sText);
+            m_nWritePosition = m_sOutput.length();
+        }
     }
 
     void Write(_In_ const std::wstring& sText) override
     {
-        m_sOutput.append(ra::Narrow(sText));
+        Write(ra::Narrow(sText));
     }
 
     void WriteLine() override
     {
-        m_sOutput.append("\n");
+        Write(std::string("\n"));
+    }
+
+    long GetPosition() const override
+    {
+        return m_nWritePosition;
+    }
+
+    void SetPosition(long nNewPosition) override
+    {
+        assert(nNewPosition >= 0 && nNewPosition <= ra::to_signed(m_sOutput.length()));
+        m_nWritePosition = static_cast<size_t>(nNewPosition);
     }
 
     std::string& GetString() { return m_sOutput; }
@@ -43,6 +64,7 @@ public:
 private:
     std::string& m_sOutput;
     std::string m_sBuffer;
+    size_t m_nWritePosition;
 };
 
 } // namespace impl

--- a/tests/RA_Integration.Tests.vcxproj
+++ b/tests/RA_Integration.Tests.vcxproj
@@ -211,6 +211,7 @@
     <ClCompile Include="..\src\api\impl\ConnectedServer.cpp" />
     <ClCompile Include="..\src\api\impl\DisconnectedServer.cpp" />
     <ClCompile Include="..\src\api\impl\OfflineServer.cpp" />
+    <ClCompile Include="..\src\data\SessionTracker.cpp" />
     <ClCompile Include="..\src\md5.c" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" />
     <ClCompile Include="..\src\data\GameContext.cpp" />
     <ClCompile Include="..\src\pch.cpp">
@@ -230,6 +231,7 @@
     <ClCompile Include="..\src\services\SearchResults.cpp" />
     <ClCompile Include="api\ConnectedServer_Tests.cpp" />
     <ClCompile Include="api\DisconnectedServer_Tests.cpp" />
+    <ClCompile Include="data\SessionTracker_Tests.cpp" />
     <ClCompile Include="RA_RichPresence_Tests.cpp" />
     <ClInclude Include="..\rcheevos\src\rcheevos\internal.h" />
     <ClInclude Include="..\src\RA_Achievement.h" />
@@ -268,6 +270,7 @@
     <ClInclude Include="mocks\MockGameContext.hh" />
     <ClInclude Include="mocks\MockHttpRequester.hh" />
     <ClInclude Include="mocks\MockLocalStorage.hh" />
+    <ClInclude Include="mocks\MockServer.hh" />
     <ClInclude Include="mocks\MockThreadPool.hh" />
     <ClInclude Include="RA_UnitTestHelpers.h" />
     <ClCompile Include="RA_Condition_Tests.cpp" />

--- a/tests/RA_Integration.Tests.vcxproj.filters
+++ b/tests/RA_Integration.Tests.vcxproj.filters
@@ -28,6 +28,9 @@
     <Filter Include="Tests\API">
       <UniqueIdentifier>{1e60322d-0fb7-4ef7-ab07-0aafd85db9d2}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Tests\Data">
+      <UniqueIdentifier>{17ed66bb-227e-47fb-a220-1813059ee45f}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\src\RA_Condition.cpp">
@@ -62,9 +65,6 @@
     </ClCompile>
     <ClCompile Include="..\src\RA_Achievement.cpp">
       <Filter>Code</Filter>
-    </ClCompile>
-    <ClCompile Include="RA_Achievement_Tests.cpp">
-      <Filter>Tests</Filter>
     </ClCompile>
     <ClCompile Include="..\src\md5.c">
       <Filter>Code</Filter>
@@ -169,6 +169,12 @@
       <Filter>Code</Filter>
     </ClCompile>
     <ClCompile Include="..\src\api\impl\DisconnectedServer.cpp">
+      <Filter>Code</Filter>
+    </ClCompile>
+    <ClCompile Include="data\SessionTracker_Tests.cpp">
+      <Filter>Tests\Data</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\data\SessionTracker.cpp">
       <Filter>Code</Filter>
     </ClCompile>
   </ItemGroup>
@@ -313,6 +319,10 @@
       <Filter>Code\rcheevos</Filter>
     </ClInclude>
     <ClInclude Include="mocks\MockHttpRequester.hh">
+      <Filter>Tests\Mocks</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\pch.h" />
+    <ClInclude Include="mocks\MockServer.hh">
       <Filter>Tests\Mocks</Filter>
     </ClInclude>
   </ItemGroup>

--- a/tests/data/SessionTracker_Tests.cpp
+++ b/tests/data/SessionTracker_Tests.cpp
@@ -1,0 +1,372 @@
+#include "CppUnitTest.h"
+
+#include "data\SessionTracker.hh"
+
+#include "tests\RA_UnitTestHelpers.h"
+
+#include "tests\mocks\MockClock.hh"
+#include "tests\mocks\MockConfiguration.hh"
+#include "tests\mocks\MockGameContext.hh"
+#include "tests\mocks\MockLocalStorage.hh"
+#include "tests\mocks\MockServer.hh"
+#include "tests\mocks\MockThreadPool.hh"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+using ra::services::StorageItemType;
+
+namespace ra {
+namespace data {
+namespace tests {
+
+TEST_CLASS(SessionTracker_Tests)
+{
+public:
+    class SessionTrackerHarness : public SessionTracker
+    {
+    public:
+        SessionTrackerHarness(const char* sUsername = "User") noexcept
+            : m_sUsername(sUsername), m_sUsernameWide(ra::Widen(sUsername))
+        {
+        }
+
+        ra::api::mocks::MockServer mockServer;
+        ra::data::mocks::MockGameContext mockGameContext;
+        ra::services::mocks::MockClock mockClock;
+        ra::services::mocks::MockConfiguration mockConfiguration;
+        ra::services::mocks::MockLocalStorage mockStorage;
+        ra::services::mocks::MockThreadPool mockThreadPool;
+
+        bool HasStoredData() const
+        {
+            return mockStorage.HasStoredData(StorageItemType::SessionStats, m_sUsernameWide);
+        }
+
+        const std::string& GetStoredData() const
+        {
+            return mockStorage.GetStoredData(StorageItemType::SessionStats, m_sUsernameWide);
+        }
+
+        void MockStoredData(const std::string& sContents)
+        {
+            mockStorage.MockStoredData(StorageItemType::SessionStats, m_sUsernameWide, sContents);
+        }
+
+        void MockInspectingMemory(bool bInspectingMemory)
+        {
+            m_bInspectingMemory = bInspectingMemory;
+        }
+
+        std::wstring GetActivity() const
+        {
+            return SessionTracker::GetCurrentActivity();
+        }
+
+    protected:
+        bool IsInspectingMemory() const override { return m_bInspectingMemory; }
+
+    private:
+        bool m_bInspectingMemory{ false };
+        std::string m_sUsername;
+        std::wstring m_sUsernameWide;
+    };
+
+    TEST_METHOD(TestEmptyFile)
+    {
+        SessionTrackerHarness tracker;
+
+        tracker.Initialize("User");
+        Assert::IsFalse(tracker.HasStoredData());
+
+        bool bSessionStarted = false;
+        tracker.mockServer.HandleRequest<ra::api::StartSession>([&bSessionStarted](const ra::api::StartSession::Request& request, ra::api::StartSession::Response& response)
+        {
+            Assert::AreEqual(1234U, request.GameId);
+            bSessionStarted = true;
+            return false;
+        });
+
+        // BeginSession should begin the session, but not write to the file
+        tracker.mockGameContext.SetGameId(1234U);
+        tracker.BeginSession(1234U);
+        tracker.mockThreadPool.ExecuteNextTask(); // execute async server call
+        Assert::AreEqual(1U, tracker.mockThreadPool.PendingTasks());
+        Assert::IsFalse(tracker.HasStoredData());
+        Assert::IsTrue(bSessionStarted);
+
+        // after 30 seconds, the callback will be called, but the file shouldn't be written until at least 60 seconds have elapsed
+        tracker.mockClock.AdvanceTime(std::chrono::seconds(30));
+        tracker.mockThreadPool.AdvanceTime(std::chrono::seconds(30));
+        tracker.mockThreadPool.ExecuteNextTask(); // execute async server call
+        Assert::AreEqual(1U, tracker.mockThreadPool.PendingTasks());
+        Assert::IsFalse(tracker.HasStoredData());
+
+        // after two minutes, the callback will be called again, and the file finally written
+        tracker.mockClock.AdvanceTime(std::chrono::seconds(120));
+        tracker.mockThreadPool.AdvanceTime(std::chrono::seconds(120));
+        tracker.mockThreadPool.ExecuteNextTask(); // execute async server call
+        Assert::AreEqual(1U, tracker.mockThreadPool.PendingTasks());
+        Assert::IsTrue(tracker.HasStoredData());
+        Assert::AreEqual(std::string("1234:1534889323:150:5d\n"), tracker.GetStoredData());
+
+        // after two more minutes, the callback will be called again, and the file updated
+        tracker.mockClock.AdvanceTime(std::chrono::seconds(120));
+        tracker.mockThreadPool.AdvanceTime(std::chrono::seconds(120));
+        tracker.mockThreadPool.ExecuteNextTask(); // execute async server call
+        Assert::AreEqual(1U, tracker.mockThreadPool.PendingTasks());
+        Assert::IsTrue(tracker.HasStoredData());
+        Assert::AreEqual(std::string("1234:1534889323:270:f9\n"), tracker.GetStoredData());
+    }
+
+    TEST_METHOD(TestNonEmptyFile)
+    {
+        std::string sInitialValue("1234:1534000000:1732:f5\n");
+        SessionTrackerHarness tracker;
+        tracker.MockStoredData(sInitialValue);
+
+        tracker.Initialize("User");
+        Assert::IsTrue(tracker.HasStoredData());
+
+        bool bSessionStarted = false;
+        tracker.mockServer.HandleRequest<ra::api::StartSession>([&bSessionStarted](const ra::api::StartSession::Request& request, ra::api::StartSession::Response& response)
+        {
+            Assert::AreEqual(1234U, request.GameId);
+            bSessionStarted = true;
+            return false;
+        });
+
+        // BeginSession should begin the session, but not write to the file
+        tracker.mockGameContext.SetGameId(1234U);
+        tracker.BeginSession(1234U);
+        tracker.mockThreadPool.ExecuteNextTask(); // execute async server call
+        Assert::AreEqual(sInitialValue, tracker.GetStoredData());
+        Assert::IsTrue(bSessionStarted);
+
+        // after 30 seconds, the callback will be called, but the file shouldn't be written until at least 60 seconds have elapsed
+        tracker.mockClock.AdvanceTime(std::chrono::seconds(30));
+        tracker.mockThreadPool.AdvanceTime(std::chrono::seconds(30));
+        tracker.mockThreadPool.ExecuteNextTask(); // execute async server call
+        Assert::AreEqual(sInitialValue, tracker.GetStoredData());
+
+        // after two minutes, the callback will be called again, and a new entry added to the file
+        tracker.mockClock.AdvanceTime(std::chrono::seconds(120));
+        tracker.mockThreadPool.AdvanceTime(std::chrono::seconds(120));
+        Assert::AreEqual(std::string("1234:1534000000:1732:f5\n1234:1534889323:150:5d\n"), tracker.GetStoredData());
+
+        // after two more minutes, the callback will be called again, and the new entry updated
+        tracker.mockClock.AdvanceTime(std::chrono::seconds(120));
+        tracker.mockThreadPool.AdvanceTime(std::chrono::seconds(120));
+        Assert::AreEqual(std::string("1234:1534000000:1732:f5\n1234:1534889323:270:f9\n"), tracker.GetStoredData());
+
+        // total playtime should include current session and previous session
+        Assert::AreEqual(1732U + 270U, static_cast<unsigned int>(tracker.GetTotalPlaytime(1234U).count()));
+
+        // ending session should count any time in the since the last callback
+        tracker.mockClock.AdvanceTime(std::chrono::seconds(23));
+        tracker.EndSession();
+        Assert::AreEqual(std::string("1234:1534000000:1732:f5\n1234:1534889323:293:c9\n"), tracker.GetStoredData());
+        Assert::AreEqual(1732U + 293U, static_cast<unsigned int>(tracker.GetTotalPlaytime(1234U).count()));
+    }
+
+    TEST_METHOD(TestNonEmptyFileBadChecksum)
+    {
+        std::string sInitialValue("1234:1534000000:1732:00\n");
+        SessionTrackerHarness tracker;
+        tracker.MockStoredData(sInitialValue);
+        tracker.mockGameContext.SetGameId(1234U);
+
+        tracker.Initialize("User");
+        tracker.BeginSession(1234U);
+        tracker.mockClock.AdvanceTime(std::chrono::seconds(180));
+        Assert::AreEqual(180U, static_cast<unsigned int>(tracker.GetTotalPlaytime(1234U).count()));
+    }
+
+    TEST_METHOD(TestNonEmptyFileMultipleGames)
+    {
+        std::string sInitialValue("1234:1534000000:1732:f5\n"
+                                  "9999:1534100000:963:4e\n"
+                                  "1234:1534200000:591:0b\n");
+        SessionTrackerHarness tracker;
+        tracker.MockStoredData(sInitialValue);
+        tracker.mockGameContext.SetGameId(1234U);
+
+        tracker.Initialize("User");
+        tracker.BeginSession(1234U);
+        tracker.mockClock.AdvanceTime(std::chrono::seconds(180));
+        Assert::AreEqual(1732U + 591U + 180U, static_cast<unsigned int>(tracker.GetTotalPlaytime(1234U).count()));
+        Assert::AreEqual(963U, static_cast<unsigned int>(tracker.GetTotalPlaytime(9999U).count()));
+    }
+
+    TEST_METHOD(TestMultipleSessions)
+    {
+        std::string sInitialValue("1234:1534000000:1732:f5\n");
+        SessionTrackerHarness tracker;
+        tracker.MockStoredData(sInitialValue);
+
+        tracker.Initialize("User");
+        Assert::IsTrue(tracker.HasStoredData());
+
+        tracker.mockGameContext.SetGameId(1234U);
+        tracker.BeginSession(1234U);
+        Assert::AreEqual(sInitialValue, tracker.GetStoredData());
+
+        // after 30 seconds, the callback will be called, but the file shouldn't be written until at least 60 seconds have elapsed
+        tracker.mockClock.AdvanceTime(std::chrono::seconds(30));
+        tracker.mockThreadPool.AdvanceTime(std::chrono::seconds(30));
+
+        // after two minutes, the callback will be called again, and a new entry added to the file
+        tracker.mockClock.AdvanceTime(std::chrono::seconds(120));
+        tracker.mockThreadPool.AdvanceTime(std::chrono::seconds(120));
+        Assert::AreEqual(std::string("1234:1534000000:1732:f5\n1234:1534889323:150:5d\n"), tracker.GetStoredData());
+
+        // end session should include time since last callback
+        tracker.mockClock.AdvanceTime(std::chrono::seconds(23));
+        tracker.EndSession();
+        Assert::AreEqual(std::string("1234:1534000000:1732:f5\n1234:1534889323:173:bb\n"), tracker.GetStoredData());
+
+        // start new session
+        tracker.BeginSession(9999U);
+
+        // after 30 seconds, the callback will be called, but the file shouldn't be written until at least 60 seconds have elapsed
+        tracker.mockClock.AdvanceTime(std::chrono::seconds(30));
+        tracker.mockThreadPool.AdvanceTime(std::chrono::seconds(30));
+
+        // after two minutes, the callback will be called again, and a new entry added to the file
+        tracker.mockClock.AdvanceTime(std::chrono::seconds(120));
+        tracker.mockThreadPool.AdvanceTime(std::chrono::seconds(120));
+        Assert::AreEqual(std::string("1234:1534000000:1732:f5\n1234:1534889323:173:bb\n9999:1534889496:150:d0\n"), tracker.GetStoredData());
+
+        // end session should include time since last callback
+        tracker.mockClock.AdvanceTime(std::chrono::seconds(19));
+        tracker.EndSession();
+        Assert::AreEqual(std::string("1234:1534000000:1732:f5\n1234:1534889323:173:bb\n9999:1534889496:169:14\n"), tracker.GetStoredData());
+    }
+
+    TEST_METHOD(TestPing)
+    {
+        SessionTrackerHarness tracker;
+
+        tracker.Initialize("User");
+
+        int nPings = 0;
+        tracker.mockServer.HandleRequest<ra::api::Ping>([&nPings](const ra::api::Ping::Request& request, ra::api::Ping::Response& response)
+        {
+            Assert::AreEqual(1234U, request.GameId);
+            Assert::AreEqual(std::wstring(L"Playing Banana"), request.CurrentActivity);
+            ++nPings;
+            return false;
+        });
+
+        // BeginSession should begin the session, but not write to the file
+        tracker.mockGameContext.SetGameId(1234U);
+        tracker.mockGameContext.SetGameTitle(L"Banana");
+        tracker.BeginSession(1234U);
+        tracker.mockThreadPool.ExecuteNextTask(); // execute async server call StartSession
+        Assert::AreEqual(0, nPings);
+
+        // after 30 seconds, the callback will be called, and the first ping should occur
+        tracker.mockClock.AdvanceTime(std::chrono::seconds(30));
+        tracker.mockThreadPool.AdvanceTime(std::chrono::seconds(30));
+        tracker.mockThreadPool.ExecuteNextTask(); // execute async server call
+        Assert::AreEqual(1U, tracker.mockThreadPool.PendingTasks());
+        Assert::AreEqual(1, nPings);
+
+        // after two minutes, the callback will be called again, and the second ping should occur
+        tracker.mockClock.AdvanceTime(std::chrono::seconds(120));
+        tracker.mockThreadPool.AdvanceTime(std::chrono::seconds(120));
+        tracker.mockThreadPool.ExecuteNextTask(); // execute async server call
+        Assert::AreEqual(2, nPings);
+
+        // after two more minutes, the callback will be called again, and the third ping should occur
+        tracker.mockClock.AdvanceTime(std::chrono::seconds(120));
+        tracker.mockThreadPool.AdvanceTime(std::chrono::seconds(120));
+        tracker.mockThreadPool.ExecuteNextTask(); // execute async server call
+        Assert::AreEqual(3, nPings);
+
+        // once the session is ended, pinging should stop
+        tracker.EndSession();
+        tracker.mockClock.AdvanceTime(std::chrono::seconds(120));
+        tracker.mockThreadPool.AdvanceTime(std::chrono::seconds(120));
+        tracker.mockThreadPool.ExecuteNextTask(); // execute async server call
+        Assert::AreEqual(3, nPings);
+    }
+
+    TEST_METHOD(TestCurrentActivityNoAchievements)
+    {
+        SessionTrackerHarness tracker;
+        tracker.mockGameContext.SetGameTitle(L"GameTitle");
+        Assert::AreEqual(std::wstring(L"Playing GameTitle"), tracker.GetActivity());
+    }
+
+    TEST_METHOD(TestCurrentActivityNoRichPresence)
+    {
+        SessionTrackerHarness tracker;
+        tracker.mockGameContext.SetHasActiveAchievements(true);
+        Assert::AreEqual(std::wstring(L"Earning Achievements"), tracker.GetActivity());
+    }
+
+    TEST_METHOD(TestCurrentActivityRichPresence)
+    {
+        SessionTrackerHarness tracker;
+        tracker.mockGameContext.SetRichPresenceDisplayString(L"Level 10");
+        Assert::AreEqual(std::wstring(L"Level 10"), tracker.GetActivity());
+    }
+
+    TEST_METHOD(TestCurrentActivityInspectingMemoryNoAchievements)
+    {
+        SessionTrackerHarness tracker;
+        tracker.MockInspectingMemory(true);
+        Assert::AreEqual(std::wstring(L"Developing Achievements"), tracker.GetActivity());
+    }
+
+    TEST_METHOD(TestCurrentActivityInspectingMemoryNoAchievementsHardcore)
+    {
+        SessionTrackerHarness tracker;
+        tracker.MockInspectingMemory(true);
+        tracker.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, true);
+        Assert::AreEqual(std::wstring(L"Developing Achievements"), tracker.GetActivity());
+    }
+
+    TEST_METHOD(TestCurrentActivityInspectingMemoryHardcore)
+    {
+        SessionTrackerHarness tracker;
+        tracker.MockInspectingMemory(true);
+        tracker.mockGameContext.SetHasActiveAchievements(true);
+        tracker.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, true);
+        Assert::AreEqual(std::wstring(L"Inspecting Memory in Hardcore mode"), tracker.GetActivity());
+    }
+
+    TEST_METHOD(TestCurrentActivityInspectingMemoryCoreAchievements)
+    {
+        SessionTrackerHarness tracker;
+        tracker.MockInspectingMemory(true);
+        tracker.mockGameContext.SetHasActiveAchievements(true);
+        tracker.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, false);
+        tracker.mockGameContext.SetActiveAchievementType(AchievementSet::Type::Core);
+        Assert::AreEqual(std::wstring(L"Fixing Achievements"), tracker.GetActivity());
+    }
+
+    TEST_METHOD(TestCurrentActivityInspectingMemoryUnofficialAchievements)
+    {
+        SessionTrackerHarness tracker;
+        tracker.MockInspectingMemory(true);
+        tracker.mockGameContext.SetHasActiveAchievements(true);
+        tracker.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, false);
+        tracker.mockGameContext.SetActiveAchievementType(AchievementSet::Type::Unofficial);
+        Assert::AreEqual(std::wstring(L"Developing Achievements"), tracker.GetActivity());
+    }
+
+    TEST_METHOD(TestCurrentActivityInspectingMemoryLocalAchievements)
+    {
+        SessionTrackerHarness tracker;
+        tracker.MockInspectingMemory(true);
+        tracker.mockGameContext.SetHasActiveAchievements(true);
+        tracker.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, false);
+        tracker.mockGameContext.SetActiveAchievementType(AchievementSet::Type::Local);
+        Assert::AreEqual(std::wstring(L"Developing Achievements"), tracker.GetActivity());
+    }
+};
+
+} // namespace tests
+} // namespace data
+} // namespace ra

--- a/tests/mocks/MockGameContext.hh
+++ b/tests/mocks/MockGameContext.hh
@@ -37,10 +37,26 @@ public:
     /// </summary>
     void SetRichPresenceDisplayString(std::wstring sValue) { m_sRichPresenceDisplayString = sValue; }
 
+    bool HasActiveAchievements() const override { return m_bHasActiveAchievements;}
+    
+    /// <summary>
+    /// Sets the value for <see cref="HasActiveAchievements" />
+    /// </summary>
+    void SetHasActiveAchievements(bool bValue) { m_bHasActiveAchievements = bValue; }
+
+    AchievementSet::Type ActiveAchievementType() const { return m_nActiveAchievementType; }
+
+    /// <summary>
+    /// Sets the value for <see cref="HasActiveAchievements" />
+    /// </summary>
+    void SetActiveAchievementType(AchievementSet::Type bValue) { m_nActiveAchievementType = bValue; }
+
 private:
     ra::services::ServiceLocator::ServiceOverride<ra::data::GameContext> m_Override;
 
     std::wstring m_sRichPresenceDisplayString;
+    bool m_bHasActiveAchievements{ false };
+    AchievementSet::Type m_nActiveAchievementType{ AchievementSet::Type::Core };
 };
 
 } // namespace mocks

--- a/tests/mocks/MockServer.hh
+++ b/tests/mocks/MockServer.hh
@@ -1,0 +1,90 @@
+#ifndef RA_SERVICES_MOCK_SERVER_HH
+#define RA_SERVICES_MOCK_SERVER_HH
+#pragma once
+
+#include "api\IServer.hh"
+#include "services\ServiceLocator.hh"
+
+namespace ra {
+namespace api {
+namespace mocks {
+
+class MockServer : public IServer
+{
+public:
+    MockServer() noexcept
+        : m_Override(this)
+    {
+    }
+
+    const char* Name() const noexcept override { return "MockServer"; }
+
+    /// <summary>
+    /// Registers a callback method to handle the associated request type.
+    /// </summary>
+    /// <remarks>
+    /// Callback should return <c>true</c> if it populated the response, <c>false</c> to return the default response (unsupported)
+    /// </remarks>
+    template<typename TApi>
+    void HandleRequest(std::function<bool(const typename TApi::Request&, typename TApi::Response&)>&& fHandler)
+    {
+        m_mHandlers.insert_or_assign(std::string(TApi::Name()), [fHandler=std::move(fHandler)](void* pRequest, void* pResponse)
+        {
+            const TApi::Request* pTRequest = reinterpret_cast<const TApi::Request*>(pRequest);
+            TApi::Response* pTResponse = reinterpret_cast<TApi::Response*>(pResponse);
+            return fHandler(*pTRequest, *pTResponse);
+        });
+    }
+
+    // === user functions ===
+
+    Login::Response Login(_UNUSED const Login::Request& request) noexcept override
+    {
+        return HandleRequest<ra::api::Login>(request);
+    }
+
+    Logout::Response Logout(_UNUSED const Logout::Request& request) noexcept override
+    {
+        return HandleRequest<ra::api::Logout>(request);
+    }
+
+    StartSession::Response StartSession(_UNUSED const StartSession::Request& request) noexcept override
+    {
+        return HandleRequest<ra::api::StartSession>(request);
+    }
+
+    Ping::Response Ping(_UNUSED const Ping::Request& request) noexcept override
+    {
+        return HandleRequest<ra::api::Ping>(request);
+    }
+
+protected:
+    template<typename TApi>
+    inline typename TApi::Response HandleRequest(const ApiRequestBase& pRequest) const noexcept
+    {
+        TApi::Response response;
+        std::string sApiName(TApi::Name());
+
+        auto pIter = m_mHandlers.find(sApiName);
+        if (pIter != m_mHandlers.end())
+        {
+            if (pIter->second(reinterpret_cast<void*>(const_cast<ApiRequestBase*>(&pRequest)), reinterpret_cast<void*>(&response)))
+                return std::move(response);
+        }
+
+        response.Result = ApiResult::Unsupported;
+        response.ErrorMessage = sApiName + " is not supported by " + Name();
+        return std::move(response);
+    }
+
+private:
+    std::unordered_map<std::string, std::function<bool(void*, void*)>> m_mHandlers;
+
+    ra::services::ServiceLocator::ServiceOverride<ra::api::IServer> m_Override;
+};
+
+} // namespace mocks
+} // namespace api
+} // namespace ra
+
+#endif // !RA_SERVICES_MOCK_SERVER_HH


### PR DESCRIPTION
* Adds `Ping` and `StartSession` APIs
* Adds "seek" capability to `TextReader` and `TextWriter`
* Adds new `SessionTracker` class for tracking session duration
  * Persisted data is stored in `RACache\[User]-history.txt`
* Moves "current activity" calculation from RA_HttpThread to `SessionTracker`
* Displays total play time for current game on Achievements overlay:
![image](https://user-images.githubusercontent.com/32680403/48319004-337dca80-e5c5-11e8-82f7-49d192695a10.png)
