### PR TITLE
Don't attempt to acquire mutex during DLL initialization

### DIFF
--- a/src/services/impl/FileLogger.hh
+++ b/src/services/impl/FileLogger.hh
@@ -5,6 +5,7 @@
 #include "services\IClock.hh"
 #include "services\IFileSystem.hh"
 #include "services\ILogger.hh"
+#include "services\IThreadPool.hh"
 #include "services\ServiceLocator.hh"
 #include "services\TextWriter.hh"
 #include "services\impl\FileTextWriter.hh"
@@ -66,24 +67,19 @@ public:
         strftime(sBuffer, sizeof(sBuffer), "%H%M%S", &tTimeStruct);
         sprintf_s(&sBuffer[6], sizeof(sBuffer) - 6, ".%03u|", tMilliseconds);
 
+        // WinXP hangs if we try to acquire a mutex while the DLL in initializing. Since DllMain writes 
+        // a header block to the log file, we have to do that without using a mutex. Luckily, we're not
+        // going to have multiple threads trying to write to the file, so it'll be safe, and we can
+        // use the presence (or lack thereof) of the ThreadPool implementation to determine if we're
+        // being called from DllMain.
+        if (ServiceLocator::Exists<IThreadPool>())
         {
             std::scoped_lock<std::mutex> oLock(m_oMutex);
-            m_pWriter->Write(sBuffer);
-
-            // mark the level
-            switch (level)
-            {
-                case LogLevel::Info: m_pWriter->Write("INFO"); break;
-                case LogLevel::Warn: m_pWriter->Write("WARN"); break;
-                case LogLevel::Error: m_pWriter->Write("ERR "); break;
-            }
-            m_pWriter->Write("| ");
-
-            // write the message
-            m_pWriter->Write(sMessage);
-
-            // newline
-            m_pWriter->WriteLine();
+            LogMessage(*m_pWriter, sBuffer, level, sMessage);
+        }
+        else
+        {
+            LogMessage(*m_pWriter, sBuffer, level, sMessage);
         }
 
         // if writing to a file, flush immediately
@@ -93,6 +89,27 @@ public:
     }
 
 private:
+
+    static void LogMessage(ra::services::TextWriter& pWriter, char* sTimestamp, LogLevel level, const std::string& sMessage)
+    {
+        pWriter.Write(sTimestamp);
+
+        // mark the level
+        switch (level)
+        {
+            case LogLevel::Info: pWriter.Write("INFO"); break;
+            case LogLevel::Warn: pWriter.Write("WARN"); break;
+            case LogLevel::Error: pWriter.Write("ERR "); break;
+        }
+        pWriter.Write("| ");
+
+        // write the message
+        pWriter.Write(sMessage);
+
+        // newline
+        pWriter.WriteLine();
+    }
+
     std::unique_ptr<ra::services::TextWriter> m_pWriter;
     mutable std::mutex m_oMutex;
 };


### PR DESCRIPTION
Prevents hanging issue when trying to load the DLL on WinXP. 