### PR TITLE
automatically reload rich presence script when it is externally modified (implements #133)

### DIFF
--- a/src/services/ILocalStorage.hh
+++ b/src/services/ILocalStorage.hh
@@ -28,6 +28,12 @@ public:
     ILocalStorage& operator=(const ILocalStorage&) noexcept = delete;
     ILocalStorage(ILocalStorage&&) noexcept = delete;
     ILocalStorage& operator=(ILocalStorage&&) noexcept = delete;
+    
+    /// <summary>
+    /// Gets the last time the stored data was modified.
+    /// </summary>
+    /// <returns>Time the stored data was last modified, <c>0</c> if it doesn't exist.</returns>
+    virtual std::chrono::system_clock::time_point GetLastModified(StorageItemType nType, const std::wstring& sKey) = 0;
 
     /// <summary>
     ///   Begins reading stored data for the specified <paramref name="nType" /> and <paramref name="sKey" />.

--- a/src/services/impl/FileLocalStorage.cpp
+++ b/src/services/impl/FileLocalStorage.cpp
@@ -122,6 +122,11 @@ std::wstring FileLocalStorage::GetPath(StorageItemType nType, const std::wstring
     return sPath;
 }
 
+std::chrono::system_clock::time_point FileLocalStorage::GetLastModified(StorageItemType nType, const std::wstring& sKey)
+{
+    return m_pFileSystem.GetLastModified(GetPath(nType, sKey));
+}
+
 std::unique_ptr<TextReader> FileLocalStorage::ReadText(StorageItemType nType, const std::wstring& sKey)
 {
     return m_pFileSystem.OpenTextFile(GetPath(nType, sKey));

--- a/src/services/impl/FileLocalStorage.hh
+++ b/src/services/impl/FileLocalStorage.hh
@@ -14,6 +14,8 @@ class FileLocalStorage : public ILocalStorage
 public:
     explicit FileLocalStorage(IFileSystem& pFileSystem) noexcept;
 
+    std::chrono::system_clock::time_point GetLastModified(StorageItemType nType, const std::wstring& sKey) override;
+
     std::unique_ptr<TextReader> ReadText(StorageItemType nType, const std::wstring& sKey) override;
     std::unique_ptr<TextWriter> WriteText(StorageItemType nType, const std::wstring& sKey) override;
     std::unique_ptr<TextWriter> AppendText(StorageItemType nType, const std::wstring& sKey) override;

--- a/src/ui/viewmodels/RichPresenceMonitorViewModel.hh
+++ b/src/ui/viewmodels/RichPresenceMonitorViewModel.hh
@@ -56,6 +56,8 @@ private:
     };
 
     MonitorState m_nState{ MonitorState::None };
+
+    time_t m_tRichPresenceFileTime{ 0 };
 };
 
 } // namespace viewmodels

--- a/tests/mocks/MockLocalStorage.hh
+++ b/tests/mocks/MockLocalStorage.hh
@@ -40,6 +40,11 @@ public:
         return sEmpty;
     }
 
+    std::chrono::system_clock::time_point GetLastModified(StorageItemType nType, const std::wstring& sKey) override
+    {
+        return std::chrono::system_clock::time_point();
+    }
+
     std::unique_ptr<TextReader> ReadText(StorageItemType nType, const std::wstring& sKey) override
     {
         std::string* pText = GetText(nType, sKey, false);

--- a/tests/ui/viewmodels/RichPresenceMonitorViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/RichPresenceMonitorViewModel_Tests.cpp
@@ -8,11 +8,13 @@
 
 #include "tests\RA_UnitTestHelpers.h"
 #include "tests\mocks\MockGameContext.hh"
+#include "tests\mocks\MockLocalStorage.hh"
 #include "tests\mocks\MockThreadPool.hh"
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
 using ra::data::mocks::MockGameContext;
+using ra::services::mocks::MockLocalStorage;
 using ra::services::mocks::MockThreadPool;
 
 namespace ra {
@@ -54,6 +56,7 @@ TEST_CLASS(RichPresenceMonitorViewModel_Tests)
     {
         MockGameContext mockGameContext;
         MockThreadPool mockThreadPool;
+        MockLocalStorage mockLocalStorage;
         RichPresenceMonitorViewModel vmRichPresence;
 
         // with no game loaded, message should be static and no callback registered
@@ -66,6 +69,7 @@ TEST_CLASS(RichPresenceMonitorViewModel_Tests)
     {
         MockGameContext mockGameContext;
         MockThreadPool mockThreadPool;
+        MockLocalStorage mockLocalStorage;
         RichPresenceMonitorViewModel vmRichPresence;
 
         // with no rich presence, message should be static and no callback registered
@@ -79,6 +83,7 @@ TEST_CLASS(RichPresenceMonitorViewModel_Tests)
     {
         MockGameContext mockGameContext;
         MockThreadPool mockThreadPool;
+        MockLocalStorage mockLocalStorage;
         RichPresenceMonitorViewModel vmRichPresence;
 
         mockGameContext.SetGameId(1);
@@ -107,6 +112,7 @@ TEST_CLASS(RichPresenceMonitorViewModel_Tests)
     {
         MockGameContext mockGameContext;
         MockThreadPool mockThreadPool;
+        MockLocalStorage mockLocalStorage;
         RichPresenceMonitorViewModel vmRichPresence;
 
         mockGameContext.SetGameId(1);
@@ -130,6 +136,7 @@ TEST_CLASS(RichPresenceMonitorViewModel_Tests)
     {
         MockGameContext mockGameContext;
         MockThreadPool mockThreadPool;
+        MockLocalStorage mockLocalStorage;
         RichPresenceMonitorViewModel vmRichPresence;
 
         // with no game loaded, message should be static and no callback registered
@@ -160,6 +167,7 @@ TEST_CLASS(RichPresenceMonitorViewModel_Tests)
     {
         MockGameContext mockGameContext;
         MockThreadPool mockThreadPool;
+        MockLocalStorage mockLocalStorage;
         RichPresenceMonitorViewModel vmRichPresence;
 
         mockGameContext.SetGameId(1);


### PR DESCRIPTION
Just before each time the Rich Presence Monitor window refreshes, it will check the local file for modifications. If found, will refresh the rich presence script before updating the Rich Presence Monitor.

Only occurs while the Rich Presence Monitor window is open.