### PR TITLE
Add ToString, AppendString, and BuildString methods

### DIFF
--- a/src/RA_Dlg_GameLibrary.cpp
+++ b/src/RA_Dlg_GameLibrary.cpp
@@ -237,7 +237,7 @@ void Dlg_GameLibrary::AddTitle(const std::string& sTitle, const std::string& sFi
 
     //	id:
     item.iSubItem = 0;
-    ra::tstring sID = ra::to_tstring(nGameID);	//scoped cache!
+    auto sID = NativeStr(ra::ToString(nGameID)); //scoped cache!
     item.pszText = sID.data();
     item.iItem = ListView_InsertItem(hList, &item);
 

--- a/src/RA_StringUtils.cpp
+++ b/src/RA_StringUtils.cpp
@@ -113,4 +113,124 @@ bool StringEndsWith(const std::wstring& sString, const std::wstring& sMatch) noe
     return (sString.compare(sString.length() - sMatch.length(), sMatch.length(), sMatch) == 0);
 }
 
+void StringBuilder::AppendToString(_Inout_ std::string& sResult) const
+{
+    size_t nNeeded = 0;
+    for (auto& pPending : m_vPending)
+    {
+        switch (pPending.DataType)
+        {
+            case PendingString::Type::String:
+                nNeeded += pPending.String.length();
+                break;
+
+            case PendingString::Type::WString:
+                pPending.String = ra::Narrow(pPending.WString);
+                pPending.DataType = PendingString::Type::String;
+                nNeeded += pPending.String.length();
+                break;
+
+            case PendingString::Type::StringRef:
+                nNeeded += pPending.Ref.String->length();
+                break;
+
+            case PendingString::Type::WStringRef:
+                pPending.String = ra::Narrow(*pPending.Ref.WString);
+                pPending.DataType = PendingString::Type::String;
+                nNeeded += pPending.String.length();
+                break;
+
+            case PendingString::Type::CharRef:
+                nNeeded += pPending.Ref.Char.Length;
+                break;
+
+            case PendingString::Type::WCharRef:
+                pPending.String = ra::Narrow(std::wstring(pPending.Ref.WChar.Pointer, pPending.Ref.WChar.Length));
+                pPending.DataType = PendingString::Type::String;
+                nNeeded += pPending.String.length();
+                break;
+        }
+    }
+
+    sResult.reserve(sResult.length() + nNeeded + 1);
+
+    for (auto& pPending : m_vPending)
+    {
+        switch (pPending.DataType)
+        {
+            case PendingString::Type::String:
+                sResult.append(pPending.String);
+                break;
+
+            case PendingString::Type::StringRef:
+                sResult.append(*pPending.Ref.String);
+                break;
+
+            case PendingString::Type::CharRef:
+                sResult.append(pPending.Ref.Char.Pointer, pPending.Ref.Char.Length);
+                break;
+        }
+    }
+}
+
+void StringBuilder::AppendToWString(_Inout_ std::wstring& sResult) const
+{
+    size_t nNeeded = 0;
+    for (auto& pPending : m_vPending)
+    {
+        switch (pPending.DataType)
+        {
+            case PendingString::Type::WString:
+                nNeeded += pPending.WString.length();
+                break;
+
+            case PendingString::Type::String:
+                pPending.WString = ra::Widen(pPending.String);
+                pPending.DataType = PendingString::Type::WString;
+                nNeeded += pPending.WString.length();
+                break;
+
+            case PendingString::Type::WStringRef:
+                nNeeded += pPending.Ref.WString->length();
+                break;
+
+            case PendingString::Type::StringRef:
+                pPending.WString = ra::Widen(*pPending.Ref.String);
+                pPending.DataType = PendingString::Type::WString;
+                nNeeded += pPending.WString.length();
+                break;
+
+            case PendingString::Type::WCharRef:
+                nNeeded += pPending.Ref.WChar.Length;
+                break;
+
+            case PendingString::Type::CharRef:
+                pPending.WString = ra::Widen(std::string(pPending.Ref.Char.Pointer, pPending.Ref.Char.Length));
+                pPending.DataType = PendingString::Type::WString;
+                nNeeded += pPending.WString.length();
+                break;
+        }
+    }
+
+    sResult.reserve(sResult.length() + nNeeded + 1);
+
+    for (auto& pPending : m_vPending)
+    {
+        switch (pPending.DataType)
+        {
+            case PendingString::Type::WString:
+                sResult.append(pPending.WString);
+                break;
+
+            case PendingString::Type::WStringRef:
+                sResult.append(*pPending.Ref.WString);
+                break;
+
+            case PendingString::Type::WCharRef:
+                sResult.append(pPending.Ref.WChar.Pointer, pPending.Ref.WChar.Length);
+                break;
+        }
+    }
+}
+
 } /* namespace ra */

--- a/src/RA_StringUtils.h
+++ b/src/RA_StringUtils.h
@@ -187,7 +187,7 @@ public:
         m_vPending.emplace_back(std::move(pPending));
     }
 
-    void Append(const std::string&& arg)
+    void Append(std::string&& arg)
     {
         PendingString pPending;
         pPending.String = std::move(arg);
@@ -195,7 +195,7 @@ public:
         m_vPending.emplace_back(std::move(pPending));
     }
 
-    void Append(const std::wstring&& arg)
+    void Append(std::wstring&& arg)
     {
         PendingString pPending;
         pPending.WString = std::move(arg);
@@ -239,11 +239,16 @@ public:
         m_vPending.emplace_back(std::move(pPending));
     }
 
+    void Append()
+    {
+        // just in case one of the variadic methods gets called with 0 parameters
+    }
+
     template<typename T, typename... Ts>
-    void Append(const T&& arg, const Ts&&... args)
+    void Append(const T&& arg, Ts&&... args)
     {
         Append(arg);
-        Append(std::forward<const Ts>(args)...);
+        Append(std::forward<Ts>(args)...);
     }
 
     template<typename T>
@@ -320,7 +325,7 @@ public:
     }
 
     template<typename CharT, typename = std::enable_if_t<is_char_v<CharT>>, typename T, typename... Ts>
-    void AppendPrintf(const CharT* const pFormat, const T& value, const Ts... args)
+    void AppendPrintf(const CharT* const pFormat, const T& value, Ts&&... args)
     {
         auto* pScan = pFormat;
         while (*pScan && *pScan != '%')
@@ -340,7 +345,7 @@ public:
                 break;
             case '%':
                 AppendSubString(pScan - 1, 1);
-                AppendPrintf(++pScan, value, std::forward<const Ts>(args)...);
+                AppendPrintf(++pScan, value, std::forward<Ts>(args)...);
                 break;
             case 'l': // assume ll, or li
             case 'z': // assume zu
@@ -352,7 +357,7 @@ public:
             case 'f':
             case 'g':
                 Append(value);
-                AppendPrintf(++pScan, std::forward<const Ts>(args)...);
+                AppendPrintf(++pScan, std::forward<Ts>(args)...);
                 break;
 
             default:
@@ -376,7 +381,7 @@ public:
                 }
 
                 AppendFormat(value, sFormat);
-                AppendPrintf(++pScan, std::forward<const Ts>(args)...);
+                AppendPrintf(++pScan, std::forward<Ts>(args)...);
                 break;
         }
     }
@@ -440,34 +445,34 @@ private:
 }; // namespace ra
 
 template<typename... Ts>
-void AppendString(std::string& sString, const Ts... args)
+void AppendString(std::string& sString, Ts&&... args)
 {
     StringBuilder builder;
-    builder.Append(std::forward<const Ts>(args)...);
+    builder.Append(std::forward<Ts>(args)...);
     builder.AppendToString(sString);
 }
 
 template<typename... Ts>
-void AppendWString(std::wstring& sString, const Ts... args)
+void AppendWString(std::wstring& sString, Ts&&... args)
 {
     StringBuilder builder(true);
-    builder.Append(std::forward<const Ts>(args)...);
+    builder.Append(std::forward<Ts>(args)...);
     builder.AppendToWString(sString);
 }
 
 template<typename... Ts>
-std::string BuildString(const Ts... args)
+std::string BuildString(Ts&&... args)
 {
     StringBuilder builder;
-    builder.Append(std::forward<const Ts>(args)...);
+    builder.Append(std::forward<Ts>(args)...);
     return builder.ToString();
 }
 
 template<typename... Ts>
-std::wstring BuildWString(const Ts... args)
+std::wstring BuildWString(Ts&&... args)
 {
     StringBuilder builder(true);
-    builder.Append(std::forward<const Ts>(args)...);
+    builder.Append(std::forward<Ts>(args)...);
     return builder.ToWString();
 }
 

--- a/tests/RA_StringUtils_Tests.cpp
+++ b/tests/RA_StringUtils_Tests.cpp
@@ -125,6 +125,7 @@ public:
             StringPrintf("'Twas the %s before %s and all through the %s, not a %s was %s, not even a %s.", "night", "Christmas", "house", "creature", "stirring", "mouse"));
         Assert::AreEqual(std::string("01AE"), StringPrintf("%04X", 0x1AEU));
         Assert::AreEqual(std::string("01ae"), StringPrintf("%04x", 0x1AEU));
+        Assert::AreEqual(std::string("01ae"), StringPrintf("%04x", 0x1AEUL));
         Assert::AreEqual(std::string("0080"), StringPrintf("%04d", 80));
         Assert::AreEqual(std::string("  80"), StringPrintf("%4d", 80));
     }

--- a/tests/RA_StringUtils_Tests.cpp
+++ b/tests/RA_StringUtils_Tests.cpp
@@ -52,6 +52,68 @@ public:
         Assert::AreEqual(std::string("test\r\n"), TrimLineEnding(std::string("test\r\n\r\n")));
     }
 
+    TEST_METHOD(TestToString)
+    {
+        Assert::AreEqual(std::string("0"), ToString(0));
+        Assert::AreEqual(std::string("1"), ToString(1));
+        Assert::AreEqual(std::string("99"), ToString(99));
+        Assert::AreEqual(std::string("-3"), ToString(-3));
+        Assert::AreEqual(std::string("0"), ToString(0U));
+        Assert::AreEqual(std::string("1"), ToString(1U));
+        Assert::AreEqual(std::string("99"), ToString(99U));
+        Assert::AreEqual(std::string("Apple"), ToString("Apple"));
+        Assert::AreEqual(std::string("Apple"), ToString(std::string("Apple")));
+        Assert::AreEqual(std::string("Apple"), ToString(L"Apple"));
+        Assert::AreEqual(std::string("Apple"), ToString(std::wstring(L"Apple")));
+    }
+
+    TEST_METHOD(TestToWString)
+    {
+        Assert::AreEqual(std::wstring(L"0"), ToWString(0));
+        Assert::AreEqual(std::wstring(L"1"), ToWString(1));
+        Assert::AreEqual(std::wstring(L"99"), ToWString(99));
+        Assert::AreEqual(std::wstring(L"-3"), ToWString(-3));
+        Assert::AreEqual(std::wstring(L"0"), ToWString(0U));
+        Assert::AreEqual(std::wstring(L"1"), ToWString(1U));
+        Assert::AreEqual(std::wstring(L"99"), ToWString(99U));
+        Assert::AreEqual(std::wstring(L"Apple"), ToWString("Apple"));
+        Assert::AreEqual(std::wstring(L"Apple"), ToWString(std::string("Apple")));
+        Assert::AreEqual(std::wstring(L"Apple"), ToWString(L"Apple"));
+        Assert::AreEqual(std::wstring(L"Apple"), ToWString(std::wstring(L"Apple")));
+    }
+
+    TEST_METHOD(TestAppendString)
+    {
+        std::string sTest;
+        AppendString(sTest, "Happy ", 40, std::string("th Birthday!"));
+        Assert::AreEqual(std::string("Happy 40th Birthday!"), sTest);
+
+        AppendString(sTest, L"Happy ", 50U, std::wstring(L"th Birthday!"));
+        Assert::AreEqual(std::string("Happy 40th Birthday!Happy 50th Birthday!"), sTest);
+    }
+
+    TEST_METHOD(TestBuildString)
+    {
+        std::string sTest = BuildString("Happy ", 40, std::string("th Birthday!"));
+        Assert::AreEqual(std::string("Happy 40th Birthday!"), sTest);
+    }
+
+    TEST_METHOD(TestAppendWString)
+    {
+        std::wstring sTest;
+        AppendWString(sTest, "Happy ", 40, std::string("th Birthday!"));
+        Assert::AreEqual(std::wstring(L"Happy 40th Birthday!"), sTest);
+
+        AppendWString(sTest, L"Happy ", 50U, std::wstring(L"th Birthday!"));
+        Assert::AreEqual(std::wstring(L"Happy 40th Birthday!Happy 50th Birthday!"), sTest);
+    }
+
+    TEST_METHOD(TestBuildWString)
+    {
+        std::wstring sTest = BuildWString(L"Happy ", 40, std::wstring(L"th Birthday!"));
+        Assert::AreEqual(std::wstring(L"Happy 40th Birthday!"), sTest);
+    }
+
     TEST_METHOD(TestStringPrintf)
     {
         Assert::AreEqual(std::string("This is a test."), StringPrintf("This is a %s.", "test"));
@@ -61,6 +123,21 @@ public:
         Assert::AreEqual(std::string(), StringPrintf(""));
         Assert::AreEqual(std::string("'Twas the night before Christmas and all through the house, not a creature was stirring, not even a mouse."), 
             StringPrintf("'Twas the %s before %s and all through the %s, not a %s was %s, not even a %s.", "night", "Christmas", "house", "creature", "stirring", "mouse"));
+        Assert::AreEqual(std::string("01AE"), StringPrintf("%04X", 0x1AEU));
+        Assert::AreEqual(std::string("01ae"), StringPrintf("%04x", 0x1AEU));
+        Assert::AreEqual(std::string("0080"), StringPrintf("%04d", 80));
+        Assert::AreEqual(std::string("  80"), StringPrintf("%4d", 80));
+    }
+
+    TEST_METHOD(TestWStringPrintf)
+    {
+        Assert::AreEqual(std::wstring(L"This is a test."), StringPrintf(L"This is a %s.", "test"));
+        Assert::AreEqual(std::wstring(L"1, 2, 3, 4"), StringPrintf(L"%d, %u, %zu, %li", 1, 2U, 3U, 4L));
+        Assert::AreEqual(std::wstring(L"53.45%"), StringPrintf(L"%.2f%%", 53.45f));
+        Assert::AreEqual(std::wstring(L"Nothing to replace"), StringPrintf(L"Nothing to replace"));
+        Assert::AreEqual(std::wstring(), StringPrintf(L""));
+        Assert::AreEqual(std::wstring(L"'Twas the night before Christmas and all through the house, not a creature was stirring, not even a mouse."),
+            StringPrintf(L"'Twas the %s before %s and all through the %s, not a %s was %s, not even a %s.", "night", "Christmas", "house", "creature", "stirring", "mouse"));
     }
 
     TEST_METHOD(TestStringStartsWith)


### PR DESCRIPTION
This provides a variadic template version of `StingPrintf`, as well as more straight-forward `AppendString` and `BuildString` methods. All are built on top of a templated `ToString` method. `AppendString`, `BuildString` and `ToString` have unicode variants: `ToWString`, `AppendWString`, and `BuildWString` - primarily because `ToString` and `BuildString` don't have any sort of identifiable input. `StringPrintf` is still overloaded to support either UTF-8 or Unicode via the `format` parameter.

`ToString` converts pretty much anything to a string, including unicode text.
```
        Assert::AreEqual(std::string("99"), ToString(99));
        Assert::AreEqual(std::string("-3"), ToString(-3));
        Assert::AreEqual(std::string("0"), ToString(0U));
        Assert::AreEqual(std::string("99"), ToString(99U));
        Assert::AreEqual(std::string("4.200000"), ToString(4.2));
        Assert::AreEqual(std::string("Apple"), ToString("Apple"));
        Assert::AreEqual(std::string("Apple"), ToString(std::string("Apple")));
        Assert::AreEqual(std::string("Apple"), ToString(L"Apple"));
        Assert::AreEqual(std::string("Apple"), ToString(std::wstring(L"Apple")));
```

`BuildString` combines a series of items using `ToString`:
```
        std::string sTest = BuildString("Happy ", 40, std::string("th Birthday!"));
        Assert::AreEqual(std::string("Happy 40th Birthday!"), sTest);
```

`AppendString` works just like `BuildString`, but modifies an input string:
```
        std::string sTest;
        AppendString(sTest, "Happy ", 40, std::string("th Birthday!"));
        Assert::AreEqual(std::string("Happy 40th Birthday!"), sTest);

        AppendString(sTest, L"Happy ", 50U, std::wstring(L"th Birthday!"));
        Assert::AreEqual(std::string("Happy 40th Birthday!Happy 50th Birthday!"), sTest);
```

`StringPrintf` works just like before, but leverages `AppendString`:
```
        Assert::AreEqual(std::string("This is a test."), StringPrintf("This is a %s.", "test"));
        Assert::AreEqual(std::string("1, 2, 3, 4"), StringPrintf("%d, %u, %zu, %li", 1, 2U, 3U, 4L));
        Assert::AreEqual(std::string("53.45%"), StringPrintf("%.2f%%", 53.45f));
        Assert::AreEqual(std::string("01ae"), StringPrintf("%04x", 0x1AEU));
        Assert::AreEqual(std::string("0080"), StringPrintf("%04d", 80));
        Assert::AreEqual(std::string("  80"), StringPrintf("%4d", 80));
```

Internally, `AppendString` builds a list of string references, constructing strings where needed. Then it totals the required size for all of the references and does one `reserve`. Finally, it iterates over the references one last time and copies the data into the output string.

In a release build, running the `TestStringPrintf` in a loop resulted in similar performance. (37.9us per iteration vs. 38.4us per iteration with the previous code).

A comparison of the performance of various string building methods (release build) for concatenating three strings and an integer:
```
1.5us direct append
1.7us StringPrintf
1.8us AppendString
1.8us BuildString
3.1us ostringstream
```