### PR TITLE
Compile-time check for literal types

### DIFF
--- a/src/RA_Dlg_Achievement.h
+++ b/src/RA_Dlg_Achievement.h
@@ -6,11 +6,6 @@
 
 inline constexpr int MAX_TEXT_ITEM_SIZE = 80;
 
-//extern const char* g_sColTitles[];
-//extern const int g_nColSizes[];
-
-//typedef struct Achievement;
-
 class Dlg_Achievements
 {
     using AchievementDlgRow = std::vector<std::string>;
@@ -24,12 +19,9 @@ public:
         Author,
         Achieved,
         Active = Achieved,
-        Modified,       
+        Modified,
         Votes = Modified
     };
-
-public:
-    Dlg_Achievements();
 
 public:
     static INT_PTR CALLBACK s_AchievementsProc(HWND, UINT, WPARAM, LPARAM);
@@ -48,7 +40,7 @@ public:
     {
         // we need to check stuff to prevent throwing in release mode
         assert(nRow >= 0 && nRow < m_lbxData.size());
-        auto& rowRef{ m_lbxData.at(nRow) };
+        auto& rowRef{m_lbxData.at(nRow)};
 
         using namespace ra::rel_ops;
         assert(nCol >= 0 && nCol < rowRef.size());
@@ -76,6 +68,5 @@ private:
 };
 
 extern Dlg_Achievements g_AchievementsDialog;
-
 
 #endif // !RA_DLG_ACHIEVEMENT_H

--- a/src/RA_Dlg_Achievement.h
+++ b/src/RA_Dlg_Achievement.h
@@ -6,6 +6,11 @@
 
 inline constexpr int MAX_TEXT_ITEM_SIZE = 80;
 
+//extern const char* g_sColTitles[];
+//extern const int g_nColSizes[];
+
+//typedef struct Achievement;
+
 class Dlg_Achievements
 {
     using AchievementDlgRow = std::vector<std::string>;
@@ -19,9 +24,12 @@ public:
         Author,
         Achieved,
         Active = Achieved,
-        Modified,
+        Modified,       
         Votes = Modified
     };
+
+public:
+    Dlg_Achievements();
 
 public:
     static INT_PTR CALLBACK s_AchievementsProc(HWND, UINT, WPARAM, LPARAM);

--- a/src/RA_StringUtils.h
+++ b/src/RA_StringUtils.h
@@ -47,16 +47,7 @@ _NODISCARD inline auto StringPrintf(_In_z_ _Printf_format_string_ const CharT* c
     {
         assert(std::wstring_view{ sFormat }.find(L"%n") == std::wstring_view::npos);
         assert(sFormatted.capacity() > 0U && (sFormatted.capacity() < RSIZE_MAX/sizeof(wchar_t)));
-
-        while(nNeeded < 0)
-        {
-            nNeeded = std::vswprintf(sFormatted.data(), sFormatted.capacity(), sFormat, pArgs);
-            if (nNeeded < 0)
-            {
-                const auto nCap = sFormatted.capacity();
-                sFormatted.reserve(nCap*2); // if it's still too small
-            }
-        }
+        nNeeded = std::vswprintf(sFormatted.data(), sFormatted.capacity(), sFormat, pArgs);
     }
     va_end(pArgs);
     assert(nNeeded >= 0);

--- a/src/RA_StringUtils.h
+++ b/src/RA_StringUtils.h
@@ -47,7 +47,16 @@ _NODISCARD inline auto StringPrintf(_In_z_ _Printf_format_string_ const CharT* c
     {
         assert(std::wstring_view{ sFormat }.find(L"%n") == std::wstring_view::npos);
         assert(sFormatted.capacity() > 0U && (sFormatted.capacity() < RSIZE_MAX/sizeof(wchar_t)));
-        nNeeded = std::vswprintf(sFormatted.data(), sFormatted.capacity(), sFormat, pArgs);
+
+        while(nNeeded < 0)
+        {
+            nNeeded = std::vswprintf(sFormatted.data(), sFormatted.capacity(), sFormat, pArgs);
+            if (nNeeded < 0)
+            {
+                const auto nCap = sFormatted.capacity();
+                sFormatted.reserve(nCap*2); // if it's still too small
+            }
+        }
     }
     va_end(pArgs);
     assert(nNeeded >= 0);

--- a/src/ra_fwd.h
+++ b/src/ra_fwd.h
@@ -82,12 +82,14 @@ using LPTSTR  = TCHAR*;
 #endif // !_WINNT_
 
 namespace ra {
+
 using tstring = std::basic_string<TCHAR>;
 
 using ARGB          = DWORD;
 using ByteAddress   = std::size_t;
 using AchievementID = std::size_t;
 using LeaderboardID = std::size_t;
+
 } /* namespace ra */
 
 #endif /* !RA_FWD_H */

--- a/src/ra_type_traits.h
+++ b/src/ra_type_traits.h
@@ -33,14 +33,16 @@ struct _NODISCARD is_char : std::bool_constant<(std::is_same_v<CharT, char> || s
 /// <summary>
 ///   This should only be used to compare the sizes of data types and not objects.
 /// </summary>
-template<typename T, typename U> struct _NODISCARD is_same_size : std::bool_constant<sizeof(T) == sizeof(U)>
+template<typename T, typename U>
+struct _NODISCARD is_same_size : std::bool_constant<sizeof(T) == sizeof(U)>
 {
 };
 
 /// <summary>
 ///   This should only be used to compare the sizes of data types and not objects.
 /// </summary>
-template<typename T, typename U> struct _NODISCARD has_smaller_size_than : std::bool_constant<sizeof(T) < sizeof(U)>
+template<typename T, typename U>
+struct _NODISCARD has_smaller_size_than : std::bool_constant<sizeof(T) < sizeof(U)>
 {
 };
 
@@ -53,7 +55,8 @@ struct _NODISCARD has_smaller_or_same_size_than : std::bool_constant<!has_smalle
 };
 } // namespace detail
 
-template<typename CharacterType> _CONSTANT_VAR is_char_v{detail::is_char<CharacterType>::value};
+template<typename CharacterType>
+_CONSTANT_VAR is_char_v{detail::is_char<CharacterType>::value};
 
 template<typename ValueType, typename TestType>
 _CONSTANT_VAR is_same_size_v{detail::is_same_size<ValueType, TestType>::value};
@@ -65,15 +68,17 @@ template<typename ValueType, typename TestType>
 _CONSTANT_VAR has_smaller_or_same_size_than_v{detail::has_smaller_or_same_size_than<ValueType, TestType>::value};
 
 namespace detail {
-template<typename EqualityComparable, class = std::void_t<>> struct _NODISCARD is_equality_comparable : std::false_type
+template<typename EqualityComparable, class = std::void_t<>>
+struct _NODISCARD is_equality_comparable : std::false_type
 {
 };
 
 template<typename EqualityComparable>
 struct _NODISCARD is_equality_comparable<
     EqualityComparable,
-    std::enable_if_t<std::is_convertible_v<
-        decltype(std::declval<EqualityComparable&>() == std::declval<EqualityComparable&>()), bool>>> : std::true_type
+    std::enable_if_t<
+        std::is_convertible_v<decltype(std::declval<EqualityComparable&>() == std::declval<EqualityComparable&>()),
+                              bool>>> : std::true_type
 {
 };
 
@@ -83,15 +88,17 @@ struct _NODISCARD is_nothrow_equality_comparable
 {
 };
 
-template<typename LessThanComparable, class = std::void_t<>> struct _NODISCARD is_lessthan_comparable : std::false_type
+template<typename LessThanComparable, class = std::void_t<>>
+struct _NODISCARD is_lessthan_comparable : std::false_type
 {
 };
 
 template<typename LessThanComparable>
 struct _NODISCARD is_lessthan_comparable<
-    LessThanComparable, std::enable_if_t<std::is_convertible_v<
-                            decltype(std::declval<LessThanComparable&>() < std::declval<LessThanComparable&>()), bool>>>
-    : std::true_type
+    LessThanComparable,
+    std::enable_if_t<
+        std::is_convertible_v<decltype(std::declval<LessThanComparable&>() < std::declval<LessThanComparable&>()),
+                              bool>>> : std::true_type
 {
 };
 
@@ -125,10 +132,27 @@ _CONSTANT_VAR is_lessthan_comparable_v{detail::is_lessthan_comparable<LessThanCo
 template<typename LessThanComparable>
 _CONSTANT_VAR is_nothrow_lessthan_comparable_v{detail::is_nothrow_lessthan_comparable<LessThanComparable>::value};
 
-template<typename Comparable> _CONSTANT_VAR is_comparable_v{detail::is_comparable<Comparable>::value};
+template<typename Comparable>
+_CONSTANT_VAR is_comparable_v{detail::is_comparable<Comparable>::value};
 
-template<typename Comparable> _CONSTANT_VAR
-is_nothrow_comparable_v{ detail::is_nothrow_comparable<Comparable>::value };
+template<typename Comparable>
+_CONSTANT_VAR is_nothrow_comparable_v{detail::is_nothrow_comparable<Comparable>::value};
+
+namespace detail {
+
+template<typename T>
+struct _NODISCARD is_literal_type
+    : std::bool_constant<(std::is_scalar_v<T> || std::is_reference_v<T>) ||
+                         (std::is_aggregate_v<T> && std::is_scalar_v<typename T::value_type>) ||
+                         (std::is_class_v<T> && std::is_trivially_destructible_v<T> &&
+                          std::is_nothrow_constructible_v<T>)>
+{
+};
+
+} /* namespace detail */
+
+template<typename LiteralType>
+_CONSTANT_VAR is_literal_type_v{detail::is_literal_type<LiteralType>::value};
 
 } // namespace ra
 

--- a/src/ra_type_traits.h
+++ b/src/ra_type_traits.h
@@ -27,7 +27,6 @@ namespace detail {
 /// <remarks><c>char32_t</c> is not considered valid by this type_trait.</remarks>
 template<typename CharT>
 struct _NODISCARD is_char : std::bool_constant<(std::is_same_v<CharT, char> || std::is_same_v<CharT, wchar_t>)>
-    std::bool_constant<(std::is_same_v<CharT, char> || std::is_same_v<CharT, wchar_t>)>
 {
 };
 
@@ -44,7 +43,6 @@ template<typename T, typename U> struct _NODISCARD is_same_size : std::bool_cons
 template<typename T, typename U> struct _NODISCARD has_smaller_size_than : std::bool_constant<sizeof(T) < sizeof(U)>
 {
 };
-    std::bool_constant<!has_smaller_size_than<U, T>::value> {};
 
 /// <summary>
 ///   This should only be used to compare the sizes of data types and not objects.
@@ -56,7 +54,6 @@ struct _NODISCARD has_smaller_or_same_size_than : std::bool_constant<!has_smalle
 } // namespace detail
 
 template<typename CharacterType> _CONSTANT_VAR is_char_v{detail::is_char<CharacterType>::value};
-is_char_v{ detail::is_char<CharacterType>::value };
 
 template<typename ValueType, typename TestType>
 _CONSTANT_VAR is_same_size_v{detail::is_same_size<ValueType, TestType>::value};
@@ -129,12 +126,10 @@ template<typename LessThanComparable>
 _CONSTANT_VAR is_nothrow_lessthan_comparable_v{detail::is_nothrow_lessthan_comparable<LessThanComparable>::value};
 
 template<typename Comparable> _CONSTANT_VAR is_comparable_v{detail::is_comparable<Comparable>::value};
-is_comparable_v{ detail::is_comparable<Comparable>::value };
 
 template<typename Comparable> _CONSTANT_VAR
 is_nothrow_comparable_v{ detail::is_nothrow_comparable<Comparable>::value };
 
-template<typename Comparable> _CONSTANT_VAR is_nothrow_comparable_v{detail::is_nothrow_comparable<Comparable>::value};
 } // namespace ra
 
 #endif // !RA_TYPE_TRAITS_H

--- a/src/ra_type_traits.h
+++ b/src/ra_type_traits.h
@@ -27,6 +27,7 @@ namespace detail {
 /// <remarks><c>char32_t</c> is not considered valid by this type_trait.</remarks>
 template<typename CharT>
 struct _NODISCARD is_char : std::bool_constant<(std::is_same_v<CharT, char> || std::is_same_v<CharT, wchar_t>)>
+    std::bool_constant<(std::is_same_v<CharT, char> || std::is_same_v<CharT, wchar_t>)>
 {
 };
 
@@ -43,6 +44,7 @@ template<typename T, typename U> struct _NODISCARD is_same_size : std::bool_cons
 template<typename T, typename U> struct _NODISCARD has_smaller_size_than : std::bool_constant<sizeof(T) < sizeof(U)>
 {
 };
+    std::bool_constant<!has_smaller_size_than<U, T>::value> {};
 
 /// <summary>
 ///   This should only be used to compare the sizes of data types and not objects.
@@ -54,6 +56,7 @@ struct _NODISCARD has_smaller_or_same_size_than : std::bool_constant<!has_smalle
 } // namespace detail
 
 template<typename CharacterType> _CONSTANT_VAR is_char_v{detail::is_char<CharacterType>::value};
+is_char_v{ detail::is_char<CharacterType>::value };
 
 template<typename ValueType, typename TestType>
 _CONSTANT_VAR is_same_size_v{detail::is_same_size<ValueType, TestType>::value};
@@ -126,6 +129,10 @@ template<typename LessThanComparable>
 _CONSTANT_VAR is_nothrow_lessthan_comparable_v{detail::is_nothrow_lessthan_comparable<LessThanComparable>::value};
 
 template<typename Comparable> _CONSTANT_VAR is_comparable_v{detail::is_comparable<Comparable>::value};
+is_comparable_v{ detail::is_comparable<Comparable>::value };
+
+template<typename Comparable> _CONSTANT_VAR
+is_nothrow_comparable_v{ detail::is_nothrow_comparable<Comparable>::value };
 
 template<typename Comparable> _CONSTANT_VAR is_nothrow_comparable_v{detail::is_nothrow_comparable<Comparable>::value};
 } // namespace ra

--- a/src/ra_utility.h
+++ b/src/ra_utility.h
@@ -56,8 +56,6 @@ _NODISCARD _CONSTANT_FN narrow_cast(_In_ WideType from) noexcept
 {
     return static_cast<NarrowedType>(static_cast<WideType>(from));
 }
-> _NODISCARD _CONSTANT_FN
-narrow_cast(_In_ WideType from) noexcept { return static_cast<NarrowedType>(static_cast<WideType>(from)); }
 #pragma warning(pop)
 
 template<typename Enum, typename = std::enable_if_t<std::is_enum_v<Enum>>>
@@ -73,13 +71,11 @@ _NODISCARD _CONSTANT_VAR itoe(_In_ Integral i) noexcept
 {
     return static_cast<Enum>(i);
 }
-> _NODISCARD _CONSTANT_VAR
-itoe(_In_ Integral i) noexcept { return static_cast<Enum>(i); }
+
 
 // function alias templates for etoi (EnumToIntegral) and itoe (IntegralToEnum)
 template<typename Enum> _CONSTANT_VAR to_integral{etoi<Enum>};
 template<typename Enum, typename Integral = std::underlying_type_t<Enum>> _CONSTANT_VAR to_enum{itoe<Enum, Integral>};
-_CONSTANT_VAR to_enum{ itoe<Enum, Integral> };
 
 /// <summary>Calculates the size of any standard fstream.</summary>
 /// <param name="filename">The filename.</param>
@@ -188,9 +184,6 @@ _NODISCARD _CONSTANT_FN operator>=(_In_ std::underlying_type_t<Enum> a, _In_ Enu
     return (!(a < etoi(b)));
 }
 
-template<typename Enum, typename = std::enable_if_t<std::is_enum_v<Enum>>> _NODISCARD _CONSTANT_FN
-operator>=(_In_ Enum a, _In_ std::underlying_type_t<Enum> b) noexcept { return (!(etoi(a) < b)); }
-
 template<typename Enum, typename = std::enable_if_t<std::is_enum_v<Enum>>>
 _NODISCARD _CONSTANT_FN operator>=(_In_ Enum a, _In_ std::underlying_type_t<Enum> b) noexcept
 {
@@ -216,9 +209,6 @@ _CONSTANT_FN& operator|=(_Inout_ Enum& a, _In_ Enum b) noexcept
 {
     return (a = a | b);
 }
-
-template<typename Enum, class = std::enable_if_t<std::is_enum_v<Enum>>> _CONSTANT_FN&
-operator&=(_Inout_ Enum& a, _In_ Enum b) noexcept { return (a = a & b); }
 
 template<typename Enum, typename = std::enable_if_t<std::is_enum_v<Enum>>>
 _CONSTANT_FN& operator&=(_Inout_ Enum& a, _In_ Enum b) noexcept

--- a/src/ra_utility.h
+++ b/src/ra_utility.h
@@ -12,6 +12,7 @@
 namespace ra {
 #pragma warning(push)
 
+#pragma warning(push)
 // TODO: Finish narrow_cast in another PR
 // we don't use gsl::narrow_cast, ra::narrow_cast won't trigger this when its
 // done
@@ -55,6 +56,8 @@ _NODISCARD _CONSTANT_FN narrow_cast(_In_ WideType from) noexcept
 {
     return static_cast<NarrowedType>(static_cast<WideType>(from));
 }
+> _NODISCARD _CONSTANT_FN
+narrow_cast(_In_ WideType from) noexcept { return static_cast<NarrowedType>(static_cast<WideType>(from)); }
 #pragma warning(pop)
 
 template<typename Enum, typename = std::enable_if_t<std::is_enum_v<Enum>>>
@@ -70,10 +73,13 @@ _NODISCARD _CONSTANT_VAR itoe(_In_ Integral i) noexcept
 {
     return static_cast<Enum>(i);
 }
+> _NODISCARD _CONSTANT_VAR
+itoe(_In_ Integral i) noexcept { return static_cast<Enum>(i); }
 
 // function alias templates for etoi (EnumToIntegral) and itoe (IntegralToEnum)
 template<typename Enum> _CONSTANT_VAR to_integral{etoi<Enum>};
 template<typename Enum, typename Integral = std::underlying_type_t<Enum>> _CONSTANT_VAR to_enum{itoe<Enum, Integral>};
+_CONSTANT_VAR to_enum{ itoe<Enum, Integral> };
 
 /// <summary>Calculates the size of any standard fstream.</summary>
 /// <param name="filename">The filename.</param>
@@ -182,6 +188,9 @@ _NODISCARD _CONSTANT_FN operator>=(_In_ std::underlying_type_t<Enum> a, _In_ Enu
     return (!(a < etoi(b)));
 }
 
+template<typename Enum, typename = std::enable_if_t<std::is_enum_v<Enum>>> _NODISCARD _CONSTANT_FN
+operator>=(_In_ Enum a, _In_ std::underlying_type_t<Enum> b) noexcept { return (!(etoi(a) < b)); }
+
 template<typename Enum, typename = std::enable_if_t<std::is_enum_v<Enum>>>
 _NODISCARD _CONSTANT_FN operator>=(_In_ Enum a, _In_ std::underlying_type_t<Enum> b) noexcept
 {
@@ -207,6 +216,9 @@ _CONSTANT_FN& operator|=(_Inout_ Enum& a, _In_ Enum b) noexcept
 {
     return (a = a | b);
 }
+
+template<typename Enum, class = std::enable_if_t<std::is_enum_v<Enum>>> _CONSTANT_FN&
+operator&=(_Inout_ Enum& a, _In_ Enum b) noexcept { return (a = a & b); }
 
 template<typename Enum, typename = std::enable_if_t<std::is_enum_v<Enum>>>
 _CONSTANT_FN& operator&=(_Inout_ Enum& a, _In_ Enum b) noexcept

--- a/src/services/impl/FileLogger.hh
+++ b/src/services/impl/FileLogger.hh
@@ -110,6 +110,13 @@ private:
         pWriter.WriteLine();
     }
 
+        // if writing to a file, flush immediately
+        auto* pFileWriter = dynamic_cast<ra::services::impl::FileTextWriter*>(m_pWriter.get());
+        if (pFileWriter != nullptr)
+            pFileWriter->GetFStream().flush();
+    }
+
+private:
     std::unique_ptr<ra::services::TextWriter> m_pWriter;
     mutable std::mutex m_oMutex;
 };

--- a/src/services/impl/FileLogger.hh
+++ b/src/services/impl/FileLogger.hh
@@ -35,10 +35,7 @@ public:
             m_pWriter->WriteLine();
     }
 
-    bool IsEnabled([[maybe_unused]] LogLevel level) const override
-    {
-        return true;
-    }
+    bool IsEnabled([[maybe_unused]] LogLevel level) const override { return true; }
 
     void LogMessage(LogLevel level, const std::string& sMessage) const override
     {
@@ -51,7 +48,8 @@ public:
         if (ServiceLocator::Exists<IClock>())
         {
             const auto tNow = ServiceLocator::Get<IClock>().Now();
-            tMilliseconds = static_cast<unsigned int>(std::chrono::time_point_cast<std::chrono::milliseconds>(tNow).time_since_epoch().count() % 1000);
+            tMilliseconds = static_cast<unsigned int>(
+                std::chrono::time_point_cast<std::chrono::milliseconds>(tNow).time_since_epoch().count() % 1000);
             tTime = std::chrono::system_clock::to_time_t(tNow);
         }
         else
@@ -67,7 +65,7 @@ public:
         strftime(sBuffer, sizeof(sBuffer), "%H%M%S", &tTimeStruct);
         sprintf_s(&sBuffer[6], sizeof(sBuffer) - 6, ".%03u|", tMilliseconds);
 
-        // WinXP hangs if we try to acquire a mutex while the DLL in initializing. Since DllMain writes 
+        // WinXP hangs if we try to acquire a mutex while the DLL in initializing. Since DllMain writes
         // a header block to the log file, we have to do that without using a mutex. Luckily, we're not
         // going to have multiple threads trying to write to the file, so it'll be safe, and we can
         // use the presence (or lack thereof) of the ThreadPool implementation to determine if we're
@@ -89,17 +87,23 @@ public:
     }
 
 private:
-
-    static void LogMessage(ra::services::TextWriter& pWriter, char* sTimestamp, LogLevel level, const std::string& sMessage)
+    static void LogMessage(ra::services::TextWriter& pWriter, char* sTimestamp, LogLevel level,
+                           const std::string& sMessage)
     {
         pWriter.Write(sTimestamp);
 
         // mark the level
         switch (level)
         {
-            case LogLevel::Info: pWriter.Write("INFO"); break;
-            case LogLevel::Warn: pWriter.Write("WARN"); break;
-            case LogLevel::Error: pWriter.Write("ERR "); break;
+            case LogLevel::Info:
+                pWriter.Write("INFO");
+                break;
+            case LogLevel::Warn:
+                pWriter.Write("WARN");
+                break;
+            case LogLevel::Error:
+                pWriter.Write("ERR ");
+                break;
         }
         pWriter.Write("| ");
 
@@ -110,13 +114,6 @@ private:
         pWriter.WriteLine();
     }
 
-        // if writing to a file, flush immediately
-        auto* pFileWriter = dynamic_cast<ra::services::impl::FileTextWriter*>(m_pWriter.get());
-        if (pFileWriter != nullptr)
-            pFileWriter->GetFStream().flush();
-    }
-
-private:
     std::unique_ptr<ra::services::TextWriter> m_pWriter;
     mutable std::mutex m_oMutex;
 };


### PR DESCRIPTION
To attempt to optimize code further, I made this `type_trait` to adjust for situations if a type `T` is a primitive or not. I'll explain some things after this PR is submitted.

The only thing I couldn't figure out how to do was test for unions, but aggregate types pass/fail as expected.

Example:
```
static_assert(ra::is_literal_type<std::array<int, 5>>); // passes
static_assert(ra::is_literal_type<std::array<std::string, 5>>); // fails, std::string is not a literal type.
```

Reference:
https://en.cppreference.com/w/cpp/named_req/LiteralType