### PR TITLE
Use ISurface rendering for leaderboards

### DIFF
--- a/src/RA_AchievementPopup.cpp
+++ b/src/RA_AchievementPopup.cpp
@@ -47,10 +47,8 @@ void AchievementPopup::AddMessage(MessagePopup&& msg)
     PlayAudio();
 }
 
-void AchievementPopup::Update(_UNUSED ControllerInput, float fDelta, _UNUSED bool, bool bPaused)
+void AchievementPopup::Update(float fDelta)
 {
-    if (bPaused)
-        fDelta = 0.0F;
     fDelta = std::clamp(fDelta, 0.0F, 0.3F); // Limit this!
     if (m_vMessages.size() > 0)
     {
@@ -157,12 +155,10 @@ const ra::ui::drawing::ISurface& MessagePopup::GetRendered()
     return *m_pSurface;
 }
 
-void AchievementPopup::Render(HDC hDC, const RECT& rcDest)
+void AchievementPopup::Render(ra::ui::drawing::ISurface& pSurface)
 {
     if (!MessagesPresent())
         return;
-
-    ra::ui::drawing::gdi::GDISurface pSurface(hDC, rcDest);
 
     float fFadeInY = GetYOffsetPct() * (POPUP_DIST_Y_FROM_PCT * static_cast<float>(pSurface.GetHeight()));
     fFadeInY += (POPUP_DIST_Y_TO_PCT * static_cast<float>(pSurface.GetHeight()));

--- a/src/RA_AchievementPopup.h
+++ b/src/RA_AchievementPopup.h
@@ -57,8 +57,8 @@ private:
 class AchievementPopup
 {
 public:
-    void Update(_UNUSED ControllerInput, float fDelta, _UNUSED bool, bool bPaused);
-    void Render(_In_ HDC hDC, _In_ const RECT& rcDest);
+    void Update(float fDelta);
+    void Render(ra::ui::drawing::ISurface& pSurface);
 
     void AddMessage(MessagePopup&& msg);
     float GetYOffsetPct() const;

--- a/src/RA_LeaderboardPopup.cpp
+++ b/src/RA_LeaderboardPopup.cpp
@@ -7,6 +7,8 @@
 #include "services\ILeaderboardManager.hh"
 #include "services\ServiceLocator.hh"
 
+#include "ui\drawing\ISurface.hh"
+
 //	No emulator-specific code here please!
 
 namespace {
@@ -17,11 +19,8 @@ const float SCOREBOARD_FINISH_AT = 7.0f;
 
 const char* FONT_TO_USE = "Tahoma";
 
-const COLORREF g_ColBG = RGB(32, 32, 32);
-
-const int FONT_SIZE_TITLE = 28;
-const int FONT_SIZE_SUBTITLE = 22;
-const int FONT_SIZE_TEXT = 16;
+const int FONT_SIZE_TITLE = 22;
+const int FONT_SIZE_TEXT = 22;
 
 }
 
@@ -52,14 +51,11 @@ void LeaderboardPopup::Reset()
     m_nState = PopupState::ShowingProgress;
 }
 
-void LeaderboardPopup::Update(_UNUSED ControllerInput, float fDelta, _UNUSED BOOL, BOOL bPaused)
+void LeaderboardPopup::Update(float fDelta)
 {
     auto& pConfiguration = ra::services::ServiceLocator::Get<ra::services::IConfiguration>();
     if (!pConfiguration.IsFeatureEnabled(ra::services::Feature::Leaderboards))	//	If not, simply ignore them.
         return;
-
-    if (bPaused)
-        fDelta = 0.0f;
 
     if (m_fScoreboardShowTimer >= SCOREBOARD_FINISH_AT)
     {
@@ -162,65 +158,19 @@ float LeaderboardPopup::GetOffsetPct() const
 }
 
 _Use_decl_annotations_
-void LeaderboardPopup::Render(HDC hDC, const RECT& rcDest)
+void LeaderboardPopup::Render(ra::ui::drawing::ISurface& pSurface)
 {
     auto& pConfiguration = ra::services::ServiceLocator::Get<ra::services::IConfiguration>();
     if (!pConfiguration.IsFeatureEnabled(ra::services::Feature::Leaderboards))	//	If not, simply ignore them.
         return;
 
-    SetBkColor(hDC, COL_TEXT_HIGHLIGHT);
-    SetTextColor(hDC, COL_POPUP);
+    const int nWidth = pSurface.GetWidth();
+    const int nHeight = pSurface.GetHeight();
 
-    HFONT hFontTitle = CreateFont(FONT_SIZE_TITLE, 0, 0, 0, FW_NORMAL, FALSE, FALSE, FALSE,
-        DEFAULT_CHARSET, OUT_DEFAULT_PRECIS, CLIP_CHARACTER_PRECIS, ANTIALIASED_QUALITY,/*NONANTIALIASED_QUALITY,*/
-        DEFAULT_PITCH, NativeStr(FONT_TO_USE).c_str());
-
-    HFONT hFontDesc = CreateFont(FONT_SIZE_SUBTITLE, 0, 0, 0, FW_NORMAL, FALSE, FALSE, FALSE,
-        DEFAULT_CHARSET, OUT_DEFAULT_PRECIS, CLIP_CHARACTER_PRECIS, ANTIALIASED_QUALITY,/*NONANTIALIASED_QUALITY,*/
-        DEFAULT_PITCH, NativeStr(FONT_TO_USE).c_str());
-
-    HFONT hFontText = CreateFont(FONT_SIZE_TEXT, 0, 0, 0, FW_NORMAL, FALSE, FALSE, FALSE,
-        DEFAULT_CHARSET, OUT_DEFAULT_PRECIS, CLIP_CHARACTER_PRECIS, ANTIALIASED_QUALITY,/*NONANTIALIASED_QUALITY,*/
-        DEFAULT_PITCH, NativeStr(FONT_TO_USE).c_str());
-
-
-    const int nWidth = rcDest.right - rcDest.left;
-    const int nHeight = rcDest.bottom - rcDest.top;
-
-    //float fOffscreenAmount = ( GetOffsetPct() * ( POPUP_DIST_FROM_PCT * (float)nWidth ) );
-    const float fOffscreenAmount = (GetOffsetPct() * 600);
-    //float fFadeOffs = (POPUP_DIST_TO_PCT * (float)nWidth ) + fOffscreenAmount;
-    const float fFadeOffs = (nWidth - 300) + fOffscreenAmount;
-
-    const int nScoreboardX = (int)fFadeOffs;
-    const int nScoreboardY = (int)nHeight - 200;
-
-    const int nRightLim = (int)((nWidth - 8) + fOffscreenAmount);
-
-    //if( GetMessageType() == 1 )
-    //{
-    //	DrawImage( hDC, GetImage(), nTitleX, nTitleY, 64, 64 );
-
-    //	nTitleX += 64+4+2;	//	Negate the 2 from earlier!
-    //	nDescX += 64+4;
-    //}
-
-
-    HGDIOBJ hPen = CreatePen(PS_SOLID, 2, RGB(0, 0, 0));
-
-    HBRUSH hBrushBG = CreateSolidBrush(g_ColBG);
-
-    RECT rcScoreboardFrame;
-    if (pConfiguration.IsFeatureEnabled(ra::services::Feature::LeaderboardScoreboards))
-    {
-        SetRect(&rcScoreboardFrame, nScoreboardX, nScoreboardY, nRightLim, nHeight - 8);
-        InflateRect(&rcScoreboardFrame, 2, 2);
-    }
-    else
-        SetRect(&rcScoreboardFrame, 0, 0, 0, 0);
-    FillRect(hDC, &rcScoreboardFrame, hBrushBG);
-
-    HGDIOBJ hOld = SelectObject(hDC, hFontDesc);
+    const ra::ui::Color nColorBackground(0, 255, 0, 255);
+    const ra::ui::Color nColorBlack(0, 0, 0);
+    const ra::ui::Color nColorPopup(251, 102, 0);
+    constexpr int nShadowOffset = 2;
 
     switch (m_nState)
     {
@@ -229,32 +179,36 @@ void LeaderboardPopup::Render(HDC hDC, const RECT& rcDest)
             if (!pConfiguration.IsFeatureEnabled(ra::services::Feature::LeaderboardCounters))
                 break;
 
+            const auto& pSurfaceFactory = ra::services::ServiceLocator::Get<ra::ui::drawing::ISurfaceFactory>();
+            auto pTempSurface = pSurfaceFactory.CreateSurface(1, 1);
+            auto nFontText = pTempSurface->LoadFont(FONT_TO_USE, FONT_SIZE_TEXT, ra::ui::FontStyles::Normal);
+
             auto& pLeaderboardManager = ra::services::ServiceLocator::Get<ra::services::ILeaderboardManager>();
-            int nProgressYOffs = 0;
+            int nY = pSurface.GetHeight() - 10;
             std::vector<unsigned int>::const_iterator iter = m_vActiveLBIDs.begin();
             while (iter != m_vActiveLBIDs.end())
             {
                 const RA_Leaderboard* pLB = pLeaderboardManager.FindLB(*iter);
                 if (pLB != nullptr)
                 {
-                    //	Show current progress:
-                    std::string sScoreSoFar = std::string(" ") + pLB->FormatScore(static_cast<int>(pLB->GetCurrentValue())) + std::string(" ");
+                    const auto sScoreSoFar = ra::Widen(pLB->FormatScore(static_cast<int>(pLB->GetCurrentValue())));
+                    auto szScoreSoFar = pTempSurface->MeasureText(nFontText, sScoreSoFar);
 
-                    SIZE szProgress;
-                    GetTextExtentPoint32(hDC, NativeStr(sScoreSoFar).c_str(), sScoreSoFar.length(), &szProgress);
+                    auto pRenderSurface = pSurfaceFactory.CreateTransparentSurface(szScoreSoFar.Width + 8 + 2, szScoreSoFar.Height + 2);
 
-                    HGDIOBJ hBkup = SelectObject(hDC, hPen);
+                    // background
+                    pRenderSurface->FillRectangle(0, 0, pRenderSurface->GetWidth(), pRenderSurface->GetHeight(), nColorBackground);
 
-                    MoveToEx(hDC, nWidth - 8, nHeight - 8 - szProgress.cy + nProgressYOffs, nullptr);
-                    LineTo(hDC, nWidth - 8, nHeight - 8 + nProgressYOffs);							//	down
-                    LineTo(hDC, nWidth - 8 - szProgress.cx, nHeight - 8 + nProgressYOffs);			//	left
+                    // text
+                    pRenderSurface->FillRectangle(nShadowOffset, nShadowOffset, szScoreSoFar.Width + 8, szScoreSoFar.Height, nColorBlack);
+                    pRenderSurface->FillRectangle(0, 0, szScoreSoFar.Width + 8, szScoreSoFar.Height, nColorPopup);
+                    pRenderSurface->WriteText(4, 0, nFontText, nColorBlack, sScoreSoFar);
 
-                    RECT rcProgress;
-                    SetRect(&rcProgress, 0, 0, nWidth - 8, nHeight - 8 + nProgressYOffs);
-                    DrawText(hDC, NativeStr(sScoreSoFar).c_str(), sScoreSoFar.length(), &rcProgress, DT_BOTTOM | DT_RIGHT | DT_SINGLELINE);
+                    pRenderSurface->SetOpacity(0.85);
 
-                    SelectObject(hDC, hBkup);
-                    nProgressYOffs -= 26;
+                    nY -= pRenderSurface->GetHeight();
+                    pSurface.DrawSurface(nWidth - pRenderSurface->GetWidth() - 10, nY, *pRenderSurface);
+                    nY -= 2;
                 }
 
                 iter++;
@@ -267,67 +221,63 @@ void LeaderboardPopup::Render(HDC hDC, const RECT& rcDest)
             if (!pConfiguration.IsFeatureEnabled(ra::services::Feature::LeaderboardScoreboards))
                 break;
 
+            const ra::ui::Color nColorBackgroundFill(32, 32, 32);
+
             auto& pLeaderboardManager = ra::services::ServiceLocator::Get<ra::services::ILeaderboardManager>();
             const RA_Leaderboard* pLB = pLeaderboardManager.FindLB(m_vScoreboardQueue.front());
             if (pLB != nullptr)
             {
-                char buffer[1024];
-                sprintf_s(buffer, 1024, " Results: %s ", pLB->Title().c_str());
-                RECT rcTitle = { nScoreboardX + 2, nScoreboardY + 2, nRightLim - 2, nHeight - 8 };
-                DrawText(hDC, NativeStr(buffer).c_str(), strlen(buffer), &rcTitle, DT_TOP | DT_LEFT | DT_SINGLELINE);
+                const auto& pSurfaceFactory = ra::services::ServiceLocator::Get<ra::ui::drawing::ISurfaceFactory>();
+                auto pRenderSurface = pSurfaceFactory.CreateTransparentSurface(300, 200);
+                auto nFontTitle = pRenderSurface->LoadFont(FONT_TO_USE, FONT_SIZE_TITLE, ra::ui::FontStyles::Normal);
+                auto nFontText = pRenderSurface->LoadFont(FONT_TO_USE, FONT_SIZE_TEXT, ra::ui::FontStyles::Normal);
 
-                //	Show scoreboard
-                RECT rcScoreboard = { nScoreboardX + 2, nScoreboardY + 32, nRightLim - 2, nHeight - 16 };
-                for (size_t i = 0; i < pLB->GetRankInfoCount(); ++i)
+                // background
+                pRenderSurface->FillRectangle(0, 0, pRenderSurface->GetWidth(), pRenderSurface->GetHeight(), nColorBackground);
+                pRenderSurface->FillRectangle(2, 2, pRenderSurface->GetWidth() - nShadowOffset, pRenderSurface->GetHeight() - nShadowOffset, nColorBlack);
+                pRenderSurface->FillRectangle(0, 0, pRenderSurface->GetWidth() - nShadowOffset, pRenderSurface->GetHeight() - nShadowOffset, nColorBackgroundFill);
+
+                // title
+                const auto sResultsTitle = ra::StringPrintf(L"Results: %s", pLB->Title());
+                pRenderSurface->FillRectangle(4, 4, pRenderSurface->GetWidth() - nShadowOffset - 8, FONT_SIZE_TITLE, nColorPopup);
+                pRenderSurface->WriteText(8, 3, nFontTitle, nColorBlack, sResultsTitle);
+
+                // scoreboard
+                size_t nY = 4 + FONT_SIZE_TITLE + 4;
+                size_t i = 0;
+                while (i < pLB->GetRankInfoCount() && nY + FONT_SIZE_TEXT < pRenderSurface->GetHeight())
                 {
-                    const RA_Leaderboard::Entry& lbInfo = pLB->GetRankInfo(i);
+                    const RA_Leaderboard::Entry& lbInfo = pLB->GetRankInfo(i++);
+                    ra::ui::Color nTextColor = nColorPopup;
 
-                    if (lbInfo.m_sUsername.compare(RAUsers::LocalUser().Username()) == 0)
+                    if (i == 3) //lbInfo.m_sUsername.compare(RAUsers::LocalUser().Username()) == 0)
                     {
-                        SetBkMode(hDC, OPAQUE);
-                        SetTextColor(hDC, COL_POPUP);
-                    }
-                    else
-                    {
-                        SetBkMode(hDC, TRANSPARENT);
-                        SetTextColor(hDC, COL_TEXT_HIGHLIGHT);
+                        //pRenderSurface->FillRectangle(4, nY, pRenderSurface->GetWidth() - nShadowOffset - 8, FONT_SIZE_TEXT, nColorPopup);
+                        nTextColor = ra::ui::Color(255, 192, 128);
                     }
 
-                    
-                    {
-                        const auto str{
-                            ra::StringPrintf(_T(" %u %s "), lbInfo.m_nRank, lbInfo.m_sUsername.c_str())
-                        };
+                    pRenderSurface->WriteText(8, nY, nFontText, nTextColor, ra::ToWString(i));
+                    pRenderSurface->WriteText(24, nY, nFontText, nTextColor, ra::Widen(lbInfo.m_sUsername));
 
-                        DrawText(hDC, str.c_str(), ra::narrow_cast<int>(str.length()),
-                                    &rcScoreboard, DT_TOP | DT_LEFT | DT_SINGLELINE);
-                    }
-                    std::string sScore(" " + pLB->FormatScore(lbInfo.m_nScore) + " ");
-                    DrawText(hDC, NativeStr(sScore).c_str(), sScore.length(), &rcScoreboard, DT_TOP | DT_RIGHT | DT_SINGLELINE);
+                    const auto sScore = ra::Widen(pLB->FormatScore(lbInfo.m_nScore));
+                    auto szScore = pRenderSurface->MeasureText(nFontText, sScore);
+                    pRenderSurface->WriteText(pRenderSurface->GetWidth() - 4 - szScore.Width - 8, nY, nFontText, nTextColor, sScore);
 
-                    rcScoreboard.top += 24;
-
-                    //	If we're about to draw the local, outranked player, offset a little more
-                    if (i == 5)
-                        rcScoreboard.top += 4;
+                    nY += FONT_SIZE_TEXT + 2;
                 }
-            }
 
-            //	Restore
-            //SetBkMode( hDC, nOldBkMode );
+                pRenderSurface->SetOpacity(0.85);
+
+                const float fOffscreenAmount = (GetOffsetPct() * 600);
+                const float fFadeOffs = (nWidth - 300 - 10) + fOffscreenAmount;
+                const int nScoreboardX = (int)fFadeOffs;
+                const int nScoreboardY = (int)nHeight - 200 - 10;
+                pSurface.DrawSurface(nScoreboardX, nScoreboardY, *pRenderSurface);
+            }
         }
         break;
 
         default:
             break;
     }
-
-    //	Restore old obj
-    SelectObject(hDC, hOld);
-
-    DeleteObject(hBrushBG);
-    DeleteObject(hPen);
-    DeleteObject(hFontTitle);
-    DeleteObject(hFontDesc);
-    DeleteObject(hFontText);
 }

--- a/src/RA_LeaderboardPopup.h
+++ b/src/RA_LeaderboardPopup.h
@@ -36,6 +36,8 @@ private:
     float m_fScoreboardShowTimer;
     std::vector<unsigned int> m_vActiveLBIDs;
     std::queue<unsigned int> m_vScoreboardQueue;
+
+    std::unique_ptr<ra::ui::drawing::ISurface> m_pScoreboardSurface;
 };
 
 

--- a/src/RA_LeaderboardPopup.h
+++ b/src/RA_LeaderboardPopup.h
@@ -4,6 +4,8 @@
 
 #include "RA_AchievementOverlay.h"
 
+#include "ui\drawing\ISurface.hh"
+
 //	Graphic to display current leaderboard progress
 
 class LeaderboardPopup
@@ -17,8 +19,8 @@ class LeaderboardPopup
 public:
     LeaderboardPopup();
 
-    void Update(_UNUSED ControllerInput, float fDelta, _UNUSED BOOL, BOOL bPaused);
-    void Render(_In_ HDC hDC, _In_ const RECT& rcDest);
+    void Update(float fDelta);
+    void Render(ra::ui::drawing::ISurface& pSurface);
 
     void Reset();
     BOOL Activate(_In_ ra::LeaderboardID nLBID);

--- a/src/RA_PopupWindows.cpp
+++ b/src/RA_PopupWindows.cpp
@@ -8,7 +8,7 @@ LeaderboardPopup PopupWindows::m_LeaderboardPopups;
 
 //	Stubs for non-class based, indirect calling of these functions.
 _Use_decl_annotations_
-API int _RA_UpdatePopups(ControllerInput* __restrict input, float fDTime, bool Full_Screen, bool Paused)
+API int _RA_UpdatePopups(_UNUSED ControllerInput* __restrict input, float fDTime, _UNUSED bool Full_Screen, bool Paused)
 {
     if (Paused)
         fDTime = 0.0F;

--- a/src/RA_PopupWindows.cpp
+++ b/src/RA_PopupWindows.cpp
@@ -10,7 +10,10 @@ LeaderboardPopup PopupWindows::m_LeaderboardPopups;
 _Use_decl_annotations_
 API int _RA_UpdatePopups(ControllerInput* __restrict input, float fDTime, bool Full_Screen, bool Paused)
 {
-    PopupWindows::Update(input, fDTime, Full_Screen, Paused);
+    if (Paused)
+        fDTime = 0.0F;
+
+    PopupWindows::Update(fDTime);
     return 0;
 }
 

--- a/src/RA_PopupWindows.h
+++ b/src/RA_PopupWindows.h
@@ -6,22 +6,23 @@
 #include "RA_LeaderboardPopup.h"
 #include "RA_Core.h"
 
+#include "ui\drawing\gdi\GDISurface.hh"
+
 class PopupWindows
 {
 public:
-    static void Update(_In_ const ControllerInput* const __restrict pInput,
-                       _In_ float fDelta,
-                       _In_ bool bFullscreen,
-                       _In_ bool bPaused)
+    static void Update( _In_ float fDelta)
     {
-        m_AchievementPopups.Update(*pInput, fDelta, bFullscreen, bPaused);
-        m_LeaderboardPopups.Update(*pInput, fDelta, bFullscreen, bPaused);
+        m_AchievementPopups.Update(fDelta);
+        m_LeaderboardPopups.Update(fDelta);
     }
 
     static void Render(_In_ HDC hDC, const RECT* const __restrict rcDest)
     {
-        m_AchievementPopups.Render(hDC, *rcDest);
-        m_LeaderboardPopups.Render(hDC, *rcDest);
+        ra::ui::drawing::gdi::GDISurface pSurface(hDC, *rcDest);
+
+        m_AchievementPopups.Render(pSurface);
+        m_LeaderboardPopups.Render(pSurface);
     }
 
     static void Clear()

--- a/src/ui/drawing/gdi/GDIBitmapSurface.cpp
+++ b/src/ui/drawing/gdi/GDIBitmapSurface.cpp
@@ -94,6 +94,8 @@ void GDIAlphaBitmapSurface::WriteText(int nX, int nY, int nFont, Color nColor, c
 
     UINT32* pTextBits{};
     HBITMAP hBitmap = CreateDIBSection(hMemDC, &bmi, DIB_RGB_COLORS, reinterpret_cast<LPVOID*>(&pTextBits), nullptr, 0);
+    assert(hBitmap != nullptr);
+    assert(pTextBits != nullptr);
     SelectBitmap(hMemDC, hBitmap);
 
     SelectFont(hMemDC, m_pResourceRepository.GetHFont(nFont));
@@ -104,6 +106,7 @@ void GDIAlphaBitmapSurface::WriteText(int nX, int nY, int nFont, Color nColor, c
     // copy the greyscale text to the forground using the grey value as the alpha for antialiasing
     auto nStride = GetWidth();
     auto nFirstScanline = (GetHeight() - nY - szText.cy); // bitmap memory starts with the bottom scanline
+    assert(ra::to_signed(nFirstScanline) >= 0);
     auto pBits = m_pBits + nStride * nFirstScanline + nX;
 
     auto nLines = szText.cy;

--- a/src/ui/drawing/gdi/GDIBitmapSurface.hh
+++ b/src/ui/drawing/gdi/GDIBitmapSurface.hh
@@ -30,12 +30,14 @@ public:
 
     ~GDIBitmapSurface() noexcept
     {
-        if (m_hBitmap) DeleteBitmap(m_hBitmap);
-        if (m_hMemDC) DeleteDC(m_hMemDC);
+        if (m_hBitmap)
+            DeleteBitmap(m_hBitmap);
+        if (m_hMemDC)
+            DeleteDC(m_hMemDC);
     }
 
 protected:
-    UINT32* m_pBits;
+    UINT32* m_pBits; // see note below about initializing this
 
 private:
     HDC CreateBitmapHDC(const int nWidth, const int nHeight)
@@ -55,14 +57,18 @@ private:
 
         LPVOID pBits{};
         m_hBitmap = CreateDIBSection(m_hMemDC, &bmi, DIB_RGB_COLORS, &pBits, nullptr, 0);
+        assert(m_hBitmap != nullptr);
+        assert(pBits != nullptr);
         m_pBits = reinterpret_cast<UINT32*>(pBits);
 
         SelectObject(m_hMemDC, m_hBitmap);
         return m_hMemDC;
     }
 
-    HBITMAP m_hBitmap{};
-    HDC m_hMemDC{};
+    // IMPORTANT: m_hBitmap, m_hMemDC, and m_pBits are set by CreateBitmapHDC, which is called from the constructor.
+    // explicitly setting an initial value causes the constructor calculated values to be overridden.
+    HBITMAP m_hBitmap;
+    HDC m_hMemDC;
 };
 
 class GDIAlphaBitmapSurface : public GDIBitmapSurface


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/32680403/49334981-acf35200-f5a0-11e8-9226-f244fcb2b58b.png)

After:
![image](https://user-images.githubusercontent.com/32680403/49334965-38201800-f5a0-11e8-8126-2bfa51a2a570.png)

* Title banner extended across entire popup
* Added 15% transparency
* Added drop-shadow
* Increased margin to edge of window
* Current player (hard-coded as I'm not on the list) changed from inverted rectangle to alternate color
* Enlarged popup slightly to fit 7th entry