### PR TITLE
Cppcorecheck function rules

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -5,13 +5,13 @@
 AlignAfterOpenBracket: true
 AlignEscapedNewlinesLeft: true
 AlignTrailingComments: true
-AlignConsecutiveAssignments: true
+AlignConsecutiveAssignments: false
 
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortFunctionsOnASingleLine: All
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
-AllowShortCaseLabelsOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: false
 
 AlwaysBreakBeforeMultilineStrings: true
 AlwaysBreakTemplateDeclarations: true

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "lua"]
 	path = lua
 	url = https://github.com/lua/lua.git
+[submodule "GSL"]
+	path = GSL
+	url = https://github.com/Microsoft/GSL.git

--- a/RA_Integration.sln
+++ b/RA_Integration.sln
@@ -13,6 +13,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "RA_Integration.Tests", "tests\RA_Integration.Tests.vcxproj", "{876DEBDF-C7C8-4713-8CEF-EBDEE65306A7}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "rcheevos", "src\rcheevos.vcxproj", "{9D55EBE7-1392-4FA1-A9B9-F022F764CE35}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Analysis|Win32 = Analysis|Win32
@@ -42,6 +44,16 @@ Global
 		{876DEBDF-C7C8-4713-8CEF-EBDEE65306A7}.Release|Win32.Build.0 = Release|Win32
 		{876DEBDF-C7C8-4713-8CEF-EBDEE65306A7}.ReleaseWithDebug|Win32.ActiveCfg = Release|Win32
 		{876DEBDF-C7C8-4713-8CEF-EBDEE65306A7}.ReleaseWithDebug|Win32.Build.0 = Release|Win32
+		{9D55EBE7-1392-4FA1-A9B9-F022F764CE35}.Analysis|Win32.ActiveCfg = Release|Win32
+		{9D55EBE7-1392-4FA1-A9B9-F022F764CE35}.Analysis|Win32.Build.0 = Release|Win32
+		{9D55EBE7-1392-4FA1-A9B9-F022F764CE35}.AnalysisUnicode|Win32.ActiveCfg = Release|Win32
+		{9D55EBE7-1392-4FA1-A9B9-F022F764CE35}.AnalysisUnicode|Win32.Build.0 = Release|Win32
+		{9D55EBE7-1392-4FA1-A9B9-F022F764CE35}.Debug|Win32.ActiveCfg = Debug|Win32
+		{9D55EBE7-1392-4FA1-A9B9-F022F764CE35}.Debug|Win32.Build.0 = Debug|Win32
+		{9D55EBE7-1392-4FA1-A9B9-F022F764CE35}.Release|Win32.ActiveCfg = Release|Win32
+		{9D55EBE7-1392-4FA1-A9B9-F022F764CE35}.Release|Win32.Build.0 = Release|Win32
+		{9D55EBE7-1392-4FA1-A9B9-F022F764CE35}.ReleaseWithDebug|Win32.ActiveCfg = Release|Win32
+		{9D55EBE7-1392-4FA1-A9B9-F022F764CE35}.ReleaseWithDebug|Win32.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/RA_Integration.sln
+++ b/RA_Integration.sln
@@ -9,6 +9,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		.clang-format = .clang-format
 		.editorconfig = .editorconfig
+		src\ra_rules.ruleset = src\ra_rules.ruleset
 	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "RA_Integration.Tests", "tests\RA_Integration.Tests.vcxproj", "{876DEBDF-C7C8-4713-8CEF-EBDEE65306A7}"

--- a/src/RA_Achievement.cpp
+++ b/src/RA_Achievement.cpp
@@ -192,7 +192,7 @@ void Achievement::ParseTrigger(const char* sTrigger)
     }
 }
 
-const char* Achievement::ParseLine(const char* pBuffer)
+const char* Achievement::ParseLine(const char* restrict pBuffer)
 {
 #ifndef RA_UTEST
     std::string sTemp;

--- a/src/RA_Achievement.cpp
+++ b/src/RA_Achievement.cpp
@@ -67,7 +67,7 @@ void Achievement::RebuildTrigger()
     SetDirtyFlag(DirtyFlags::Conditions);
 }
 
-static MemSize GetCompVariableSize(char nOperandSize)
+static constexpr MemSize GetCompVariableSize(char nOperandSize) noexcept
 {
     switch (nOperandSize)
     {
@@ -203,9 +203,9 @@ const char* Achievement::ParseLine(const char* pBuffer)
     if (pBuffer[0] == '/' || pBuffer[0] == '\\')
         return pBuffer;
 
-    //	Read ID of achievement:
+    // Read ID of achievement:
     _ReadStringTil(sTemp, ':', pBuffer);
-    SetID((unsigned int)atol(sTemp.c_str()));
+    SetID(std::stoul(sTemp));
 
     //	parse conditions
     const char* pTrigger = pBuffer;
@@ -241,13 +241,13 @@ const char* Achievement::ParseLine(const char* pBuffer)
     SetAuthor(sTemp);
 
     _ReadStringTil(sTemp, ':', pBuffer);
-    SetPoints((unsigned int)atol(sTemp.c_str()));
+    SetPoints(std::stoul(sTemp));
 
     _ReadStringTil(sTemp, ':', pBuffer);
-    SetCreatedDate((time_t)atol(sTemp.c_str()));
+    SetCreatedDate(std::stoll(sTemp));
 
     _ReadStringTil(sTemp, ':', pBuffer);
-    SetModifiedDate((time_t)atol(sTemp.c_str()));
+    SetModifiedDate(std::stoll(sTemp));
 
     _ReadStringTil(sTemp, ':', pBuffer);
     // SetUpvotes( (unsigned short)atol( sTemp.c_str() ) );
@@ -261,7 +261,7 @@ const char* Achievement::ParseLine(const char* pBuffer)
     return pBuffer;
 }
 
-static bool HasHitCounts(const rc_condset_t* pCondSet)
+static constexpr bool HasHitCounts(const rc_condset_t* pCondSet) noexcept
 {
     rc_condition_t* condition = pCondSet->conditions;
     while (condition != nullptr)
@@ -318,7 +318,7 @@ bool Achievement::Test()
     return bRetVal;
 }
 
-static rc_condition_t* GetTriggerCondition(rc_trigger_t* pTrigger, size_t nGroup, size_t nIndex)
+static constexpr rc_condition_t* GetTriggerCondition(rc_trigger_t* pTrigger, size_t nGroup, size_t nIndex) noexcept
 {
     rc_condset_t* pGroup = pTrigger->requirement;
     if (nGroup > 0)
@@ -430,13 +430,13 @@ void Achievement::RemoveConditionGroup()
     m_vConditions.RemoveLastGroup();
 }
 
-void Achievement::SetID(ra::AchievementID nID)
+void Achievement::SetID(ra::AchievementID nID) noexcept
 {
     m_nAchievementID = nID;
     SetDirtyFlag(DirtyFlags::ID);
 }
 
-void Achievement::SetActive(BOOL bActive)
+void Achievement::SetActive(BOOL bActive) noexcept
 {
     if (m_bActive != bActive)
     {
@@ -457,12 +457,12 @@ void Achievement::SetActive(BOOL bActive)
 //	SetDirtyFlag( Dirty_Votes );
 //}
 
-void Achievement::SetModified(BOOL bModified)
+void Achievement::SetModified(BOOL bModified) noexcept
 {
     if (m_bModified != bModified)
     {
         m_bModified = bModified;
-        SetDirtyFlag(DirtyFlags::All);	//	TBD? questionable...
+        SetDirtyFlag(DirtyFlags::All); // TBD? questionable...
     }
 }
 
@@ -476,7 +476,7 @@ void Achievement::SetBadgeImage(const std::string& sBadgeURI)
         m_sBadgeImageURI = sBadgeURI;
 }
 
-void Achievement::Reset()
+void Achievement::Reset() noexcept
 {
     if (m_pTrigger)
     {

--- a/src/RA_Achievement.cpp
+++ b/src/RA_Achievement.cpp
@@ -275,7 +275,7 @@ static constexpr bool HasHitCounts(const rc_condset_t* pCondSet) noexcept
     return false;
 }
 
-static bool HasHitCounts(const rc_trigger_t* pTrigger)
+static constexpr bool HasHitCounts(const rc_trigger_t* pTrigger) noexcept
 {
     if (HasHitCounts(pTrigger->requirement))
         return true;
@@ -292,7 +292,7 @@ static bool HasHitCounts(const rc_trigger_t* pTrigger)
     return false;
 }
 
-bool Achievement::Test()
+bool Achievement::Test() noexcept
 {
     if (m_pTrigger == nullptr)
         return false;
@@ -346,7 +346,7 @@ static constexpr rc_condition_t* GetTriggerCondition(rc_trigger_t* pTrigger, siz
     return pCondition;
 }
 
-unsigned int Achievement::GetConditionHitCount(size_t nGroup, size_t nIndex) const
+unsigned int Achievement::GetConditionHitCount(size_t nGroup, size_t nIndex) const noexcept
 {
     if (m_pTrigger == nullptr)
         return 0U;
@@ -356,7 +356,7 @@ unsigned int Achievement::GetConditionHitCount(size_t nGroup, size_t nIndex) con
     return pCondition ? pCondition->current_hits : 0U;
 }
 
-int Achievement::StoreConditionState(size_t nGroup, size_t nIndex, char *pBuffer) const
+int Achievement::StoreConditionState(size_t nGroup, size_t nIndex, char* pBuffer) const noexcept
 {
     if (m_pTrigger != nullptr)
     {
@@ -372,7 +372,8 @@ int Achievement::StoreConditionState(size_t nGroup, size_t nIndex, char *pBuffer
     return snprintf(pBuffer, 128, "0:0:0:0:0:");
 }
 
-void Achievement::RestoreConditionState(size_t nGroup, size_t nIndex, unsigned int nCurrentHits, unsigned int nValue, unsigned int nPreviousValue)
+void Achievement::RestoreConditionState(size_t nGroup, size_t nIndex, unsigned int nCurrentHits, unsigned int nValue,
+                                        unsigned int nPreviousValue) noexcept
 {
     if (m_pTrigger == nullptr)
         return;
@@ -387,7 +388,7 @@ void Achievement::RestoreConditionState(size_t nGroup, size_t nIndex, unsigned i
     pCondition->operand2.previous = nPreviousValue;
 }
 
-void Achievement::Clear()
+void Achievement::Clear() noexcept
 {
     m_vConditions.Clear();
 
@@ -409,10 +410,10 @@ void Achievement::Clear()
     ClearDirtyFlag();
 
     m_bProgressEnabled = FALSE;
-    m_sProgress[0] = '\0';
-    m_sProgressMax[0] = '\0';
-    m_sProgressFmt[0] = '\0';
-    m_fProgressLastShown = 0.0f;
+    m_sProgress.clear();
+    m_sProgressMax.clear();
+    m_sProgressFmt.clear();
+    m_fProgressLastShown = 0.0F;
 
     m_nTimestampCreated = 0;
     m_nTimestampModified = 0;
@@ -420,15 +421,8 @@ void Achievement::Clear()
     //m_nDownvotes = 0;
 }
 
-void Achievement::AddConditionGroup()
-{
-    m_vConditions.AddGroup();
-}
-
-void Achievement::RemoveConditionGroup()
-{
-    m_vConditions.RemoveLastGroup();
-}
+void Achievement::AddConditionGroup() noexcept { m_vConditions.AddGroup(); }
+void Achievement::RemoveConditionGroup() { m_vConditions.RemoveLastGroup(); }
 
 void Achievement::SetID(ra::AchievementID nID) noexcept
 {

--- a/src/RA_Achievement.h
+++ b/src/RA_Achievement.h
@@ -17,14 +17,14 @@ public:
     enum class DirtyFlags
     {
         Clean,
-        Title = 1 << 0,
-        Desc = 1 << 1,
-        Points = 1 << 2,
-        Author = 1 << 3,
-        ID = 1 << 4,
-        Badge = 1 << 5,
-        Conditions = 1 << 6,
-        Votes = 1 << 7,
+        Title       = 1 << 0,
+        Desc        = 1 << 1,
+        Points      = 1 << 2,
+        Author      = 1 << 3,
+        ID          = 1 << 4,
+        Badge       = 1 << 5,
+        Conditions  = 1 << 6,
+        Votes       = 1 << 7,
         Description = 1 << 8,
 
         All = std::numeric_limits<std::underlying_type_t<DirtyFlags>>::max()
@@ -107,7 +107,7 @@ public:
 
     // Returns the new char* offset after parsing.
     [[gsl::suppress(f.6)]] const char*
-        ParseLine(const char* sBuffer); /*Doesn't throw in tests but does in Integration */
+        ParseLine(const char* restrict sBuffer); /*Doesn't throw in tests but might in Integration */
     const char* ParseStateString(const char* sBuffer, const std::string& sSalt);
 
 #ifndef RA_UTEST

--- a/src/RA_Achievement.h
+++ b/src/RA_Achievement.h
@@ -17,14 +17,14 @@ public:
     enum class DirtyFlags
     {
         Clean,
-        Title       = 1 << 0,
-        Desc        = 1 << 1,
-        Points      = 1 << 2,
-        Author      = 1 << 3,
-        ID          = 1 << 4,
-        Badge       = 1 << 5,
-        Conditions  = 1 << 6,
-        Votes       = 1 << 7,
+        Title = 1 << 0,
+        Desc = 1 << 1,
+        Points = 1 << 2,
+        Author = 1 << 3,
+        ID = 1 << 4,
+        Badge = 1 << 5,
+        Conditions = 1 << 6,
+        Votes = 1 << 7,
         Description = 1 << 8,
 
         All = std::numeric_limits<std::underlying_type_t<DirtyFlags>>::max()
@@ -43,67 +43,71 @@ public:
 
     void Set(const Achievement& rRHS);
 
-    inline BOOL Active() const { return m_bActive; }
-    void SetActive(BOOL bActive);
+    inline BOOL Active() const noexcept { return m_bActive; }
+    void SetActive(BOOL bActive) noexcept;
 
-    inline BOOL Modified() const { return m_bModified; }
-    void SetModified(BOOL bModified);
+    inline BOOL Modified() const noexcept { return m_bModified; }
+    void SetModified(BOOL bModified) noexcept;
 
-    inline BOOL GetPauseOnTrigger() const { return m_bPauseOnTrigger; }
-    void SetPauseOnTrigger(BOOL bPause) { m_bPauseOnTrigger = bPause; }
+    inline BOOL GetPauseOnTrigger() const noexcept { return m_bPauseOnTrigger; }
+    void SetPauseOnTrigger(BOOL bPause) noexcept { m_bPauseOnTrigger = bPause; }
 
-    inline BOOL GetPauseOnReset() const { return m_bPauseOnReset; }
-    void SetPauseOnReset(BOOL bPause) { m_bPauseOnReset = bPause; }
+    inline BOOL GetPauseOnReset() const noexcept { return m_bPauseOnReset; }
+    void SetPauseOnReset(BOOL bPause) noexcept { m_bPauseOnReset = bPause; }
 
-    void SetID(ra::AchievementID nID);
-    inline ra::AchievementID ID() const { return m_nAchievementID; }
+    void SetID(ra::AchievementID nID) noexcept;
+    inline ra::AchievementID ID() const noexcept { return m_nAchievementID; }
 
-    inline const std::string& Title() const { return m_sTitle; }
+    inline const std::string& Title() const noexcept { return m_sTitle; }
     void SetTitle(const std::string& sTitle) { m_sTitle = sTitle; }
-    inline const std::string& Description() const { return m_sDescription; }
+    inline const std::string& Description() const noexcept { return m_sDescription; }
     void SetDescription(const std::string& sDescription) { m_sDescription = sDescription; }
-    inline const std::string& Author() const { return m_sAuthor; }
+    inline const std::string& Author() const noexcept { return m_sAuthor; }
     void SetAuthor(const std::string& sAuthor) { m_sAuthor = sAuthor; }
-    inline unsigned int Points() const { return m_nPointValue; }
-    void SetPoints(unsigned int nPoints) { m_nPointValue = nPoints; }
+    inline unsigned int Points() const noexcept { return m_nPointValue; }
+    void SetPoints(unsigned int nPoints) noexcept { m_nPointValue = nPoints; }
 
-    inline time_t CreatedDate() const { return m_nTimestampCreated; }
-    void SetCreatedDate(time_t nTimeCreated) { m_nTimestampCreated = nTimeCreated; }
-    inline time_t ModifiedDate() const { return m_nTimestampModified; }
-    void SetModifiedDate(time_t nTimeModified) { m_nTimestampModified = nTimeModified; }
+    inline time_t CreatedDate() const noexcept { return m_nTimestampCreated; }
+    void SetCreatedDate(time_t nTimeCreated) noexcept { m_nTimestampCreated = nTimeCreated; }
+    inline time_t ModifiedDate() const noexcept { return m_nTimestampModified; }
+    void SetModifiedDate(time_t nTimeModified) noexcept { m_nTimestampModified = nTimeModified; }
 
-    inline unsigned short Upvotes() const { return m_nUpvotes; }
-    inline unsigned short Downvotes() const { return m_nDownvotes; }
+    inline unsigned short Upvotes() const noexcept { return m_nUpvotes; }
+    inline unsigned short Downvotes() const noexcept { return m_nDownvotes; }
 
-    inline const std::string& Progress() const { return m_sProgress; }
+    inline const std::string& Progress() const noexcept { return m_sProgress; }
     void SetProgressIndicator(const std::string& sProgress) { m_sProgress = sProgress; }
-    inline const std::string& ProgressMax() const { return m_sProgressMax; }
+    inline const std::string& ProgressMax() const noexcept { return m_sProgressMax; }
     void SetProgressIndicatorMax(const std::string& sProgressMax) { m_sProgressMax = sProgressMax; }
-    inline const std::string& ProgressFmt() const { return m_sProgressFmt; }
+    inline const std::string& ProgressFmt() const noexcept { return m_sProgressFmt; }
     void SetProgressIndicatorFormat(const std::string& sProgressFmt) { m_sProgressFmt = sProgressFmt; }
-
 
     void AddConditionGroup();
     void RemoveConditionGroup();
 
     inline size_t NumConditionGroups() const { return m_vConditions.GroupCount(); }
-    inline size_t NumConditions(size_t nGroup) const { return nGroup < m_vConditions.GroupCount() ? m_vConditions.GetGroup(nGroup).Count() : 0; }
+    inline size_t NumConditions(size_t nGroup) const
+    {
+        return nGroup < m_vConditions.GroupCount() ? m_vConditions.GetGroup(nGroup).Count() : 0;
+    }
 
-    inline const std::string& BadgeImageURI() const { return m_sBadgeImageURI; }
+    inline const std::string& BadgeImageURI() const noexcept { return m_sBadgeImageURI; }
     void SetBadgeImage(const std::string& sFilename);
 
     Condition& GetCondition(size_t nCondGroup, size_t i) { return m_vConditions.GetGroup(nCondGroup).GetAt(i); }
     unsigned int GetConditionHitCount(size_t nCondGroup, size_t i) const;
     int StoreConditionState(size_t nCondGroup, size_t i, char* pBuffer) const;
-    void RestoreConditionState(size_t nCondGroup, size_t i, unsigned int nCurrentHits, unsigned int nValue, unsigned int nPrevValue);
+    void RestoreConditionState(size_t nCondGroup, size_t i, unsigned int nCurrentHits, unsigned int nValue,
+                               unsigned int nPrevValue);
 
     std::string CreateMemString() const;
     std::string CreateStateString(const std::string& sSalt) const;
 
-    void Reset();
+    void Reset() noexcept;
 
-    //	Returns the new char* offset after parsing.
-    const char* ParseLine(const char* sBuffer);
+    // Returns the new char* offset after parsing.
+    [[gsl::suppress(f.6)]] const char*
+        ParseLine(const char* sBuffer); /*Doesn't throw in tests but does in Integration */
     const char* ParseStateString(const char* sBuffer, const std::string& sSalt);
 
 #ifndef RA_UTEST
@@ -128,13 +132,13 @@ public:
 protected:
     void ParseTrigger(const char* pTrigger);
 
-    void*                             m_pTrigger = nullptr; //  rc_trigger_t
-    std::shared_ptr<unsigned char[]>  m_pTriggerBuffer;     //  buffer for rc_trigger_t
+    void* m_pTrigger = nullptr;                        //  rc_trigger_t
+    std::shared_ptr<unsigned char[]> m_pTriggerBuffer; //  buffer for rc_trigger_t
 
 private:
     ra::AchievementID m_nAchievementID;
 
-    ConditionSet                      m_vConditions;        //  UI wrappers for trigger
+    ConditionSet m_vConditions; //  UI wrappers for trigger
 
     std::string m_sTitle;
     std::string m_sDescription;
@@ -148,15 +152,15 @@ private:
     BOOL m_bPauseOnReset{};
 
     //	Progress:
-    BOOL m_bProgressEnabled{};	//	on/off
+    BOOL m_bProgressEnabled{}; //	on/off
 
-    std::string m_sProgress;	//	How to calculate the progress so far (syntactical)
-    std::string m_sProgressMax;	//	Upper limit of the progress (syntactical? value?)
-    std::string m_sProgressFmt;	//	Format of the progress to be shown (currency? step?)
+    std::string m_sProgress;    //	How to calculate the progress so far (syntactical)
+    std::string m_sProgressMax; //	Upper limit of the progress (syntactical? value?)
+    std::string m_sProgressFmt; //	Format of the progress to be shown (currency? step?)
 
-    float m_fProgressLastShown{};	//	The last shown progress
+    float m_fProgressLastShown{}; //	The last shown progress
 
-    DirtyFlags m_nDirtyFlags{};	//	Use for rendering when editing.
+    DirtyFlags m_nDirtyFlags{}; //	Use for rendering when editing.
 
     time_t m_nTimestampCreated{};
     time_t m_nTimestampModified{};

--- a/src/RA_Achievement.h
+++ b/src/RA_Achievement.h
@@ -33,8 +33,8 @@ public:
     Achievement() noexcept;
 
 public:
-    void Clear();
-    bool Test();
+    void Clear() noexcept;
+    [[gsl::suppress(f.6)]] bool Test() noexcept;
 
     size_t AddCondition(size_t nConditionGroup, const Condition& pNewCond);
     size_t InsertCondition(size_t nConditionGroup, size_t nIndex, const Condition& pNewCond);
@@ -82,10 +82,10 @@ public:
     inline const std::string& ProgressFmt() const noexcept { return m_sProgressFmt; }
     void SetProgressIndicatorFormat(const std::string& sProgressFmt) { m_sProgressFmt = sProgressFmt; }
 
-    void AddConditionGroup();
+    void AddConditionGroup() noexcept;
     void RemoveConditionGroup();
 
-    inline size_t NumConditionGroups() const { return m_vConditions.GroupCount(); }
+    inline size_t NumConditionGroups() const noexcept { return m_vConditions.GroupCount(); }
     inline size_t NumConditions(size_t nGroup) const
     {
         return nGroup < m_vConditions.GroupCount() ? m_vConditions.GetGroup(nGroup).Count() : 0;
@@ -95,10 +95,10 @@ public:
     void SetBadgeImage(const std::string& sFilename);
 
     Condition& GetCondition(size_t nCondGroup, size_t i) { return m_vConditions.GetGroup(nCondGroup).GetAt(i); }
-    unsigned int GetConditionHitCount(size_t nCondGroup, size_t i) const;
-    int StoreConditionState(size_t nCondGroup, size_t i, char* pBuffer) const;
+    unsigned int GetConditionHitCount(size_t nCondGroup, size_t i) const noexcept;
+    int StoreConditionState(size_t nCondGroup, size_t i, char* pBuffer) const noexcept;
     void RestoreConditionState(size_t nCondGroup, size_t i, unsigned int nCurrentHits, unsigned int nValue,
-                               unsigned int nPrevValue);
+                               unsigned int nPrevValue) noexcept;
 
     std::string CreateMemString() const;
     std::string CreateStateString(const std::string& sSalt) const;

--- a/src/RA_Achievement.h
+++ b/src/RA_Achievement.h
@@ -34,7 +34,7 @@ public:
 
 public:
     void Clear() noexcept;
-    [[gsl::suppress(f.6)]] bool Test() noexcept;
+    GSL_SUPPRESS(f.6) bool Test() noexcept;
 
     size_t AddCondition(size_t nConditionGroup, const Condition& pNewCond);
     size_t InsertCondition(size_t nConditionGroup, size_t nIndex, const Condition& pNewCond);
@@ -106,7 +106,7 @@ public:
     void Reset() noexcept;
 
     // Returns the new char* offset after parsing.
-    [[gsl::suppress(f.6)]] const char*
+    GSL_SUPPRESS(f.6) const char*
         ParseLine(const char* restrict sBuffer); /*Doesn't throw in tests but might in Integration */
     const char* ParseStateString(const char* sBuffer, const std::string& sSalt);
 

--- a/src/RA_AchievementOverlay.cpp
+++ b/src/RA_AchievementOverlay.cpp
@@ -1491,14 +1491,6 @@ void AchievementOverlay::UpdateImages() noexcept
     m_hUserImage.ChangeReference(ra::ui::ImageType::UserPic, RAUsers::LocalUser().Username());
 }
 
-AchievementExamine::AchievementExamine() :
-    m_pSelectedAchievement(nullptr),
-    m_bHasData(false),
-    m_nTotalWinners(0),
-    m_nPossibleWinners(0)
-{
-}
-
 void AchievementExamine::Clear()
 {
     m_pSelectedAchievement = nullptr;

--- a/src/RA_AchievementOverlay.cpp
+++ b/src/RA_AchievementOverlay.cpp
@@ -472,7 +472,8 @@ void AchievementOverlay::DrawAchievementsPage(HDC hDC, int nDX, int nDY, const R
     const int nHeight = rcTarget.bottom - rcTarget.top;
 
     auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::GameContext>();
-    auto nPlayTime = static_cast<unsigned int>(ra::services::ServiceLocator::Get<ra::data::SessionTracker>().GetTotalPlaytime(pGameContext.GameId()).count());
+    const auto nPlayTime = static_cast<unsigned int>(
+        ra::services::ServiceLocator::Get<ra::data::SessionTracker>().GetTotalPlaytime(pGameContext.GameId()).count());
 
     // title
     const auto& sGameTitle = pGameContext.GameTitle();
@@ -527,7 +528,7 @@ void AchievementOverlay::DrawAchievementsPage(HDC hDC, int nDX, int nDY, const R
     {
         for (int i = 0; i < nAchievementsToDraw; ++i)
         {
-            int nAchIdx = (*pnScrollOffset) + i;
+            const int nAchIdx = (*pnScrollOffset) + i;
             if (nAchIdx < static_cast<int>(nNumberOfAchievements))
             {
                 const BOOL bSelected = ((*pnSelectedItem) - (*pnScrollOffset) == i);

--- a/src/RA_AchievementOverlay.cpp
+++ b/src/RA_AchievementOverlay.cpp
@@ -48,27 +48,19 @@ AchievementOverlay g_AchievementOverlay;
 AchievementExamine g_AchExamine;
 LeaderboardExamine g_LBExamine;
 
-const COLORREF COL_TEXT = RGB(17, 102, 221);
-const COLORREF COL_TEXT_HIGHLIGHT = RGB(251, 102, 0);
-const COLORREF COL_SELECTED = RGB(255, 255, 255);
-const COLORREF COL_TEXT_LOCKED = RGB(137, 137, 137);
-const COLORREF COL_SELECTED_LOCKED = RGB(202, 202, 202);
-const COLORREF COL_BLACK = RGB(0, 0, 0);
-const COLORREF COL_WHITE = RGB(255, 255, 255);
-const COLORREF COL_BAR = RGB(0, 40, 0);
-const COLORREF COL_BAR_BG = RGB(0, 212, 0);
-const COLORREF COL_POPUP = RGB(0, 0, 40);
-const COLORREF COL_POPUP_BG = RGB(212, 212, 212);
-const COLORREF COL_POPUP_SHADOW = RGB(0, 0, 0);
-const COLORREF COL_USER_FRAME_BG = RGB(32, 32, 32);
-const COLORREF COL_SELECTED_BOX_BG = RGB(22, 22, 60);
-const COLORREF COL_WARNING = RGB(255, 0, 0);
-const COLORREF COL_WARNING_BG = RGB(80, 0, 0);
+_CONSTANT_VAR COL_TEXT_LOCKED     = RGB(137, 137, 137);
+_CONSTANT_VAR COL_SELECTED_LOCKED = RGB(202, 202, 202);
+_CONSTANT_VAR COL_BAR             = RGB(0, 40, 0);
+_CONSTANT_VAR COL_BAR_BG          = RGB(0, 212, 0);
+_CONSTANT_VAR COL_USER_FRAME_BG   = RGB(32, 32, 32);
+_CONSTANT_VAR COL_SELECTED_BOX_BG = RGB(22, 22, 60);
+_CONSTANT_VAR COL_WARNING         = RGB(255, 0, 0);
+_CONSTANT_VAR COL_WARNING_BG      = RGB(80, 0, 0);
 
-const unsigned int OVERLAY_WIDTH = 1024;
-const unsigned int OVERLAY_HEIGHT = 1024;
+_CONSTANT_VAR OVERLAY_WIDTH  = 1024U;
+_CONSTANT_VAR OVERLAY_HEIGHT = 1024U;
 
-void AchievementOverlay::SelectNextTopLevelPage(BOOL bPressedRight)
+void AchievementOverlay::SelectNextTopLevelPage(BOOL bPressedRight) noexcept
 {
     switch (m_Pages.at(m_nPageStackPointer))
     {
@@ -94,7 +86,7 @@ void AchievementOverlay::SelectNextTopLevelPage(BOOL bPressedRight)
     }
 }
 
-void AchievementOverlay::Activate()
+void AchievementOverlay::Activate() noexcept
 {
     if (m_nTransitionState != TransitionState::Hold)
     {
@@ -103,7 +95,7 @@ void AchievementOverlay::Activate()
     }
 }
 
-void AchievementOverlay::Deactivate()
+void AchievementOverlay::Deactivate() noexcept
 {
     if (m_nTransitionState != TransitionState::Off && m_nTransitionState != TransitionState::Out)
     {
@@ -115,7 +107,7 @@ void AchievementOverlay::Deactivate()
 }
 
 //	Returns TRUE if we are ready to exit the overlay.
-BOOL AchievementOverlay::GoBack()
+BOOL AchievementOverlay::GoBack() noexcept
 {
     if (m_nPageStackPointer == 0)
     {
@@ -573,20 +565,8 @@ void AchievementOverlay::DrawAchievementsPage(HDC hDC, int nDX, int nDY, const R
     m_nNumAchievementsBeingRendered = nAchievementsToDraw;
 }
 
-void AchievementOverlay::DrawMessagesPage(_UNUSED HDC, _UNUSED int, _UNUSED int, _UNUSED const RECT&) const
+void AchievementOverlay::DrawMessagesPage(_UNUSED HDC, _UNUSED int, _UNUSED int, _UNUSED const RECT&) const noexcept
 {
-    // 		for( size_t i = 0; i < 256; ++i )
-    // 			buffer[i] = (char)(i);
-    // 
-    // 		SelectObject( hDC, hFontDesc );
-    // 		TextOut( hDC, nDX+8, 40, buffer, 32 );
-    // 		TextOut( hDC, nDX+8, 60, buffer+32, 32 );
-    // 		TextOut( hDC, nDX+8, 80, buffer+64, 32 );
-    // 		TextOut( hDC, nDX+8, 100, buffer+96, 32 );
-    // 		TextOut( hDC, nDX+8, 120, buffer+128, 32 );
-    // 		TextOut( hDC, nDX+8, 140, buffer+160, 32 );
-    // 		TextOut( hDC, nDX+8, 160, buffer+192, 32 );
-    // 		TextOut( hDC, nDX+8, 180, buffer+224, 32 );
 }
 
 void AchievementOverlay::DrawFriendsPage(HDC hDC, int nDX, _UNUSED int, const RECT& rcTarget) const
@@ -1249,7 +1229,7 @@ void AchievementOverlay::Render(HDC hRealDC, const RECT* rcDest) const
     ::DeleteDC(hDC);
 }
 
-void AchievementOverlay::DrawBar(HDC hDC, int nX, int nY, int nW, int nH, int nMax, int nSel) const
+void AchievementOverlay::DrawBar(HDC hDC, int nX, int nY, int nW, int nH, int nMax, int nSel) const noexcept
 {
     HBRUSH hBarBack = static_cast<HBRUSH>(GetStockObject(DKGRAY_BRUSH));
     HBRUSH hBarFront = static_cast<HBRUSH>(GetStockObject(LTGRAY_BRUSH));
@@ -1377,7 +1357,7 @@ _Use_decl_annotations_ void AchievementOverlay::DrawUserFrame(HDC hDC, int nX, i
     DeleteObject(hBrush2);
 }
 
-int* AchievementOverlay::GetActiveScrollOffset() const
+int* AchievementOverlay::GetActiveScrollOffset() const noexcept
 {
     switch (m_Pages.at(m_nPageStackPointer))
     {
@@ -1403,7 +1383,7 @@ int* AchievementOverlay::GetActiveScrollOffset() const
     }
 }
 
-int* AchievementOverlay::GetActiveSelectedItem() const
+int* AchievementOverlay::GetActiveSelectedItem() const noexcept
 {
     switch (m_Pages.at(m_nPageStackPointer))
     {
@@ -1429,7 +1409,7 @@ int* AchievementOverlay::GetActiveSelectedItem() const
     }
 }
 
-void AchievementOverlay::OnLoad_NewRom()
+void AchievementOverlay::OnLoad_NewRom() noexcept
 {
     m_nAchievementsSelectedItem = 0;
     m_nAchievementsScrollOffset = 0;
@@ -1491,7 +1471,7 @@ void AchievementOverlay::UpdateImages() noexcept
     m_hUserImage.ChangeReference(ra::ui::ImageType::UserPic, RAUsers::LocalUser().Username());
 }
 
-void AchievementExamine::Clear()
+void AchievementExamine::Clear() noexcept
 {
     m_pSelectedAchievement = nullptr;
     m_CreatedDate.clear();
@@ -1553,7 +1533,7 @@ void AchievementExamine::OnReceiveData(rapidjson::Document& doc)
         const auto nDateAwarded{ static_cast<time_t>(ra::to_signed(NextWinner["DateAwarded"].GetUint())) };
         std::ostringstream oss;
         oss << NextWinner["User"].GetString() << " (" << NextWinner["RAPoints"].GetUint() << ")";
-        RecentWinners.push_back({ oss.str(), _TimeStampToString(nDateAwarded) });
+        RecentWinners.emplace_back(oss.str(), _TimeStampToString(nDateAwarded));
     }
 
     m_bHasData = true;

--- a/src/RA_AchievementOverlay.h
+++ b/src/RA_AchievementOverlay.h
@@ -3,8 +3,8 @@
 #pragma once
 
 #include "RA_Achievement.h"
-#include "RA_User.h"
 #include "RA_Core.h" // RA_Interface
+#include "RA_User.h"
 
 #include "ui\ImageReference.hh"
 
@@ -12,7 +12,7 @@ class LeaderboardExamine
 {
 public:
     void Initialize(const unsigned int nLBIDIn);
-    //static void CB_OnReceiveData( void* pRequestObject );
+    // static void CB_OnReceiveData( void* pRequestObject );
     void OnReceiveData(const rapidjson::Document& doc);
 
 public:
@@ -22,19 +22,14 @@ public:
 };
 extern LeaderboardExamine g_LBExamine;
 
-
 class AchievementExamine
 {
 public:
     class RecentWinnerData
     {
     public:
-        RecentWinnerData(const std::string& sUser, const std::string& sWonAt) :
-            m_sUser(sUser), m_sWonAt(sWonAt)
-        {
-        }
-        const std::string& User() const { return m_sUser; }
-        const std::string& WonAt() const { return m_sWonAt; }
+        const std::string& User() const noexcept { return m_sUser; }
+        const std::string& WonAt() const noexcept { return m_sWonAt; }
 
     private:
         const std::string m_sUser;
@@ -42,22 +37,18 @@ public:
     };
 
 public:
-    AchievementExamine();
-
-public:
     void Initialize(const Achievement* pAchIn);
     void Clear();
     void OnReceiveData(rapidjson::Document& doc);
 
-    bool HasData() const { return m_bHasData; }
-    const std::string& CreatedDate() const { return m_CreatedDate; }
-    const std::string& ModifiedDate() const { return m_LastModifiedDate; }
-    size_t NumRecentWinners() const { return RecentWinners.size(); }
+    bool HasData() const noexcept { return m_bHasData; }
+    const std::string& CreatedDate() const noexcept { return m_CreatedDate; }
+    const std::string& ModifiedDate() const noexcept { return m_LastModifiedDate; }
+    size_t NumRecentWinners() const noexcept { return RecentWinners.size(); }
     const RecentWinnerData& GetRecentWinner(size_t nOffs) const { return RecentWinners.at(nOffs); }
 
-    unsigned int TotalWinners() const { return m_nTotalWinners; }
-    unsigned int PossibleWinners() const { return m_nPossibleWinners; }
-
+    unsigned int TotalWinners() const noexcept { return m_nTotalWinners; }
+    unsigned int PossibleWinners() const noexcept { return m_nPossibleWinners; }
 
     _NODISCARD inline auto begin() noexcept { return RecentWinners.begin(); }
     _NODISCARD inline auto begin() const noexcept { return RecentWinners.begin(); }
@@ -65,20 +56,19 @@ public:
     _NODISCARD inline auto end() const noexcept { return RecentWinners.end(); }
 
 private:
-    const Achievement* m_pSelectedAchievement;
+    const Achievement* m_pSelectedAchievement{};
     std::string m_CreatedDate;
     std::string m_LastModifiedDate;
 
-    bool m_bHasData;
+    bool m_bHasData{};
 
     //	Data found:
-    unsigned int m_nTotalWinners;
-    unsigned int m_nPossibleWinners;
+    unsigned int m_nTotalWinners{};
+    unsigned int m_nPossibleWinners{};
 
     std::vector<RecentWinnerData> RecentWinners;
 };
 extern AchievementExamine g_AchExamine;
-
 
 class AchievementOverlay
 {
@@ -111,11 +101,10 @@ public:
     void Deactivate();
 
     void Render(_In_ HDC hDC, _In_ const RECT* rcDest) const;
-    _Success_(return)
-    _NODISCARD BOOL Update(_In_ const ControllerInput* input, _In_ float fDelta,
-                           _In_ BOOL bFullScreen, _In_ BOOL bPaused);
+    _Success_(return ) _NODISCARD BOOL
+        Update(_In_ const ControllerInput* input, _In_ float fDelta, _In_ BOOL bFullScreen, _In_ BOOL bPaused);
 
-    _NODISCARD _CONSTANT_FN IsActive() const noexcept { return(m_nTransitionState != TransitionState::Off); }
+    _NODISCARD _CONSTANT_FN IsActive() const noexcept { return (m_nTransitionState != TransitionState::Off); }
     _NODISCARD _CONSTANT_FN IsFullyVisible() const noexcept { return (m_nTransitionState == TransitionState::Hold); }
 
     int* GetActiveScrollOffset() const;
@@ -132,9 +121,7 @@ public:
     void DrawLeaderboardExaminePage(HDC hDC, int nDX, _UNUSED int, _UNUSED const RECT&) const;
 
     void DrawBar(HDC hDC, int nX, int nY, int nW, int nH, int nMax, int nSel) const;
-    void DrawUserFrame(_In_ HDC hDC,
-                       _In_ int nX,  _In_ int nY,
-                       _In_ int nW,  _In_ int nH) const;
+    void DrawUserFrame(_In_ HDC hDC, _In_ int nX, _In_ int nY, _In_ int nW, _In_ int nH) const;
     void DrawAchievement(HDC hDC, const Achievement* Ach, int nX, int nY, BOOL bSelected, BOOL bCanLock) const;
 
     _NODISCARD _CONSTANT_FN CurrentPage() const noexcept { return m_Pages.at(m_nPageStackPointer); }
@@ -164,32 +151,32 @@ public:
     };
 
 private:
-    inline static constexpr auto PAGE_TRANSITION_IN{ -0.200F };
-    inline static constexpr auto PAGE_TRANSITION_OUT{ 0.2F };
+    inline static constexpr auto PAGE_TRANSITION_IN{-0.200F};
+    inline static constexpr auto PAGE_TRANSITION_OUT{0.2F};
 
-    mutable int	m_nAchievementsScrollOffset{};
-    mutable int	m_nFriendsScrollOffset{};
-    mutable int	m_nMessagesScrollOffset{};
-    mutable int	m_nNewsScrollOffset{};
-    mutable int	m_nLeaderboardScrollOffset{};
+    mutable int m_nAchievementsScrollOffset{};
+    mutable int m_nFriendsScrollOffset{};
+    mutable int m_nMessagesScrollOffset{};
+    mutable int m_nNewsScrollOffset{};
+    mutable int m_nLeaderboardScrollOffset{};
 
-    mutable int	m_nAchievementsSelectedItem{};
-    mutable int	m_nFriendsSelectedItem{};
-    mutable int	m_nMessagesSelectedItem{};
-    mutable int	m_nNewsSelectedItem{};
-    mutable int	m_nLeaderboardSelectedItem{};
+    mutable int m_nAchievementsSelectedItem{};
+    mutable int m_nFriendsSelectedItem{};
+    mutable int m_nMessagesSelectedItem{};
+    mutable int m_nNewsSelectedItem{};
+    mutable int m_nLeaderboardSelectedItem{};
 
     mutable int m_nNumAchievementsBeingRendered{};
     mutable int m_nNumFriendsBeingRendered{};
     mutable int m_nNumLeaderboardsBeingRendered{};
 
-    BOOL                  m_bInputLock{}; // Waiting for pad release
+    BOOL m_bInputLock{}; // Waiting for pad release
     std::vector<NewsItem> m_LatestNews{};
-    TransitionState       m_nTransitionState{};
-    float                 m_fTransitionTimer{ PAGE_TRANSITION_IN };
+    TransitionState m_nTransitionState{};
+    float m_fTransitionTimer{PAGE_TRANSITION_IN};
 
-    std::array<Page, 5>   m_Pages{ Page::Achievements };
-    unsigned int          m_nPageStackPointer{};
+    std::array<Page, 5> m_Pages{Page::Achievements};
+    unsigned int m_nPageStackPointer{};
 
     ra::ui::ImageReference m_hOverlayBackground;
     ra::ui::ImageReference m_hUserImage;
@@ -199,11 +186,10 @@ extern AchievementOverlay g_AchievementOverlay;
 
 //	Exposed to DLL
 _EXTERN_C
-// Can't use restrict since the pointer is aliased
-[[gsl::suppress(con.3)]]
-API int _RA_UpdateOverlay(_In_ ControllerInput* pInput, _In_ float fDTime, _In_ bool Full_Screen, _In_ bool Paused);
-[[gsl::suppress(con.3)]]
-API void _RA_RenderOverlay(_In_ HDC hDC, _In_ RECT* rcSize);
+    // Can't use restrict since the pointer is aliased
+    [[gsl::suppress(con .3)]] API int
+    _RA_UpdateOverlay(_In_ ControllerInput* pInput, _In_ float fDTime, _In_ bool Full_Screen, _In_ bool Paused);
+[[gsl::suppress(con .3)]] API void _RA_RenderOverlay(_In_ HDC hDC, _In_ RECT* rcSize);
 API bool _RA_IsOverlayFullyVisible();
 _END_EXTERN_C
 
@@ -215,6 +201,5 @@ extern const COLORREF COL_BLACK;
 extern const COLORREF COL_POPUP;
 extern const COLORREF COL_POPUP_BG;
 extern const COLORREF COL_POPUP_SHADOW;
-
 
 #endif // !RA_ACHIEVEMENTOVERLAY_H

--- a/src/RA_AchievementOverlay.h
+++ b/src/RA_AchievementOverlay.h
@@ -106,8 +106,8 @@ public:
     void Deactivate() noexcept;
 
     void Render(_In_ HDC hDC, _In_ const RECT* rcDest) const;
-    _Success_(return ) _NODISCARD BOOL
-        Update(_In_ const ControllerInput* input, _In_ float fDelta, _In_ BOOL bFullScreen, _In_ BOOL bPaused);
+    _NODISCARD BOOL Update(_In_ const ControllerInput* input, _In_ float fDelta, _In_ BOOL bFullScreen,
+                           _In_ BOOL bPaused);
 
     _NODISCARD _CONSTANT_FN IsActive() const noexcept { return (m_nTransitionState != TransitionState::Off); }
     _NODISCARD _CONSTANT_FN IsFullyVisible() const noexcept { return (m_nTransitionState == TransitionState::Hold); }
@@ -140,7 +140,7 @@ public:
     void SelectNextTopLevelPage(BOOL bPressedRight) noexcept;
     void InstallNewsArticlesFromFile();
 
-    [[gsl::suppress(f.6)]] void UpdateImages() noexcept;
+    [[gsl::suppress(f .6)]] void UpdateImages() noexcept;
 
 public:
     struct NewsItem
@@ -189,14 +189,13 @@ private:
 };
 extern AchievementOverlay g_AchievementOverlay;
 
-//	Exposed to DLL
-_EXTERN_C
-    // Can't use restrict since the pointer is aliased
-    [[gsl::suppress(con .3)]] API int
-    _RA_UpdateOverlay(_In_ ControllerInput* pInput, _In_ float fDTime, _In_ bool Full_Screen, _In_ bool Paused);
-[[gsl::suppress(con .3)]] API void _RA_RenderOverlay(_In_ HDC hDC, _In_ RECT* rcSize);
+// Exposed to DLL
+extern "C" {
+[[gsl::suppress(con.3)]] API int _RA_UpdateOverlay(_In_ ControllerInput* pInput, _In_ float fDTime,
+                                                   _In_ bool Full_Screen, _In_ bool Paused);
+[[gsl::suppress(con.3)]] API void _RA_RenderOverlay(_In_ HDC hDC, _In_ RECT* rcSize);
 API bool _RA_IsOverlayFullyVisible();
-_END_EXTERN_C
+}
 
 _CONSTANT_VAR COL_TEXT           = RGB(17, 102, 221);
 _CONSTANT_VAR COL_TEXT_HIGHLIGHT = RGB(251, 102, 0);

--- a/src/RA_AchievementOverlay.h
+++ b/src/RA_AchievementOverlay.h
@@ -28,6 +28,11 @@ public:
     class RecentWinnerData
     {
     public:
+        explicit RecentWinnerData(const std::string& sUser, const std::string& sWonAt) :
+            m_sUser{sUser},
+            m_sWonAt{sWonAt}
+        {}
+
         const std::string& User() const noexcept { return m_sUser; }
         const std::string& WonAt() const noexcept { return m_sWonAt; }
 
@@ -38,7 +43,7 @@ public:
 
 public:
     void Initialize(const Achievement* pAchIn);
-    void Clear();
+    void Clear() noexcept;
     void OnReceiveData(rapidjson::Document& doc);
 
     bool HasData() const noexcept { return m_bHasData; }
@@ -97,8 +102,8 @@ class AchievementOverlay
     };
 
 public:
-    void Activate();
-    void Deactivate();
+    void Activate() noexcept;
+    void Deactivate() noexcept;
 
     void Render(_In_ HDC hDC, _In_ const RECT* rcDest) const;
     _Success_(return ) _NODISCARD BOOL
@@ -107,20 +112,20 @@ public:
     _NODISCARD _CONSTANT_FN IsActive() const noexcept { return (m_nTransitionState != TransitionState::Off); }
     _NODISCARD _CONSTANT_FN IsFullyVisible() const noexcept { return (m_nTransitionState == TransitionState::Hold); }
 
-    int* GetActiveScrollOffset() const;
-    int* GetActiveSelectedItem() const;
+    int* GetActiveScrollOffset() const noexcept;
+    int* GetActiveSelectedItem() const noexcept;
 
-    void OnLoad_NewRom();
+    void OnLoad_NewRom() noexcept;
 
     void DrawAchievementsPage(HDC hDC, int nDX, int nDY, const RECT& rcTarget) const;
     void DrawAchievementExaminePage(HDC hDC, int nDX, _UNUSED int, _UNUSED const RECT&) const;
-    void DrawMessagesPage(_UNUSED HDC, _UNUSED int, _UNUSED int, _UNUSED const RECT&) const;
+    void DrawMessagesPage(_UNUSED HDC, _UNUSED int, _UNUSED int, _UNUSED const RECT&) const noexcept;
     void DrawFriendsPage(HDC hDC, int nDX, _UNUSED int, const RECT& rcTarget) const;
     void DrawNewsPage(HDC hDC, int nDX, _UNUSED int, const RECT& rcTarget) const;
     void DrawLeaderboardPage(HDC hDC, int nDX, _UNUSED int, const RECT& rcTarget) const;
     void DrawLeaderboardExaminePage(HDC hDC, int nDX, _UNUSED int, _UNUSED const RECT&) const;
 
-    void DrawBar(HDC hDC, int nX, int nY, int nW, int nH, int nMax, int nSel) const;
+    void DrawBar(HDC hDC, int nX, int nY, int nW, int nH, int nMax, int nSel) const noexcept;
     void DrawUserFrame(_In_ HDC hDC, _In_ int nX, _In_ int nY, _In_ int nW, _In_ int nH) const;
     void DrawAchievement(HDC hDC, const Achievement* Ach, int nX, int nY, BOOL bSelected, BOOL bCanLock) const;
 
@@ -131,11 +136,11 @@ public:
         m_Pages.at(m_nPageStackPointer) = NewPage;
     }
 
-    BOOL GoBack();
-    void SelectNextTopLevelPage(BOOL bPressedRight);
+    BOOL GoBack() noexcept;
+    void SelectNextTopLevelPage(BOOL bPressedRight) noexcept;
     void InstallNewsArticlesFromFile();
 
-    void UpdateImages() noexcept;
+    [[gsl::suppress(f.6)]] void UpdateImages() noexcept;
 
 public:
     struct NewsItem
@@ -193,13 +198,13 @@ _EXTERN_C
 API bool _RA_IsOverlayFullyVisible();
 _END_EXTERN_C
 
-extern const COLORREF COL_TEXT;
-extern const COLORREF COL_TEXT_HIGHLIGHT;
-extern const COLORREF COL_SELECTED;
-extern const COLORREF COL_WHITE;
-extern const COLORREF COL_BLACK;
-extern const COLORREF COL_POPUP;
-extern const COLORREF COL_POPUP_BG;
-extern const COLORREF COL_POPUP_SHADOW;
+_CONSTANT_VAR COL_TEXT           = RGB(17, 102, 221);
+_CONSTANT_VAR COL_TEXT_HIGHLIGHT = RGB(251, 102, 0);
+_CONSTANT_VAR COL_SELECTED       = RGB(255, 255, 255);
+_CONSTANT_VAR COL_BLACK          = RGB(0, 0, 0);
+_CONSTANT_VAR COL_WHITE          = RGB(255, 255, 255);
+_CONSTANT_VAR COL_POPUP          = RGB(0, 0, 40);
+_CONSTANT_VAR COL_POPUP_BG       = RGB(212, 212, 212);
+_CONSTANT_VAR COL_POPUP_SHADOW   = RGB(0, 0, 0);
 
 #endif // !RA_ACHIEVEMENTOVERLAY_H

--- a/src/RA_AchievementPopup.cpp
+++ b/src/RA_AchievementPopup.cpp
@@ -106,11 +106,11 @@ const ra::ui::drawing::ISurface& MessagePopup::GetRendered()
 
     auto nFontTitle = pSurface->LoadFont(FONT_TO_USE, FONT_SIZE_TITLE, ra::ui::FontStyles::Normal);
     const auto sTitle = ra::Widen(Title());
-    auto szTitle = pSurface->MeasureText(nFontTitle, sTitle);
+    const auto szTitle = pSurface->MeasureText(nFontTitle, sTitle);
 
     auto nFontSubtitle = pSurface->LoadFont(FONT_TO_USE, FONT_SIZE_SUBTITLE, ra::ui::FontStyles::Normal);
     const auto sSubTitle = ra::Widen(Subtitle());
-    auto szSubTitle = pSurface->MeasureText(nFontSubtitle, sSubTitle);
+    const auto szSubTitle = pSurface->MeasureText(nFontSubtitle, sSubTitle);
 
     // create the actual surface
     const int nWidth = 64 + 6 + std::max(szTitle.Width, szSubTitle.Width) + 8 + 2;

--- a/src/RA_AchievementPopup.cpp
+++ b/src/RA_AchievementPopup.cpp
@@ -63,7 +63,7 @@ void AchievementPopup::Update(_UNUSED ControllerInput, float fDelta, _UNUSED boo
     }
 }
 
-float AchievementPopup::GetYOffsetPct() const
+float AchievementPopup::GetYOffsetPct() const noexcept
 {
     float fVal = 0.0F;
 

--- a/src/RA_AchievementPopup.h
+++ b/src/RA_AchievementPopup.h
@@ -61,7 +61,7 @@ public:
     void Render(_In_ HDC hDC, _In_ const RECT& rcDest);
 
     void AddMessage(MessagePopup&& msg);
-    float GetYOffsetPct() const;
+    float GetYOffsetPct() const noexcept;
 
     bool MessagesPresent() const { return (m_vMessages.size() > 0); }
 

--- a/src/RA_AchievementPopup.h
+++ b/src/RA_AchievementPopup.h
@@ -42,10 +42,10 @@ public:
     {
     }
 
-    const std::string& Title() const { return m_sMessageTitle; }
-    const std::string& Subtitle() const { return m_sMessageSubtitle; }
-    PopupMessageType Type() const { return m_nMessageType; }
-    const ra::ui::ImageReference& Image() const { return m_hMessageImage; }
+    const std::string& Title() const noexcept { return m_sMessageTitle; }
+    const std::string& Subtitle() const noexcept { return m_sMessageSubtitle; }
+    PopupMessageType Type() const noexcept { return m_nMessageType; }
+    const ra::ui::ImageReference& Image() const noexcept { return m_hMessageImage; }
 
     const ra::ui::drawing::ISurface& GetRendered();
 

--- a/src/RA_AchievementSet.cpp
+++ b/src/RA_AchievementSet.cpp
@@ -129,14 +129,10 @@ unsigned int AchievementSet::NumActive() const
     return nNumActive;
 }
 
-void AchievementSet::Clear()
+void AchievementSet::Clear() noexcept
 {
-    std::vector<Achievement>::iterator iter = m_Achievements.begin();
-    while (iter != m_Achievements.end())
-    {
-        iter->Clear();
-        iter++;
-    }
+    for (auto& ach : m_Achievements)
+        ach.Clear();
 
     m_Achievements.clear();
     m_bProcessingActive = TRUE;
@@ -222,7 +218,7 @@ void AchievementSet::Test()
     }
 }
 
-void AchievementSet::Reset()
+void AchievementSet::Reset() noexcept
 {
     for (Achievement& ach : m_Achievements)
         ach.Reset();

--- a/src/RA_AchievementSet.h
+++ b/src/RA_AchievementSet.h
@@ -41,7 +41,7 @@ public:
 
     //	Get Achievement at offset
     Achievement& GetAchievement(size_t nIter) { return m_Achievements[nIter]; }
-    inline size_t NumAchievements() const { return m_Achievements.size(); }
+    inline size_t NumAchievements() const noexcept { return m_Achievements.size(); }
 
     // Get Points Total
     inline unsigned int PointTotal()
@@ -72,8 +72,8 @@ public:
 
     unsigned int NumActive() const;
 
-    BOOL ProcessingActive() const { return m_bProcessingActive; }
-    void SetPaused(BOOL bIsPaused) { m_bProcessingActive = !bIsPaused; }
+    BOOL ProcessingActive() const noexcept { return m_bProcessingActive; }
+    void SetPaused(BOOL bIsPaused) noexcept { m_bProcessingActive = !bIsPaused; }
 
     BOOL HasUnsavedChanges();
 

--- a/src/RA_AchievementSet.h
+++ b/src/RA_AchievementSet.h
@@ -31,9 +31,9 @@ public:
 #endif // !RA_UTEST
 
 public:
-    void Clear();
+    void Clear() noexcept;
     void Test();
-    void Reset();
+    void Reset() noexcept;
 
     _Success_(return)
     bool LoadFromFile(_Inout_ unsigned int nGameID);
@@ -44,7 +44,7 @@ public:
     inline size_t NumAchievements() const noexcept { return m_Achievements.size(); }
 
     // Get Points Total
-    inline unsigned int PointTotal()
+    inline unsigned int PointTotal() noexcept
     {
         unsigned int total = 0U;
         for (auto& ach : m_Achievements) total += ach.Points();

--- a/src/RA_CodeNotes.cpp
+++ b/src/RA_CodeNotes.cpp
@@ -39,7 +39,7 @@ size_t CodeNotes::Load(unsigned int nID)
         const auto nAddr { static_cast<ra::ByteAddress>(std::stoul(sAddr, nullptr, 16)) };
         const std::string& sAuthor { note["User"].GetString() }; // Author?
 
-        m_CodeNotes.try_emplace(nAddr, CodeNoteObj{ sAuthor, sNote });
+        m_CodeNotes.try_emplace(nAddr, CodeNoteObj(sAuthor, sNote));
     }
 
     return m_CodeNotes.size();
@@ -77,7 +77,7 @@ void CodeNotes::OnCodeNotesResponse(rapidjson::Document& doc)
 void CodeNotes::Add(const ra::ByteAddress& nAddr, const std::string& sAuthor, const std::string& sNote)
 {
     if (m_CodeNotes.find(nAddr) == m_CodeNotes.end())
-        m_CodeNotes.insert(std::map<ra::ByteAddress, CodeNoteObj>::value_type(nAddr, CodeNoteObj(sAuthor, sNote)));
+        m_CodeNotes.try_emplace(nAddr, CodeNoteObj(sAuthor, sNote));
     else
         m_CodeNotes.at(nAddr).SetNote(sNote);
 

--- a/src/RA_CodeNotes.h
+++ b/src/RA_CodeNotes.h
@@ -10,6 +10,9 @@ public:
     class CodeNoteObj
     {
     public:
+        explicit CodeNoteObj(const std::string& sAuthor, const std::string& sNote) : m_sAuthor{sAuthor}, m_sNote{sNote}
+        {}
+
         const std::string& Author() const noexcept { return m_sAuthor; }
         const std::string& Note() const noexcept { return m_sNote; }
 

--- a/src/RA_CodeNotes.h
+++ b/src/RA_CodeNotes.h
@@ -10,14 +10,8 @@ public:
     class CodeNoteObj
     {
     public:
-        CodeNoteObj(const std::string& sAuthor, std::string sNote) :
-            m_sAuthor(sAuthor), m_sNote(sNote)
-        {
-        }
-
-    public:
-        const std::string& Author() const { return m_sAuthor; }
-        const std::string& Note() const { return m_sNote; }
+        const std::string& Author() const noexcept { return m_sAuthor; }
+        const std::string& Note() const noexcept { return m_sNote; }
 
         void SetNote(const std::string& sNote) { m_sNote = sNote; }
 
@@ -43,8 +37,8 @@ public:
         return(iter != m_CodeNotes.end()) ? &iter->second : nullptr;
     }
 
-    std::map<ra::ByteAddress, CodeNoteObj>::const_iterator FirstNote() const { return m_CodeNotes.begin(); }
-    std::map<ra::ByteAddress, CodeNoteObj>::const_iterator EndOfNotes() const { return m_CodeNotes.end(); }
+    _NODISCARD inline auto begin() const noexcept { return m_CodeNotes.cbegin(); }
+    _NODISCARD inline auto end() const noexcept { return m_CodeNotes.cend(); }
 
 private:
     std::map<ra::ByteAddress, CodeNoteObj> m_CodeNotes;

--- a/src/RA_Condition.h
+++ b/src/RA_Condition.h
@@ -184,7 +184,7 @@ public:
     void Clear() noexcept { m_vConditionGroups.clear(); }
     size_t GroupCount() const noexcept { return m_vConditionGroups.size(); }
     // TODO: Put in a type_trait for nothrow EmplaceConstructible to give a nothrow guarantee
-    [[gsl::suppress(f.6)]] void AddGroup() noexcept { m_vConditionGroups.emplace_back(); }
+    GSL_SUPPRESS(f.6) void AddGroup() noexcept { m_vConditionGroups.emplace_back(); }
     void RemoveLastGroup() { m_vConditionGroups.pop_back(); }
     ConditionGroup& GetGroup(size_t i) { return m_vConditionGroups[i]; }
     const ConditionGroup& GetGroup(size_t i) const { return m_vConditionGroups[i]; }

--- a/src/RA_Condition.h
+++ b/src/RA_Condition.h
@@ -183,7 +183,8 @@ public:
 
     void Clear() noexcept { m_vConditionGroups.clear(); }
     size_t GroupCount() const noexcept { return m_vConditionGroups.size(); }
-    void AddGroup() { m_vConditionGroups.emplace_back(); }
+    // TODO: Put in a type_trait for nothrow EmplaceConstructible to give a nothrow guarantee
+    [[gsl::suppress(f.6)]] void AddGroup() noexcept { m_vConditionGroups.emplace_back(); }
     void RemoveLastGroup() { m_vConditionGroups.pop_back(); }
     ConditionGroup& GetGroup(size_t i) { return m_vConditionGroups[i]; }
     const ConditionGroup& GetGroup(size_t i) const { return m_vConditionGroups[i]; }

--- a/src/RA_Condition.h
+++ b/src/RA_Condition.h
@@ -163,13 +163,13 @@ class ConditionGroup
 public:
     void SerializeAppend(std::string& buffer) const;
 
-    size_t Count() const { return m_Conditions.size(); }
+    size_t Count() const noexcept { return m_Conditions.size(); }
 
     void Add(const Condition& newCond) { m_Conditions.push_back(newCond); }
     void Insert(size_t i, const Condition& newCond) { m_Conditions.insert(m_Conditions.begin() + i, newCond); }
     Condition& GetAt(size_t i) { return m_Conditions[i]; }
     const Condition& GetAt(size_t i) const { return m_Conditions[i]; }
-    void Clear() { m_Conditions.clear(); }
+    void Clear() noexcept { m_Conditions.clear(); }
     void RemoveAt(size_t i);
 
 protected:
@@ -181,8 +181,8 @@ class ConditionSet
 public:
     void Serialize(std::string& buffer) const;
 
-    void Clear() { m_vConditionGroups.clear(); }
-    size_t GroupCount() const { return m_vConditionGroups.size(); }
+    void Clear() noexcept { m_vConditionGroups.clear(); }
+    size_t GroupCount() const noexcept { return m_vConditionGroups.size(); }
     void AddGroup() { m_vConditionGroups.emplace_back(); }
     void RemoveLastGroup() { m_vConditionGroups.pop_back(); }
     ConditionGroup& GetGroup(size_t i) { return m_vConditionGroups[i]; }

--- a/src/RA_Core.cpp
+++ b/src/RA_Core.cpp
@@ -495,7 +495,7 @@ API void CCONV _RA_ClearMemoryBanks()
 //	}
 //}
 
-static unsigned long long ParseVersion(const char* sVersion)
+static unsigned long long ParseVersion(const char* sVersion) noexcept
 {
     char* pPart;
     const auto major = strtoull(sVersion, &pPart, 10);
@@ -1288,7 +1288,7 @@ void CCONV _RA_InstallSharedFunctionsExt(bool(*fpIsActive)(void), void(*fpCauseU
 
 //////////////////////////////////////////////////////////////////////////
 
-BOOL _ReadTil(const char nChar, char buffer[], unsigned int nSize, DWORD* pCharsReadOut, FILE* pFile)
+BOOL _ReadTil(const char nChar, char* buffer, unsigned int nSize, DWORD* pCharsReadOut, FILE* pFile) noexcept
 {
     char pNextChar = '\0';
     memset(buffer, '\0', nSize);
@@ -1307,7 +1307,7 @@ BOOL _ReadTil(const char nChar, char buffer[], unsigned int nSize, DWORD* pChars
     return ((*pCharsReadOut) > 0);
 }
 
-char* _ReadStringTil(char nChar, char*& pOffsetInOut, BOOL bTerminate)
+char* _ReadStringTil(char nChar, char* restrict& pOffsetInOut, BOOL bTerminate) noexcept
 {
     char* pStartString = pOffsetInOut;
 
@@ -1341,8 +1341,7 @@ void _WriteBufferToFile(const std::wstring& sFileName, const std::string& raw)
     ofile.write(raw.c_str(), ra::to_signed(raw.length()));
 }
 
-_Use_decl_annotations_
-bool _ReadBufferFromFile(std::string& buffer, const wchar_t* const __restrict sFile)
+_Use_decl_annotations_ bool _ReadBufferFromFile(std::string& buffer, const wchar_t* const restrict sFile)
 {
     buffer.clear();
     std::ifstream file(sFile);
@@ -1358,7 +1357,7 @@ bool _ReadBufferFromFile(std::string& buffer, const wchar_t* const __restrict sF
     return true;
 }
 
-char* _MallocAndBulkReadFileToBuffer(const wchar_t* sFilename, long& nFileSizeOut)
+char* _MallocAndBulkReadFileToBuffer(const wchar_t* sFilename, long& nFileSizeOut) noexcept
 {
     nFileSizeOut = 0L;
     FILE* pf = nullptr;
@@ -1416,7 +1415,7 @@ BrowseCallbackProc(_In_ HWND hwnd, _In_ UINT uMsg, _In_ _UNUSED LPARAM lParam, _
 
 } /* namespace ra */
 
-std::string GetFolderFromDialog() noexcept
+std::string GetFolderFromDialog()
 {
     auto lpbi{ std::make_unique<BROWSEINFO>() };
     lpbi->hwndOwner = ::GetActiveWindow();
@@ -1426,7 +1425,7 @@ std::string GetFolderFromDialog() noexcept
     lpbi->lpszTitle = _T("Select ROM folder...");
 
     if (::OleInitialize(nullptr) != S_OK)
-        return "";
+        return std::string();
 
     lpbi->ulFlags = BIF_USENEWUI | BIF_VALIDATE;
     lpbi->lpfn    = ra::BrowseCallbackProc;
@@ -1445,13 +1444,13 @@ std::string GetFolderFromDialog() noexcept
         if (!owner)
         {
             ::OleUninitialize();
-            return "";
+            return std::string();
         }
 
         if (::SHGetPathFromIDList(owner.get(), lpbi->pszDisplayName) == 0)
         {
             ::OleUninitialize();
-            return "";
+            return std::string();
         }
         ret = ra::Narrow(lpbi->pszDisplayName);
     }
@@ -1459,7 +1458,7 @@ std::string GetFolderFromDialog() noexcept
     return ret;
 }
 
-BOOL CanCausePause()
+BOOL CanCausePause() noexcept
 {
     return (_RA_CausePause != nullptr);
 }

--- a/src/RA_Core.h
+++ b/src/RA_Core.h
@@ -7,7 +7,7 @@
 
 #include "Exports.hh"
 
-//	Non-exposed:
+// Non-exposed:
 extern std::wstring g_sHomeDir;
 
 extern HINSTANCE g_hRAKeysDLL;
@@ -19,24 +19,24 @@ extern const char* g_sClientVersion;
 extern const char* g_sClientName;
 extern bool g_bRAMTamperedWith;
 
-//	Read a file to a malloc'd buffer. Returns nullptr on error. Owner MUST free() buffer if not nullptr.
-extern char* _MallocAndBulkReadFileToBuffer(_In_z_ const wchar_t* sFilename, _Out_ long& nFileSizeOut);
+// Read a file to a malloc'd buffer. Returns nullptr on error. Owner MUST free() buffer if not nullptr.
+extern char* _MallocAndBulkReadFileToBuffer(_In_z_ const wchar_t* sFilename, _Out_ long& nFileSizeOut) noexcept;
 
-//  Read a file to a std::string. Returns false on error.
-_Success_(return)
-_NODISCARD bool _ReadBufferFromFile(_Out_ std::string& buffer, _In_ const wchar_t* const __restrict sFile);
+// Read a file to a std::string. Returns false on error.
+_Success_(return) _NODISCARD
+bool _ReadBufferFromFile(_Out_ std::string& buffer, _In_ const wchar_t* restrict sFile);
 
-//	Read file until reaching the end of the file, or the specified char.
-extern BOOL _ReadTil(const char nChar, char buffer[], unsigned int nSize, DWORD* pCharsRead, FILE* pFile);
+// Read file until reaching the end of the file, or the specified char.
+extern BOOL _ReadTil(const char nChar, char* buffer, unsigned int nSize, DWORD* pCharsRead, FILE* pFile) noexcept;
 
-//	Read a string til the end of the string, or nChar. bTerminate==TRUE replaces that char with \0.
-extern char* _ReadStringTil(char nChar, char*& pOffsetInOut, BOOL bTerminate);
+// Read a string til the end of the string, or nChar. bTerminate==TRUE replaces that char with \0.
+extern char* _ReadStringTil(char nChar, char* restrict& pOffsetInOut, BOOL bTerminate) noexcept;
 extern void  _ReadStringTil(std::string& sValue, char nChar, const char*& pOffsetInOut);
 
-//	Write out the buffer to a file
+// Write out the buffer to a file
 extern void _WriteBufferToFile(const std::wstring& sFileName, const std::string& sString);
 
-//	Fetch various interim txt/data files
+// Fetch various interim txt/data files
 extern void _FetchGameHashLibraryFromWeb();
 extern void _FetchGameTitlesFromWeb();
 extern void _FetchMyProgressFromWeb();
@@ -44,10 +44,10 @@ extern void _FetchMyProgressFromWeb();
 
 extern std::string _TimeStampToString(time_t nTime);
 
-_NODISCARD std::string GetFolderFromDialog() noexcept;
+_NODISCARD std::string GetFolderFromDialog();
 
 void DownloadAndActivateAchievementData(unsigned int nGameID);
-BOOL CanCausePause();
+BOOL CanCausePause() noexcept;
 
 void RestoreWindowPosition(HWND hDlg, const char* sDlgKey, bool bToRight, bool bToBottom);
 void RememberWindowPosition(HWND hDlg, const char* sDlgKey);

--- a/src/RA_Defs.h
+++ b/src/RA_Defs.h
@@ -62,8 +62,8 @@ _CONSTANT_VAR MAX_BUFSIZ{ BUFSIZ*128U }; // Try not to use this one
 class RARect : public RECT
 {
 public:
-    RARect() {}
-    RARect(LONG nX, LONG nY, LONG nW, LONG nH)
+    RARect() noexcept = default;
+    explicit RARect(LONG nX, LONG nY, LONG nW, LONG nH) noexcept
     {
         left = nX;
         right = nX + nW;
@@ -72,8 +72,8 @@ public:
     }
 
 public:
-    inline int Width() const { return(right - left); }
-    inline int Height() const { return(bottom - top); }
+    _NODISCARD _CONSTANT_FN Width() const noexcept { return (right - left); }
+    _NODISCARD _CONSTANT_FN Height() const noexcept { return (bottom - top); }
 };
 
 class ResizeContent

--- a/src/RA_Dlg_AchEditor.cpp
+++ b/src/RA_Dlg_AchEditor.cpp
@@ -43,7 +43,7 @@ Dlg_AchievementEditor g_AchievementEditorDialog;
 std::vector<ResizeContent> vDlgAchEditorResize;
 POINT pDlgAchEditorMin;
 
-INT_PTR CALLBACK AchProgressProc(HWND hDlg, UINT nMsg, WPARAM wParam, _UNUSED LPARAM)
+INT_PTR CALLBACK AchProgressProc(HWND hDlg, UINT nMsg, WPARAM wParam, _UNUSED LPARAM) noexcept
 {
     switch (nMsg)
     {
@@ -78,7 +78,7 @@ INT_PTR CALLBACK AchProgressProc(HWND hDlg, UINT nMsg, WPARAM wParam, _UNUSED LP
     return FALSE;
 }
 
-Dlg_AchievementEditor::Dlg_AchievementEditor()
+Dlg_AchievementEditor::Dlg_AchievementEditor() noexcept
 {
     for (size_t i = 0; i < MAX_CONDITIONS; ++i)
     {
@@ -132,7 +132,7 @@ void Dlg_AchievementEditor::SetupColumns(HWND hList)
     // bSuccess = ListView_EnableGroupView( hGroupList, FALSE );
 }
 
-BOOL Dlg_AchievementEditor::IsActive() const
+BOOL Dlg_AchievementEditor::IsActive() const noexcept
 {
     return (g_AchievementEditorDialog.GetHWND() != nullptr) && (IsWindowVisible(g_AchievementEditorDialog.GetHWND()));
 }
@@ -226,7 +226,7 @@ HWND g_hIPEEdit;
 int nSelItem;
 int nSelSubItem;
 
-long _stdcall EditProc(HWND hwnd, UINT nMsg, WPARAM wParam, LPARAM lParam)
+LRESULT CALLBACK EditProc(HWND hwnd, UINT nMsg, WPARAM wParam, LPARAM lParam) noexcept
 {
     switch (nMsg)
     {
@@ -290,7 +290,7 @@ long _stdcall EditProc(HWND hwnd, UINT nMsg, WPARAM wParam, LPARAM lParam)
     return CallWindowProc(EOldProc, hwnd, nMsg, wParam, lParam);
 }
 
-long _stdcall DropDownProc(HWND hwnd, UINT nMsg, WPARAM wParam, LPARAM lParam)
+LRESULT CALLBACK DropDownProc(HWND hwnd, UINT nMsg, WPARAM wParam, LPARAM lParam) noexcept
 {
     if (nMsg == WM_COMMAND)
     {
@@ -656,7 +656,7 @@ BOOL CreateIPE(int nItem, CondSubItems nSubItem)
 }
 
 // static
-LRESULT CALLBACK Dlg_AchievementEditor::ListViewWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
+LRESULT CALLBACK Dlg_AchievementEditor::ListViewWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) noexcept
 {
     switch (uMsg)
     {
@@ -1828,7 +1828,8 @@ void Dlg_AchievementEditor::UpdateBadge(const std::string& sNewName)
     UpdateSelectedBadgeImage(sNewName.c_str());
 }
 
-_Use_decl_annotations_ void Dlg_AchievementEditor::RepopulateGroupList(const Achievement* const pCheevo)
+_Use_decl_annotations_ void
+Dlg_AchievementEditor::RepopulateGroupList(const Achievement* const restrict pCheevo) noexcept
 {
     HWND hGroupList = GetDlgItem(m_hAchievementEditorDlg, IDC_RA_ACH_GROUP);
     if (hGroupList == nullptr)
@@ -1854,7 +1855,7 @@ _Use_decl_annotations_ void Dlg_AchievementEditor::RepopulateGroupList(const Ach
     }
 }
 
-_Use_decl_annotations_ void Dlg_AchievementEditor::PopulateConditions(const Achievement* const pCheevo)
+_Use_decl_annotations_ void Dlg_AchievementEditor::PopulateConditions(const Achievement* const restrict pCheevo)
 {
     HWND hCondList = GetDlgItem(m_hAchievementEditorDlg, IDC_RA_LBX_CONDITIONS);
     if (hCondList == nullptr)
@@ -2047,7 +2048,7 @@ void Dlg_AchievementEditor::LoadAchievement(Achievement* pCheevo, _UNUSED BOOL)
     // RedrawWindow( hList, nullptr, nullptr, RDW_INVALIDATE );
 }
 
-inline char* Dlg_AchievementEditor::LbxDataAt(unsigned int nRow, CondSubItems nCol)
+inline char* Dlg_AchievementEditor::LbxDataAt(unsigned int nRow, CondSubItems nCol) noexcept
 {
     return m_lbxData[nRow][ra::etoi(nCol)];
 }
@@ -2072,7 +2073,7 @@ void Dlg_AchievementEditor::OnLoad_NewRom()
     }
 }
 
-size_t Dlg_AchievementEditor::GetSelectedConditionGroup() const
+size_t Dlg_AchievementEditor::GetSelectedConditionGroup() const noexcept
 {
     HWND hList = GetDlgItem(g_AchievementEditorDialog.GetHWND(), IDC_RA_ACH_GROUP);
     const int nSel = ListBox_GetCurSel(hList);
@@ -2085,7 +2086,7 @@ size_t Dlg_AchievementEditor::GetSelectedConditionGroup() const
     return static_cast<size_t>(nSel);
 }
 
-void Dlg_AchievementEditor::SetSelectedConditionGroup(size_t nGrp) const
+void Dlg_AchievementEditor::SetSelectedConditionGroup(size_t nGrp) const noexcept
 {
     HWND hList = GetDlgItem(g_AchievementEditorDialog.GetHWND(), IDC_RA_ACH_GROUP);
     ListBox_SetCurSel(hList, static_cast<int>(nGrp));

--- a/src/RA_Dlg_AchEditor.h
+++ b/src/RA_Dlg_AchEditor.h
@@ -2,33 +2,28 @@
 #define RA_DLG_ACHEDITOR_H
 #pragma once
 
-#include "RA_httpthread.h"
 #include "RA_Achievement.h"
+#include "RA_httpthread.h"
 
 #include "ui\ImageReference.hh"
 
 namespace {
 const size_t MAX_CONDITIONS = 200;
 const size_t MEM_STRING_TEXT_LEN = 80;
-}
+} // namespace
 
 class BadgeNames
 {
 public:
-    BadgeNames()
-        : m_hDestComboBox(nullptr)
-    {
-    }
-    void InstallAchEditorCombo(HWND hCombo) { m_hDestComboBox = hCombo; }
+    void InstallAchEditorCombo(HWND hCombo) noexcept { m_hDestComboBox = hCombo; }
 
     void FetchNewBadgeNamesThreaded();
     void AddNewBadgeName(const char* pStr, bool bAndSelect);
     void OnNewBadgeNames(const rapidjson::Document& data);
 
 private:
-    HWND m_hDestComboBox;
+    HWND m_hDestComboBox{};
 };
-
 
 class Dlg_AchievementEditor
 {
@@ -38,27 +33,29 @@ public:
 public:
     static INT_PTR CALLBACK s_AchievementEditorProc(HWND, UINT, WPARAM, LPARAM);
     INT_PTR AchievementEditorProc(HWND, UINT, WPARAM, LPARAM);
+
 public:
     void OnLoad_NewRom();
     void LoadAchievement(Achievement* pCheevo, _UNUSED BOOL);
 
-    inline void SetICEControl(HWND hIce) { m_hICEControl = hIce; }
-    inline char* LbxDataAt(unsigned int nRow, unsigned int nCol) { return m_lbxData[nRow][nCol]; }
+    inline void SetICEControl(HWND hIce) noexcept { m_hICEControl = hIce; }
+    inline char* LbxDataAt(unsigned int nRow, unsigned int nCol) noexcept { return m_lbxData[nRow][nCol]; }
 
-    HWND GetICEControl() const { return m_hICEControl; }
+    HWND GetICEControl() const noexcept { return m_hICEControl; }
 
-    void InstallHWND(HWND hWnd) { m_hAchievementEditorDlg = hWnd; }
-    HWND GetHWND() const { return m_hAchievementEditorDlg; }
+    void InstallHWND(HWND hWnd) noexcept { m_hAchievementEditorDlg = hWnd; }
+    HWND GetHWND() const noexcept { return m_hAchievementEditorDlg; }
     BOOL IsActive() const;
 
-    Achievement* ActiveAchievement() const { return m_pSelectedAchievement; }
-    BOOL IsPopulatingAchievementEditorData() const { return m_bPopulatingAchievementEditorData; }
-    void SetIgnoreEdits(BOOL bIgnore) { m_bPopulatingAchievementEditorData = bIgnore; }
+    Achievement* ActiveAchievement() const noexcept { return m_pSelectedAchievement; }
+    BOOL IsPopulatingAchievementEditorData() const noexcept { return m_bPopulatingAchievementEditorData; }
+    void SetIgnoreEdits(BOOL bIgnore) noexcept { m_bPopulatingAchievementEditorData = bIgnore; }
 
-    void UpdateBadge(const std::string& sNewName);							//	Call to set/update data
-    void UpdateSelectedBadgeImage(const std::string& sBackupBadgeToUse = "");	//	Call to just update the badge image/bitmap
+    void UpdateBadge(const std::string& sNewName); //	Call to set/update data
+    void UpdateSelectedBadgeImage(
+        const std::string& sBackupBadgeToUse = ""); //	Call to just update the badge image/bitmap
 
-    BadgeNames& GetBadgeNames() { return m_BadgeNames; }
+    BadgeNames& GetBadgeNames() noexcept { return m_BadgeNames; }
 
     size_t GetSelectedConditionGroup() const;
     void SetSelectedConditionGroup(size_t nGrp) const;
@@ -77,7 +74,7 @@ private:
     void UpdateCondition(HWND hList, LV_ITEM& item, const Condition& Cond, unsigned int nCurrentHits);
 
 private:
-    static const int m_nNumCols = 10;//;sizeof( g_sColTitles ) / sizeof( g_sColTitles[0] );
+    static const int m_nNumCols = 10; //;sizeof( g_sColTitles ) / sizeof( g_sColTitles[0] );
 
     HWND m_hAchievementEditorDlg;
     HWND m_hICEControl;
@@ -101,6 +98,5 @@ private:
 void GenerateResizes(HWND hDlg);
 
 extern Dlg_AchievementEditor g_AchievementEditorDialog;
-
 
 #endif // !RA_DLG_ACHEDITOR_H

--- a/src/RA_Dlg_AchEditor.h
+++ b/src/RA_Dlg_AchEditor.h
@@ -10,6 +10,7 @@
 class BadgeNames
 {
 public:
+    void InstallAchEditorCombo(HWND hCombo) noexcept { m_hDestComboBox = hCombo; }
 
     void FetchNewBadgeNamesThreaded();
     void AddNewBadgeName(const char* pStr, bool bAndSelect);
@@ -23,7 +24,7 @@ enum class CondSubItems : std::size_t;
 class Dlg_AchievementEditor
 {
 public:
-    Dlg_AchievementEditor();
+    Dlg_AchievementEditor() noexcept;
 
 public:
     static INT_PTR CALLBACK s_AchievementEditorProc(HWND, UINT, WPARAM, LPARAM);
@@ -34,13 +35,13 @@ public:
     void LoadAchievement(Achievement* pCheevo, _UNUSED BOOL);
 
     inline void SetICEControl(HWND hIce) noexcept { m_hICEControl = hIce; }
-    inline char* LbxDataAt(unsigned int nRow, CondSubItems nCol);
+    inline char* LbxDataAt(unsigned int nRow, CondSubItems nCol) noexcept;
 
     HWND GetICEControl() const noexcept { return m_hICEControl; }
 
     void InstallHWND(HWND hWnd) noexcept { m_hAchievementEditorDlg = hWnd; }
     HWND GetHWND() const noexcept { return m_hAchievementEditorDlg; }
-    BOOL IsActive() const;
+    BOOL IsActive() const noexcept;
 
     Achievement* ActiveAchievement() const noexcept { return m_pSelectedAchievement; }
     BOOL IsPopulatingAchievementEditorData() const noexcept { return m_bPopulatingAchievementEditorData; }
@@ -52,17 +53,17 @@ public:
 
     BadgeNames& GetBadgeNames() noexcept { return m_BadgeNames; }
 
-    size_t GetSelectedConditionGroup() const;
-    void SetSelectedConditionGroup(size_t nGrp) const;
+    size_t GetSelectedConditionGroup() const noexcept;
+    void SetSelectedConditionGroup(size_t nGrp) const noexcept;
 
     ConditionGroup m_ConditionClipboard;
 
 private:
-    void RepopulateGroupList(_In_ const Achievement* const pCheevo);
-    void PopulateConditions(_In_ const Achievement* const pCheevo);
+    void RepopulateGroupList(_In_ const Achievement* const restrict pCheevo) noexcept;
+    void PopulateConditions(_In_ const Achievement* const restrict pCheevo);
     void SetupColumns(HWND hList);
 
-    static LRESULT CALLBACK ListViewWndProc(HWND, UINT, WPARAM, LPARAM);
+    static LRESULT CALLBACK ListViewWndProc(HWND, UINT, WPARAM, LPARAM) noexcept;
     void GetListViewTooltip();
 
     const int AddCondition(HWND hList, const Condition& Cond, unsigned int nCurrentHits);

--- a/src/RA_Dlg_Achievement.cpp
+++ b/src/RA_Dlg_Achievement.cpp
@@ -1055,7 +1055,7 @@ INT_PTR Dlg_Achievements::CommitAchievements(HWND hDlg)
     return TRUE;
 }
 
-void Dlg_Achievements::UpdateSelectedAchievementButtons(const Achievement* Cheevo)
+void Dlg_Achievements::UpdateSelectedAchievementButtons(const Achievement* restrict Cheevo) noexcept
 {
     if (Cheevo == nullptr)
     {
@@ -1216,7 +1216,7 @@ void Dlg_Achievements::OnEditData(size_t nItem, Column nColumn, const std::strin
     }
 }
 
-int Dlg_Achievements::GetSelectedAchievementIndex()
+int Dlg_Achievements::GetSelectedAchievementIndex() noexcept
 {
     HWND hList = GetDlgItem(m_hAchievementsDlg, IDC_RA_LISTACHIEVEMENTS);
     return ListView_GetSelectionMark(hList);

--- a/src/RA_Dlg_Achievement.h
+++ b/src/RA_Dlg_Achievement.h
@@ -28,7 +28,7 @@ public:
     INT_PTR AchievementsProc(HWND, UINT, WPARAM, LPARAM);
 
 public:
-    int GetSelectedAchievementIndex();
+    int GetSelectedAchievementIndex() noexcept;
     void OnLoad_NewRom(unsigned int nGameID);
     void OnGet_Achievement(const Achievement& ach);
     void ReloadLBXData(int nOffset);
@@ -47,8 +47,8 @@ public:
         return rowRef.at(ra::etoi(nCol));
     }
 
-    inline HWND GetHWND() const { return m_hAchievementsDlg; }
-    void InstallHWND(HWND hWnd) { m_hAchievementsDlg = hWnd; }
+    inline HWND GetHWND() const noexcept { return m_hAchievementsDlg; }
+    void InstallHWND(HWND hWnd) noexcept { m_hAchievementsDlg = hWnd; }
 
 private:
     void SetupColumns(HWND hList);
@@ -60,7 +60,7 @@ private:
 
     INT_PTR CommitAchievements(HWND hDlg);
 
-    void UpdateSelectedAchievementButtons(const Achievement* Cheevo);
+    void UpdateSelectedAchievementButtons(const Achievement* restrict Cheevo) noexcept;
 
 private:
     HWND m_hAchievementsDlg = nullptr;

--- a/src/RA_Dlg_AchievementsReporter.cpp
+++ b/src/RA_Dlg_AchievementsReporter.cpp
@@ -254,7 +254,7 @@ INT_PTR CALLBACK Dlg_AchievementsReporter::AchievementsReporterProc(HWND hDlg, U
 }
 
 //static
-void Dlg_AchievementsReporter::DoModalDialog(HINSTANCE hInst, HWND hParent)
+void Dlg_AchievementsReporter::DoModalDialog(HINSTANCE hInst, HWND hParent) noexcept
 {
     if (g_pActiveAchievements->NumAchievements() == 0)
         MessageBox(hParent, TEXT("No ROM loaded!"), TEXT("Error"), MB_OK);

--- a/src/RA_Dlg_AchievementsReporter.h
+++ b/src/RA_Dlg_AchievementsReporter.h
@@ -30,7 +30,7 @@ class Dlg_AchievementsReporter
     inline static constexpr std::array<int, 5> COL_SIZE{ 19, 105, 205, 75, 62 };
 
 public:
-    static void DoModalDialog(HINSTANCE hInst, HWND hParent);
+    static void DoModalDialog(HINSTANCE hInst, HWND hParent) noexcept;
     static INT_PTR CALLBACK AchievementsReporterProc(HWND, UINT, WPARAM, _UNUSED LPARAM);
 
 public:

--- a/src/RA_Dlg_GameLibrary.cpp
+++ b/src/RA_Dlg_GameLibrary.cpp
@@ -249,7 +249,8 @@ void Dlg_GameLibrary::AddTitle(const std::string& sTitle, const std::string& sFi
     item.iSubItem = 3;
     ListView_SetItemText(hList, item.iItem, 3, NativeStr(sFilename).data());
 
-    m_vGameEntries.emplace_back(sTitle, sFilename, nGameID);
+    // NB: Perfect forwarding seems to cause an access violation here, so it's using an rvalue instead
+    m_vGameEntries.emplace_back(GameEntry(sTitle, sFilename, nGameID));
 }
 
 void Dlg_GameLibrary::ClearTitles() noexcept

--- a/src/RA_Dlg_GameLibrary.cpp
+++ b/src/RA_Dlg_GameLibrary.cpp
@@ -78,7 +78,7 @@ bool ListFiles(std::string path, std::string mask, std::deque<std::string>& rFil
 
 namespace ra {
 
-[[gsl::suppress(f.6)]] inline static void LogErrno() noexcept
+GSL_SUPPRESS(f.6) inline static void LogErrno() noexcept
 {
     char buf[2048U]{};
     strerror_s(buf, errno);

--- a/src/RA_Dlg_GameLibrary.cpp
+++ b/src/RA_Dlg_GameLibrary.cpp
@@ -18,7 +18,6 @@ namespace {
 
 inline constexpr std::array<LPCTSTR, 4> COL_TITLE{ _T("ID"), _T("Game Title"), _T("Completion"), _T("File Path") };
 inline constexpr std::array<int, 4> COL_SIZE{ 30, 230, 110, 170 };
-static_assert(SIZEOF_ARRAY(COL_TITLE) == SIZEOF_ARRAY(COL_SIZE), "Must match!");
 inline constexpr auto bCancelScan = false;
 
 std::mutex mtx;
@@ -250,7 +249,7 @@ void Dlg_GameLibrary::AddTitle(const std::string& sTitle, const std::string& sFi
     item.iSubItem = 3;
     ListView_SetItemText(hList, item.iItem, 3, NativeStr(sFilename).data());
 
-    m_vGameEntries.push_back(GameEntry(sTitle, sFilename, nGameID));
+    m_vGameEntries.emplace_back(sTitle, sFilename, nGameID);
 }
 
 void Dlg_GameLibrary::ClearTitles() noexcept
@@ -289,7 +288,7 @@ void Dlg_GameLibrary::ThreadedScanProc()
             // May have caused a buffer overrun, this is way to big to be on the stack
             auto pBuf{ std::make_unique<unsigned char[]>(6 * 1024 * 1024) };
 
-            fread(static_cast<void*>(pBuf.get()), sizeof(unsigned char), nSize, pf);	//Check
+            fread(static_cast<void*>(pBuf.get()), sizeof(unsigned char), nSize, pf); //Check
             Results.insert_or_assign(FilesToScan.front(), RAGenerateMD5(pBuf.get(), nSize));
 
             SendMessage(g_GameLibrary.GetHWND(), WM_TIMER, 0U, 0L);

--- a/src/RA_Dlg_GameLibrary.cpp
+++ b/src/RA_Dlg_GameLibrary.cpp
@@ -79,7 +79,7 @@ bool ListFiles(std::string path, std::string mask, std::deque<std::string>& rFil
 
 namespace ra {
 
-inline static void LogErrno() noexcept
+[[gsl::suppress(f.6)]] inline static void LogErrno() noexcept
 {
     char buf[2048U]{};
     strerror_s(buf, errno);
@@ -253,7 +253,7 @@ void Dlg_GameLibrary::AddTitle(const std::string& sTitle, const std::string& sFi
     m_vGameEntries.push_back(GameEntry(sTitle, sFilename, nGameID));
 }
 
-void Dlg_GameLibrary::ClearTitles()
+void Dlg_GameLibrary::ClearTitles() noexcept
 {
     nNumParsed = 0;
 

--- a/src/RA_Dlg_GameLibrary.h
+++ b/src/RA_Dlg_GameLibrary.h
@@ -12,9 +12,9 @@ public:
     {
     }
 
-    const std::string& Title() const { return m_sTitle; }
-    const std::string& Filename() const { return m_sFilename; }
-    unsigned int GameID() const { return m_nGameID; }
+    const std::string& Title() const noexcept { return m_sTitle; }
+    const std::string& Filename() const noexcept { return m_sFilename; }
+    unsigned int GameID() const noexcept { return m_nGameID; }
 
     const std::string m_sTitle;
     const std::string m_sFilename;
@@ -29,11 +29,11 @@ public:
     INT_PTR CALLBACK GameLibraryProc(HWND, UINT, WPARAM, LPARAM);
 
 public:
-    void InstallHWND(HWND hWnd) { m_hDialogBox = hWnd; }
-    HWND GetHWND() const { return m_hDialogBox; }
+    void InstallHWND(HWND hWnd) noexcept { m_hDialogBox = hWnd; }
+    HWND GetHWND() const noexcept { return m_hDialogBox; }
 
     void AddTitle(const std::string& sTitle, const std::string& sFilename, unsigned int nGameID);
-    void ClearTitles();
+    void ClearTitles() noexcept;
 
     void LoadAll();
     void SaveAll();

--- a/src/RA_Dlg_Login.cpp
+++ b/src/RA_Dlg_Login.cpp
@@ -14,7 +14,7 @@
 #include "ui\viewmodels\MessageBoxViewModel.hh"
 
 // static
-BOOL RA_Dlg_Login::DoModalLogin()
+INT_PTR RA_Dlg_Login::DoModalLogin() noexcept
 {
     return DialogBox(g_hThisDLLInst, MAKEINTRESOURCE(IDD_RA_LOGIN), g_RAMainWnd, RA_Dlg_Login::RA_Dlg_LoginProc);
 }

--- a/src/RA_Dlg_Login.h
+++ b/src/RA_Dlg_Login.h
@@ -5,10 +5,10 @@
 class RA_Dlg_Login
 {
 public:
-    static BOOL DoModalLogin();
+    static INT_PTR DoModalLogin() noexcept;
 
 public:
-    static INT_PTR CALLBACK RA_Dlg_LoginProc(HWND, UINT, WPARAM, LPARAM);
+    static INT_PTR CALLBACK RA_Dlg_LoginProc(HWND, UINT, WPARAM, [[maybe_unused]] LPARAM);
 };
 
 

--- a/src/RA_Dlg_MemBookmark.cpp
+++ b/src/RA_Dlg_MemBookmark.cpp
@@ -458,7 +458,7 @@ INT_PTR Dlg_MemBookmark::MemBookmarkDialogProc(HWND hDlg, UINT uMsg, WPARAM wPar
     return FALSE;
 }
 
-BOOL Dlg_MemBookmark::IsActive() const
+BOOL Dlg_MemBookmark::IsActive() const noexcept
 {
     return(g_MemBookmarkDialog.GetHWND() != nullptr) && (IsWindowVisible(g_MemBookmarkDialog.GetHWND()));
 }

--- a/src/RA_Dlg_MemBookmark.h
+++ b/src/RA_Dlg_MemBookmark.h
@@ -57,7 +57,7 @@ public:
 
     void InstallHWND(HWND hWnd) noexcept { m_hMemBookmarkDialog = hWnd; }
     HWND GetHWND() const noexcept { return m_hMemBookmarkDialog; }
-    BOOL IsActive() const;
+    BOOL IsActive() const noexcept;
 
     std::vector<MemBookmark*> Bookmarks() { return m_vBookmarks; }
     void UpdateBookmarks(bool bForceWrite);

--- a/src/RA_Dlg_MemBookmark.h
+++ b/src/RA_Dlg_MemBookmark.h
@@ -8,25 +8,25 @@ class MemBookmark
 {
 public:
     void SetDescription(const std::wstring& string) { m_sDescription = string; }
-    void SetAddress(unsigned int nVal) { m_nAddress = nVal; }
-    void SetType(unsigned int nVal) { m_nType = nVal; }
-    void SetValue(unsigned int nVal) { m_sValue = nVal; }
-    void SetPrevious(unsigned int nVal) { m_sPrevious = nVal; }
-    void IncreaseCount() { m_nCount++; }
-    void ResetCount() { m_nCount = 0; }
+    void SetAddress(unsigned int nVal) noexcept { m_nAddress = nVal; }
+    void SetType(unsigned int nVal) noexcept { m_nType = nVal; }
+    void SetValue(unsigned int nVal) noexcept { m_sValue = nVal; }
+    void SetPrevious(unsigned int nVal) noexcept { m_sPrevious = nVal; }
+    void IncreaseCount() noexcept { m_nCount++; }
+    void ResetCount() noexcept { m_nCount = 0; }
 
-    void SetFrozen(bool b) { m_bFrozen = b; }
-    void SetDecimal(bool b) { m_bDecimal = b; }
+    void SetFrozen(bool b) noexcept { m_bFrozen = b; }
+    void SetDecimal(bool b) noexcept { m_bDecimal = b; }
 
-    inline const std::wstring& Description() const { return m_sDescription; }
-    unsigned int Address() const { return m_nAddress; }
-    unsigned int Type() const { return m_nType; }
-    unsigned int Value() const { return m_sValue; }
-    unsigned int Previous() const { return m_sPrevious; }
-    unsigned int Count() const { return m_nCount; }
+    inline const std::wstring& Description() const noexcept { return m_sDescription; }
+    unsigned int Address() const noexcept { return m_nAddress; }
+    unsigned int Type() const noexcept { return m_nType; }
+    unsigned int Value() const noexcept { return m_sValue; }
+    unsigned int Previous() const noexcept { return m_sPrevious; }
+    unsigned int Count() const noexcept { return m_nCount; }
 
-    bool Frozen() const { return m_bFrozen; }
-    bool Decimal() const { return m_bDecimal; }
+    bool Frozen() const noexcept { return m_bFrozen; }
+    bool Decimal() const noexcept { return m_bDecimal; }
 
 private:
     std::wstring m_sDescription;
@@ -55,8 +55,8 @@ public:
     static INT_PTR CALLBACK s_MemBookmarkDialogProc(HWND, UINT, WPARAM, LPARAM);
     INT_PTR MemBookmarkDialogProc(HWND, UINT, WPARAM, LPARAM);
 
-    void InstallHWND(HWND hWnd) { m_hMemBookmarkDialog = hWnd; }
-    HWND GetHWND() const { return m_hMemBookmarkDialog; }
+    void InstallHWND(HWND hWnd) noexcept { m_hMemBookmarkDialog = hWnd; }
+    HWND GetHWND() const noexcept { return m_hMemBookmarkDialog; }
     BOOL IsActive() const;
 
     std::vector<MemBookmark*> Bookmarks() { return m_vBookmarks; }

--- a/src/RA_Dlg_Memory.cpp
+++ b/src/RA_Dlg_Memory.cpp
@@ -18,7 +18,7 @@
 
 namespace {
 
-const size_t MIN_RESULTS_TO_DUMP  = 500000;
+const size_t MIN_RESULTS_TO_DUMP = 500000;
 const size_t MIN_SEARCH_PAGE_SIZE = 50;
 
 } // namespace
@@ -32,16 +32,16 @@ HWND Dlg_Memory::m_hWnd = nullptr;
 HFONT MemoryViewerControl::m_hViewerFont = nullptr;
 SIZE MemoryViewerControl::m_szFontSize;
 unsigned int MemoryViewerControl::m_nDataStartXOffset = 0;
-unsigned int MemoryViewerControl::m_nAddressOffset    = 0;
-unsigned int MemoryViewerControl::m_nWatchedAddress   = 0;
-MemSize MemoryViewerControl::m_nDataSize              = MemSize::EightBit;
-unsigned int MemoryViewerControl::m_nEditAddress      = 0;
-unsigned int MemoryViewerControl::m_nEditNibble       = 0;
-bool MemoryViewerControl::m_bHasCaret                 = 0;
-unsigned int MemoryViewerControl::m_nCaretWidth       = 0;
-unsigned int MemoryViewerControl::m_nCaretHeight      = 0;
-unsigned int MemoryViewerControl::m_nDisplayedLines   = 8;
-unsigned short MemoryViewerControl::m_nActiveMemBank  = 0;
+unsigned int MemoryViewerControl::m_nAddressOffset = 0;
+unsigned int MemoryViewerControl::m_nWatchedAddress = 0;
+MemSize MemoryViewerControl::m_nDataSize = MemSize::EightBit;
+unsigned int MemoryViewerControl::m_nEditAddress = 0;
+unsigned int MemoryViewerControl::m_nEditNibble = 0;
+bool MemoryViewerControl::m_bHasCaret = 0;
+unsigned int MemoryViewerControl::m_nCaretWidth = 0;
+unsigned int MemoryViewerControl::m_nCaretHeight = 0;
+unsigned int MemoryViewerControl::m_nDisplayedLines = 8;
+unsigned short MemoryViewerControl::m_nActiveMemBank = 0;
 
 unsigned int m_nPage = 0;
 
@@ -57,9 +57,12 @@ _NODISCARD _CONSTANT_FN GetMaxNibble(_In_ MemSize size) noexcept
     switch (size)
     {
         default:
-        case MemSize::EightBit: return 1U;
-        case MemSize::SixteenBit: return 3U;
-        case MemSize::ThirtyTwoBit: return 7U;
+        case MemSize::EightBit:
+            return 1U;
+        case MemSize::SixteenBit:
+            return 3U;
+        case MemSize::ThirtyTwoBit:
+            return 7U;
     }
 }
 
@@ -68,13 +71,18 @@ LRESULT CALLBACK MemoryViewerControl::s_MemoryDrawProc(HWND hDlg, UINT uMsg, WPA
     switch (uMsg)
     {
         case WM_NCCREATE:
-        case WM_NCDESTROY: return TRUE;
+        case WM_NCDESTROY:
+            return TRUE;
 
-        case WM_CREATE: return TRUE;
+        case WM_CREATE:
+            return TRUE;
 
-        case WM_PAINT: RenderMemViewer(hDlg); return 0;
+        case WM_PAINT:
+            RenderMemViewer(hDlg);
+            return 0;
 
-        case WM_ERASEBKGND: return TRUE;
+        case WM_ERASEBKGND:
+            return TRUE;
 
         case WM_MOUSEWHEEL:
             if (GET_WHEEL_DELTA_WPARAM(wParam) > 0 && m_nAddressOffset > (0x40))
@@ -83,11 +91,15 @@ LRESULT CALLBACK MemoryViewerControl::s_MemoryDrawProc(HWND hDlg, UINT uMsg, WPA
                 setAddress(m_nAddressOffset + 32);
             return FALSE;
 
-        case WM_LBUTTONUP: OnClick({GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam)}); return FALSE;
+        case WM_LBUTTONUP:
+            OnClick({GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam)});
+            return FALSE;
 
-        case WM_KEYDOWN: return (!OnKeyDown(static_cast<UINT>(LOWORD(wParam))));
+        case WM_KEYDOWN:
+            return (!OnKeyDown(static_cast<UINT>(LOWORD(wParam))));
 
-        case WM_CHAR: return (!OnEditInput(static_cast<UINT>(LOWORD(wParam))));
+        case WM_CHAR:
+            return (!OnEditInput(static_cast<UINT>(LOWORD(wParam))));
     }
 
     return DefWindowProc(hDlg, uMsg, wParam, lParam);
@@ -116,9 +128,13 @@ bool MemoryViewerControl::OnKeyDown(UINT nChar)
                 moveAddress(0, -1);
             return true;
 
-        case VK_DOWN: moveAddress(0x10, 0); return true;
+        case VK_DOWN:
+            moveAddress(0x10, 0);
+            return true;
 
-        case VK_UP: moveAddress(-0x10, 0); return true;
+        case VK_UP:
+            moveAddress(-0x10, 0);
+            return true;
 
         case VK_PRIOR: //	Page up (!)
             moveAddress(-(int)(m_nDisplayedLines << 4), 0);
@@ -130,13 +146,13 @@ bool MemoryViewerControl::OnKeyDown(UINT nChar)
 
         case VK_HOME:
             m_nEditAddress = 0;
-            m_nEditNibble  = 0;
+            m_nEditNibble = 0;
             setAddress(0);
             return true;
 
         case VK_END:
             m_nEditAddress = g_MemManager.TotalBankSize() - 0x10;
-            m_nEditNibble  = 0;
+            m_nEditNibble = 0;
             setAddress(m_nEditAddress);
             return true;
     }
@@ -303,7 +319,7 @@ bool MemoryViewerControl::OnEditInput(UINT c)
         // value <<= 4*(maxNibble-m_nEditNibble);
         // unsigned int mask = ~(15 << 4*(maxNibble - m_nEditNibble));
 
-        const bool bLowerNibble   = (m_nEditNibble % 2 == 1);
+        const bool bLowerNibble = (m_nEditNibble % 2 == 1);
         unsigned int nByteAddress = m_nEditAddress;
 
         if (g_MemBookmarkDialog.GetHWND() != nullptr)
@@ -345,8 +361,8 @@ void MemoryViewerControl::createEditCaret(int w, int h) noexcept
 {
     if (!m_bHasCaret || ra::to_signed(m_nCaretWidth) != w || ra::to_signed(m_nCaretHeight) != h)
     {
-        m_bHasCaret    = true;
-        m_nCaretWidth  = w;
+        m_bHasCaret = true;
+        m_nCaretWidth = w;
         m_nCaretHeight = h;
         ::CreateCaret(GetDlgItem(g_MemoryDialog.GetHWND(), IDC_RA_MEMTEXTVIEWER), (HBITMAP)0, w, h);
     }
@@ -393,9 +409,15 @@ void MemoryViewerControl::SetCaretPos()
 
     switch (m_nDataSize)
     {
-        case MemSize::EightBit: x += 3 * m_szFontSize.cx * (subAddress & 15); break;
-        case MemSize::SixteenBit: x += 5 * m_szFontSize.cx * ((subAddress >> 1) & 7); break;
-        case MemSize::ThirtyTwoBit: x += 9 * m_szFontSize.cx * ((subAddress >> 2) & 3); break;
+        case MemSize::EightBit:
+            x += 3 * m_szFontSize.cx * (subAddress & 15);
+            break;
+        case MemSize::SixteenBit:
+            x += 5 * m_szFontSize.cx * ((subAddress >> 1) & 7);
+            break;
+        case MemSize::ThirtyTwoBit:
+            x += 9 * m_szFontSize.cx * ((subAddress >> 2) & 3);
+            break;
     }
 
     RECT r;
@@ -423,33 +445,33 @@ void MemoryViewerControl::OnClick(POINT point)
 
     HWND hOurDlg = GetDlgItem(g_MemoryDialog.GetHWND(), IDC_RA_MEMTEXTVIEWER);
 
-    int x          = point.x;
-    const int y    = point.y - m_szFontSize.cy; //	Adjust for header
+    int x = point.x;
+    const int y = point.y - m_szFontSize.cy; //	Adjust for header
     const int line = ((y - 3) / m_szFontSize.cy);
 
     if (line == -1 || line >= (int)m_nDisplayedLines)
         return; //	clicked on header
 
     int rowLengthPx = m_nDataStartXOffset;
-    int inc         = 1;
-    int sub         = 3 * m_szFontSize.cx;
+    int inc = 1;
+    int sub = 3 * m_szFontSize.cx;
 
     switch (m_nDataSize)
     {
         case MemSize::EightBit:
             rowLengthPx += 47 * m_szFontSize.cx;
-            inc = 1;                   //	increment mem offset by 1 each subset
-            sub = 3 * m_szFontSize.cx; //	2 char set plus one char space
+            inc = 1;                   // increment mem offset by 1 each subset
+            sub = 3 * m_szFontSize.cx; // 2 char set plus one char space
             break;
         case MemSize::SixteenBit:
             rowLengthPx += 39 * m_szFontSize.cx;
-            inc = 2;                   //	increment mem offset by 2 each subset
-            sub = 5 * m_szFontSize.cx; //	4 char set plus one char space
+            inc = 2;                   // increment mem offset by 2 each subset
+            sub = 5 * m_szFontSize.cx; // 4 char set plus one char space
             break;
         case MemSize::ThirtyTwoBit:
             rowLengthPx += 35 * m_szFontSize.cx;
-            inc = 4;                   //	increment mem offset by 4 each subset
-            sub = 9 * m_szFontSize.cx; //	8 char set plus one char space
+            inc = 4;                   // increment mem offset by 4 each subset
+            sub = 9 * m_szFontSize.cx; // 8 char set plus one char space
             break;
     }
 
@@ -457,10 +479,10 @@ void MemoryViewerControl::OnClick(POINT point)
 
     const int nAddressRowClicked = (nTopLeft + (line << 4));
 
-    //	Clamp:
+    // Clamp:
     if (nAddressRowClicked < 0 || nAddressRowClicked > (int)g_MemManager.TotalBankSize())
     {
-        //	ignore; clicked above limit
+        // ignore; clicked above limit
         return;
     }
 
@@ -473,7 +495,7 @@ void MemoryViewerControl::OnClick(POINT point)
 
         while (x > 0)
         {
-            //	Adjust x by one subset til we find out the correct offset:
+            // Adjust x by one subset til we find out the correct offset:
             x -= sub;
             if (x >= 0)
                 m_nEditAddress += inc;
@@ -511,7 +533,7 @@ void MemoryViewerControl::RenderMemViewer(HWND hTarget)
         m_hViewerFont = (HFONT)GetStockObject(SYSTEM_FIXED_FONT);
     HGDIOBJ hOldFont = SelectObject(hMemDC, m_hViewerFont);
 
-    HBITMAP hBitmap    = CreateCompatibleBitmap(dc, w, rect.bottom - rect.top);
+    HBITMAP hBitmap = CreateCompatibleBitmap(dc, w, rect.bottom - rect.top);
     HGDIOBJ hOldBitmap = SelectObject(hMemDC, hBitmap);
 
     GetTextExtentPoint32(hMemDC, TEXT("0"), 1, &m_szFontSize);
@@ -524,12 +546,18 @@ void MemoryViewerControl::RenderMemViewer(HWND hTarget)
     const char* sHeader;
     switch (m_nDataSize)
     {
-        case MemSize::ThirtyTwoBit: sHeader = "          0        4        8        c"; break;
-        case MemSize::SixteenBit: sHeader = "          0    2    4    6    8    a    c    e"; break;
+        case MemSize::ThirtyTwoBit:
+            sHeader = "          0        4        8        c";
+            break;
+        case MemSize::SixteenBit:
+            sHeader = "          0    2    4    6    8    a    c    e";
+            break;
         default:
             m_nDataSize = MemSize::EightBit;
             // fallthrough to MemSize::EightBit
-        case MemSize::EightBit: sHeader = "          0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f"; break;
+        case MemSize::EightBit:
+            sHeader = "          0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f";
+            break;
     }
 
     int lines = h / m_szFontSize.cy;
@@ -548,10 +576,10 @@ void MemoryViewerControl::RenderMemViewer(HWND hTarget)
     unsigned int freeze;
 
     RECT r;
-    r.top    = 3;
-    r.left   = 3;
+    r.top = 3;
+    r.left = 3;
     r.bottom = r.top + m_szFontSize.cy;
-    r.right  = rect.right - 3;
+    r.right = rect.right - 3;
 
     //	Draw header:
     DrawText(hMemDC, NativeStr(sHeader).c_str(), strlen(sHeader), &r, DT_TOP | DT_LEFT | DT_NOPREFIX);
@@ -568,9 +596,9 @@ void MemoryViewerControl::RenderMemViewer(HWND hTarget)
         {
             if (addr >= 0)
             {
-                notes     = 0;
+                notes = 0;
                 bookmarks = 0;
-                freeze    = 0;
+                freeze = 0;
                 for (int j = 0; j < 16; ++j)
                 {
                     notes |= (g_MemoryDialog.Notes().FindCodeNote(addr + j) != nullptr) ? (1 << j) : 0;
@@ -618,15 +646,15 @@ void MemoryViewerControl::RenderMemViewer(HWND hTarget)
                     switch (m_nDataSize)
                     {
                         case MemSize::EightBit:
-                            ptr    = bufferNative + 10 + 3 * (m_nWatchedAddress & 0x0F);
+                            ptr = bufferNative + 10 + 3 * (m_nWatchedAddress & 0x0F);
                             stride = 2;
                             break;
                         case MemSize::SixteenBit:
-                            ptr    = bufferNative + 10 + 5 * ((m_nWatchedAddress & 0x0F) / 2);
+                            ptr = bufferNative + 10 + 5 * ((m_nWatchedAddress & 0x0F) / 2);
                             stride = 4;
                             break;
                         case MemSize::ThirtyTwoBit:
-                            ptr    = bufferNative + 10 + 9 * ((m_nWatchedAddress & 0x0F) / 4);
+                            ptr = bufferNative + 10 + 9 * ((m_nWatchedAddress & 0x0F) / 4);
                             stride = 8;
                             break;
                     }
@@ -669,15 +697,15 @@ void MemoryViewerControl::RenderMemViewer(HWND hTarget)
                             switch (m_nDataSize)
                             {
                                 case MemSize::EightBit:
-                                    ptr    = bufferNative + 10 + 3 * j;
+                                    ptr = bufferNative + 10 + 3 * j;
                                     stride = 2;
                                     break;
                                 case MemSize::SixteenBit:
-                                    ptr    = bufferNative + 10 + 5 * (j / 2);
+                                    ptr = bufferNative + 10 + 5 * (j / 2);
                                     stride = 4;
                                     break;
                                 case MemSize::ThirtyTwoBit:
-                                    ptr    = bufferNative + 10 + 9 * (j / 4);
+                                    ptr = bufferNative + 10 + 9 * (j / 4);
                                     stride = 8;
                                     break;
                             }
@@ -703,7 +731,7 @@ void MemoryViewerControl::RenderMemViewer(HWND hTarget)
     }
 
     {
-        HPEN hPen       = CreatePen(PS_SOLID, 1, RGB(0, 0, 0));
+        HPEN hPen = CreatePen(PS_SOLID, 1, RGB(0, 0, 0));
         HGDIOBJ hOldPen = SelectObject(hMemDC, hPen);
 
         MoveToEx(hMemDC, 3 + m_szFontSize.cx * 9, 3 + m_szFontSize.cy, nullptr);
@@ -727,10 +755,10 @@ void MemoryViewerControl::RenderMemViewer(HWND hTarget)
 void Dlg_Memory::Init() noexcept
 {
     WNDCLASSEX wc{sizeof(WNDCLASSEX)};
-    wc.style         = ra::to_unsigned(CS_PARENTDC | CS_HREDRAW | CS_VREDRAW | CS_GLOBALCLASS);
-    wc.lpfnWndProc   = MemoryViewerControl::s_MemoryDrawProc;
-    wc.hInstance     = g_hThisDLLInst;
-    wc.hCursor       = LoadCursor(nullptr, IDC_ARROW);
+    wc.style = ra::to_unsigned(CS_PARENTDC | CS_HREDRAW | CS_VREDRAW | CS_GLOBALCLASS);
+    wc.lpfnWndProc = MemoryViewerControl::s_MemoryDrawProc;
+    wc.hInstance = g_hThisDLLInst;
+    wc.hCursor = LoadCursor(nullptr, IDC_ARROW);
     wc.hbrBackground = GetStockBrush(WHITE_BRUSH);
     wc.lpszClassName = TEXT("MemoryViewerControl");
 
@@ -801,15 +829,15 @@ INT_PTR Dlg_Memory::MemoryProc(HWND hDlg, UINT nMsg, WPARAM wParam, LPARAM lPara
             RECT rc;
             LVCOLUMN Col;
             Col.mask = LVCF_FMT | LVCF_ORDER | LVCF_SUBITEM | LVCF_TEXT | LVCF_WIDTH;
-            Col.fmt  = LVCFMT_CENTER;
+            Col.fmt = LVCFMT_CENTER;
             GetWindowRect(GetDlgItem(hDlg, IDC_RA_MEM_LIST), &rc);
             for (int i = 0; i < 1; i++)
             {
-                Col.iOrder   = i;
+                Col.iOrder = i;
                 Col.iSubItem = i;
                 ra::tstring str{_T("Search Result")};
                 Col.pszText = str.data();
-                Col.cx      = rc.right - rc.left - 24;
+                Col.cx = rc.right - rc.left - 24;
                 ListView_InsertColumn(GetDlgItem(hDlg, IDC_RA_MEM_LIST), i, &Col);
             }
             ListView_SetExtendedListViewStyle(GetDlgItem(hDlg, IDC_RA_MEM_LIST),
@@ -829,15 +857,16 @@ INT_PTR Dlg_Memory::MemoryProc(HWND hDlg, UINT nMsg, WPARAM wParam, LPARAM lPara
 
         case WM_MEASUREITEM:
             PMEASUREITEMSTRUCT pmis;
-            pmis             = (PMEASUREITEMSTRUCT)lParam;
+            pmis = (PMEASUREITEMSTRUCT)lParam;
             pmis->itemHeight = 16;
             return TRUE;
 
         case WM_DRAWITEM:
+        {
             LPDRAWITEMSTRUCT pDIS;
             HWND hListbox;
 
-            pDIS     = (LPDRAWITEMSTRUCT)lParam;
+            pDIS = (LPDRAWITEMSTRUCT)lParam;
             hListbox = GetDlgItem(hDlg, IDC_RA_MEM_LIST);
             if (pDIS->hwndItem == hListbox)
             {
@@ -933,6 +962,7 @@ INT_PTR Dlg_Memory::MemoryProc(HWND hDlg, UINT nMsg, WPARAM wParam, LPARAM lPara
                 }
             }
             return TRUE;
+        }
 
         case WM_NOTIFY:
         {
@@ -977,9 +1007,9 @@ INT_PTR Dlg_Memory::MemoryProc(HWND hDlg, UINT nMsg, WPARAM wParam, LPARAM lPara
 
         case WM_GETMINMAXINFO:
         {
-            LPMINMAXINFO lpmmi      = (LPMINMAXINFO)lParam;
+            LPMINMAXINFO lpmmi = (LPMINMAXINFO)lParam;
             lpmmi->ptMaxTrackSize.x = pDlgMemoryMin.x;
-            lpmmi->ptMinTrackSize   = pDlgMemoryMin;
+            lpmmi->ptMinTrackSize = pDlgMemoryMin;
         }
             return TRUE;
 
@@ -988,14 +1018,16 @@ INT_PTR Dlg_Memory::MemoryProc(HWND hDlg, UINT nMsg, WPARAM wParam, LPARAM lPara
             RARect winRect;
             GetWindowRect(hDlg, &winRect);
 
-            for (ResizeContent content : vDlgMemoryResize)
+            for (ResizeContent& content : vDlgMemoryResize)
                 content.Resize(winRect.Width(), winRect.Height());
 
             RememberWindowSize(hDlg, "Memory Inspector");
-        }
             return TRUE;
+        }
 
-        case WM_MOVE: RememberWindowPosition(hDlg, "Memory Inspector"); break;
+        case WM_MOVE:
+            RememberWindowPosition(hDlg, "Memory Inspector");
+            break;
 
         case WM_COMMAND:
         {
@@ -1030,8 +1062,8 @@ INT_PTR Dlg_Memory::MemoryProc(HWND hDlg, UINT nMsg, WPARAM wParam, LPARAM lPara
                     EnableWindow(GetDlgItem(hDlg, IDC_RA_RESULTS_FORWARD), FALSE);
 
                     SearchResult& srPrevious = *(m_SearchResults.end() - 2);
-                    SearchResult& sr         = m_SearchResults.back();
-                    sr.m_nCompareType        = nCmpType;
+                    SearchResult& sr = m_SearchResults.back();
+                    sr.m_nCompareType = nCmpType;
 
                     if (IsDlgButtonChecked(hDlg, IDC_RA_CBO_GIVENVAL) == BST_UNCHECKED)
                     {
@@ -1082,8 +1114,8 @@ INT_PTR Dlg_Memory::MemoryProc(HWND hDlg, UINT nMsg, WPARAM wParam, LPARAM lPara
                         ListView_SetItemCount(GetDlgItem(hDlg, IDC_RA_MEM_LIST), nMatches + 2);
 
                     EnableWindow(GetDlgItem(hDlg, IDC_RA_DOTEST), nMatches > 0);
-                }
                     return TRUE;
+                }
 
                 case IDC_RA_MEMVIEW8BIT:
                     MemoryViewerControl::SetDataSize(MemSize::EightBit);
@@ -1131,8 +1163,8 @@ INT_PTR Dlg_Memory::MemoryProc(HWND hDlg, UINT nMsg, WPARAM wParam, LPARAM lPara
                     ra::ByteAddress start, end;
                     if (GetSelectedMemoryRange(start, end))
                     {
-                        m_nStart       = start;
-                        m_nEnd         = end;
+                        m_nStart = start;
+                        m_nEnd = end;
                         m_nCompareSize = nCompSize;
 
                         sr.m_results.Initialize(start, end - start + 1, nCompSize);
@@ -1143,7 +1175,9 @@ INT_PTR Dlg_Memory::MemoryProc(HWND hDlg, UINT nMsg, WPARAM wParam, LPARAM lPara
                     return FALSE;
                 }
 
-                case ID_OK: EndDialog(hDlg, TRUE); return TRUE;
+                case ID_OK:
+                    EndDialog(hDlg, TRUE);
+                    return TRUE;
 
                 case IDC_RA_CBO_GIVENVAL:
                 case IDC_RA_CBO_LASTKNOWNVAL:
@@ -1167,7 +1201,7 @@ INT_PTR Dlg_Memory::MemoryProc(HWND hDlg, UINT nMsg, WPARAM wParam, LPARAM lPara
                     GetDlgItemTextW(hDlg, IDC_RA_MEMSAVENOTE, sNewNoteWide, 512);
                     const std::string sNewNote = ra::Narrow(sNewNoteWide);
 
-                    const ra::ByteAddress nAddr              = MemoryViewerControl::getWatchedAddress();
+                    const ra::ByteAddress nAddr = MemoryViewerControl::getWatchedAddress();
                     const CodeNotes::CodeNoteObj* pSavedNote = m_CodeNotes.FindCodeNote(nAddr);
                     if ((pSavedNote != nullptr) && (pSavedNote->Note().length() > 0))
                     {
@@ -1293,7 +1327,7 @@ INT_PTR Dlg_Memory::MemoryProc(HWND hDlg, UINT nMsg, WPARAM wParam, LPARAM lPara
                 case IDC_RA_RESULTS_REMOVE:
                 {
                     HWND hList = GetDlgItem(hDlg, IDC_RA_MEM_LIST);
-                    int nSel   = ListView_GetNextItem(hList, -1, LVNI_SELECTED);
+                    int nSel = ListView_GetNextItem(hList, -1, LVNI_SELECTED);
 
                     if (nSel != -1)
                     {
@@ -1373,7 +1407,7 @@ INT_PTR Dlg_Memory::MemoryProc(HWND hDlg, UINT nMsg, WPARAM wParam, LPARAM lPara
                         case LBN_SELCHANGE:
                         {
                             RA_LOG("Sel detected!");
-                            HWND hMemBanks         = GetDlgItem(m_hWnd, IDC_RA_MEMBANK);
+                            HWND hMemBanks = GetDlgItem(m_hWnd, IDC_RA_MEMBANK);
                             const int nSelectedIdx = ComboBox_GetCurSel(hMemBanks);
 
                             const unsigned short nBankID =
@@ -1389,13 +1423,17 @@ INT_PTR Dlg_Memory::MemoryProc(HWND hDlg, UINT nMsg, WPARAM wParam, LPARAM lPara
 
                     return TRUE;
 
-                default: return FALSE; //	unhandled
+                default:
+                    return FALSE; //	unhandled
             }
         }
 
-        case WM_CLOSE: EndDialog(hDlg, 0); return TRUE;
+        case WM_CLOSE:
+            EndDialog(hDlg, 0);
+            return TRUE;
 
-        default: return FALSE; //	unhandled
+        default:
+            return FALSE; //	unhandled
     }
 
     return FALSE;
@@ -1405,7 +1443,7 @@ void Dlg_Memory::OnWatchingMemChange()
 {
     TCHAR sAddrNative[1024];
     GetDlgItemText(m_hWnd, IDC_RA_WATCHING, sAddrNative, 1024);
-    std::string sAddr           = ra::Narrow(sAddrNative);
+    std::string sAddr = ra::Narrow(sAddrNative);
     const ra::ByteAddress nAddr = static_cast<ra::ByteAddress>(std::strtoul(sAddr.c_str() + 2, nullptr, 16));
 
     const CodeNotes::CodeNoteObj* pSavedNote = m_CodeNotes.FindCodeNote(nAddr);
@@ -1421,7 +1459,7 @@ void Dlg_Memory::RepopulateMemNotesFromFile()
     size_t nSize = 0;
 
     const auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::GameContext>();
-    const auto nGameID       = pGameContext.GameId();
+    const auto nGameID = pGameContext.GameId();
     if (nGameID != 0)
         nSize = m_CodeNotes.Load(nGameID);
 
@@ -1551,7 +1589,7 @@ void Dlg_Memory::UpdateBits() const
     if (g_MemManager.TotalBankSize() != 0 && MemoryViewerControl::GetDataSize() == MemSize::EightBit)
     {
         const ra::ByteAddress nAddr = MemoryViewerControl::getWatchedAddress();
-        const unsigned char nVal    = g_MemManager.ActiveBankRAMByteRead(nAddr);
+        const unsigned char nVal = g_MemManager.ActiveBankRAMByteRead(nAddr);
 
         _stprintf_s(sNewValue, 64, _T("      %d %d %d %d %d %d %d %d"), static_cast<int>((nVal & (1 << 7)) != 0),
                     static_cast<int>((nVal & (1 << 6)) != 0), static_cast<int>((nVal & (1 << 5)) != 0),
@@ -1600,7 +1638,7 @@ void Dlg_Memory::AddBank(size_t nBankID)
         return;
 
     HWND hMemBanks = GetDlgItem(m_hWnd, IDC_RA_MEMBANK);
-    int nIndex     = ComboBox_AddString(hMemBanks, NativeStr(std::to_string(nBankID)).c_str());
+    int nIndex = ComboBox_AddString(hMemBanks, NativeStr(std::to_string(nBankID)).c_str());
     if (nIndex != CB_ERR)
     {
         ComboBox_SetItemData(hMemBanks, nIndex, nBankID);
@@ -1617,7 +1655,7 @@ bool Dlg_Memory::GetSystemMemoryRange(ra::ByteAddress& start, ra::ByteAddress& e
         case ConsoleID::NES:
             // $0000-$07FF are the 2KB internal RAM for the NES. It's mirrored every 2KB until $1FFF.
             start = 0x0000;
-            end   = 0x07FF;
+            end = 0x07FF;
             return TRUE;
 
         case ConsoleID::SNES:
@@ -1626,7 +1664,7 @@ bool Dlg_Memory::GetSystemMemoryRange(ra::ByteAddress& start, ra::ByteAddress& e
             // addresses this data from $000000-$1FFFFF. For simplicity, we'll treat LowRAM and HighRAM
             // as system memory and Expanded RAM as game memory.
             start = 0x0000;
-            end   = 0x7FFF;
+            end = 0x7FFF;
             return TRUE;
 
         case ConsoleID::GB:
@@ -1634,7 +1672,7 @@ bool Dlg_Memory::GetSystemMemoryRange(ra::ByteAddress& start, ra::ByteAddress& e
             // $C000-$CFFF is fixed internal RAM, $D000-$DFFF is banked internal RAM. $C000-$DFFF is
             // mirrored to $E000-$FDFF.
             start = 0xC000;
-            end   = 0xDFFF;
+            end = 0xDFFF;
             return TRUE;
 
         case ConsoleID::GBA:
@@ -1643,7 +1681,7 @@ bool Dlg_Memory::GetSystemMemoryRange(ra::ByteAddress& start, ra::ByteAddress& e
             // game pak RAM. The Memory Manager sees the in-chip RAM as $00000-$07FF0, and the
             // on-board as $8000-$47FFF
             start = 0x8000;
-            end   = 0x47FFF;
+            end = 0x47FFF;
             return TRUE;
 
         case ConsoleID::MegaDrive:
@@ -1651,25 +1689,25 @@ bool Dlg_Memory::GetSystemMemoryRange(ra::ByteAddress& start, ra::ByteAddress& e
             // each $E0-$FF lead byte. Typically, it's only accessed from $FFxxxx. I'm not sure
             // what memory is represented by $10000-$1FFFF in the Memory Manager.
             start = 0x0000;
-            end   = 0xFFFF;
+            end = 0xFFFF;
             return TRUE;
 
         case ConsoleID::MasterSystem:
             // $C000-$DFFF is system RAM. It's mirrored at $E000-$FFFF.
             start = 0xC000;
-            end   = 0xDFFF;
+            end = 0xDFFF;
             return TRUE;
 
         case ConsoleID::N64:
             // $00000-$3FFFFF covers the standard 4MB RDRAM.
             // $00000-$1FFFFF is RDRAM range 0, while $200000-$3FFFFF is RDRAM range 1.
             start = 0x000000;
-            end   = 0x3FFFFF;
+            end = 0x3FFFFF;
             return TRUE;
 
         default:
             start = 0;
-            end   = 0;
+            end = 0;
             return FALSE;
     }
 }
@@ -1682,7 +1720,7 @@ bool Dlg_Memory::GetGameMemoryRange(ra::ByteAddress& start, ra::ByteAddress& end
             // $4020-$FFFF is cartridge memory and subranges will vary by mapper. The most common mappers reference
             // battery-backed RAM or additional work RAM in the $6000-$7FFF range. $8000-$FFFF is usually read-only.
             start = 0x4020;
-            end   = 0xFFFF;
+            end = 0xFFFF;
             return TRUE;
 
         case ConsoleID::SNES:
@@ -1691,14 +1729,14 @@ bool Dlg_Memory::GetGameMemoryRange(ra::ByteAddress& start, ra::ByteAddress& end
             // addresses this data from $000000-$1FFFFF. For simplicity, we'll treat LowRAM and HighRAM
             // as system memory and Expanded RAM as game memory.
             start = 0x008000;
-            end   = 0x1FFFFF;
+            end = 0x1FFFFF;
             return TRUE;
 
         case ConsoleID::GB:
         case ConsoleID::GBC:
             // $A000-$BFFF is 8KB is external RAM (in cartridge)
             start = 0xA000;
-            end   = 0xBFFF;
+            end = 0xBFFF;
             return TRUE;
 
         case ConsoleID::GBA:
@@ -1707,13 +1745,13 @@ bool Dlg_Memory::GetGameMemoryRange(ra::ByteAddress& start, ra::ByteAddress& end
             // game pak RAM. The Memory Manager sees the in-chip RAM as $00000-$07FF0, and the
             // on-board as $8000-$47FFF
             start = 0x0000;
-            end   = 0x7FFF;
+            end = 0x7FFF;
             return TRUE;
 
         case ConsoleID::MasterSystem:
             // $0000-$BFFF is cartridge ROM/RAM
             start = 0x0000;
-            end   = 0xBFFF;
+            end = 0xBFFF;
             return TRUE;
 
         case ConsoleID::N64:
@@ -1722,7 +1760,7 @@ bool Dlg_Memory::GetGameMemoryRange(ra::ByteAddress& start, ra::ByteAddress& end
             if (g_MemManager.TotalBankSize() > 0x400000)
             {
                 start = 0x400000;
-                end   = 0x7FFFFF;
+                end = 0x7FFFFF;
                 return TRUE;
             }
             else
@@ -1732,7 +1770,7 @@ bool Dlg_Memory::GetGameMemoryRange(ra::ByteAddress& start, ra::ByteAddress& end
 
         default:
             start = 0;
-            end   = 0;
+            end = 0;
             return FALSE;
     }
 }
@@ -1779,7 +1817,7 @@ bool Dlg_Memory::GetSelectedMemoryRange(ra::ByteAddress& start, ra::ByteAddress&
     {
         // all items are in "All" range
         start = 0;
-        end   = g_MemManager.TotalBankSize() - 1;
+        end = g_MemManager.TotalBankSize() - 1;
         return TRUE;
     }
 
@@ -1846,13 +1884,27 @@ bool Dlg_Memory::CompareSearchResult(unsigned int nCurVal, unsigned int nPrevVal
 
     switch (m_SearchResults[m_nPage].m_nCompareType)
     {
-        case ComparisonType::Equals: bResult = (nCurVal == nVal); break;
-        case ComparisonType::LessThan: bResult = (nCurVal < nVal); break;
-        case ComparisonType::LessThanOrEqual: bResult = (nCurVal <= nVal); break;
-        case ComparisonType::GreaterThan: bResult = (nCurVal > nVal); break;
-        case ComparisonType::GreaterThanOrEqual: bResult = (nCurVal >= nVal); break;
-        case ComparisonType::NotEqualTo: bResult = (nCurVal != nVal); break;
-        default: bResult = false; break;
+        case ComparisonType::Equals:
+            bResult = (nCurVal == nVal);
+            break;
+        case ComparisonType::LessThan:
+            bResult = (nCurVal < nVal);
+            break;
+        case ComparisonType::LessThanOrEqual:
+            bResult = (nCurVal <= nVal);
+            break;
+        case ComparisonType::GreaterThan:
+            bResult = (nCurVal > nVal);
+            break;
+        case ComparisonType::GreaterThanOrEqual:
+            bResult = (nCurVal >= nVal);
+            break;
+        case ComparisonType::NotEqualTo:
+            bResult = (nCurVal != nVal);
+            break;
+        default:
+            bResult = false;
+            break;
     }
     return bResult;
 }

--- a/src/RA_Dlg_Memory.h
+++ b/src/RA_Dlg_Memory.h
@@ -9,13 +9,13 @@
 class MemoryViewerControl
 {
 public:
-    static INT_PTR CALLBACK s_MemoryDrawProc(HWND, UINT, WPARAM, LPARAM);
+    static LRESULT CALLBACK s_MemoryDrawProc(HWND, UINT, WPARAM, LPARAM);
 
 public:
     static void RenderMemViewer(HWND hTarget);
 
-    static void createEditCaret(int w, int h);
-    static void destroyEditCaret();
+    static void createEditCaret(int w, int h) noexcept;
+    static void destroyEditCaret() noexcept;
     static void SetCaretPos();
     static void OnClick(POINT point);
 
@@ -23,14 +23,18 @@ public:
     static bool OnEditInput(UINT c);
 
     static void setAddress(unsigned int nAddr);
-    static void setWatchedAddress(unsigned int nAddr);
-    static unsigned int getWatchedAddress() { return m_nWatchedAddress; }
+    static void setWatchedAddress(unsigned int nAddr) noexcept;
+    static unsigned int getWatchedAddress() noexcept { return m_nWatchedAddress; }
     static void moveAddress(int offset, int nibbleOff);
     static void editData(unsigned int nByteAddress, bool bLowerNibble, unsigned int value);
-    static void Invalidate();
+    static void Invalidate() noexcept;
 
-    static void SetDataSize(MemSize value) { m_nDataSize = value; Invalidate(); }
-    static MemSize GetDataSize() { return m_nDataSize; }
+    static void SetDataSize(MemSize value) noexcept
+    {
+        m_nDataSize = value;
+        Invalidate();
+    }
+    static MemSize GetDataSize() noexcept { return m_nDataSize; }
 
 public:
     static unsigned short m_nActiveMemBank;
@@ -69,18 +73,15 @@ struct SearchResult
 class Dlg_Memory
 {
 public:
-    Dlg_Memory() {}
+    void Init() noexcept;
 
-public:
-    void Init();
-
-    void ClearLogOutput();
+    void ClearLogOutput() noexcept;
 
     static INT_PTR CALLBACK s_MemoryProc(HWND, UINT, WPARAM, LPARAM);
     INT_PTR MemoryProc(HWND, UINT, WPARAM, LPARAM);
 
-    void InstallHWND(HWND hWnd) { m_hWnd = hWnd; }
-    HWND GetHWND() const { return m_hWnd; }
+    void InstallHWND(HWND hWnd) noexcept { m_hWnd = hWnd; }
+    HWND GetHWND() const noexcept { return m_hWnd; }
 
     void OnLoad_NewRom();
 
@@ -91,19 +92,19 @@ public:
 
     void SetWatchingAddress(unsigned int nAddr);
     void UpdateBits() const;
-    BOOL IsActive() const;
+    BOOL IsActive() const noexcept;
 
-    const CodeNotes& Notes() const { return m_CodeNotes; }
+    const CodeNotes& Notes() const noexcept { return m_CodeNotes; }
 
-    void ClearBanks();
+    void ClearBanks() noexcept;
     void AddBank(size_t nBankID);
     void GenerateResizes(HWND hDlg);
 
 private:
-    bool GetSystemMemoryRange(ra::ByteAddress& start, ra::ByteAddress& end);
-    bool GetGameMemoryRange(ra::ByteAddress& start, ra::ByteAddress& end);
+    bool GetSystemMemoryRange(ra::ByteAddress& start, ra::ByteAddress& end) noexcept;
+    bool GetGameMemoryRange(ra::ByteAddress& start, ra::ByteAddress& end) noexcept;
 
-    bool GetSelectedMemoryRange(ra::ByteAddress& start, ra::ByteAddress& end);
+    bool GetSelectedMemoryRange(ra::ByteAddress& start, ra::ByteAddress& end) noexcept;
 
     void UpdateSearchResult(const ra::services::SearchResults::Result& result, _Out_ unsigned int& nMemVal, TCHAR(&buffer)[1024]);
     bool CompareSearchResult(unsigned int nCurVal, unsigned int nPrevVal);

--- a/src/RA_Integration.vcxproj
+++ b/src/RA_Integration.vcxproj
@@ -393,7 +393,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;RA_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
-      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <ControlFlowGuard>false</ControlFlowGuard>

--- a/src/RA_Integration.vcxproj
+++ b/src/RA_Integration.vcxproj
@@ -230,7 +230,7 @@
     <ProjectName>RA_Integration</ProjectName>
     <ProjectGuid>{825CB292-F069-4B27-82CF-3417746ACDF3}</ProjectGuid>
     <RootNamespace>RA_Integration</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
@@ -323,7 +323,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Analysis|Win32'">
     <TargetName>RA_Integration</TargetName>
-    <CodeAnalysisRuleSet>ra_rules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>CppCoreCheckFuncRules.ruleset</CodeAnalysisRuleSet>
     <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugUnicode|Win32'">

--- a/src/RA_Integration.vcxproj
+++ b/src/RA_Integration.vcxproj
@@ -35,43 +35,11 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\lua\lapi.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" WarningLevel="Level3" />
-    <ClCompile Include="..\lua\lauxlib.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" WarningLevel="Level3" />
-    <ClCompile Include="..\lua\lcode.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" WarningLevel="Level3" />
-    <ClCompile Include="..\lua\lctype.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" WarningLevel="Level3" />
-    <ClCompile Include="..\lua\ldebug.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" WarningLevel="Level3" />
-    <ClCompile Include="..\lua\ldo.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" WarningLevel="Level3" />
-    <ClCompile Include="..\lua\ldump.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" WarningLevel="Level3" />
-    <ClCompile Include="..\lua\lfunc.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" WarningLevel="Level3" />
-    <ClCompile Include="..\lua\lgc.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" WarningLevel="Level3" />
-    <ClCompile Include="..\lua\llex.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" WarningLevel="Level3" />
-    <ClCompile Include="..\lua\lmem.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" WarningLevel="Level3" />
-    <ClCompile Include="..\lua\lobject.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" WarningLevel="Level3" />
-    <ClCompile Include="..\lua\lopcodes.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" WarningLevel="Level3" />
-    <ClCompile Include="..\lua\lparser.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" WarningLevel="Level3" />
-    <ClCompile Include="..\lua\lstate.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" WarningLevel="Level3" />
-    <ClCompile Include="..\lua\lstring.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" WarningLevel="Level3" />
-    <ClCompile Include="..\lua\ltable.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" WarningLevel="Level3" />
-    <ClCompile Include="..\lua\ltm.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" WarningLevel="Level3" />
-    <ClCompile Include="..\lua\lundump.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" WarningLevel="Level3" />
-    <ClCompile Include="..\lua\lvm.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" WarningLevel="Level3" />
-    <ClCompile Include="..\lua\lzio.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" WarningLevel="Level3" />
-    <ClCompile Include="..\rcheevos\src\rcheevos\alloc.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" WarningLevel="Level3" />
-    <ClCompile Include="..\rcheevos\src\rcheevos\condition.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" WarningLevel="Level3" />
-    <ClCompile Include="..\rcheevos\src\rcheevos\condset.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" WarningLevel="Level3" />
-    <ClCompile Include="..\rcheevos\src\rcheevos\expression.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" WarningLevel="Level3" />
-    <ClCompile Include="..\rcheevos\src\rcheevos\format.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" WarningLevel="Level3" />
-    <ClCompile Include="..\rcheevos\src\rcheevos\lboard.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" WarningLevel="Level3" />
-    <ClCompile Include="..\rcheevos\src\rcheevos\operand.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" WarningLevel="Level3" />
-    <ClCompile Include="..\rcheevos\src\rcheevos\term.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" WarningLevel="Level3" />
-    <ClCompile Include="..\rcheevos\src\rcheevos\trigger.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" WarningLevel="Level3" />
-    <ClCompile Include="..\rcheevos\src\rcheevos\value.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" WarningLevel="Level3" />
     <ClCompile Include="api\ApiCall.cpp" />
     <ClCompile Include="api\impl\ConnectedServer.cpp" />
     <ClCompile Include="api\impl\DisconnectedServer.cpp" />
     <ClCompile Include="api\impl\OfflineServer.cpp" />
     <ClCompile Include="data\SessionTracker.cpp" />
-    <ClCompile Include="md5.c" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='DebugUnicode|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='AnalysisUnicode|Win32'">Create</PrecompiledHeader>
@@ -138,8 +106,6 @@
     <ClCompile Include="ui\WindowViewModelBase.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\rcheevos\include\rcheevos.h" />
-    <ClInclude Include="..\rcheevos\src\rcheevos\internal.h" />
     <ClInclude Include="api\ApiCall.hh" />
     <ClInclude Include="api\impl\ConnectedServer.hh" />
     <ClInclude Include="api\impl\DisconnectedServer.hh" />
@@ -154,7 +120,6 @@
     <ClInclude Include="data\SessionTracker.hh" />
     <ClInclude Include="data\UserContext.hh" />
     <ClInclude Include="Exports.hh" />
-    <ClInclude Include="md5.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="pch_cppcorecheck_suppressions.h" />
     <ClInclude Include="pch_microsoft_suppressions.h" />
@@ -255,6 +220,11 @@
     </None>
     <None Include="ra_type_traits.h" />
     <None Include="ra_utility.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="rcheevos.vcxproj">
+      <Project>{9d55ebe7-1392-4fa1-a9b9-f022f764ce35}</Project>
+    </ProjectReference>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectName>RA_Integration</ProjectName>
@@ -512,7 +482,6 @@
     <Link>
       <AdditionalDependencies>windowscodecs.lib;winmm.lib;Winhttp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <LinkTimeCodeGeneration>UseFastLinkTimeCodeGeneration</LinkTimeCodeGeneration>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>false</GenerateDebugInformation>
     </Link>
@@ -537,7 +506,6 @@
     <Link>
       <AdditionalDependencies>windowscodecs.lib;winmm.lib;Winhttp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <LinkTimeCodeGeneration>UseFastLinkTimeCodeGeneration</LinkTimeCodeGeneration>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
@@ -561,8 +529,6 @@
     <Link>
       <AdditionalDependencies>windowscodecs.lib;winmm.lib;Winhttp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <LinkTimeCodeGeneration>
-      </LinkTimeCodeGeneration>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>false</GenerateDebugInformation>
     </Link>
@@ -586,8 +552,6 @@
     <Link>
       <AdditionalDependencies>windowscodecs.lib;winmm.lib;Winhttp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <LinkTimeCodeGeneration>
-      </LinkTimeCodeGeneration>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>

--- a/src/RA_Integration.vcxproj
+++ b/src/RA_Integration.vcxproj
@@ -393,7 +393,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;RA_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
-      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <ControlFlowGuard>false</ControlFlowGuard>
@@ -407,6 +407,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
       <SubSystem>Windows</SubSystem>
+      <IgnoreSpecificDefaultLibraries>libc.lib, libcmt.lib, msvcrt.lib, libcd.lib, libcmtd.lib</IgnoreSpecificDefaultLibraries>
     </Link>
     <PreBuildEvent>
       <Command>..\MakeBuildVer.bat</Command>

--- a/src/RA_Integration.vcxproj
+++ b/src/RA_Integration.vcxproj
@@ -323,7 +323,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Analysis|Win32'">
     <TargetName>RA_Integration</TargetName>
-    <CodeAnalysisRuleSet>CppCoreCheckFuncRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>ra_rules.ruleset</CodeAnalysisRuleSet>
     <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugUnicode|Win32'">

--- a/src/RA_Integration.vcxproj
+++ b/src/RA_Integration.vcxproj
@@ -230,7 +230,7 @@
     <ProjectName>RA_Integration</ProjectName>
     <ProjectGuid>{825CB292-F069-4B27-82CF-3417746ACDF3}</ProjectGuid>
     <RootNamespace>RA_Integration</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/src/RA_Integration.vcxproj.filters
+++ b/src/RA_Integration.vcxproj.filters
@@ -22,12 +22,6 @@
     <Filter Include="Helpers">
       <UniqueIdentifier>{cd433aa7-9c74-461e-ba0e-3ce327a59b7a}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Data\rcheevos">
-      <UniqueIdentifier>{22424437-af0c-41fb-99ff-d5883c57b62a}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Data\lua">
-      <UniqueIdentifier>{8bf8f543-5155-4587-a22b-0016c9742bc4}</UniqueIdentifier>
-    </Filter>
     <Filter Include="UI\ViewModels">
       <UniqueIdentifier>{0badbd6c-a477-4f69-b999-f27b050c3a17}</UniqueIdentifier>
     </Filter>
@@ -54,9 +48,6 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="md5.c">
-      <Filter>Services</Filter>
-    </ClCompile>
     <ClCompile Include="RA_Achievement.cpp">
       <Filter>Data</Filter>
     </ClCompile>
@@ -137,99 +128,6 @@
     </ClCompile>
     <ClCompile Include="services\SearchResults.cpp">
       <Filter>Services</Filter>
-    </ClCompile>
-    <ClCompile Include="..\rcheevos\src\rcheevos\alloc.c">
-      <Filter>Data\rcheevos</Filter>
-    </ClCompile>
-    <ClCompile Include="..\rcheevos\src\rcheevos\condition.c">
-      <Filter>Data\rcheevos</Filter>
-    </ClCompile>
-    <ClCompile Include="..\rcheevos\src\rcheevos\condset.c">
-      <Filter>Data\rcheevos</Filter>
-    </ClCompile>
-    <ClCompile Include="..\rcheevos\src\rcheevos\expression.c">
-      <Filter>Data\rcheevos</Filter>
-    </ClCompile>
-    <ClCompile Include="..\rcheevos\src\rcheevos\format.c">
-      <Filter>Data\rcheevos</Filter>
-    </ClCompile>
-    <ClCompile Include="..\rcheevos\src\rcheevos\lboard.c">
-      <Filter>Data\rcheevos</Filter>
-    </ClCompile>
-    <ClCompile Include="..\rcheevos\src\rcheevos\operand.c">
-      <Filter>Data\rcheevos</Filter>
-    </ClCompile>
-    <ClCompile Include="..\rcheevos\src\rcheevos\term.c">
-      <Filter>Data\rcheevos</Filter>
-    </ClCompile>
-    <ClCompile Include="..\rcheevos\src\rcheevos\trigger.c">
-      <Filter>Data\rcheevos</Filter>
-    </ClCompile>
-    <ClCompile Include="..\rcheevos\src\rcheevos\value.c">
-      <Filter>Data\rcheevos</Filter>
-    </ClCompile>
-    <ClCompile Include="..\lua\lapi.c">
-      <Filter>Data\lua</Filter>
-    </ClCompile>
-    <ClCompile Include="..\lua\lcode.c">
-      <Filter>Data\lua</Filter>
-    </ClCompile>
-    <ClCompile Include="..\lua\lctype.c">
-      <Filter>Data\lua</Filter>
-    </ClCompile>
-    <ClCompile Include="..\lua\ldebug.c">
-      <Filter>Data\lua</Filter>
-    </ClCompile>
-    <ClCompile Include="..\lua\ldo.c">
-      <Filter>Data\lua</Filter>
-    </ClCompile>
-    <ClCompile Include="..\lua\ldump.c">
-      <Filter>Data\lua</Filter>
-    </ClCompile>
-    <ClCompile Include="..\lua\lfunc.c">
-      <Filter>Data\lua</Filter>
-    </ClCompile>
-    <ClCompile Include="..\lua\lgc.c">
-      <Filter>Data\lua</Filter>
-    </ClCompile>
-    <ClCompile Include="..\lua\llex.c">
-      <Filter>Data\lua</Filter>
-    </ClCompile>
-    <ClCompile Include="..\lua\lmem.c">
-      <Filter>Data\lua</Filter>
-    </ClCompile>
-    <ClCompile Include="..\lua\lobject.c">
-      <Filter>Data\lua</Filter>
-    </ClCompile>
-    <ClCompile Include="..\lua\lopcodes.c">
-      <Filter>Data\lua</Filter>
-    </ClCompile>
-    <ClCompile Include="..\lua\lparser.c">
-      <Filter>Data\lua</Filter>
-    </ClCompile>
-    <ClCompile Include="..\lua\lstate.c">
-      <Filter>Data\lua</Filter>
-    </ClCompile>
-    <ClCompile Include="..\lua\lstring.c">
-      <Filter>Data\lua</Filter>
-    </ClCompile>
-    <ClCompile Include="..\lua\ltable.c">
-      <Filter>Data\lua</Filter>
-    </ClCompile>
-    <ClCompile Include="..\lua\ltm.c">
-      <Filter>Data\lua</Filter>
-    </ClCompile>
-    <ClCompile Include="..\lua\lundump.c">
-      <Filter>Data\lua</Filter>
-    </ClCompile>
-    <ClCompile Include="..\lua\lvm.c">
-      <Filter>Data\lua</Filter>
-    </ClCompile>
-    <ClCompile Include="..\lua\lzio.c">
-      <Filter>Data\lua</Filter>
-    </ClCompile>
-    <ClCompile Include="..\lua\lauxlib.c">
-      <Filter>Data\lua</Filter>
     </ClCompile>
     <ClCompile Include="services\impl\JsonFileConfiguration.cpp">
       <Filter>Services\Impl</Filter>
@@ -332,9 +230,6 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="md5.h">
-      <Filter>Services</Filter>
-    </ClInclude>
     <ClInclude Include="RA_Achievement.h">
       <Filter>Data</Filter>
     </ClInclude>
@@ -451,12 +346,6 @@
     </ClInclude>
     <ClInclude Include="ra_fwd.h">
       <Filter>Helpers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\rcheevos\include\rcheevos.h">
-      <Filter>Data\rcheevos</Filter>
-    </ClInclude>
-    <ClInclude Include="..\rcheevos\src\rcheevos\internal.h">
-      <Filter>Data\rcheevos</Filter>
     </ClInclude>
     <ClInclude Include="services\IFileSystem.hh">
       <Filter>Services</Filter>

--- a/src/RA_Interface.cpp
+++ b/src/RA_Interface.cpp
@@ -1,14 +1,14 @@
 #include "RA_Interface.h"
 
-//	Exposed, shared
-//	App-level:
-bool	(CCONV *_RA_GameIsActive) (void) = nullptr;
-void	(CCONV *_RA_CauseUnpause) (void) = nullptr;
-void	(CCONV *_RA_CausePause) (void) = nullptr;
-void	(CCONV *_RA_RebuildMenu) (void) = nullptr;
-void	(CCONV *_RA_ResetEmulation) (void) = nullptr;
-void	(CCONV *_RA_GetEstimatedGameTitle) (char* sNameOut) = nullptr;
-void	(CCONV *_RA_LoadROM) (const char* sNameOut) = nullptr;
+// Exposed, shared
+// App-level:
+bool (CCONV *_RA_GameIsActive) (void) = nullptr;
+void (CCONV *_RA_CauseUnpause) (void) = nullptr;
+void (CCONV *_RA_CausePause) (void) = nullptr;
+void (CCONV *_RA_RebuildMenu) (void) = nullptr;
+void (CCONV *_RA_ResetEmulation) (void) = nullptr;
+void (CCONV *_RA_GetEstimatedGameTitle) (char* sNameOut) = nullptr;
+void (CCONV *_RA_LoadROM) (const char* sNameOut) = nullptr;
 
 bool RA_GameIsActive()
 {

--- a/src/RA_Interface.h
+++ b/src/RA_Interface.h
@@ -15,22 +15,22 @@ struct ControllerInput
     BOOL m_bDownPressed;
     BOOL m_bLeftPressed;
     BOOL m_bRightPressed;
-    BOOL m_bConfirmPressed; //	Usually C or A
-    BOOL m_bCancelPressed;  //	Usually B
-    BOOL m_bQuitPressed;    //	Usually Start
+    BOOL m_bConfirmPressed; // Usually C or A
+    BOOL m_bCancelPressed;  // Usually B
+    BOOL m_bQuitPressed;    // Usually Start
 };
 
 enum EmulatorID
 {
-    RA_Gens             = 0,
-    RA_Project64        = 1,
-    RA_Snes9x           = 2,
+    RA_Gens = 0,
+    RA_Project64 = 1,
+    RA_Snes9x = 2,
     RA_VisualboyAdvance = 3,
-    RA_Nester           = 4,
-    RA_FCEUX            = 5,
-    RA_PCE              = 6,
-    RA_Libretro         = 7,
-    RA_Meka             = 8,
+    RA_Nester = 4,
+    RA_FCEUX = 5,
+    RA_PCE = 6,
+    RA_Libretro = 7,
+    RA_Meka = 8,
 
     NumEmulatorIDs,
     UnknownEmulator = NumEmulatorIDs
@@ -40,59 +40,59 @@ enum EmulatorID
 enum ConsoleID
 {
     UnknownConsoleID = 0,
-    MegaDrive        = 1, //	DB
-    N64              = 2,
-    SNES             = 3,
-    GB               = 4,
-    GBA              = 5,
-    GBC              = 6,
-    NES              = 7,
-    PCEngine         = 8,
-    SegaCD           = 9,
-    Sega32X          = 10,
-    MasterSystem     = 11,
-    PlayStation      = 12,
-    Lynx             = 13,
-    NeoGeoPocket     = 14,
-    GameGear         = 15,
-    GameCube         = 16,
-    Jaguar           = 17,
-    DS               = 18,
-    WII              = 19,
-    WIIU             = 20,
-    PlayStation2     = 21,
-    Xbox             = 22,
-    Events           = 23, // not an actual console
-    XboxOne          = 24,
-    Atari2600        = 25,
-    MSDOS            = 26,
-    Arcade           = 27,
-    VirtualBoy       = 28,
-    MSX              = 29,
-    C64              = 30,
-    ZX81             = 31,
+    MegaDrive = 1, //	DB
+    N64 = 2,
+    SNES = 3,
+    GB = 4,
+    GBA = 5,
+    GBC = 6,
+    NES = 7,
+    PCEngine = 8,
+    SegaCD = 9,
+    Sega32X = 10,
+    MasterSystem = 11,
+    PlayStation = 12,
+    Lynx = 13,
+    NeoGeoPocket = 14,
+    GameGear = 15,
+    GameCube = 16,
+    Jaguar = 17,
+    DS = 18,
+    WII = 19,
+    WIIU = 20,
+    PlayStation2 = 21,
+    Xbox = 22,
+    Events = 23, // not an actual console
+    XboxOne = 24,
+    Atari2600 = 25,
+    MSDOS = 26,
+    Arcade = 27,
+    VirtualBoy = 28,
+    MSX = 29,
+    C64 = 30,
+    ZX81 = 31,
     // unused32 = 32,
-    SG1000        = 33,
-    VIC20         = 34,
-    Amiga         = 35,
-    AmigaST       = 36,
-    AmstradCPC    = 37,
-    AppleII       = 38,
-    Saturn        = 39,
-    Dreamcast     = 40,
-    PSP           = 41,
-    CDi           = 42,
-    ThreeDO       = 43,
-    Colecovision  = 44,
+    SG1000 = 33,
+    VIC20 = 34,
+    Amiga = 35,
+    AmigaST = 36,
+    AmstradCPC = 37,
+    AppleII = 38,
+    Saturn = 39,
+    Dreamcast = 40,
+    PSP = 41,
+    CDi = 42,
+    ThreeDO = 43,
+    Colecovision = 44,
     Intellivision = 45,
-    Vectrex       = 46,
-    PC8800        = 47,
-    PC9800        = 48,
-    PCFX          = 49,
-    Atari5200     = 50,
-    Atari7800     = 51,
-    X68K          = 52,
-    WonderSwan    = 53,
+    Vectrex = 46,
+    PC8800 = 47,
+    PC9800 = 48,
+    PCFX = 49,
+    Atari5200 = 50,
+    Atari7800 = 51,
+    X68K = 52,
+    WonderSwan = 53,
 
     NumConsoleIDs
 };
@@ -119,6 +119,7 @@ extern void RA_LoadROM(const char* sFullPath);
 #ifdef __cplusplus
 }
 #endif // __cplusplus
+
 #ifndef RA_EXPORTS
 
 #include <wtypes.h>

--- a/src/RA_Interface.h
+++ b/src/RA_Interface.h
@@ -15,22 +15,22 @@ struct ControllerInput
     BOOL m_bDownPressed;
     BOOL m_bLeftPressed;
     BOOL m_bRightPressed;
-    BOOL m_bConfirmPressed;	//	Usually C or A
-    BOOL m_bCancelPressed;	//	Usually B
-    BOOL m_bQuitPressed;	//	Usually Start
+    BOOL m_bConfirmPressed; //	Usually C or A
+    BOOL m_bCancelPressed;  //	Usually B
+    BOOL m_bQuitPressed;    //	Usually Start
 };
 
 enum EmulatorID
 {
-    RA_Gens = 0,
-    RA_Project64 = 1,
-    RA_Snes9x = 2,
+    RA_Gens             = 0,
+    RA_Project64        = 1,
+    RA_Snes9x           = 2,
     RA_VisualboyAdvance = 3,
-    RA_Nester = 4,
-    RA_FCEUX = 5,
-    RA_PCE = 6,
-    RA_Libretro = 7,
-    RA_Meka = 8,
+    RA_Nester           = 4,
+    RA_FCEUX            = 5,
+    RA_PCE              = 6,
+    RA_Libretro         = 7,
+    RA_Meka             = 8,
 
     NumEmulatorIDs,
     UnknownEmulator = NumEmulatorIDs
@@ -40,73 +40,75 @@ enum EmulatorID
 enum ConsoleID
 {
     UnknownConsoleID = 0,
-    MegaDrive = 1,	//	DB
-    N64 = 2,
-    SNES = 3,
-    GB = 4,
-    GBA = 5,
-    GBC = 6,
-    NES = 7,
-    PCEngine = 8,
-    SegaCD = 9,
-    Sega32X = 10,
-    MasterSystem = 11,
-    PlayStation = 12,
-    Lynx = 13,
-    NeoGeoPocket = 14,
-    GameGear = 15,
-    GameCube = 16,
-    Jaguar = 17,
-    DS = 18,
-    WII = 19,
-    WIIU = 20,
-    PlayStation2 = 21,
-    Xbox = 22,
-    Events = 23, // not an actual console
-    XboxOne = 24,
-    Atari2600 = 25,
-    MSDOS = 26,
-    Arcade = 27,
-    VirtualBoy = 28,
-    MSX = 29,
-    C64 = 30,
-    ZX81 = 31,
-    //unused32 = 32,
-    SG1000 = 33,
-    VIC20 = 34,
-    Amiga = 35,
-    AmigaST = 36,
-    AmstradCPC = 37,
-    AppleII = 38,
-    Saturn = 39,
-    Dreamcast = 40,
-    PSP = 41,
-    CDi = 42,
-    ThreeDO = 43,
-    Colecovision = 44,
+    MegaDrive        = 1, //	DB
+    N64              = 2,
+    SNES             = 3,
+    GB               = 4,
+    GBA              = 5,
+    GBC              = 6,
+    NES              = 7,
+    PCEngine         = 8,
+    SegaCD           = 9,
+    Sega32X          = 10,
+    MasterSystem     = 11,
+    PlayStation      = 12,
+    Lynx             = 13,
+    NeoGeoPocket     = 14,
+    GameGear         = 15,
+    GameCube         = 16,
+    Jaguar           = 17,
+    DS               = 18,
+    WII              = 19,
+    WIIU             = 20,
+    PlayStation2     = 21,
+    Xbox             = 22,
+    Events           = 23, // not an actual console
+    XboxOne          = 24,
+    Atari2600        = 25,
+    MSDOS            = 26,
+    Arcade           = 27,
+    VirtualBoy       = 28,
+    MSX              = 29,
+    C64              = 30,
+    ZX81             = 31,
+    // unused32 = 32,
+    SG1000        = 33,
+    VIC20         = 34,
+    Amiga         = 35,
+    AmigaST       = 36,
+    AmstradCPC    = 37,
+    AppleII       = 38,
+    Saturn        = 39,
+    Dreamcast     = 40,
+    PSP           = 41,
+    CDi           = 42,
+    ThreeDO       = 43,
+    Colecovision  = 44,
     Intellivision = 45,
-    Vectrex = 46,
-    PC8800 = 47,
-    PC9800 = 48,
-    PCFX = 49,
-    Atari5200 = 50,
-    Atari7800 = 51,
-    X68K = 52,
-    WonderSwan = 53,
+    Vectrex       = 46,
+    PC8800        = 47,
+    PC9800        = 48,
+    PCFX          = 49,
+    Atari5200     = 50,
+    Atari7800     = 51,
+    X68K          = 52,
+    WonderSwan    = 53,
 
     NumConsoleIDs
 };
 
+extern bool (*_RA_GameIsActive)();
+extern void (*_RA_CauseUnpause)();
+extern void (*_RA_CausePause)();
+extern void (*_RA_RebuildMenu)();
+extern void (*_RA_GetEstimatedGameTitle)(char* sNameOut);
+extern void (*_RA_ResetEmulation)();
+extern void (*_RA_LoadROM)(const char* sFullPath);
 
-extern bool(*_RA_GameIsActive)();
-extern void(*_RA_CauseUnpause)();
-extern void(*_RA_CausePause)();
-extern void(*_RA_RebuildMenu)();
-extern void(*_RA_GetEstimatedGameTitle)(char* sNameOut);
-extern void(*_RA_ResetEmulation)();
-extern void(*_RA_LoadROM)(const char* sFullPath);
-
-//	Shared funcs, should be implemented by emulator.
+// Shared funcs, should be implemented by emulator.
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
 extern bool RA_GameIsActive();
 extern void RA_CauseUnpause();
 extern void RA_CausePause();
@@ -114,7 +116,9 @@ extern void RA_RebuildMenu();
 extern void RA_GetEstimatedGameTitle(char* sNameOut);
 extern void RA_ResetEmulation();
 extern void RA_LoadROM(const char* sFullPath);
-
+#ifdef __cplusplus
+}
+#endif // __cplusplus
 #ifndef RA_EXPORTS
 
 #include <wtypes.h>
@@ -126,26 +130,28 @@ extern void RA_LoadROM(const char* sFullPath);
 
 // resource values for menu items - needed by MFC ON_COMMAND_RANGE macros
 // they're not all currently used, allowing additional items without forcing recompilation of the emulators
-#define IDM_RA_MENUSTART                1700
-#define IDM_RA_MENUEND                  1739
+#define IDM_RA_MENUSTART 1700
+#define IDM_RA_MENUEND 1739
 
 //	Captures the RA_DLL and installs/allocs all required information.
 //	Populates all function pointers so they can be used by the app.
-extern void RA_Init(HWND hMainHWND, /*enum ConsoleType*/int console, const char* sClientVersion);
+extern void RA_Init(HWND hMainHWND, /*enum ConsoleType*/ int console, const char* sClientVersion);
 
 //	Call with shared function pointers from app.
-extern void RA_InstallSharedFunctions(bool(*fpIsActive)(void), void(*fpCauseUnpause)(void), void(*fpCausePause)(void), void(*fpRebuildMenu)(void), void(*fpEstimateTitle)(char*), void(*fpResetEmulator)(void), void(*fpLoadROM)(const char*));
+extern void RA_InstallSharedFunctions(bool (*fpIsActive)(void), void (*fpCauseUnpause)(void),
+                                      void (*fpCausePause)(void), void (*fpRebuildMenu)(void),
+                                      void (*fpEstimateTitle)(char*), void (*fpResetEmulator)(void),
+                                      void (*fpLoadROM)(const char*));
 
 //	Shuts down, tidies up and deallocs the RA DLL from the app's perspective.
 extern void RA_Shutdown();
 
-
 //	Perform one test for all achievements in the current set. Call this once per frame/cycle.
 extern void RA_DoAchievementsFrame();
 
-
 //	Updates and renders all on-screen overlays.
-extern void RA_UpdateRenderOverlay(HDC hDC, ControllerInput* pInput, float fDeltaTime, RECT* prcSize, bool Full_Screen, bool Paused);
+extern void RA_UpdateRenderOverlay(HDC hDC, ControllerInput* pInput, float fDeltaTime, RECT* prcSize, bool Full_Screen,
+                                   bool Paused);
 
 //  Determines if the overlay is completely covering the screen.
 extern bool RA_IsOverlayFullyVisible();
@@ -160,8 +166,8 @@ extern void RA_OnLoadNewRom(BYTE* pROMData, unsigned int nROMSize);
 extern void RA_ClearMemoryBanks();
 
 //	Call once for each memory bank found, immediately after a new rom or load
-//pReader is typedef unsigned char (_RAMByteReadFn)( size_t nOffset );
-//pWriter is typedef void (_RAMByteWriteFn)( unsigned int nOffs, unsigned int nVal );
+// pReader is typedef unsigned char (_RAMByteReadFn)( size_t nOffset );
+// pWriter is typedef void (_RAMByteWriteFn)( unsigned int nOffs, unsigned int nVal );
 extern void RA_InstallMemoryBank(int nBankID, void* pReader, void* pWriter, int nBankSize);
 
 //	Call this before loading a new ROM or quitting, to ensure no developer changes are lost.
@@ -200,7 +206,6 @@ extern void RA_InvokeDialog(LPARAM nID);
 //	Returns TRUE if HC mode is ongoing
 extern int RA_HardcoreModeIsActive();
 
-#endif //RA_EXPORTS
-
+#endif // RA_EXPORTS
 
 #endif // !RA_INTERFACE_H

--- a/src/RA_Leaderboard.cpp
+++ b/src/RA_Leaderboard.cpp
@@ -98,6 +98,7 @@ void RA_Leaderboard::SubmitRankInfo(unsigned int nRank, const std::string& sUser
 
 bool RA_Leaderboard::EntryExists(unsigned int nRank)
 {
+    SortRankInfo();
     return (std::binary_search(m_RankInfo.begin(), m_RankInfo.end(), nRank));
 }
 

--- a/src/RA_Leaderboard.cpp
+++ b/src/RA_Leaderboard.cpp
@@ -8,12 +8,10 @@
 
 #include <ctime>
 
-RA_Leaderboard::RA_Leaderboard(const ra::LeaderboardID nLeaderboardID) noexcept :
-    m_nID(nLeaderboardID)
-{
-}
+RA_Leaderboard::RA_Leaderboard(const ra::LeaderboardID nLeaderboardID) noexcept : m_nID(nLeaderboardID) {}
 
-//{"ID":"3","Mem":"STA:0xfe10=h0001_0xhf601=h0c_d0xhf601!=h0c_0xhfffb=0::CAN:0xhfe13<d0xhfe13::SUB:0xf7cc!=0_d0xf7cc=0::VAL:0xhfe24*1_0xhfe25*60_0xhfe22*3600","Format":"TIME","Title":"Green Hill Act 2","Description":"Complete this act in the fastest time!"},
+//{"ID":"3","Mem":"STA:0xfe10=h0001_0xhf601=h0c_d0xhf601!=h0c_0xhfffb=0::CAN:0xhfe13<d0xhfe13::SUB:0xf7cc!=0_d0xf7cc=0::VAL:0xhfe24*1_0xhfe25*60_0xhfe22*3600","Format":"TIME","Title":"Green
+//Hill Act 2","Description":"Complete this act in the fastest time!"},
 
 void RA_Leaderboard::ParseFromString(const char* sBuffer, const char* sFormat)
 {
@@ -42,7 +40,7 @@ std::string RA_Leaderboard::FormatScore(unsigned int nValue) const
     return std::string(buffer);
 }
 
-void RA_Leaderboard::Reset()
+void RA_Leaderboard::Reset() noexcept
 {
     if (m_pLeaderboard != nullptr)
     {
@@ -56,7 +54,7 @@ void RA_Leaderboard::Test()
     if (m_pLeaderboard != nullptr)
     {
         rc_lboard_t* pLboard = static_cast<rc_lboard_t*>(m_pLeaderboard);
-        const int nResult = rc_evaluate_lboard(pLboard, &m_nCurrentValue, rc_peek_callback, nullptr, nullptr);
+        const int nResult    = rc_evaluate_lboard(pLboard, &m_nCurrentValue, rc_peek_callback, nullptr, nullptr);
         switch (nResult)
         {
             default:
@@ -65,17 +63,11 @@ void RA_Leaderboard::Test()
                 // no change, do nothing
                 break;
 
-            case RC_LBOARD_STARTED:
-                Start();
-                break;
+            case RC_LBOARD_STARTED: Start(); break;
 
-            case RC_LBOARD_CANCELED:
-                Cancel();
-                break;
+            case RC_LBOARD_CANCELED: Cancel(); break;
 
-            case RC_LBOARD_TRIGGERED:
-                Submit(m_nCurrentValue);
-                break;
+            case RC_LBOARD_TRIGGERED: Submit(m_nCurrentValue); break;
         }
     }
 }
@@ -97,40 +89,16 @@ void RA_Leaderboard::Submit(unsigned int nScore)
 
 void RA_Leaderboard::SubmitRankInfo(unsigned int nRank, const std::string& sUsername, int nScore, time_t nAchieved)
 {
-    Entry newEntry;
-    newEntry.m_nRank = nRank;
-    newEntry.m_sUsername = sUsername;
-    newEntry.m_nScore = nScore;
-    newEntry.m_TimeAchieved = nAchieved;
+    if (EntryExists(nRank))
+        return;
 
-    std::vector<Entry>::iterator iter = m_RankInfo.begin();
-    while (iter != m_RankInfo.end())
-    {
-        if ((*iter).m_nRank == nRank)
-        {
-            (*iter) = newEntry;
-            return;
-        }
-        iter++;
-    }
-
-    //	If not found, add new entry.
-    m_RankInfo.push_back(newEntry);
+    // If not found, add new entry.
+    m_RankInfo.emplace_back(nRank, sUsername, nScore, nAchieved);
 }
 
-void RA_Leaderboard::SortRankInfo()
+bool RA_Leaderboard::EntryExists(unsigned int nRank)
 {
-    for (size_t i = 0; i < m_RankInfo.size(); ++i)
-    {
-        for (size_t j = i + 1; j < m_RankInfo.size(); ++j)
-        {
-            if (m_RankInfo.at(i).m_nRank > m_RankInfo.at(j).m_nRank)
-            {
-                Entry temp = m_RankInfo[i];
-                m_RankInfo[i] = m_RankInfo[j];
-                m_RankInfo[j] = temp;
-            }
-        }
-    }
+    return (std::binary_search(m_RankInfo.begin(), m_RankInfo.end(), nRank));
 }
 
+void RA_Leaderboard::SortRankInfo() { std::sort(m_RankInfo.begin(), m_RankInfo.end()); }

--- a/src/RA_Leaderboard.h
+++ b/src/RA_Leaderboard.h
@@ -8,10 +8,10 @@ class RA_Leaderboard
 {
 public:
     explicit RA_Leaderboard(_In_ const ra::LeaderboardID nLBID) noexcept;
-    virtual ~RA_Leaderboard() noexcept             = default;
+    virtual ~RA_Leaderboard() noexcept = default;
     RA_Leaderboard(const RA_Leaderboard&) noexcept = delete;
     RA_Leaderboard& operator=(const RA_Leaderboard&) noexcept = delete;
-    RA_Leaderboard(RA_Leaderboard&&) noexcept                 = default;
+    RA_Leaderboard(RA_Leaderboard&&) noexcept = default;
     RA_Leaderboard& operator=(RA_Leaderboard&&) noexcept = default;
 
     void ParseFromString(const char* sBuffer, const char* sFormat);
@@ -34,7 +34,7 @@ public:
     struct Entry
     {
         Entry() noexcept = default;
-        /*implicit*/ Entry(unsigned int nRank, const std::string& sUsername, int nScore, std::time_t nAchieved) :
+        explicit Entry(unsigned int nRank, const std::string& sUsername, int nScore, std::time_t nAchieved) :
             m_nRank{nRank},
             m_sUsername{sUsername},
             m_nScore{nScore},

--- a/src/RA_Leaderboard.h
+++ b/src/RA_Leaderboard.h
@@ -8,41 +8,55 @@ class RA_Leaderboard
 {
 public:
     explicit RA_Leaderboard(_In_ const ra::LeaderboardID nLBID) noexcept;
-    virtual ~RA_Leaderboard() noexcept = default;
+    virtual ~RA_Leaderboard() noexcept             = default;
     RA_Leaderboard(const RA_Leaderboard&) noexcept = delete;
     RA_Leaderboard& operator=(const RA_Leaderboard&) noexcept = delete;
-    RA_Leaderboard(RA_Leaderboard&&) noexcept = default;
+    RA_Leaderboard(RA_Leaderboard&&) noexcept                 = default;
     RA_Leaderboard& operator=(RA_Leaderboard&&) noexcept = default;
 
     void ParseFromString(const char* sBuffer, const char* sFormat);
 
     void Test();
-    virtual void Reset();
+    virtual void Reset() noexcept;
 
-    unsigned int GetCurrentValue() const { return m_nCurrentValue; }
+    unsigned int GetCurrentValue() const noexcept { return m_nCurrentValue; }
 
-    ra::LeaderboardID ID() const { return m_nID; }
+    ra::LeaderboardID ID() const noexcept { return m_nID; }
 
-    const std::string& Title() const { return m_sTitle; }
+    const std::string& Title() const noexcept { return m_sTitle; }
     void SetTitle(const std::string& sValue) { m_sTitle = sValue; }
 
-    const std::string& Description() const { return m_sDescription; }
+    const std::string& Description() const noexcept { return m_sDescription; }
     void SetDescription(const std::string& sValue) { m_sDescription = sValue; }
 
     std::string FormatScore(unsigned int nValue) const;
 
     struct Entry
     {
-        unsigned int m_nRank;
+        Entry() noexcept = default;
+        /*implicit*/ Entry(unsigned int nRank, const std::string& sUsername, int nScore, std::time_t nAchieved) :
+            m_nRank{nRank},
+            m_sUsername{sUsername},
+            m_nScore{nScore},
+            m_TimeAchieved{nAchieved}
+        {}
+        ~Entry() noexcept = default;
+        Entry(const Entry&) = delete;
+        Entry& operator=(const Entry&) = delete;
+        Entry(Entry&&) noexcept = default;
+        Entry& operator=(Entry&&) noexcept = default;
+
+        unsigned int m_nRank{};
         std::string m_sUsername;
-        int m_nScore;
-        time_t m_TimeAchieved;
+        int m_nScore{};
+        std::time_t m_TimeAchieved{};
     };
 
     void SubmitRankInfo(unsigned int nRank, const std::string& sUsername, int nScore, time_t nAchieved);
-    void ClearRankInfo() { m_RankInfo.clear(); }
+    bool EntryExists(unsigned int nRank);
+    void ClearRankInfo() noexcept { m_RankInfo.clear(); }
     const Entry& GetRankInfo(unsigned int nAt) const { return m_RankInfo.at(nAt); }
-    size_t GetRankInfoCount() const { return m_RankInfo.size(); }
+    size_t GetRankInfoCount() const noexcept { return m_RankInfo.size(); }
     void SortRankInfo();
 
 protected:
@@ -51,18 +65,41 @@ protected:
     virtual void Submit(unsigned int nScore);
 
 private:
-    const ra::LeaderboardID          m_nID;                 //  DB ID for this LB
+    const ra::LeaderboardID m_nID = ra::LeaderboardID(); //  DB ID for this LB
 
-    void*                            m_pLeaderboard;        //  rc_lboard_t
-    std::shared_ptr<unsigned char[]> m_pLeaderboardBuffer;  //  buffer for rc_lboard_t
-    unsigned int                     m_nCurrentValue = 0;
+    void* m_pLeaderboard = nullptr;                        //  rc_lboard_t
+    std::shared_ptr<unsigned char[]> m_pLeaderboardBuffer; //  buffer for rc_lboard_t
+    unsigned int m_nCurrentValue = 0U;
 
-    int                              m_nFormat = 0;         // A format to output. Typically "%d" for score or "%02d:%02d.%02d" for time
+    int m_nFormat = 0; // A format to output. Typically "%d" for score or "%02d:%02d.%02d" for time
 
-    std::string                      m_sTitle;              //  The title of the leaderboard
-    std::string                      m_sDescription;        //  A brief description of the leaderboard
+    std::string m_sTitle;       //  The title of the leaderboard
+    std::string m_sDescription; //  A brief description of the leaderboard
 
-    std::vector<Entry>               m_RankInfo;            //  Recent users ranks
+    std::vector<Entry> m_RankInfo; //  Recent users ranks
 };
+
+// Comparison
+_NODISCARD _CONSTANT_FN operator==(const RA_Leaderboard::Entry& a, const RA_Leaderboard::Entry& b) noexcept
+{
+    return (a.m_nRank == b.m_nRank);
+}
+
+// Sorting
+_NODISCARD _CONSTANT_FN operator<(const RA_Leaderboard::Entry& a, const RA_Leaderboard::Entry& b) noexcept
+{
+    return (a.m_nRank < b.m_nRank);
+}
+
+// binary search
+_NODISCARD _CONSTANT_FN operator<(unsigned int key, const RA_Leaderboard::Entry& value) noexcept
+{
+    return key < value.m_nRank;
+}
+
+_NODISCARD _CONSTANT_FN operator<(const RA_Leaderboard::Entry& value, unsigned int key) noexcept
+{
+    return value.m_nRank < key;
+}
 
 #endif // !RA_LEADERBOARD_H

--- a/src/RA_LeaderboardPopup.cpp
+++ b/src/RA_LeaderboardPopup.cpp
@@ -25,12 +25,6 @@ const int FONT_SIZE_TEXT = 16;
 
 }
 
-
-LeaderboardPopup::LeaderboardPopup()
-{
-    Reset();
-}
-
 void LeaderboardPopup::ShowScoreboard(ra::LeaderboardID nID)
 {
     m_vScoreboardQueue.push(nID);
@@ -125,7 +119,7 @@ BOOL LeaderboardPopup::Deactivate(ra::LeaderboardID nLBID)
     return FALSE;
 }
 
-float LeaderboardPopup::GetOffsetPct() const
+float LeaderboardPopup::GetOffsetPct() const noexcept
 {
     float fVal = 0.0f;
 

--- a/src/RA_LeaderboardPopup.h
+++ b/src/RA_LeaderboardPopup.h
@@ -15,8 +15,6 @@ class LeaderboardPopup
     };
 
 public:
-    LeaderboardPopup();
-
     void Update(_UNUSED ControllerInput, float fDelta, _UNUSED BOOL, BOOL bPaused);
     void Render(_In_ HDC hDC, _In_ const RECT& rcDest);
 
@@ -27,14 +25,13 @@ public:
     void ShowScoreboard(ra::LeaderboardID nLBID);
 
 private:
-    float GetOffsetPct() const;
+    float GetOffsetPct() const noexcept;
 
 private:
-    PopupState m_nState;
-    float m_fScoreboardShowTimer;
+    PopupState m_nState{};
+    float m_fScoreboardShowTimer{};
     std::vector<unsigned int> m_vActiveLBIDs;
     std::queue<unsigned int> m_vScoreboardQueue;
 };
-
 
 #endif // !RA_LEADERBOARDPOPUP_H

--- a/src/RA_MemManager.cpp
+++ b/src/RA_MemManager.cpp
@@ -30,7 +30,7 @@ void MemManager::AddMemoryBank(size_t nBankID, _RAMByteReadFn* pReader, _RAMByte
     m_Banks[nBankID].Writer = pWriter;
 }
 
-void MemManager::ChangeActiveMemBank(_UNUSED unsigned short)
+void MemManager::ChangeActiveMemBank(_UNUSED unsigned short) noexcept
 {
     ASSERT(!"Not Implemented!");
     return;

--- a/src/RA_MemManager.h
+++ b/src/RA_MemManager.h
@@ -49,16 +49,14 @@ public:
 public:
     void ClearMemoryBanks() noexcept;
     void AddMemoryBank(size_t nBankID, _RAMByteReadFn* pReader, _RAMByteWriteFn* pWriter, size_t nBankSize);
-    size_t NumMemoryBanks() const { return m_Banks.size(); }
+    size_t NumMemoryBanks() const noexcept { return m_Banks.size(); }
 
     inline size_t BankSize(unsigned short nBank) const { return m_Banks.at(nBank).BankSize; }
-    //inline size_t ActiveBankSize() const							{ return m_Banks.at( m_nActiveMemBank ).BankSize; }
-    //inline unsigned short ActiveBankID() const					{ return m_nActiveMemBank; }
-    inline size_t TotalBankSize() const { return m_nTotalBankSize; }
+    inline size_t TotalBankSize() const noexcept { return m_nTotalBankSize; }
 
     std::vector<size_t> GetBankIDs() const;
 
-    void ChangeActiveMemBank(_UNUSED unsigned short);
+    void ChangeActiveMemBank(_UNUSED unsigned short) noexcept;
 
     unsigned char ActiveBankRAMByteRead(ra::ByteAddress nOffs) const;
     void ActiveBankRAMByteWrite(ra::ByteAddress nOffs, unsigned int nVal);

--- a/src/RA_PopupWindows.h
+++ b/src/RA_PopupWindows.h
@@ -29,15 +29,15 @@ public:
         m_AchievementPopups.Clear();
     }
 
-    static AchievementPopup& AchievementPopups() { return m_AchievementPopups; }
-    static LeaderboardPopup& LeaderboardPopups() { return m_LeaderboardPopups; }
+    static AchievementPopup& AchievementPopups() noexcept { return m_AchievementPopups; }
+    static LeaderboardPopup& LeaderboardPopups() noexcept { return m_LeaderboardPopups; }
 
 private:
     static AchievementPopup m_AchievementPopups;
     static LeaderboardPopup m_LeaderboardPopups;
 };
 
-//	Exposed to DLL
+// Exposed to DLL
 _EXTERN_C
 [[gsl::suppress(con.3)]]
 API int _RA_UpdatePopups(_In_ ControllerInput* __restrict input, _In_ float fDTime,

--- a/src/RA_RichPresence.cpp
+++ b/src/RA_RichPresence.cpp
@@ -22,10 +22,6 @@ const std::string& RA_RichPresenceInterpreter::Lookup::GetText(unsigned int nVal
     return m_sDefault;
 }
 
-RA_RichPresenceInterpreter::DisplayString::DisplayString()
-{
-}
-
 RA_RichPresenceInterpreter::DisplayString::DisplayString(const std::string& sCondition)
 {
     const int nSize = rc_trigger_size(sCondition.c_str());
@@ -148,7 +144,7 @@ void RA_RichPresenceInterpreter::DisplayString::InitializeValue(RA_RichPresenceI
     }
 }
 
-bool RA_RichPresenceInterpreter::DisplayString::Test()
+bool RA_RichPresenceInterpreter::DisplayString::Test() noexcept
 {
     rc_trigger_t* pTrigger = static_cast<rc_trigger_t*>(m_pTrigger);
     return pTrigger && rc_test_trigger(pTrigger, rc_peek_callback, nullptr, nullptr);

--- a/src/RA_RichPresence.h
+++ b/src/RA_RichPresence.h
@@ -12,7 +12,7 @@
 class RA_RichPresenceInterpreter
 {
 public:
-    [[gsl::suppress(f.6)]] bool Load(); /*Test won't throw but Integration might*/
+    GSL_SUPPRESS(f.6) bool Load(); /*Test won't throw but Integration might*/
     std::string GetRichPresenceString();
 
     bool Enabled() const noexcept { return !m_vDisplayStrings.empty(); }

--- a/src/RA_RichPresence.h
+++ b/src/RA_RichPresence.h
@@ -4,20 +4,18 @@
 
 #include "RA_Condition.h"
 
-#include <memory>
 #include <map>
+#include <memory>
 
 #include "services\TextReader.hh"
 
 class RA_RichPresenceInterpreter
 {
 public:
-    RA_RichPresenceInterpreter() noexcept = default;
-
-    bool Load();
+    [[gsl::suppress(f.6)]] bool Load(); /*Test won't throw but Integration might*/
     std::string GetRichPresenceString();
-    
-    bool Enabled() const { return !m_vDisplayStrings.empty(); }
+
+    bool Enabled() const noexcept { return !m_vDisplayStrings.empty(); }
 
 protected:
     bool Load(ra::services::TextReader& pReader);
@@ -25,14 +23,14 @@ protected:
     class Lookup
     {
     public:
-        Lookup(const std::string& sDesc);
+        explicit Lookup(const std::string& sDesc);
 
-        const std::string& Description() const { return m_sLookupDescription; }
+        const std::string& Description() const noexcept { return m_sLookupDescription; }
         const std::string& GetText(unsigned int nValue) const;
 
         void AddLookupData(unsigned int nValue, const std::string& sLookupData) { m_mLookupData[nValue] = sLookupData; }
         void SetDefault(const std::string& sDefault) { m_sDefault = sDefault; }
-        size_t NumItems() const { return m_mLookupData.size(); }
+        size_t NumItems() const noexcept { return m_mLookupData.size(); }
 
     private:
         std::string m_sDefault;
@@ -43,33 +41,33 @@ protected:
     class DisplayString
     {
     public:
-        DisplayString();
-        DisplayString(const std::string& sCondition);
-        void InitializeParts(const std::string& sDisplayString,
-            std::map<std::string, int>& mFormats, std::vector<Lookup>& vLookups);
+        DisplayString() noexcept = default;
+        explicit DisplayString(const std::string& sCondition);
+        void InitializeParts(const std::string& sDisplayString, std::map<std::string, int>& mFormats,
+                             std::vector<Lookup>& vLookups);
 
-        bool Test();
+        bool Test() noexcept;
         std::string GetDisplayString() const;
 
     protected:
         struct Part
         {
-            std::string                      m_sDisplayString;
+            std::string m_sDisplayString;
 
-            void*                            m_pValue;        //  rc_value_t
-            std::shared_ptr<unsigned char[]> m_pValueBuffer;  //  buffer for rc_value_t
+            void* m_pValue;                                  //  rc_value_t
+            std::shared_ptr<unsigned char[]> m_pValueBuffer; //  buffer for rc_value_t
 
-            const Lookup*                    m_pLookup = nullptr;
-            int                              m_nFormat = 0;
+            const Lookup* m_pLookup = nullptr;
+            int m_nFormat           = 0;
         };
 
     private:
         void InitializeValue(Part& part, const char* sValue);
 
-        std::vector<Part>                m_vParts;
+        std::vector<Part> m_vParts;
 
-        void*                            m_pTrigger;        //  rc_trigger_t
-        std::shared_ptr<unsigned char[]> m_pTriggerBuffer;  //  buffer for rc_trigger_t
+        void* m_pTrigger;                                  //  rc_trigger_t
+        std::shared_ptr<unsigned char[]> m_pTriggerBuffer; //  buffer for rc_trigger_t
     };
 
     std::vector<Lookup> m_vLookups;

--- a/src/RA_StringUtils.h
+++ b/src/RA_StringUtils.h
@@ -453,10 +453,7 @@ public:
 
 private:
     template<typename CharT, typename = std::enable_if_t<is_char_v<CharT>>, typename T, typename... Ts>
-    void AppendPrintfParameterizedFormat(const CharT* const pFormat,
-                                         const std::string& sFormat,
-                                         const T& value,
-                                         Ts&&... args)
+    void AppendPrintfParameterizedFormat(const CharT* const pFormat, const std::string& sFormat, const T& value, Ts&&... args)
     {
         AppendFormat(value, sFormat);
         AppendPrintf(pFormat, std::forward<Ts>(args)...);

--- a/src/RA_StringUtils.h
+++ b/src/RA_StringUtils.h
@@ -276,7 +276,7 @@ public:
         {
             if (sFormat.back() == 'f' || sFormat.back() == 'F')
             {
-                int nIndex = sFormat.find('.');
+                const int nIndex = sFormat.find('.');
                 if (nIndex != std::string::npos)
                 {
                     int nPrecision = std::stoi(sFormat.c_str() + nIndex + 1);
@@ -308,7 +308,7 @@ public:
         }
         else
         {
-            int nLength = strlen(arg);
+            const int nLength = strlen(arg);
             int nPadding = std::stoi(sFormat.c_str());
             nPadding -= nLength;
             if (nPadding > 0)
@@ -393,7 +393,7 @@ public:
                 const CharT* pStart = pScan;
                 while (*pScan)
                 {
-                    char c = static_cast<char>(*pScan);
+                    const char c = static_cast<char>(*pScan);
                     sFormat.push_back(c);
                     if (isalpha(c))
                         break;
@@ -409,7 +409,7 @@ public:
 
                 if (sFormat.length() > 2 && sFormat.at(sFormat.length() - 2) == '*')
                 {
-                    char c = sFormat.back();
+                    const char c = sFormat.back();
                     sFormat.pop_back(); // remove 's'/'x'
                     sFormat.pop_back(); // remove '*'
                     sFormat.append(ra::ToString(value));

--- a/src/RA_StringUtils.h
+++ b/src/RA_StringUtils.h
@@ -7,11 +7,12 @@
 namespace ra {
 
 _NODISCARD std::string Narrow(_In_ const std::wstring& wstr);
-_NODISCARD std::string Narrow(_Inout_ std::wstring&& wstr) noexcept;
 _NODISCARD std::string Narrow(_In_z_ const wchar_t* wstr);
 _NODISCARD std::wstring Widen(_In_ const std::string& str);
-_NODISCARD std::wstring Widen(_Inout_ std::string&& str) noexcept;
 _NODISCARD std::wstring Widen(_In_z_ const char* str);
+
+[[gsl::suppress(f.6), nodiscard]] std::string Narrow(std::wstring&& wstr) noexcept;
+[[gsl::suppress(f.6), nodiscard]] std::wstring Widen(std::string&& str) noexcept;
 
 //	No-ops to help convert:
 _NODISCARD std::wstring Widen(_In_z_ const wchar_t* wstr);
@@ -23,7 +24,7 @@ _NODISCARD std::string Narrow(_In_ const std::string& wstr);
 /// Removes one "\r", "\n", or "\r\n" from the end of a string.
 /// </summary>
 /// <returns>Reference to <paramref name="str" /> for chaining.</returns>
-std::string& TrimLineEnding(_Inout_ std::string& str) noexcept;
+[[gsl::suppress(f.6)]] std::string& TrimLineEnding(_Inout_ std::string& str) noexcept;
 
 // ----- ToString -----
 
@@ -239,7 +240,7 @@ public:
         m_vPending.emplace_back(std::move(pPending));
     }
 
-    void Append()
+    void Append() noexcept
     {
         // just in case one of the variadic methods gets called with 0 parameters
     }
@@ -603,12 +604,14 @@ _NODISCARD _Success_(0 < return < strsz) inline auto __cdecl tcslen_s(_In_reads_
 /// <summary>
 /// Determines if <paramref name="sString" /> starts with <paramref name="sMatch" />.
 /// </summary>
-_NODISCARD bool StringStartsWith(_In_ const std::wstring& sString, _In_ const std::wstring& sMatch) noexcept;
+[[gsl::suppress(f.6), nodiscard]]
+bool StringStartsWith(_In_ const std::wstring& sString, _In_ const std::wstring& sMatch) noexcept;
 
 /// <summary>
 /// Determines if <paramref name="sString" /> ends with <paramref name="sMatch" />.
 /// </summary>
-_NODISCARD bool StringEndsWith(_In_ const std::wstring& sString, _In_ const std::wstring& sMatch) noexcept;
+[[gsl::suppress(f.6), nodiscard]]
+bool StringEndsWith(_In_ const std::wstring& sString, _In_ const std::wstring& sMatch) noexcept;
 
 } // namespace ra
 

--- a/src/RA_StringUtils.h
+++ b/src/RA_StringUtils.h
@@ -453,7 +453,10 @@ public:
 
 private:
     template<typename CharT, typename = std::enable_if_t<is_char_v<CharT>>, typename T, typename... Ts>
-    void AppendPrintfParameterizedFormat(const CharT* const pFormat, const std::string& sFormat, const T& value, Ts&&... args)
+    void AppendPrintfParameterizedFormat(const CharT* const pFormat,
+                                         const std::string& sFormat,
+                                         const T& value,
+                                         Ts&&... args)
     {
         AppendFormat(value, sFormat);
         AppendPrintf(pFormat, std::forward<Ts>(args)...);

--- a/src/RA_StringUtils.h
+++ b/src/RA_StringUtils.h
@@ -24,7 +24,7 @@ _NODISCARD std::string Narrow(_In_ const std::string& wstr);
 /// Removes one "\r", "\n", or "\r\n" from the end of a string.
 /// </summary>
 /// <returns>Reference to <paramref name="str" /> for chaining.</returns>
-[[gsl::suppress(f.6)]] std::string& TrimLineEnding(_Inout_ std::string& str) noexcept;
+GSL_SUPPRESS(f.6) std::string& TrimLineEnding(_Inout_ std::string& str) noexcept;
 
 // ----- ToString -----
 

--- a/src/RA_User.h
+++ b/src/RA_User.h
@@ -23,17 +23,17 @@ typedef struct
 class RAUser
 {
 public:
-    RAUser(const std::string& sUsername);
+    explicit RAUser(const std::string& sUsername);
 
 public:
-    unsigned int GetScore() const { return m_nScore; }
-    void SetScore(unsigned int nScore) { m_nScore = nScore; }
+    unsigned int GetScore() const noexcept { return m_nScore; }
+    void SetScore(unsigned int nScore) noexcept { m_nScore = nScore; }
 
     void SetUsername(const std::string& sUser) { m_sUsername = sUser; }
-    const std::string& Username() const { return m_sUsername; }
+    const std::string& Username() const noexcept { return m_sUsername; }
 
     void UpdateActivity(const std::string& sAct) { m_sActivity = sAct; }
-    const std::string& Activity() const { return m_sActivity; }
+    const std::string& Activity() const noexcept { return m_sActivity; }
 
 private:
     /*const*/ std::string m_sUsername;
@@ -56,7 +56,7 @@ public:
     RAUser* FindFriend(const std::string& sName);
 
     RAUser* GetFriendByIter(size_t nOffs) { return nOffs < m_aFriends.size() ? m_aFriends[nOffs] : nullptr; }
-    const size_t NumFriends() const { return m_aFriends.size(); }
+    const size_t NumFriends() const noexcept { return m_aFriends.size(); }
 
     const std::string& Token() const
     {
@@ -71,7 +71,7 @@ private:
 class RAUsers
 {
 public:
-    static LocalRAUser& LocalUser() { return ms_LocalUser; }
+    static LocalRAUser& LocalUser() noexcept { return ms_LocalUser; }
     static BOOL DatabaseContainsUser(const std::string& sUser);
 
     static void RegisterUser(const std::string& sUsername, RAUser* pUser) { UserDatabase[sUsername] = pUser; }

--- a/src/RA_httpthread.cpp
+++ b/src/RA_httpthread.cpp
@@ -109,7 +109,7 @@ static void AppendIntegrationVersion(_Inout_ std::string& sUserAgent)
     sUserAgent.append(ra::StringPrintf("%d.%d.%d.%d", RA_INTEGRATION_VERSION_MAJOR,
                                        RA_INTEGRATION_VERSION_MINOR, RA_INTEGRATION_VERSION_REVISION,
                                        RA_INTEGRATION_VERSION_MODIFIED));
-
+    
     if constexpr (_CONSTANT_LOC pos{ std::string_view{ RA_INTEGRATION_VERSION_PRODUCT }.find('-') }; pos != std::string_view::npos)
     {
         constexpr std::string_view sAppend{ RA_INTEGRATION_VERSION_PRODUCT };

--- a/src/RA_httpthread.cpp
+++ b/src/RA_httpthread.cpp
@@ -445,7 +445,7 @@ void HttpResults::Clear()
     ReleaseMutex(RAWeb::Mutex());
 }
 
-size_t HttpResults::Count() const
+size_t HttpResults::Count() const noexcept
 {
     size_t nCount = 0;
     WaitForSingleObject(RAWeb::Mutex(), INFINITE);

--- a/src/RA_httpthread.h
+++ b/src/RA_httpthread.h
@@ -68,12 +68,12 @@ public:
     }
 
 public:
-    const RequestType GetRequestType() const { return m_nType; }
-    const PostArgs& GetPostArgs() const { return m_PostArgs; }
-    const std::string& GetData() const { return m_sData; }
+    const RequestType GetRequestType() const noexcept { return m_nType; }
+    const PostArgs& GetPostArgs() const noexcept { return m_PostArgs; }
+    const std::string& GetData() const noexcept { return m_sData; }
 
-    std::string& GetResponse() { return m_sResponse; }
-    const std::string& GetResponse() const { return m_sResponse; }
+    std::string& GetResponse() noexcept { return m_sResponse; }
+    const std::string& GetResponse() const noexcept { return m_sResponse; }
     void SetResponse(const std::string& sResponse) { m_sResponse = sResponse; }
 
     BOOL ParseResponseToJSON(rapidjson::Document& rDocOut);
@@ -94,7 +94,7 @@ public:
     const RequestObject* PeekNextItem() const;
     void PushItem(RequestObject* pObj);
     void Clear();
-    size_t Count() const;
+    size_t Count() const noexcept;
 
 private:
     std::deque<RequestObject*> m_aRequests;
@@ -110,12 +110,12 @@ public:
 
     static BOOL DoBlockingImageUpload(UploadType nType, const std::string& sFilename, rapidjson::Document& ResponseOut);
 
-    static HANDLE Mutex() { return ms_hHTTPMutex; }
+    static HANDLE Mutex() noexcept { return ms_hHTTPMutex; }
     static RequestObject* PopNextHttpResult() { return ms_LastHttpResults.PopNextItem(); }
 
     static void SetUserAgentString();
     static void SetUserAgent(const std::string& sValue) { m_sUserAgent = ra::Widen(sValue); }
-    static const std::wstring& GetUserAgent() { return m_sUserAgent; }
+    static const std::wstring& GetUserAgent() noexcept { return m_sUserAgent; }
 
 private:
     static HANDLE ms_hHTTPMutex;

--- a/src/api/ApiCall.cpp
+++ b/src/api/ApiCall.cpp
@@ -12,10 +12,10 @@ GSL_SUPPRESS(f.6) static ra::api::IServer& Server() noexcept /*Service expected 
     return ra::services::ServiceLocator::GetMutable<ra::api::IServer>();
 }
 
-Login::Response Login::Request::Call() const { return Server().Login(*this); }
-Logout::Response Logout::Request::Call() const { return Server().Logout(*this); }
-StartSession::Response StartSession::Request::Call() const { return Server().StartSession(*this); }
-Ping::Response Ping::Request::Call() const { return Server().Ping(*this); }
+Login::Response Login::Request::Call() const noexcept { return Server().Login(*this); }
+Logout::Response Logout::Request::Call() const noexcept { return Server().Logout(*this); }
+StartSession::Response StartSession::Request::Call() const noexcept { return Server().StartSession(*this); }
+Ping::Response Ping::Request::Call() const noexcept { return Server().Ping(*this); }
 
 } // namespace api
 } // namespace ra

--- a/src/api/ApiCall.cpp
+++ b/src/api/ApiCall.cpp
@@ -7,30 +7,15 @@
 namespace ra {
 namespace api {
 
-static ra::api::IServer& Server() noexcept
+[[gsl::suppress(f.6)]] static ra::api::IServer& Server() noexcept /*Service expected to exist*/
 {
     return ra::services::ServiceLocator::GetMutable<ra::api::IServer>();
 }
 
-Login::Response Login::Request::Call() const noexcept
-{
-    return Server().Login(*this);
-}
-
-Logout::Response Logout::Request::Call() const noexcept
-{
-    return Server().Logout(*this);
-}
-
-StartSession::Response StartSession::Request::Call() const noexcept
-{
-    return Server().StartSession(*this);
-}
-
-Ping::Response Ping::Request::Call() const noexcept
-{
-    return Server().Ping(*this);
-}
+Login::Response Login::Request::Call() const { return Server().Login(*this); }
+Logout::Response Logout::Request::Call() const { return Server().Logout(*this); }
+StartSession::Response StartSession::Request::Call() const { return Server().StartSession(*this); }
+Ping::Response Ping::Request::Call() const { return Server().Ping(*this); }
 
 } // namespace api
 } // namespace ra

--- a/src/api/ApiCall.cpp
+++ b/src/api/ApiCall.cpp
@@ -7,7 +7,7 @@
 namespace ra {
 namespace api {
 
-[[gsl::suppress(f.6)]] static ra::api::IServer& Server() noexcept /*Service expected to exist*/
+GSL_SUPPRESS(f.6) static ra::api::IServer& Server() noexcept /*Service expected to exist*/
 {
     return ra::services::ServiceLocator::GetMutable<ra::api::IServer>();
 }

--- a/src/api/ApiCall.hh
+++ b/src/api/ApiCall.hh
@@ -24,10 +24,8 @@ struct ApiRequestBase
     template<class TRequest, class TCallback>
     static void CallAsync(const TRequest& request, TCallback&& callback)
     {
-        ra::services::ServiceLocator::GetMutable<ra::services::IThreadPool>().RunAsync([request, callback = std::move(callback)]
-            {
-                callback(request.Call());
-            });
+        ra::services::ServiceLocator::GetMutable<ra::services::IThreadPool>().RunAsync(
+            [request, callback = std::move(callback)] { callback(request.Call()); });
     }
 };
 

--- a/src/api/IServer.hh
+++ b/src/api/IServer.hh
@@ -16,12 +16,10 @@ public:
     virtual const char* Name() const noexcept = 0;
 
     // === user functions ===
-    // TBD: Overrides can throw
-    [[gsl::suppress(f.6)]] virtual Login::Response Login(const Login::Request& request)    = 0;
-    [[gsl::suppress(f.6)]] virtual Logout::Response Logout(const Logout::Request& request) = 0;
-    [[gsl::suppress(f.6)]] 
-    virtual StartSession::Response StartSession(const StartSession::Request& request) = 0;
-    [[gsl::suppress(f.6)]] virtual Ping::Response Ping(const Ping::Request& request) = 0;
+    virtual Login::Response Login(const Login::Request& request) noexcept = 0;
+    virtual Logout::Response Logout(const Logout::Request& request) noexcept = 0;
+    virtual StartSession::Response StartSession(const StartSession::Request& request) noexcept = 0;
+    virtual Ping::Response Ping(const Ping::Request& request) noexcept = 0;
 
 protected:
     IServer() noexcept = default;

--- a/src/api/IServer.hh
+++ b/src/api/IServer.hh
@@ -16,11 +16,12 @@ public:
     virtual const char* Name() const noexcept = 0;
 
     // === user functions ===
-
-    virtual Login::Response Login(const Login::Request& request) noexcept = 0;
-    virtual Logout::Response Logout(const Logout::Request& request) noexcept = 0;
-    virtual StartSession::Response StartSession(const StartSession::Request& request) noexcept = 0;
-    virtual Ping::Response Ping(const Ping::Request& request) noexcept = 0;
+    // TBD: Overrides can throw
+    [[gsl::suppress(f.6)]] virtual Login::Response Login(const Login::Request& request)    = 0;
+    [[gsl::suppress(f.6)]] virtual Logout::Response Logout(const Logout::Request& request) = 0;
+    [[gsl::suppress(f.6)]] 
+    virtual StartSession::Response StartSession(const StartSession::Request& request) = 0;
+    [[gsl::suppress(f.6)]] virtual Ping::Response Ping(const Ping::Request& request) = 0;
 
 protected:
     IServer() noexcept = default;

--- a/src/api/Login.hh
+++ b/src/api/Login.hh
@@ -28,7 +28,7 @@ public:
 
         using Callback = std::function<void(const Response& response)>;
 
-        Response Call() const;
+        Response Call() const noexcept;
 
         void CallAsync(Callback&& callback) const
         {

--- a/src/api/Login.hh
+++ b/src/api/Login.hh
@@ -28,7 +28,7 @@ public:
 
         using Callback = std::function<void(const Response& response)>;
 
-        Response Call() const noexcept;
+        Response Call() const;
 
         void CallAsync(Callback&& callback) const
         {

--- a/src/api/Logout.hh
+++ b/src/api/Logout.hh
@@ -20,7 +20,7 @@ public:
     {
         using Callback = std::function<void(const Response& response)>;
 
-        Response Call() const noexcept;
+        Response Call() const;
 
         void CallAsync(Callback&& callback) const
         {

--- a/src/api/Logout.hh
+++ b/src/api/Logout.hh
@@ -20,7 +20,7 @@ public:
     {
         using Callback = std::function<void(const Response& response)>;
 
-        Response Call() const;
+        Response Call() const noexcept;
 
         void CallAsync(Callback&& callback) const
         {

--- a/src/api/Ping.hh
+++ b/src/api/Ping.hh
@@ -23,7 +23,7 @@ public:
 
         using Callback = std::function<void(const Response& response)>;
 
-        Response Call() const noexcept;
+        Response Call() const;
 
         void CallAsync(Callback&& callback) const
         {

--- a/src/api/Ping.hh
+++ b/src/api/Ping.hh
@@ -23,7 +23,7 @@ public:
 
         using Callback = std::function<void(const Response& response)>;
 
-        Response Call() const;
+        Response Call() const noexcept;
 
         void CallAsync(Callback&& callback) const
         {

--- a/src/api/StartSession.hh
+++ b/src/api/StartSession.hh
@@ -22,7 +22,7 @@ public:
 
         using Callback = std::function<void(const Response& response)>;
 
-        Response Call() const noexcept;
+        Response Call() const;
 
         void CallAsync(Callback&& callback) const
         {

--- a/src/api/StartSession.hh
+++ b/src/api/StartSession.hh
@@ -22,7 +22,7 @@ public:
 
         using Callback = std::function<void(const Response& response)>;
 
-        Response Call() const;
+        Response Call() const noexcept;
 
         void CallAsync(Callback&& callback) const
         {

--- a/src/api/impl/ConnectedServer.cpp
+++ b/src/api/impl/ConnectedServer.cpp
@@ -52,7 +52,7 @@ _NODISCARD static bool GetJson([[maybe_unused]] _In_ const char* sApiName,
         return false;
     }
 
-    RA_LOG_INFO("-- %s Response: %s", sApiName, httpResponse.Content().c_str());
+    RA_LOG_INFO("-- %s Response: %s", sApiName, httpResponse.Content());
 
     pDocument.Parse(httpResponse.Content());
     if (pDocument.HasParseError())
@@ -69,7 +69,7 @@ _NODISCARD static bool GetJson([[maybe_unused]] _In_ const char* sApiName,
     {
         pResponse.Result       = ApiResult::Error;
         pResponse.ErrorMessage = pDocument["Error"].GetString();
-        RA_LOG_ERR("-- %s Error: %s", sApiName, pResponse.ErrorMessage.c_str());
+        RA_LOG_ERR("-- %s Error: %s", sApiName, pResponse.ErrorMessage);
         return false;
     }
 
@@ -121,9 +121,9 @@ static void AppendUrlParam(_Inout_ std::string& sParams, _In_ const char* const 
     ra::services::Http::UrlEncodeAppend(sParams, sValue);
 }
 
-Login::Response ConnectedServer::Login(const Login::Request& request)
+Login::Response ConnectedServer::Login(const Login::Request& request) noexcept
 {
-    ra::services::Http::Request httpRequest(ra::StringPrintf("%s/login_app.php", m_sHost.c_str()));
+    ra::services::Http::Request httpRequest(ra::StringPrintf("%s/login_app.php", m_sHost));
 
     std::string sPostData;
     AppendUrlParam(sPostData, "u", request.Username);
@@ -156,7 +156,7 @@ Login::Response ConnectedServer::Login(const Login::Request& request)
     return std::move(response);
 }
 
-Logout::Response ConnectedServer::Logout(_UNUSED const Logout::Request& request)
+Logout::Response ConnectedServer::Logout(_UNUSED const Logout::Request& /*request*/) noexcept
 {
     // update the global API pointer to a disconnected API
     ra::services::ServiceLocator::Provide<ra::api::IServer>(new (std::nothrow) DisconnectedServer(m_sHost));
@@ -166,7 +166,7 @@ Logout::Response ConnectedServer::Logout(_UNUSED const Logout::Request& request)
     return std::move(response);
 }
 
-static bool DoRequest(const std::string& sHost, const char* sApiName, const char* sRequestName,
+static bool DoRequest(const std::string& sHost, const char* restrict sApiName, const char* restrict sRequestName,
                       const std::string& sInputParams, ApiResponseBase& pResponse, rapidjson::Document& document)
 {
     std::string sPostData;
@@ -182,14 +182,14 @@ static bool DoRequest(const std::string& sHost, const char* sApiName, const char
     }
     RA_LOG_INFO("%s Request: %s", sApiName, sPostData.c_str());
 
-    ra::services::Http::Request httpRequest(sHost + "/dorequest.php");
+    ra::services::Http::Request httpRequest(ra::StringPrintf("%s/dorequest.php", sHost));
     httpRequest.SetPostData(sPostData);
 
     const auto httpResponse = httpRequest.Call();
     return GetJson(sApiName, httpResponse, pResponse, document);
 }
 
-StartSession::Response ConnectedServer::StartSession(_UNUSED const StartSession::Request& request)
+StartSession::Response ConnectedServer::StartSession(const StartSession::Request& request) noexcept
 {
     StartSession::Response response;
     rapidjson::Document document;
@@ -211,7 +211,7 @@ StartSession::Response ConnectedServer::StartSession(_UNUSED const StartSession:
     return std::move(response);
 }
 
-Ping::Response ConnectedServer::Ping(_UNUSED const Ping::Request& request)
+Ping::Response ConnectedServer::Ping(const Ping::Request& request) noexcept
 {
     Ping::Response response;
     rapidjson::Document document;

--- a/src/api/impl/ConnectedServer.hh
+++ b/src/api/impl/ConnectedServer.hh
@@ -13,10 +13,10 @@ public:
 
     const char* Name() const noexcept override { return m_sHost.c_str(); }
 
-    Login::Response Login(const Login::Request& request) override;
-    Logout::Response Logout(_UNUSED const Logout::Request& request) override;
-    StartSession::Response StartSession(_UNUSED const StartSession::Request& request) override;
-    Ping::Response Ping(_UNUSED const Ping::Request& request) override;
+    Login::Response Login(const Login::Request& request) noexcept override;
+    Logout::Response Logout(_UNUSED const Logout::Request& /*request*/) noexcept override;
+    StartSession::Response StartSession(const StartSession::Request& request) noexcept override;
+    Ping::Response Ping(const Ping::Request& request) noexcept override;
 
 private:
     const std::string m_sHost;

--- a/src/api/impl/ConnectedServer.hh
+++ b/src/api/impl/ConnectedServer.hh
@@ -13,10 +13,10 @@ public:
 
     const char* Name() const noexcept override { return m_sHost.c_str(); }
 
-    Login::Response Login(const Login::Request& request) noexcept override;
-    Logout::Response Logout(_UNUSED const Logout::Request& request) noexcept override;
-    StartSession::Response StartSession(_UNUSED const StartSession::Request& request) noexcept override;
-    Ping::Response Ping(_UNUSED const Ping::Request& request) noexcept override;
+    Login::Response Login(const Login::Request& request) override;
+    Logout::Response Logout(_UNUSED const Logout::Request& request) override;
+    StartSession::Response StartSession(_UNUSED const StartSession::Request& request) override;
+    Ping::Response Ping(_UNUSED const Ping::Request& request) override;
 
 private:
     const std::string m_sHost;

--- a/src/api/impl/ConnectedServer.hh
+++ b/src/api/impl/ConnectedServer.hh
@@ -13,10 +13,10 @@ public:
 
     const char* Name() const noexcept override { return m_sHost.c_str(); }
 
-    Login::Response Login(const Login::Request& request) noexcept override;
-    Logout::Response Logout(_UNUSED const Logout::Request& /*request*/) noexcept override;
-    StartSession::Response StartSession(const StartSession::Request& request) noexcept override;
-    Ping::Response Ping(const Ping::Request& request) noexcept override;
+    GSL_SUPPRESS(f.6) Login::Response Login(const Login::Request& request) noexcept override;
+    GSL_SUPPRESS(f.6) Logout::Response Logout(_UNUSED const Logout::Request& /*request*/) noexcept override;
+    GSL_SUPPRESS(f.6) StartSession::Response StartSession(const StartSession::Request& request) noexcept override;
+    GSL_SUPPRESS(f.6) Ping::Response Ping(const Ping::Request& request) noexcept override;
 
 private:
     const std::string m_sHost;

--- a/src/api/impl/DisconnectedServer.cpp
+++ b/src/api/impl/DisconnectedServer.cpp
@@ -8,7 +8,7 @@ namespace ra {
 namespace api {
 namespace impl {
 
-Login::Response DisconnectedServer::Login(const Login::Request& request)
+Login::Response DisconnectedServer::Login(const Login::Request& request) noexcept
 {
     // use the normal ServerApi to attempt to connect
     auto serverApi = std::make_unique<ConnectedServer>(m_sHost);

--- a/src/api/impl/DisconnectedServer.cpp
+++ b/src/api/impl/DisconnectedServer.cpp
@@ -8,7 +8,7 @@ namespace ra {
 namespace api {
 namespace impl {
 
-Login::Response DisconnectedServer::Login(const Login::Request& request) noexcept
+Login::Response DisconnectedServer::Login(const Login::Request& request)
 {
     // use the normal ServerApi to attempt to connect
     auto serverApi = std::make_unique<ConnectedServer>(m_sHost);

--- a/src/api/impl/DisconnectedServer.hh
+++ b/src/api/impl/DisconnectedServer.hh
@@ -13,7 +13,7 @@ public:
 
     const char* Name() const noexcept override { return "disconnected client"; }
 
-    Login::Response Login(const Login::Request& request) noexcept override;
+    GSL_SUPPRESS(f.6) Login::Response Login(const Login::Request& request) noexcept override;
 
     const std::string& Host() const noexcept { return m_sHost; }
 

--- a/src/api/impl/DisconnectedServer.hh
+++ b/src/api/impl/DisconnectedServer.hh
@@ -13,7 +13,7 @@ public:
 
     const char* Name() const noexcept override { return "disconnected client"; }
 
-    Login::Response Login(const Login::Request& request) noexcept override;
+    Login::Response Login(const Login::Request& request) override;
 
     const std::string& Host() const noexcept { return m_sHost; }
 

--- a/src/api/impl/DisconnectedServer.hh
+++ b/src/api/impl/DisconnectedServer.hh
@@ -15,7 +15,7 @@ public:
 
     Login::Response Login(const Login::Request& request) noexcept override;
 
-    const std::string& Host() const { return m_sHost; }
+    const std::string& Host() const noexcept { return m_sHost; }
 
 private:
     const std::string m_sHost;

--- a/src/api/impl/DisconnectedServer.hh
+++ b/src/api/impl/DisconnectedServer.hh
@@ -13,7 +13,7 @@ public:
 
     const char* Name() const noexcept override { return "disconnected client"; }
 
-    Login::Response Login(const Login::Request& request) override;
+    Login::Response Login(const Login::Request& request) noexcept override;
 
     const std::string& Host() const noexcept { return m_sHost; }
 

--- a/src/api/impl/OfflineServer.cpp
+++ b/src/api/impl/OfflineServer.cpp
@@ -4,7 +4,7 @@ namespace ra {
 namespace api {
 namespace impl {
 
-Login::Response OfflineServer::Login(const Login::Request& request)
+Login::Response OfflineServer::Login(const Login::Request& request) noexcept
 {
     
     Login::Response response;
@@ -14,7 +14,7 @@ Login::Response OfflineServer::Login(const Login::Request& request)
     return std::move(response);
 }
 
-Logout::Response OfflineServer::Logout(_UNUSED const Logout::Request& request) noexcept
+Logout::Response OfflineServer::Logout(_UNUSED const Logout::Request& /*request*/) noexcept
 {
     Logout::Response response;
     response.Result = ApiResult::Success;

--- a/src/api/impl/OfflineServer.cpp
+++ b/src/api/impl/OfflineServer.cpp
@@ -4,8 +4,9 @@ namespace ra {
 namespace api {
 namespace impl {
 
-Login::Response OfflineServer::Login(const Login::Request& request) noexcept
+Login::Response OfflineServer::Login(const Login::Request& request)
 {
+    
     Login::Response response;
     response.Result = ApiResult::Success;
     response.Username = request.Username;

--- a/src/api/impl/OfflineServer.hh
+++ b/src/api/impl/OfflineServer.hh
@@ -11,7 +11,7 @@ class OfflineServer : public ServerBase
 public:
     const char* Name() const noexcept override { return "offline client"; }
 
-    Login::Response Login(const Login::Request& request) noexcept override;
+    Login::Response Login(const Login::Request& request) override;
     Logout::Response Logout(_UNUSED const Logout::Request& request) noexcept override;
 };
 

--- a/src/api/impl/OfflineServer.hh
+++ b/src/api/impl/OfflineServer.hh
@@ -11,7 +11,7 @@ class OfflineServer : public ServerBase
 public:
     const char* Name() const noexcept override { return "offline client"; }
 
-    Login::Response Login(const Login::Request& request) noexcept override;
+    GSL_SUPPRESS(f.6) Login::Response Login(const Login::Request& request) noexcept override;
     Logout::Response Logout(_UNUSED const Logout::Request& /*request*/) noexcept override;
 };
 

--- a/src/api/impl/OfflineServer.hh
+++ b/src/api/impl/OfflineServer.hh
@@ -11,8 +11,8 @@ class OfflineServer : public ServerBase
 public:
     const char* Name() const noexcept override { return "offline client"; }
 
-    Login::Response Login(const Login::Request& request) override;
-    Logout::Response Logout(_UNUSED const Logout::Request& request) noexcept override;
+    Login::Response Login(const Login::Request& request) noexcept override;
+    Logout::Response Logout(_UNUSED const Logout::Request& /*request*/) noexcept override;
 };
 
 } // namespace impl

--- a/src/api/impl/ServerBase.hh
+++ b/src/api/impl/ServerBase.hh
@@ -14,29 +14,30 @@ class ServerBase : public IServer
 {
 public:
     // === user functions ===
-    [[gsl::suppress(f.6)]] Login::Response Login(_UNUSED const Login::Request& request) override
+    Login::Response Login(_UNUSED const Login::Request& /*request*/) noexcept override
     {
         return UnsupportedApi<Login::Response>(Login::Name());
     }
 
-    [[gsl::suppress(f.6)]] Logout::Response Logout(_UNUSED const Logout::Request& request) override
+    Logout::Response Logout(_UNUSED const Logout::Request& /*request*/) noexcept override
     {
         return UnsupportedApi<Logout::Response>(Logout::Name());
     }
 
-    [[gsl::suppress(f.6)]] StartSession::Response StartSession(_UNUSED const StartSession::Request& request) override
+    StartSession::Response StartSession(_UNUSED const StartSession::Request& /*request*/) noexcept override
     {
         return UnsupportedApi<StartSession::Response>(StartSession::Name());
     }
 
-    [[gsl::suppress(f.6)]] Ping::Response Ping(_UNUSED const Ping::Request& request) override
+    Ping::Response Ping(_UNUSED const Ping::Request& /*request*/) noexcept override
     {
         return UnsupportedApi<Ping::Response>(Ping::Name());
     }
 
 protected:
     template<typename TResponse>
-    inline typename TResponse UnsupportedApi(const char* const apiName) const
+    GSL_SUPPRESS(f.6) 
+    inline typename TResponse UnsupportedApi(const char* const restrict apiName) const
     {
         static_assert(std::is_base_of<ApiResponseBase, TResponse>::value, "TResponse must derive from ApiResponseBase");
 

--- a/src/api/impl/ServerBase.hh
+++ b/src/api/impl/ServerBase.hh
@@ -14,36 +14,35 @@ class ServerBase : public IServer
 {
 public:
     // === user functions ===
-
-    Login::Response Login(_UNUSED const Login::Request& request) noexcept override
+    [[gsl::suppress(f.6)]] Login::Response Login(_UNUSED const Login::Request& request) override
     {
         return UnsupportedApi<Login::Response>(Login::Name());
     }
 
-    Logout::Response Logout(_UNUSED const Logout::Request& request) noexcept override
+    [[gsl::suppress(f.6)]] Logout::Response Logout(_UNUSED const Logout::Request& request) override
     {
         return UnsupportedApi<Logout::Response>(Logout::Name());
     }
 
-    StartSession::Response StartSession(_UNUSED const StartSession::Request& request) noexcept override
+    [[gsl::suppress(f.6)]] StartSession::Response StartSession(_UNUSED const StartSession::Request& request) override
     {
         return UnsupportedApi<StartSession::Response>(StartSession::Name());
     }
 
-    Ping::Response Ping(_UNUSED const Ping::Request& request) noexcept override
+    [[gsl::suppress(f.6)]] Ping::Response Ping(_UNUSED const Ping::Request& request) override
     {
         return UnsupportedApi<Ping::Response>(Ping::Name());
     }
 
 protected:
     template<typename TResponse>
-    inline typename TResponse UnsupportedApi(const char* const apiName) const noexcept
+    inline typename TResponse UnsupportedApi(const char* const apiName) const
     {
         static_assert(std::is_base_of<ApiResponseBase, TResponse>::value, "TResponse must derive from ApiResponseBase");
 
         TResponse response;
-        response.Result = ApiResult::Unsupported;
-        response.ErrorMessage = std::string(apiName) + " is not supported by " + Name();
+        response.Result       = ApiResult::Unsupported;
+        response.ErrorMessage = ra::StringPrintf("%s is not supported by %s.", apiName, Name());
         return std::move(response);
     }
 };

--- a/src/api/impl/ServerBase.hh
+++ b/src/api/impl/ServerBase.hh
@@ -14,22 +14,22 @@ class ServerBase : public IServer
 {
 public:
     // === user functions ===
-    Login::Response Login(_UNUSED const Login::Request& /*request*/) noexcept override
+    GSL_SUPPRESS(f.6) Login::Response Login(_UNUSED const Login::Request& /*request*/) noexcept override
     {
         return UnsupportedApi<Login::Response>(Login::Name());
     }
 
-    Logout::Response Logout(_UNUSED const Logout::Request& /*request*/) noexcept override
+    GSL_SUPPRESS(f.6) Logout::Response Logout(_UNUSED const Logout::Request& /*request*/) noexcept override
     {
         return UnsupportedApi<Logout::Response>(Logout::Name());
     }
 
-    StartSession::Response StartSession(_UNUSED const StartSession::Request& /*request*/) noexcept override
+    GSL_SUPPRESS(f.6) StartSession::Response StartSession(_UNUSED const StartSession::Request& /*request*/) noexcept override
     {
         return UnsupportedApi<StartSession::Response>(StartSession::Name());
     }
 
-    Ping::Response Ping(_UNUSED const Ping::Request& /*request*/) noexcept override
+    GSL_SUPPRESS(f.6) Ping::Response Ping(_UNUSED const Ping::Request& /*request*/) noexcept override
     {
         return UnsupportedApi<Ping::Response>(Ping::Name());
     }

--- a/src/base.props
+++ b/src/base.props
@@ -4,10 +4,11 @@
   <PropertyGroup Label="UserMacros">
     <RA_DIR>$(SolutionDir)</RA_DIR>
     <RapidJSON_IncludeDir>$(RA_DIR)rapidjson\include\</RapidJSON_IncludeDir>
-    <RA_SourceDir>$(RA_DIR)src\</RA_SourceDir>
     <rcheevos_IncludePath>$(RA_DIR)rcheevos\include\</rcheevos_IncludePath>
+    <RA_SourceDir>$(RA_DIR)src\</RA_SourceDir>
+    <GSL_IncludeDir>$(RA_DIR)GSL\include\</GSL_IncludeDir>
     <Lua_Dir>$(RA_DIR)lua\</Lua_Dir>
-    <RA_IncludePath>$(RA_DIR);$(RA_SourceDir);$(RapidJSON_IncludeDir);$(rcheevos_IncludePath);$(Lua_Dir)</RA_IncludePath>
+    <RA_IncludePath>$(RA_DIR);$(RA_SourceDir);$(RapidJSON_IncludeDir);$(rcheevos_IncludePath);$(Lua_Dir);$(GSL_IncludeDir)</RA_IncludePath>
     <XPDeprecationWarning>false</XPDeprecationWarning>
   </PropertyGroup>
   <PropertyGroup>
@@ -66,12 +67,16 @@
       <Value>$(RA_SourceDir)</Value>
       <EnvironmentVariable>true</EnvironmentVariable>
     </BuildMacro>
-    <BuildMacro Include="RA_IncludePath">
-      <Value>$(RA_IncludePath)</Value>
+    <BuildMacro Include="GSL_IncludeDir">
+      <Value>$(GSL_IncludeDir)</Value>
       <EnvironmentVariable>true</EnvironmentVariable>
     </BuildMacro>
     <BuildMacro Include="Lua_Dir">
       <Value>$(Lua_Dir)</Value>
+      <EnvironmentVariable>true</EnvironmentVariable>
+    </BuildMacro>
+    <BuildMacro Include="RA_IncludePath">
+      <Value>$(RA_IncludePath)</Value>
       <EnvironmentVariable>true</EnvironmentVariable>
     </BuildMacro>
     <BuildMacro Include="XPDeprecationWarning">

--- a/src/base.props
+++ b/src/base.props
@@ -46,6 +46,7 @@
     </PostBuildEvent>
     <Link>
       <ProgramDatabaseFile>$(LocalDebuggerWorkingDirectory)\$(TargetName).pdb</ProgramDatabaseFile>
+      <IgnoreSpecificDefaultLibraries>libc.lib, libcmt.lib, libcd.lib, libcmtd.lib, msvcrtd.lib</IgnoreSpecificDefaultLibraries>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/src/base.props
+++ b/src/base.props
@@ -8,6 +8,7 @@
     <rcheevos_IncludePath>$(RA_DIR)rcheevos\include\</rcheevos_IncludePath>
     <Lua_Dir>$(RA_DIR)lua\</Lua_Dir>
     <RA_IncludePath>$(RA_DIR);$(RA_SourceDir);$(RapidJSON_IncludeDir);$(rcheevos_IncludePath);$(Lua_Dir)</RA_IncludePath>
+    <XPDeprecationWarning>false</XPDeprecationWarning>
   </PropertyGroup>
   <PropertyGroup>
     <OutDir>$(SolutionDir)bin\$(Configuration)\</OutDir>
@@ -70,6 +71,10 @@
     </BuildMacro>
     <BuildMacro Include="Lua_Dir">
       <Value>$(Lua_Dir)</Value>
+      <EnvironmentVariable>true</EnvironmentVariable>
+    </BuildMacro>
+    <BuildMacro Include="XPDeprecationWarning">
+      <Value>$(XPDeprecationWarning)</Value>
       <EnvironmentVariable>true</EnvironmentVariable>
     </BuildMacro>
   </ItemGroup>

--- a/src/data/GameContext.cpp
+++ b/src/data/GameContext.cpp
@@ -24,7 +24,7 @@ void GameContext::LoadGame(unsigned int nGameId, const std::wstring& sGameTitle)
     m_sGameTitle = sGameTitle;
 }
 
-bool GameContext::HasRichPresence() const
+bool GameContext::HasRichPresence() const noexcept
 {
     return (m_pRichPresenceInterpreter != nullptr && m_pRichPresenceInterpreter->Enabled());
 }

--- a/src/data/GameContext.hh
+++ b/src/data/GameContext.hh
@@ -28,17 +28,17 @@ public:
     /// <summary>
     /// Gets the unique identifier of the currently loaded game.
     /// </summary>
-    unsigned int GameId() const { return m_nGameId; }       
+    unsigned int GameId() const noexcept { return m_nGameId; }       
 
     /// <summary>
     /// Gets the title of the currently loaded game.
     /// </summary>
-    const std::wstring& GameTitle() const { return m_sGameTitle; }
+    const std::wstring& GameTitle() const noexcept { return m_sGameTitle; }
 
     /// <summary>
     /// Gets the hash of the currently loaded game.
     /// </summary>
-    const std::string& GameHash() const { return m_sGameHash; }
+    const std::string& GameHash() const noexcept { return m_sGameHash; }
 
     /// <summary>
     /// Sets the game hash.
@@ -48,7 +48,7 @@ public:
     /// <summary>
     /// Gets which achievements are active.
     /// </summary>
-    virtual AchievementSet::Type ActiveAchievementType() const 
+    virtual AchievementSet::Type ActiveAchievementType() const noexcept
     {
 #ifdef RA_UTEST
         return AchievementSet::Type::Core;
@@ -60,7 +60,7 @@ public:
     /// <summary>
     /// Determines if any achievements are currently active.
     /// </summary>
-    virtual bool HasActiveAchievements() const 
+    virtual bool HasActiveAchievements() const noexcept
     {
 #ifdef RA_UTEST
         return false;

--- a/src/data/GameContext.hh
+++ b/src/data/GameContext.hh
@@ -72,7 +72,7 @@ public:
     /// <summary>
     /// Gets whether or not the loaded game has a rich presence script.
     /// </summary>
-    virtual bool HasRichPresence() const;
+    virtual bool HasRichPresence() const noexcept;
     
     /// <summary>
     /// Gets the current rich presence display string.

--- a/src/data/SessionTracker.cpp
+++ b/src/data/SessionTracker.cpp
@@ -210,7 +210,7 @@ std::chrono::seconds SessionTracker::GetTotalPlaytime(unsigned int nGameId) cons
     return tPlaytime;
 }
 
-bool SessionTracker::IsInspectingMemory() const
+bool SessionTracker::IsInspectingMemory() const noexcept
 {
 #ifdef RA_UTEST
     return false;

--- a/src/data/SessionTracker.cpp
+++ b/src/data/SessionTracker.cpp
@@ -47,19 +47,19 @@ void SessionTracker::LoadSessions()
             if (nIndex == std::string::npos)
                 continue;
 
-            auto nGameId = strtoul(sLine.c_str(), nullptr, 10);
+            const auto nGameId = std::stoul(sLine);
 
             auto nIndex2 = sLine.find(':', ++nIndex);
             if (nIndex2 == std::string::npos)
                 continue;
 
-            auto nSessionStart = strtoul(&sLine[nIndex], nullptr, 10);
+            const auto nSessionStart = strtoul(&sLine[nIndex], nullptr, 10);
 
             nIndex = sLine.find(':', ++nIndex2);
             if (nIndex == std::string::npos)
                 continue;
 
-            auto nSessionLength = strtoul(&sLine[nIndex2], nullptr, 10);
+            const auto nSessionLength = strtoul(&sLine[nIndex2], nullptr, 10);
 
             auto md5 = RAGenerateMD5(reinterpret_cast<const unsigned char*>(sLine.c_str()), nIndex + 1);
             if (sLine[nIndex + 1] == md5.front() && sLine[nIndex + 2] == md5.back())

--- a/src/data/SessionTracker.hh
+++ b/src/data/SessionTracker.hh
@@ -40,7 +40,7 @@ public:
     /// <summary>
     /// Determines whether any previous session data exists.
     /// </summary>
-    bool HasSessionData() const { return !m_vGameStats.empty(); }
+    bool HasSessionData() const noexcept { return !m_vGameStats.empty(); }
 
 protected:
     virtual void LoadSessions();

--- a/src/data/SessionTracker.hh
+++ b/src/data/SessionTracker.hh
@@ -48,7 +48,7 @@ protected:
     long WriteSessionStats(std::chrono::seconds tSessionDuration) const;
     std::wstring GetCurrentActivity() const;
 
-    virtual bool IsInspectingMemory() const;
+    virtual bool IsInspectingMemory() const noexcept;
 
     std::wstring m_sUsername;
 

--- a/src/data/UserContext.hh
+++ b/src/data/UserContext.hh
@@ -30,27 +30,27 @@ public:
     /// <summary>
     /// Gets the username of the current user.
     /// </summary>
-    const std::string& GetUsername() const { return m_sUsername; }
+    const std::string& GetUsername() const noexcept { return m_sUsername; }
 
     /// <summary>
     /// Gets the API token for the current user.
     /// </summary>
-    const std::string& GetApiToken() const { return m_sApiToken; }
+    const std::string& GetApiToken() const noexcept { return m_sApiToken; }
 
     /// <summary>
     /// Determines whether the current user is logged in.
     /// </summary>
-    bool IsLoggedIn() const { return !m_sApiToken.empty(); }
+    bool IsLoggedIn() const noexcept { return !m_sApiToken.empty(); }
     
     /// <summary>
     /// Gets the number of points earned by the user.
     /// </summary>
-    unsigned int GetScore() const { return m_nScore; }
+    unsigned int GetScore() const noexcept { return m_nScore; }
 
     /// <summary>
     /// Updates the number of points earned by the user.
     /// </summary>
-    void SetScore(unsigned int nValue) { m_nScore = nValue; }
+    void SetScore(unsigned int nValue) noexcept { m_nScore = nValue; }
 
 protected:
     std::string m_sUsername;

--- a/src/md5.c
+++ b/src/md5.c
@@ -54,10 +54,6 @@
 #include "md5.h"
 #include <string.h>
 
-/* Really didn't want to have to do this but can't find a better way to do it - SyrianBallaS */
-#include <codeanalysis\warnings.h>
-#pragma warning(disable : ALL_CPPCORECHECK_WARNINGS)
-
 #undef BYTE_ORDER	/* 1 = big-endian, -1 = little-endian, 0 = unknown */
 #ifdef ARCH_IS_BIG_ENDIAN
 #  define BYTE_ORDER (ARCH_IS_BIG_ENDIAN ? 1 : -1)

--- a/src/pch.h
+++ b/src/pch.h
@@ -12,12 +12,12 @@
 #pragma warning(disable : 4091 4191 4365 4464 4571 4619 4623 4625 4626 4768 4774 5026 5027 5039 5045)
 /* Windows Stuff */
 #include "windows_nodefines.h"
+#include <ShlObj.h> // CommCtrl
+#include <WindowsX.h>
 #include <atlbase.h> // atldef.h (Windows.h), atlcore.h (tchar.h), Shlwapi.h
 #include <direct.h>
 #include <io.h>
-#include <ShlObj.h> // CommCtrl
 #include <wincodec.h>
-#include <WindowsX.h>
 #include <winhttp.h>
 
 #if WIN32_LEAN_AND_MEAN
@@ -60,10 +60,10 @@
 #define RAPIDJSON_HAS_STDSTRING 1
 #define RAPIDJSON_NOMEMBERITERATORCLASS 1
 #include <rapidjson\document.h> // has reader.h
-#include <rapidjson\writer.h> // has stringbuffer.h
+#include <rapidjson\error\en.h>
 #include <rapidjson\istreamwrapper.h>
 #include <rapidjson\ostreamwrapper.h>
-#include <rapidjson\error\en.h>  
+#include <rapidjson\writer.h> // has stringbuffer.h
 #pragma warning(pop)
 
 #include <md5.h>
@@ -77,10 +77,13 @@
 #endif /* RA_UTEST */
 
 /* rcheevos stuff */
-#pragma warning (push)
-#pragma warning (disable:4201) // nameless struct
-#include "rcheevos\include\rcheevos.h"
-#pragma warning (pop)
+#pragma warning(push)
+#pragma warning(disable : 4201) // nameless struct
+#include <rcheevos.h>
+#pragma warning(pop)
+
+/* gsl stuff */
+#include <gsl\gsl>
 
 #pragma warning(pop)
 

--- a/src/ra_rules.ruleset
+++ b/src/ra_rules.ruleset
@@ -3,4 +3,25 @@
   <Include Path="cppcorecheckclassrules.ruleset" Action="Default" />
   <Include Path="cppcorecheckconstrules.ruleset" Action="Default" />
   <Include Path="cppcorecheckfuncrules.ruleset" Action="Default" />
+  <Rules AnalyzerId="Microsoft.Analyzers.NativeCodeAnalysis" RuleNamespace="Microsoft.Rules.Native">
+    <Rule Id="C26432" Action="Warning" />
+    <Rule Id="C26433" Action="Warning" />
+    <Rule Id="C26434" Action="Warning" />
+    <Rule Id="C26435" Action="Warning" />
+    <Rule Id="C26436" Action="Warning" />
+    <Rule Id="C26439" Action="Warning" />
+    <Rule Id="C26440" Action="Warning" />
+    <Rule Id="C26443" Action="Warning" />
+    <Rule Id="C26447" Action="Warning" />
+    <Rule Id="C26455" Action="Warning" />
+    <Rule Id="C26456" Action="Warning" />
+    <Rule Id="C26460" Action="Warning" />
+    <Rule Id="C26461" Action="Warning" />
+    <Rule Id="C26462" Action="Warning" />
+    <Rule Id="C26463" Action="Warning" />
+    <Rule Id="C26464" Action="Warning" />
+    <Rule Id="C26496" Action="Warning" />
+    <Rule Id="C26497" Action="Warning" />
+    <Rule Id="C26498" Action="Warning" />
+  </Rules>
 </RuleSet>

--- a/src/ra_rules.ruleset
+++ b/src/ra_rules.ruleset
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="ra_rules" Description="ISO class, const, function rules" ToolsVersion="15.0">
+<RuleSet Name="ra_rules" ToolsVersion="15.0">
+  <Include Path="cppcorecheckclassrules.ruleset" Action="Default" />
+  <Include Path="cppcorecheckconstrules.ruleset" Action="Default" />
   <Include Path="cppcorecheckfuncrules.ruleset" Action="Default" />
-  <Include Path="ra_rules.ruleset" Action="Default" />
 </RuleSet>

--- a/src/ra_rules.ruleset
+++ b/src/ra_rules.ruleset
@@ -1,21 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="ra_rules" Description="CppCoreCheck Class, Const Rules" ToolsVersion="15.0">
-  <Include Path="cppcorecheckclassrules.ruleset" Action="Default" />
-  <Include Path="cppcorecheckconstrules.ruleset" Action="Default" />
-  <Rules AnalyzerId="Microsoft.Analyzers.NativeCodeAnalysis" RuleNamespace="Microsoft.Rules.Native">
-    <Rule Id="C26432" Action="None" />
-    <Rule Id="C26433" Action="None" />
-    <Rule Id="C26434" Action="None" />
-    <Rule Id="C26435" Action="None" />
-    <Rule Id="C26436" Action="None" />
-    <Rule Id="C26443" Action="None" />
-    <Rule Id="C26460" Action="None" />
-    <Rule Id="C26461" Action="None" />
-    <Rule Id="C26462" Action="None" />
-    <Rule Id="C26463" Action="None" />
-    <Rule Id="C26464" Action="None" />
-    <Rule Id="C26496" Action="None" />
-    <Rule Id="C26497" Action="None" />
-    <Rule Id="C26498" Action="None" />
-  </Rules>
+<RuleSet Name="ra_rules" Description="ISO class, const, function rules" ToolsVersion="15.0">
+  <Include Path="cppcorecheckfuncrules.ruleset" Action="Default" />
+  <Include Path="ra_rules.ruleset" Action="Default" />
 </RuleSet>

--- a/src/ra_utility.h
+++ b/src/ra_utility.h
@@ -72,11 +72,10 @@ _NODISCARD _CONSTANT_VAR itoe(_In_ Integral i) noexcept
     return static_cast<Enum>(i);
 }
 
+
 // function alias templates for etoi (EnumToIntegral) and itoe (IntegralToEnum)
-template<typename Enum>
-_CONSTANT_VAR to_integral{etoi<Enum>};
-template<typename Enum, typename Integral = std::underlying_type_t<Enum>>
-_CONSTANT_VAR to_enum{itoe<Enum, Integral>};
+template<typename Enum> _CONSTANT_VAR to_integral{etoi<Enum>};
+template<typename Enum, typename Integral = std::underlying_type_t<Enum>> _CONSTANT_VAR to_enum{itoe<Enum, Integral>};
 
 /// <summary>Calculates the size of any standard fstream.</summary>
 /// <param name="filename">The filename.</param>

--- a/src/ra_utility.h
+++ b/src/ra_utility.h
@@ -72,10 +72,11 @@ _NODISCARD _CONSTANT_VAR itoe(_In_ Integral i) noexcept
     return static_cast<Enum>(i);
 }
 
-
 // function alias templates for etoi (EnumToIntegral) and itoe (IntegralToEnum)
-template<typename Enum> _CONSTANT_VAR to_integral{etoi<Enum>};
-template<typename Enum, typename Integral = std::underlying_type_t<Enum>> _CONSTANT_VAR to_enum{itoe<Enum, Integral>};
+template<typename Enum>
+_CONSTANT_VAR to_integral{etoi<Enum>};
+template<typename Enum, typename Integral = std::underlying_type_t<Enum>>
+_CONSTANT_VAR to_enum{itoe<Enum, Integral>};
 
 /// <summary>Calculates the size of any standard fstream.</summary>
 /// <param name="filename">The filename.</param>

--- a/src/rcheevos.vcxproj
+++ b/src/rcheevos.vcxproj
@@ -62,9 +62,9 @@
       <CompileAs>CompileAsC</CompileAs>
       <AdditionalIncludeDirectories>$(SolutionDir)lua;$(SolutionDir)rcheevos\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ExceptionHandling>false</ExceptionHandling>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <ConformanceMode>true</ConformanceMode>
       <WarningLevel>Level3</WarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -72,6 +72,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
+    <Lib />
     <Lib>
       <IgnoreAllDefaultLibraries>true</IgnoreAllDefaultLibraries>
     </Lib>
@@ -92,9 +93,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <Lib />
-    <Lib>
-      <IgnoreAllDefaultLibraries>true</IgnoreAllDefaultLibraries>
-    </Lib>
+    <Lib />
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="..\rcheevos\include\rcheevos.h" />

--- a/src/rcheevos.vcxproj
+++ b/src/rcheevos.vcxproj
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>15.0</VCProjectVersion>
+    <ProjectGuid>{9D55EBE7-1392-4FA1-A9B9-F022F764CE35}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>RAIntegrationRcheevos</RootNamespace>
+    <WindowsTargetPlatformVersion>7.0</WindowsTargetPlatformVersion>
+    <ProjectName>rcheevos</ProjectName>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141_xp</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141_xp</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <TargetName>rcheevos</TargetName>
+    <OutDir>$(SolutionDir)bin\$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(SolutionDir)obj\$(Configuration)\$(ProjectName)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <TargetName>rcheevos</TargetName>
+    <OutDir>$(SolutionDir)bin\$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(SolutionDir)obj\$(Configuration)\$(ProjectName)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <CompileAs>CompileAsC</CompileAs>
+      <AdditionalIncludeDirectories>$(SolutionDir)lua;$(SolutionDir)rcheevos\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ExceptionHandling>false</ExceptionHandling>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <ConformanceMode>true</ConformanceMode>
+      <WarningLevel>Level3</WarningLevel>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+    <Lib>
+      <IgnoreAllDefaultLibraries>true</IgnoreAllDefaultLibraries>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <CompileAs>CompileAsC</CompileAs>
+      <AdditionalIncludeDirectories>$(SolutionDir)lua;$(SolutionDir)rcheevos\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ExceptionHandling>false</ExceptionHandling>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <ConformanceMode>true</ConformanceMode>
+      <WarningLevel>Level3</WarningLevel>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+    <Lib />
+    <Lib>
+      <IgnoreAllDefaultLibraries>true</IgnoreAllDefaultLibraries>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\rcheevos\include\rcheevos.h" />
+    <ClInclude Include="..\rcheevos\src\rcheevos\internal.h" />
+    <ClInclude Include="..\src\md5.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\lua\lapi.c" />
+    <ClCompile Include="..\lua\lauxlib.c" />
+    <ClCompile Include="..\lua\lcode.c" />
+    <ClCompile Include="..\lua\lctype.c" />
+    <ClCompile Include="..\lua\ldebug.c" />
+    <ClCompile Include="..\lua\ldo.c" />
+    <ClCompile Include="..\lua\ldump.c" />
+    <ClCompile Include="..\lua\lfunc.c" />
+    <ClCompile Include="..\lua\lgc.c" />
+    <ClCompile Include="..\lua\llex.c" />
+    <ClCompile Include="..\lua\lmem.c" />
+    <ClCompile Include="..\lua\lobject.c" />
+    <ClCompile Include="..\lua\lopcodes.c" />
+    <ClCompile Include="..\lua\lparser.c" />
+    <ClCompile Include="..\lua\lstate.c" />
+    <ClCompile Include="..\lua\lstring.c" />
+    <ClCompile Include="..\lua\ltable.c" />
+    <ClCompile Include="..\lua\ltm.c" />
+    <ClCompile Include="..\lua\lundump.c" />
+    <ClCompile Include="..\lua\lvm.c" />
+    <ClCompile Include="..\lua\lzio.c" />
+    <ClCompile Include="..\rcheevos\src\rcheevos\alloc.c" />
+    <ClCompile Include="..\rcheevos\src\rcheevos\condition.c" />
+    <ClCompile Include="..\rcheevos\src\rcheevos\condset.c" />
+    <ClCompile Include="..\rcheevos\src\rcheevos\expression.c" />
+    <ClCompile Include="..\rcheevos\src\rcheevos\format.c" />
+    <ClCompile Include="..\rcheevos\src\rcheevos\lboard.c" />
+    <ClCompile Include="..\rcheevos\src\rcheevos\operand.c" />
+    <ClCompile Include="..\rcheevos\src\rcheevos\term.c" />
+    <ClCompile Include="..\rcheevos\src\rcheevos\trigger.c" />
+    <ClCompile Include="..\rcheevos\src\rcheevos\value.c" />
+    <ClCompile Include="..\src\md5.c" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/rcheevos.vcxproj.filters
+++ b/src/rcheevos.vcxproj.filters
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="..\src\md5.c">
+      <Filter>md5</Filter>
+    </ClCompile>
+    <ClCompile Include="..\lua\lapi.c">
+      <Filter>lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\lua\lauxlib.c">
+      <Filter>lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\rcheevos\src\rcheevos\lboard.c">
+      <Filter>lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\lua\lcode.c">
+      <Filter>lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\lua\lctype.c">
+      <Filter>lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\lua\ldebug.c">
+      <Filter>lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\lua\ldo.c">
+      <Filter>lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\lua\ldump.c">
+      <Filter>lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\lua\lfunc.c">
+      <Filter>lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\lua\lgc.c">
+      <Filter>lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\lua\llex.c">
+      <Filter>lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\lua\lmem.c">
+      <Filter>lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\lua\lobject.c">
+      <Filter>lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\lua\lopcodes.c">
+      <Filter>lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\lua\lparser.c">
+      <Filter>lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\lua\lstate.c">
+      <Filter>lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\lua\lstring.c">
+      <Filter>lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\lua\ltable.c">
+      <Filter>lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\lua\ltm.c">
+      <Filter>lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\lua\lundump.c">
+      <Filter>lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\lua\lvm.c">
+      <Filter>lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\lua\lzio.c">
+      <Filter>lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\rcheevos\src\rcheevos\value.c">
+      <Filter>rcheevos</Filter>
+    </ClCompile>
+    <ClCompile Include="..\rcheevos\src\rcheevos\alloc.c">
+      <Filter>rcheevos</Filter>
+    </ClCompile>
+    <ClCompile Include="..\rcheevos\src\rcheevos\condition.c">
+      <Filter>rcheevos</Filter>
+    </ClCompile>
+    <ClCompile Include="..\rcheevos\src\rcheevos\condset.c">
+      <Filter>rcheevos</Filter>
+    </ClCompile>
+    <ClCompile Include="..\rcheevos\src\rcheevos\expression.c">
+      <Filter>rcheevos</Filter>
+    </ClCompile>
+    <ClCompile Include="..\rcheevos\src\rcheevos\format.c">
+      <Filter>rcheevos</Filter>
+    </ClCompile>
+    <ClCompile Include="..\rcheevos\src\rcheevos\operand.c">
+      <Filter>rcheevos</Filter>
+    </ClCompile>
+    <ClCompile Include="..\rcheevos\src\rcheevos\term.c">
+      <Filter>rcheevos</Filter>
+    </ClCompile>
+    <ClCompile Include="..\rcheevos\src\rcheevos\trigger.c">
+      <Filter>rcheevos</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\rcheevos\include\rcheevos.h">
+      <Filter>rcheevos</Filter>
+    </ClInclude>
+    <ClInclude Include="..\rcheevos\src\rcheevos\internal.h">
+      <Filter>rcheevos</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\md5.h">
+      <Filter>md5</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <Filter Include="lua">
+      <UniqueIdentifier>{34c1cfa0-13ee-4122-b223-0bbc286865e5}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="rcheevos">
+      <UniqueIdentifier>{551d7e10-0699-4da6-9d2d-d992d7b26a3a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="md5">
+      <UniqueIdentifier>{0d89b82c-19cc-4151-b2f6-c54895534c95}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+</Project>

--- a/src/services/Http.hh
+++ b/src/services/Http.hh
@@ -48,7 +48,7 @@ public:
     class Request
     {
     public:
-        explicit Request(const std::string& sUrl) noexcept
+        explicit Request(const std::string& sUrl)
         {
             const auto nIndex = sUrl.find('?');
             if (nIndex == std::string::npos)
@@ -97,7 +97,7 @@ public:
         /// Sets the POST data.
         /// </summary>
         /// <remarks>If not empty, POST request will be made, otherwise GET request wil be made.</remarks>
-        void SetPostData(const std::string& sValue) noexcept { m_sPostData = sValue; }
+        void SetPostData(const std::string& sValue) { m_sPostData = sValue; }
 
         /// <summary>
         /// Gets the POST data.
@@ -107,7 +107,7 @@ public:
         /// <summary>
         /// Specifies the Content-Type to send. Default: "application/x-www-form-urlencoded"
         /// </summary>
-        void SetContentType(const std::string& sValue) noexcept { m_sContentType = sValue; }
+        void SetContentType(const std::string& sValue) { m_sContentType = sValue; }
 
         /// <summary>
         /// Gets the Content-Type to send. Default: "application/x-www-form-urlencoded"

--- a/src/services/IThreadPool.hh
+++ b/src/services/IThreadPool.hh
@@ -17,12 +17,12 @@ public:
     /// <summary>
     /// Queues work for a background thread
     /// </summary>
-    virtual void RunAsync(std::function<void()>&& f) noexcept = 0;
+    virtual void RunAsync(std::function<void()>&& f) = 0;
 
     /// <summary>
     /// Queues work for a background thread to be run after a period of time
     /// </summary>
-    virtual void ScheduleAsync(std::chrono::milliseconds nDelay, std::function<void()>&& f) noexcept = 0;
+    virtual void ScheduleAsync(std::chrono::milliseconds nDelay, std::function<void()>&& f) = 0;
 
     /// <summary>
     /// Sets the <see ref="IsShutdownRequested" /> flag so threads can start winding down.

--- a/src/services/SearchResults.cpp
+++ b/src/services/SearchResults.cpp
@@ -240,7 +240,7 @@ void SearchResults::ProcessBlocksNibbles(const SearchResults& srSource, unsigned
 
         for (unsigned int i = 0; i < block.GetSize() - nPadding; ++i)
         {
-            unsigned int nValue1 = vMemory.at(i);
+            const unsigned int nValue1 = vMemory.at(i);
             unsigned int nValue2 = (nTestValue > 15) ? (block.GetByte(i) & 0x0F) : nTestValue;
 
             if (Compare(nValue1 & 0x0F, nValue2, nCompareType))

--- a/src/services/SearchResults.cpp
+++ b/src/services/SearchResults.cpp
@@ -383,7 +383,7 @@ void SearchResults::Initialize(const SearchResults& srSource, ComparisonType nCo
     m_sSummary.append(" last known value...");
 }
 
-unsigned int SearchResults::MatchingAddressCount()
+unsigned int SearchResults::MatchingAddressCount() noexcept
 {
     if (!m_bUnfiltered)
         return m_vMatchingAddresses.size();

--- a/src/services/SearchResults.h
+++ b/src/services/SearchResults.h
@@ -36,18 +36,18 @@ public:
     /// <summary>
     /// Gets the number of matching addresses.
     /// </summary>
-    unsigned int MatchingAddressCount();
+    unsigned int MatchingAddressCount() noexcept;
 
     /// <summary>
     /// Gets a summary of the results
     /// </summary>
-    const std::string& Summary() const { return m_sSummary; }
+    const std::string& Summary() const noexcept { return m_sSummary; }
 
     struct Result
     {
-        unsigned int nAddress;
-        unsigned int nValue;
-        MemSize nSize;
+        unsigned int nAddress{};
+        unsigned int nValue{};
+        MemSize nSize{};
     };
 
     /// <summary>
@@ -61,7 +61,8 @@ public:
     /// Determines whether the specified address appears in the matching address list.
     /// </summary>
     /// <param name="nAddress">The n address.</param>
-    /// <returns><c>true</c> if the specified address is in the matching address list; otherwise, <c>false</c>.</returns>
+    /// <returns><c>true</c> if the specified address is in the matching address list; otherwise,
+    /// <c>false</c>.</returns>
     bool ContainsAddress(unsigned int nAddress) const;
 
     /// <summary>
@@ -81,28 +82,27 @@ protected:
     {
     public:
         explicit MemBlock(_In_ unsigned int nAddress, _In_ unsigned int nSize) noexcept :
-            nAddress{ nAddress }, nSize{ nSize }
+            nAddress{nAddress},
+            nSize{nSize}
         {
             if (nSize > sizeof(m_vBytes))
-                m_pBytes = new unsigned char[nSize];
+                m_pBytes = new (std::nothrow) unsigned char[nSize];
         }
 
-        MemBlock(const MemBlock& other) noexcept :
-            MemBlock(other.nAddress, other.nSize)
+        MemBlock(const MemBlock& other) noexcept : MemBlock(other.nAddress, other.nSize)
         {
             if (nSize > sizeof(m_vBytes))
                 std::memcpy(m_pBytes, other.m_pBytes, nSize);
         }
         MemBlock& operator=(const MemBlock&) noexcept = delete;
 
-        MemBlock(MemBlock&& other) noexcept :
-            nAddress{ other.nAddress }, nSize{ other.nSize }
+        MemBlock(MemBlock&& other) noexcept : nAddress{other.nAddress}, nSize{other.nSize}
         {
             if (other.nSize > sizeof(m_vBytes))
             {
-                m_pBytes = other.m_pBytes;
+                m_pBytes       = other.m_pBytes;
                 other.m_pBytes = nullptr;
-                other.nSize = 0;
+                other.nSize    = 0;
             }
             else
             {
@@ -116,12 +116,12 @@ protected:
                 delete[] m_pBytes;
         }
 
-        unsigned char* GetBytes() { return (nSize > sizeof(m_vBytes)) ? m_pBytes : &m_vBytes[0]; }
-        const unsigned char* GetBytes() const { return (nSize > sizeof(m_vBytes)) ? m_pBytes : &m_vBytes[0]; }
+        unsigned char* GetBytes() noexcept { return (nSize > sizeof(m_vBytes)) ? m_pBytes : &m_vBytes[0]; }
+        const unsigned char* GetBytes() const noexcept { return (nSize > sizeof(m_vBytes)) ? m_pBytes : &m_vBytes[0]; }
         unsigned char GetByte(std::size_t nIndex) noexcept { return GetBytes()[nIndex]; }
         unsigned char GetByte(std::size_t nIndex) const noexcept { return GetBytes()[nIndex]; }
-        unsigned int GetAddress() const { return nAddress; }
-        unsigned int GetSize() const { return nSize; }
+        unsigned int GetAddress() const noexcept { return nAddress; }
+        unsigned int GetSize() const noexcept { return nSize; }
 
     private:
         union // 8 bytes
@@ -138,10 +138,15 @@ protected:
     MemBlock& AddBlock(unsigned int nAddress, unsigned int nSize);
 
 private:
-    void ProcessBlocks(const SearchResults& srSource, std::function<bool(unsigned int nIndex, const unsigned char pMemory[], const unsigned char pPrev[])> testIndexFunction);
+    void ProcessBlocks(
+        const SearchResults& srSource,
+        std::function<bool(unsigned int nIndex, const unsigned char pMemory[], const unsigned char pPrev[])>
+            testIndexFunction);
     void ProcessBlocksNibbles(const SearchResults& srSource, unsigned int nTestValue, ComparisonType nCompareType);
-    void AddMatches(unsigned int nAddressBase, const unsigned char pMemory[], const std::vector<unsigned int>& vMatches);
-    void AddMatchesNibbles(unsigned int nAddressBase, const unsigned char pMemory[], const std::vector<unsigned int>& vMatches);
+    void AddMatches(unsigned int nAddressBase, const unsigned char pMemory[],
+                    const std::vector<unsigned int>& vMatches);
+    void AddMatchesNibbles(unsigned int nAddressBase, const unsigned char pMemory[],
+                           const std::vector<unsigned int>& vMatches);
 
     std::string m_sSummary;
     std::vector<MemBlock> m_vBlocks;
@@ -153,7 +158,5 @@ private:
 
 } // namespace services
 } // namespace ra
-
-
 
 #endif /* !SEARCHRESULTS_H */

--- a/src/services/ServiceLocator.hh
+++ b/src/services/ServiceLocator.hh
@@ -45,7 +45,7 @@ public:
     /// </summary>
     /// <returns><c>true</c> if an implementation exists, <c>false</c> if not.</returns>
     template <class TClass>
-    static bool Exists()
+    static bool Exists() noexcept
     {
         return Service<TClass>::Exists();
     }
@@ -58,7 +58,7 @@ public:
     /// pointer and delete it at the end of execution or when a different implementation is provided.
     /// </param>
     template <class TClass>
-    static void Provide(TClass* pInstance)
+    static void Provide(TClass* pInstance) noexcept
     {
         Service<TClass>::s_pInstance.reset(pInstance);
     }
@@ -123,7 +123,7 @@ private:
             return *s_pInstance.get();
         }
 
-        static bool Exists()
+        static bool Exists() noexcept
         {
             return (s_pInstance != nullptr);
         }

--- a/src/services/impl/Clock.hh
+++ b/src/services/impl/Clock.hh
@@ -11,14 +11,12 @@ namespace impl {
 class Clock : public ra::services::IClock
 {
 public:
-    Clock() noexcept = default;
-
-    std::chrono::system_clock::time_point Now() const override
+    std::chrono::system_clock::time_point Now() const noexcept override
     {
         return std::chrono::system_clock::now();
     }
 
-    std::chrono::steady_clock::time_point UpTime() const override
+    std::chrono::steady_clock::time_point UpTime() const noexcept override
     {
         return std::chrono::steady_clock::now();
     }

--- a/src/services/impl/FileLocalStorage.cpp
+++ b/src/services/impl/FileLocalStorage.cpp
@@ -51,7 +51,7 @@ static void PrepareDirectory(const ra::services::IFileSystem& pFileSystem, const
     }
 }
 
-FileLocalStorage::FileLocalStorage(IFileSystem& pFileSystem) noexcept
+FileLocalStorage::FileLocalStorage(IFileSystem& pFileSystem)
     : m_pFileSystem(pFileSystem)
 {
     // Ensure all required directories are created

--- a/src/services/impl/FileLocalStorage.hh
+++ b/src/services/impl/FileLocalStorage.hh
@@ -12,7 +12,7 @@ namespace impl {
 class FileLocalStorage : public ILocalStorage
 {
 public:
-    explicit FileLocalStorage(IFileSystem& pFileSystem) noexcept;
+    explicit FileLocalStorage(IFileSystem& pFileSystem);
 
     std::chrono::system_clock::time_point GetLastModified(StorageItemType nType, const std::wstring& sKey) override;
 

--- a/src/services/impl/FileLogger.hh
+++ b/src/services/impl/FileLogger.hh
@@ -17,7 +17,7 @@ namespace impl {
 class FileLogger : public ra::services::ILogger
 {
 public:
-    explicit FileLogger(const ra::services::IFileSystem& pFileSystem) noexcept
+    explicit FileLogger(const ra::services::IFileSystem& pFileSystem)
     {
         std::wstring sLogFilePath = pFileSystem.BaseDirectory() + L"RACache\\RALog.txt";
 
@@ -35,7 +35,7 @@ public:
             m_pWriter->WriteLine();
     }
 
-    bool IsEnabled([[maybe_unused]] LogLevel level) const override { return true; }
+    bool IsEnabled([[maybe_unused]] LogLevel level) const noexcept override { return true; }
 
     void LogMessage(LogLevel level, const std::string& sMessage) const override
     {

--- a/src/services/impl/FileLogger.hh
+++ b/src/services/impl/FileLogger.hh
@@ -87,7 +87,7 @@ public:
     }
 
 private:
-    static void LogMessage(ra::services::TextWriter& pWriter, char* sTimestamp, LogLevel level,
+    static void LogMessage(ra::services::TextWriter& pWriter, const char* const sTimestamp, LogLevel level,
                            const std::string& sMessage)
     {
         pWriter.Write(sTimestamp);

--- a/src/services/impl/FileTextReader.hh
+++ b/src/services/impl/FileTextReader.hh
@@ -13,7 +13,7 @@ namespace impl {
 class FileTextReader : public ra::services::TextReader
 {
 public:
-    explicit FileTextReader(const std::wstring& sFilename) noexcept
+    explicit FileTextReader(const std::wstring& sFilename)
         : m_iStream(sFilename)
     {
     }
@@ -54,7 +54,7 @@ public:
         return static_cast<size_t>(const_cast<std::ifstream&>(m_iStream).tellg());
     }
 
-    std::ifstream& GetFStream() { return m_iStream; }
+    std::ifstream& GetFStream() noexcept { return m_iStream; }
 
 private:
     std::ifstream m_iStream;

--- a/src/services/impl/FileTextWriter.hh
+++ b/src/services/impl/FileTextWriter.hh
@@ -14,7 +14,7 @@ namespace impl {
 class FileTextWriter : public ra::services::TextWriter
 {
 public:
-    explicit FileTextWriter(const std::wstring& sFilename, std::ios_base::openmode nMode = std::ios::out) noexcept
+    explicit FileTextWriter(const std::wstring& sFilename, std::ios_base::openmode nMode = std::ios::out)
         : m_oStream(sFilename, std::ios::binary | nMode)
     {
     }
@@ -51,7 +51,7 @@ public:
         m_oStream.seekp(static_cast<std::streampos>(nNewPosition));
     }
 
-    std::ofstream& GetFStream() { return m_oStream; }
+    std::ofstream& GetFStream() noexcept { return m_oStream; }
 
 private:
     std::ofstream m_oStream;

--- a/src/services/impl/JsonFileConfiguration.cpp
+++ b/src/services/impl/JsonFileConfiguration.cpp
@@ -140,14 +140,14 @@ void JsonFileConfiguration::Save() const
         SaveDocument(doc, *pWriter);
 }
 
-bool JsonFileConfiguration::IsFeatureEnabled(Feature nFeature) const
+bool JsonFileConfiguration::IsFeatureEnabled(Feature nFeature) const noexcept
 {
-    return (m_vEnabledFeatures & (1 << static_cast<int>(nFeature)));
+    return (m_vEnabledFeatures & (1 << ra::etoi(nFeature)));
 }
 
-void JsonFileConfiguration::SetFeatureEnabled(Feature nFeature, bool bEnabled)
+void JsonFileConfiguration::SetFeatureEnabled(Feature nFeature, bool bEnabled) noexcept
 {
-    const int bit = 1 << static_cast<int>(nFeature);
+    const auto bit = 1 << ra::etoi(nFeature);
 
     if (bEnabled)
         m_vEnabledFeatures |= bit;

--- a/src/services/impl/JsonFileConfiguration.hh
+++ b/src/services/impl/JsonFileConfiguration.hh
@@ -13,16 +13,16 @@ class JsonFileConfiguration : public IConfiguration
 public:
     bool Load(const std::wstring& sFilename);
 
-    const std::string& GetUsername() const override { return m_sUsername; }
+    const std::string& GetUsername() const noexcept override { return m_sUsername; }
     void SetUsername(const std::string& sValue) override { m_sUsername = sValue; }
-    const std::string& GetApiToken() const override { return m_sApiToken; }
+    const std::string& GetApiToken() const noexcept override { return m_sApiToken; }
     void SetApiToken(const std::string& sValue) override { m_sApiToken = sValue; }
 
-    bool IsFeatureEnabled(Feature nFeature) const override;
-    void SetFeatureEnabled(Feature nFeature, bool bEnabled) override;
+    bool IsFeatureEnabled(Feature nFeature) const noexcept override;
+    void SetFeatureEnabled(Feature nFeature, bool bEnabled) noexcept override;
 
-    unsigned int GetNumBackgroundThreads() const override { return m_nBackgroundThreads; }
-    const std::string& GetRomDirectory() const override { return m_sRomDirectory; }
+    unsigned int GetNumBackgroundThreads() const noexcept override { return m_nBackgroundThreads; }
+    const std::string& GetRomDirectory() const noexcept override { return m_sRomDirectory; }
     void SetRomDirectory(const std::string& sValue) override { m_sRomDirectory = sValue; }
 
     ra::ui::Position GetWindowPosition(const std::string& sPositionKey) const override;

--- a/src/services/impl/LeaderboardManager.hh
+++ b/src/services/impl/LeaderboardManager.hh
@@ -27,10 +27,10 @@ public:
     void SubmitLeaderboardEntry(const RA_Leaderboard& lb, unsigned int nValue) const override;
 
     void AddLeaderboard(RA_Leaderboard&& lb) override;
-    size_t Count() const override { return m_Leaderboards.size(); }
+    size_t Count() const noexcept override { return m_Leaderboards.size(); }
     const RA_Leaderboard& GetLB(size_t iter) const override { return m_Leaderboards[iter]; }
     RA_Leaderboard* FindLB(ra::LeaderboardID nID) override;
-    void Clear() override { m_Leaderboards.clear(); }
+    void Clear() noexcept override { m_Leaderboards.clear(); }
 
 private:
     std::vector<RA_Leaderboard> m_Leaderboards;

--- a/src/services/impl/StringTextReader.hh
+++ b/src/services/impl/StringTextReader.hh
@@ -13,7 +13,7 @@ namespace impl {
 class StringTextReader : public ra::services::TextReader
 {
 public:
-    explicit StringTextReader(const std::string& sInput) noexcept
+    explicit StringTextReader(const std::string& sInput)
         : m_iStream(sInput)
     {
     }

--- a/src/services/impl/StringTextWriter.hh
+++ b/src/services/impl/StringTextWriter.hh
@@ -48,18 +48,18 @@ public:
         Write(std::string("\n"));
     }
 
-    long GetPosition() const override
+    long GetPosition() const noexcept override
     {
         return m_nWritePosition;
     }
 
-    void SetPosition(long nNewPosition) override
+    void SetPosition(long nNewPosition) noexcept override
     {
         assert(nNewPosition >= 0 && nNewPosition <= ra::to_signed(m_sOutput.length()));
         m_nWritePosition = static_cast<size_t>(nNewPosition);
     }
 
-    std::string& GetString() { return m_sOutput; }
+    std::string& GetString() noexcept { return m_sOutput; }
 
 private:
     std::string& m_sOutput;

--- a/src/services/impl/ThreadPool.cpp
+++ b/src/services/impl/ThreadPool.cpp
@@ -25,7 +25,7 @@ void ThreadPool::Initialize(size_t nThreads) noexcept
         m_vThreads.emplace_back(&ThreadPool::RunThread, this);
 }
 
-void ThreadPool::RunThread() noexcept
+void ThreadPool::RunThread()
 {
     do
     {
@@ -62,7 +62,7 @@ void ThreadPool::RunThread() noexcept
     } while (!m_bShutdownInitiated);
 }
 
-void ThreadPool::ProcessDelayedTasks() noexcept
+void ThreadPool::ProcessDelayedTasks()
 {
     auto& pClock = ServiceLocator::Get<IClock>();
     constexpr auto tZeroMilliseconds = std::chrono::milliseconds(0);

--- a/src/services/impl/ThreadPool.cpp
+++ b/src/services/impl/ThreadPool.cpp
@@ -75,7 +75,7 @@ void ThreadPool::ProcessDelayedTasks()
         {
             std::unique_lock<std::mutex> lock(m_oMutex);
 
-            auto tNow = pClock.UpTime();
+            const auto tNow = pClock.UpTime();
             while (!m_vDelayedTasks.empty() && m_vDelayedTasks.front().tWhen <= tNow)
             {
                 m_vQueue.emplace_front(std::move(m_vDelayedTasks.front().fTask));
@@ -109,7 +109,7 @@ void ThreadPool::ProcessDelayedTasks()
             if (m_vDelayedTasks.empty())
                 break;
 
-            auto tNext = m_vDelayedTasks.front().tWhen - pClock.UpTime();
+            const auto tNext = m_vDelayedTasks.front().tWhen - pClock.UpTime();
             if (tNext > tZeroMilliseconds)
                 m_cvDelayedWork.wait_for(lock, tNext);
         }

--- a/src/services/impl/ThreadPool.hh
+++ b/src/services/impl/ThreadPool.hh
@@ -14,20 +14,20 @@ class ThreadPool : public IThreadPool
 {
 public:
     // TODO: std::condition_variable can throw std::system_error (a.k.a fatal error).
-    //       We could just delete the compiler defaulted constructor and handle the exception in an invariant (param constructor)
+    //       We could just delete the compiler defaulted constructor and handle the exception in an invariant (param
+    //       constructor)
     // Info: https://en.cppreference.com/w/cpp/thread/condition_variable/condition_variable
-    ThreadPool() 
-        noexcept(std::is_nothrow_default_constructible_v<std::condition_variable>) = default;
+    ThreadPool() noexcept(std::is_nothrow_default_constructible_v<std::condition_variable>) = default;
 
     ~ThreadPool() noexcept;
     ThreadPool(const ThreadPool&) noexcept = delete;
     ThreadPool& operator=(const ThreadPool&) noexcept = delete;
-    ThreadPool(ThreadPool&&) noexcept = delete;
+    ThreadPool(ThreadPool&&) noexcept                 = delete;
     ThreadPool& operator=(ThreadPool&&) noexcept = delete;
 
-    void Initialize(size_t nThreads) noexcept;
+    [[gsl::suppress(f.6)]] void Initialize(size_t nThreads) noexcept;
 
-    void RunAsync(std::function<void()>&& f) noexcept override
+    void RunAsync(std::function<void()>&& f) override
     {
         if (m_bShutdownInitiated)
             return;
@@ -41,8 +41,8 @@ public:
 
         m_cvWork.notify_one();
     }
-    
-    void ScheduleAsync(std::chrono::milliseconds nDelay, std::function<void()>&& f) noexcept override
+
+    void ScheduleAsync(std::chrono::milliseconds nDelay, std::function<void()>&& f) override
     {
         if (m_bShutdownInitiated)
             return;
@@ -52,7 +52,7 @@ public:
         const auto tWhen = ServiceLocator::Get<IClock>().UpTime() + nDelay;
 
         bool bStartScheduler = false;
-        bool bNewPriority = false;
+        bool bNewPriority    = false;
         {
             std::unique_lock<std::mutex> lock(m_oMutex);
 
@@ -66,13 +66,15 @@ public:
             }
             else if (tWhen < iter->tWhen)
             {
-                // sooner than the next scheduled task, we'll need to wake the timed events thread to reset the wait time
+                // sooner than the next scheduled task, we'll need to wake the timed events thread to reset the wait
+                // time
                 bNewPriority = true;
             }
             else
             {
                 // after the next scheduled task, find where to insert it
-                do {
+                do
+                {
                     ++iter;
                 } while (iter != m_vDelayedTasks.end() && iter->tWhen < tWhen);
             }
@@ -93,24 +95,23 @@ public:
         }
     }
 
-    void Shutdown(bool bWait) noexcept override;
+    [[gsl::suppress(f.6)]] void Shutdown(bool bWait) noexcept override;
 
-    bool IsShutdownRequested() const noexcept override
-    {
-        return m_bShutdownInitiated;
-    }
+    bool IsShutdownRequested() const noexcept override { return m_bShutdownInitiated; }
 
 private:
-    void RunThread() noexcept;
-    void ProcessDelayedTasks() noexcept;
+    void RunThread();
+    void ProcessDelayedTasks();
 
     std::vector<std::thread> m_vThreads;
-    size_t m_nThreads{ 0U };
-    bool m_bShutdownInitiated{ false };
+    size_t m_nThreads{0U};
+    bool m_bShutdownInitiated{false};
 
     struct DelayedTask
     {
-        DelayedTask(std::chrono::steady_clock::time_point tWhen, std::function<void()> fTask) : tWhen(tWhen), fTask(fTask) {};
+        DelayedTask(std::chrono::steady_clock::time_point tWhen, std::function<void()> fTask) :
+            tWhen(tWhen),
+            fTask(fTask){};
 
         std::chrono::steady_clock::time_point tWhen;
         std::function<void()> fTask;

--- a/src/services/impl/ThreadPool.hh
+++ b/src/services/impl/ThreadPool.hh
@@ -25,7 +25,7 @@ public:
     ThreadPool(ThreadPool&&) noexcept                 = delete;
     ThreadPool& operator=(ThreadPool&&) noexcept = delete;
 
-    [[gsl::suppress(f.6)]] void Initialize(size_t nThreads) noexcept;
+    GSL_SUPPRESS(f.6) void Initialize(size_t nThreads) noexcept;
 
     void RunAsync(std::function<void()>&& f) override
     {
@@ -95,7 +95,7 @@ public:
         }
     }
 
-    [[gsl::suppress(f.6)]] void Shutdown(bool bWait) noexcept override;
+    GSL_SUPPRESS(f.6) void Shutdown(bool bWait) noexcept override;
 
     bool IsShutdownRequested() const noexcept override { return m_bShutdownInitiated; }
 

--- a/src/services/impl/WindowsClipboard.hh
+++ b/src/services/impl/WindowsClipboard.hh
@@ -11,7 +11,7 @@ namespace impl {
 class WindowsClipboard : public ra::services::IClipboard
 {
 public:
-    void SetText(const std::wstring& sValue) const override
+    void SetText(const std::wstring& sValue) const noexcept override
     {
         // allocate memory to be managed by the clipboard
         const SIZE_T nSize = (sValue.length() + 1) * 2; // 16-bit characters, with null terminator

--- a/src/services/impl/WindowsDebuggerFileLogger.hh
+++ b/src/services/impl/WindowsDebuggerFileLogger.hh
@@ -11,7 +11,7 @@ namespace impl {
 class WindowsDebuggerFileLogger : public FileLogger
 {
 public:
-    explicit WindowsDebuggerFileLogger(const ra::services::IFileSystem& pFileSystem) noexcept
+    explicit WindowsDebuggerFileLogger(const ra::services::IFileSystem& pFileSystem)
         : FileLogger(pFileSystem)
     {
     }

--- a/src/services/impl/WindowsFileSystem.cpp
+++ b/src/services/impl/WindowsFileSystem.cpp
@@ -142,7 +142,7 @@ std::unique_ptr<TextWriter> WindowsFileSystem::AppendTextFile(const std::wstring
     // cannot use std::ios::app, or the SetPosition method doesn't work
     // have to specify std::ios::in or the previous contents are lost
     auto pWriter = std::make_unique<FileTextWriter>(sPath, std::ios::ate | std::ios::in | std::ios::out);
-    auto* oStream = &pWriter->GetFStream();
+    const std::ofstream* oStream = &pWriter->GetFStream();
     if (!oStream->is_open())
     {
         // failed to open the file - try creating it

--- a/src/services/impl/WindowsFileSystem.cpp
+++ b/src/services/impl/WindowsFileSystem.cpp
@@ -15,21 +15,24 @@ namespace impl {
 WindowsFileSystem::WindowsFileSystem() noexcept
 {
     // determine the home directory from the executable's path
-    wchar_t sBuffer[MAX_PATH];
+    wchar_t sBuffer[MAX_PATH]{};
     GetModuleFileNameW(0, sBuffer, MAX_PATH);
     PathRemoveFileSpecW(sBuffer);
     m_sBaseDirectory = sBuffer;
-    if (m_sBaseDirectory.back() != '\\')
-        m_sBaseDirectory.push_back('\\');
+    if (!m_sBaseDirectory.empty())
+    {
+        if (m_sBaseDirectory.back() != L'\\')
+            m_sBaseDirectory.push_back(L'\\');
+    }
 }
 
-bool WindowsFileSystem::DirectoryExists(const std::wstring& sDirectory) const
+bool WindowsFileSystem::DirectoryExists(const std::wstring& sDirectory) const noexcept
 {
     const DWORD nAttrib = GetFileAttributesW(sDirectory.c_str());
     return (nAttrib != INVALID_FILE_ATTRIBUTES) && (nAttrib & FILE_ATTRIBUTE_DIRECTORY);
 }
 
-bool WindowsFileSystem::CreateDirectory(const std::wstring& sDirectory) const
+bool WindowsFileSystem::CreateDirectory(const std::wstring& sDirectory) const noexcept
 {
     return static_cast<bool>(CreateDirectoryW(sDirectory.c_str(), nullptr));
 }
@@ -55,12 +58,12 @@ size_t WindowsFileSystem::GetFilesInDirectory(const std::wstring& sDirectory, _I
     return vResults.size() - nInitialSize;
 }
 
-bool WindowsFileSystem::DeleteFile(const std::wstring& sPath) const
+bool WindowsFileSystem::DeleteFile(const std::wstring& sPath) const noexcept
 {
     return static_cast<bool>(DeleteFileW(sPath.c_str()));
 }
 
-bool WindowsFileSystem::MoveFile(const std::wstring& sOldPath, const std::wstring& sNewPath) const
+bool WindowsFileSystem::MoveFile(const std::wstring& sOldPath, const std::wstring& sNewPath) const noexcept
 {
     return static_cast<bool>(MoveFileW(sOldPath.c_str(), sNewPath.c_str()));
 }

--- a/src/services/impl/WindowsFileSystem.hh
+++ b/src/services/impl/WindowsFileSystem.hh
@@ -15,7 +15,7 @@ namespace impl {
 class WindowsFileSystem : public IFileSystem
 {
 public:
-    [[gsl::suppress(f.6)]] WindowsFileSystem() noexcept;
+    GSL_SUPPRESS(f.6) WindowsFileSystem() noexcept;
 
     const std::wstring& BaseDirectory() const noexcept override { return m_sBaseDirectory; }
     bool DirectoryExists(const std::wstring& sDirectory) const noexcept override;

--- a/src/services/impl/WindowsFileSystem.hh
+++ b/src/services/impl/WindowsFileSystem.hh
@@ -15,14 +15,14 @@ namespace impl {
 class WindowsFileSystem : public IFileSystem
 {
 public:
-    WindowsFileSystem() noexcept;
+    [[gsl::suppress(f.6)]] WindowsFileSystem() noexcept;
 
-    const std::wstring& BaseDirectory() const override { return m_sBaseDirectory; }
-    bool DirectoryExists(const std::wstring& sDirectory) const override;
-    bool CreateDirectory(const std::wstring& sDirectory) const override;
+    const std::wstring& BaseDirectory() const noexcept override { return m_sBaseDirectory; }
+    bool DirectoryExists(const std::wstring& sDirectory) const noexcept override;
+    bool CreateDirectory(const std::wstring& sDirectory) const noexcept override;
     size_t GetFilesInDirectory(const std::wstring& sDirectory, _Inout_ std::vector<std::wstring>& vResults) const override;
-    bool DeleteFile(const std::wstring& sPath) const override;
-    bool MoveFile(const std::wstring& sOldPath, const std::wstring& sNewPath) const override;
+    bool DeleteFile(const std::wstring& sPath) const noexcept override;
+    bool MoveFile(const std::wstring& sOldPath, const std::wstring& sNewPath) const noexcept override;
     int64_t GetFileSize(const std::wstring& sPath) const override;
     std::chrono::system_clock::time_point GetLastModified(const std::wstring& sPath) const override;
     std::unique_ptr<TextReader> OpenTextFile(const std::wstring& sPath) const override;

--- a/src/ui/BindingBase.hh
+++ b/src/ui/BindingBase.hh
@@ -20,7 +20,7 @@ public:
     BindingBase& operator=(BindingBase&&) noexcept = delete;
 
 protected:
-    explicit BindingBase(_Inout_ ViewModelBase& vmViewModel) noexcept :
+    explicit BindingBase(_Inout_ ViewModelBase& vmViewModel) :
         m_vmViewModel{ vmViewModel }
     {
         vmViewModel.AddNotifyTarget(*this);

--- a/src/ui/ImageReference.hh
+++ b/src/ui/ImageReference.hh
@@ -105,7 +105,7 @@ public:
     /// <summary>
     /// Releases this reference image.
     /// </summary>
-    [[gsl::suppress(f.6)]] void Release() noexcept
+    GSL_SUPPRESS(f.6) void Release() noexcept
     {
         if (m_nType != ImageType::None)
         {

--- a/src/ui/ImageReference.hh
+++ b/src/ui/ImageReference.hh
@@ -24,8 +24,9 @@ public:
     virtual ~IImageRepository() noexcept = default;
 
     IImageRepository(const IImageRepository&) noexcept = delete;
+    IImageRepository& operator=(const IImageRepository&) noexcept = delete;
     IImageRepository(IImageRepository&&) noexcept = delete;
-
+    IImageRepository& operator=(IImageRepository&&) noexcept = delete;
     /// <summary>
     /// Ensures an image is available locally.
     /// </summary>
@@ -36,7 +37,7 @@ public:
     /// <summary>Adds a reference to an image.</summary>
     /// <param name="nType">Type of the image.</param>
     /// <param name="sName">Name of the image.</param>
-    virtual void AddReference(ImageReference& pImage) noexcept = 0;
+    virtual void AddReference(ImageReference& pImage) = 0;
 
     /// <summary>Releases a reference to an image.</summary>
     /// <param name="nType">Type of the image.</param>
@@ -49,7 +50,7 @@ public:
     /// <remarks>    
     /// Updates the internal state of the <see cref="ImageReference" /> if <c>true</c>.
     /// </remarks>
-    virtual bool HasReferencedImageChanged(ImageReference& pImage) const noexcept = 0;
+    virtual bool HasReferencedImageChanged(ImageReference& pImage) const = 0;
 
 protected:
     IImageRepository() noexcept = default;
@@ -65,7 +66,7 @@ public:
             Release();
     }
 
-    explicit ImageReference(ImageType nType, const std::string& sName) noexcept
+    explicit ImageReference(ImageType nType, const std::string& sName)
         : m_nType(nType), m_sName(sName)
     {
     }
@@ -78,12 +79,12 @@ public:
     /// <summary>
     /// Get the image type.
     /// </summary>
-    ImageType Type() const { return m_nType; }
+    ImageType Type() const noexcept { return m_nType; }
     
     /// <summary>
     /// Get the image name.
     /// </summary>
-    const std::string& Name() const { return m_sName; }
+    const std::string& Name() const noexcept { return m_sName; }
 
     /// <summary>
     /// Updates the referenced image.
@@ -104,7 +105,7 @@ public:
     /// <summary>
     /// Releases this reference image.
     /// </summary>
-    void Release()
+    [[gsl::suppress(f.6)]] void Release() noexcept
     {
         if (m_nType != ImageType::None)
         {
@@ -116,12 +117,12 @@ public:
     /// <summary>
     /// Gets custom data associated to the reference - used to cache data by <see cref="ISurface::DrawImage" />.
     /// </summary>
-    unsigned long GetData() const { return m_nData; }
+    unsigned long GetData() const noexcept { return m_nData; }
 
     /// <summary>
     /// Sets custom data associated to the reference - used to cache data by <see cref="ISurface::DrawImage" />.
     /// </summary>
-    void SetData(unsigned long nValue) { m_nData = nValue; }
+    void SetData(unsigned long nValue) noexcept { m_nData = nValue; }
 
 private:
     ImageType m_nType = ImageType::None;

--- a/src/ui/ModelProperty.cpp
+++ b/src/ui/ModelProperty.cpp
@@ -11,7 +11,7 @@ int ModelPropertyBase::s_nNextKey = 1;
 std::vector<ModelPropertyBase*> ModelPropertyBase::s_vProperties;
 
 _Use_decl_annotations_
-ModelPropertyBase::ModelPropertyBase(const char* const sTypeName, const char* const sPropertyName) noexcept :
+ModelPropertyBase::ModelPropertyBase(const char* const sTypeName, const char* const sPropertyName) :
     m_sTypeName{ sTypeName },
     m_sPropertyName{ sPropertyName }
 {
@@ -32,7 +32,8 @@ ModelPropertyBase::~ModelPropertyBase() noexcept
 const ModelPropertyBase* ModelPropertyBase::GetPropertyForKey(int nKey)
 {
     ModelPropertyBase search(nKey);
-    auto iter = std::lower_bound(s_vProperties.begin(), s_vProperties.end(), &search, [](const ModelPropertyBase* left, const ModelPropertyBase* right)
+    auto iter = std::lower_bound(s_vProperties.begin(), s_vProperties.end(),
+                                 &search, [](const ModelPropertyBase* left, const ModelPropertyBase* right) noexcept
     {
         return left->GetKey() < right->GetKey();
     });

--- a/src/ui/ModelProperty.hh
+++ b/src/ui/ModelProperty.hh
@@ -8,7 +8,7 @@ namespace ui {
 class ModelPropertyBase
 {
 public:
-    virtual ~ModelPropertyBase() noexcept;
+    [[gsl::suppress(f.6)]] virtual ~ModelPropertyBase() noexcept;
     ModelPropertyBase(const ModelPropertyBase&) noexcept = delete;
     ModelPropertyBase& operator=(const ModelPropertyBase&) noexcept = delete;
     ModelPropertyBase(ModelPropertyBase&&) noexcept = delete;
@@ -17,17 +17,17 @@ public:
     /// <summary>
     /// Gets the unique identifier of the property.
     /// </summary>
-    int GetKey() const { return m_nKey; }
+    int GetKey() const noexcept { return m_nKey; }
 
     /// <summary>
     /// Gets the name of the type that owns the property.
     /// </summary>
-    const char* GetTypeName() const { return m_sTypeName; }
+    const char* GetTypeName() const noexcept { return m_sTypeName; }
 
     /// <summary>
     /// Gets the name of the property.
     /// </summary>
-    const char* GetPropertyName() const { return m_sPropertyName; }
+    const char* GetPropertyName() const noexcept { return m_sPropertyName; }
 
     /// <summary>
     /// Gets the property for specified unique identifier.
@@ -45,7 +45,7 @@ public:
     operator<(_In_ const ModelPropertyBase& that) const noexcept { return m_nKey < that.m_nKey; }
 
 protected:
-    explicit ModelPropertyBase(_In_ const char* const sTypeName, _In_ const char* const sPropertyName) noexcept;
+    explicit ModelPropertyBase(_In_ const char* const sTypeName, _In_ const char* const sPropertyName);
 
     explicit ModelPropertyBase(_In_ int nKey) noexcept { m_nKey = nKey; } // for binary search
 
@@ -62,7 +62,7 @@ template<class T>
 class ModelProperty : public ModelPropertyBase
 {
 public:
-    explicit ModelProperty(const char* sTypeName, const char* sPropertyName, T tDefaultValue) noexcept
+    explicit ModelProperty(const char* sTypeName, const char* sPropertyName, T tDefaultValue)
         : ModelPropertyBase(sTypeName, sPropertyName), m_tDefaultValue(tDefaultValue)
     {
     }
@@ -70,13 +70,13 @@ public:
     /// <summary>
     /// Gets the default value for the property.
     /// </summary>
-    const T& GetDefaultValue() const { return m_tDefaultValue; }
+    const T& GetDefaultValue() const noexcept { return m_tDefaultValue; }
 
     /// <summary>
     /// Sets the default value for the property.
     /// </summary>
     /// <remarks>Affects all existing instances where a value has not been set, not just new instances.</remarks>
-    void SetDefaultValue(const T& tValue) { m_tDefaultValue = tValue; }
+    void SetDefaultValue(const T& tValue) noexcept(std::is_nothrow_copy_assignable_v<T>) { m_tDefaultValue = tValue; }
 
     using ValueMap = std::unordered_map<int, T>;
 

--- a/src/ui/ModelProperty.hh
+++ b/src/ui/ModelProperty.hh
@@ -8,7 +8,7 @@ namespace ui {
 class ModelPropertyBase
 {
 public:
-    [[gsl::suppress(f.6)]] virtual ~ModelPropertyBase() noexcept;
+    GSL_SUPPRESS(f.6) virtual ~ModelPropertyBase() noexcept;
     ModelPropertyBase(const ModelPropertyBase&) noexcept = delete;
     ModelPropertyBase& operator=(const ModelPropertyBase&) noexcept = delete;
     ModelPropertyBase(ModelPropertyBase&&) noexcept = delete;

--- a/src/ui/Types.hh
+++ b/src/ui/Types.hh
@@ -19,66 +19,55 @@ struct Size
 
 enum class FontStyles
 {
-    Normal = 0x00,
-    Bold = 0x01,
-    Italic = 0x02,
-    Underline = 0x04,
+    Normal        = 0x00,
+    Bold          = 0x01,
+    Italic        = 0x02,
+    Underline     = 0x04,
     Strikethrough = 0x08,
 };
 
-union Color
-{
-    explicit Color(unsigned char R, unsigned char G, unsigned char B) noexcept
-        : Color(0xFF, R, G, B)
-    {
-    }
+union Color {
+    explicit Color(unsigned char R, unsigned char G, unsigned char B) noexcept : Color(0xFF, R, G, B) {}
 
-    explicit Color(unsigned char A, unsigned char R, unsigned char G, unsigned char B) noexcept
-        : Color((A << 24) | (R << 16) | (G << 8) | B)
-    {
-    }
+    explicit Color(unsigned char A, unsigned char R, unsigned char G, unsigned char B) noexcept :
+        Color((A << 24) | (R << 16) | (G << 8) | B)
+    {}
 
-    explicit Color(unsigned int ARGB) noexcept
-    {
-        this->ARGB = ARGB;
-    }
+    explicit Color(unsigned int ARGB) noexcept { this->ARGB = ARGB; }
 
     Color(const Color&) noexcept = default;
     Color& operator=(const Color&) noexcept = default;
-    Color(Color&&) noexcept = default;
+    Color(Color&&) noexcept                 = default;
     Color& operator=(Color&&) noexcept = default;
 
-    bool operator!=(const Color& that)
-    {
-        return (this->ARGB != that.ARGB);
-    }
+    bool operator!=(const Color& that) const noexcept { return (this->ARGB != that.ARGB); }
 
     /// <summary>
     /// The 32-bit ARGB value.
     /// </summary>
-    unsigned int ARGB;
+    unsigned int ARGB{};
 
     struct Channel
     {
         /// <summary>
         /// The 8-bit blue value.
         /// </summary>
-        unsigned char B;
+        unsigned char B{};
 
         /// <summary>
         /// The 8-bit green value.
         /// </summary>
-        unsigned char G;
+        unsigned char G{};
 
         /// <summary>
         /// The 8-bit red value.
         /// </summary>
-        unsigned char R;
+        unsigned char R{};
 
         /// <summary>
         /// The 8-bit alpha value.
         /// </summary>
-        unsigned char A;
+        unsigned char A{};
     } Channel;
 };
 static_assert(sizeof(Color) == sizeof(unsigned int));

--- a/src/ui/ViewModelBase.hh
+++ b/src/ui/ViewModelBase.hh
@@ -24,16 +24,15 @@ public:
         NotifyTarget(NotifyTarget&&) noexcept = default;
         NotifyTarget& operator=(NotifyTarget&&) noexcept = default;
 
-        [[gsl::suppress(f.6)]] /*Overrides can throw, we should either make this pure or suppress*/
-        virtual void OnViewModelBoolValueChanged([[maybe_unused]] const BoolModelProperty::ChangeArgs& args) {}
-        [[gsl::suppress(f.6)]] 
-        virtual void OnViewModelStringValueChanged([[maybe_unused]] const StringModelProperty::ChangeArgs& args) {}
-        [[gsl::suppress(f.6)]] 
-        virtual void OnViewModelIntValueChanged([[maybe_unused]] const IntModelProperty::ChangeArgs& args) {}
+        virtual void OnViewModelBoolValueChanged([[maybe_unused]] const BoolModelProperty::ChangeArgs& args) noexcept {}
+        virtual void OnViewModelStringValueChanged([
+            [maybe_unused]] const StringModelProperty::ChangeArgs& args) noexcept
+        {}
+        virtual void OnViewModelIntValueChanged([[maybe_unused]] const IntModelProperty::ChangeArgs& args) noexcept {}
     };
 
     void AddNotifyTarget(NotifyTarget& pTarget) { m_vNotifyTargets.insert(&pTarget); }
-    [[gsl::suppress(f.6)]] void RemoveNotifyTarget(NotifyTarget& pTarget) noexcept { m_vNotifyTargets.erase(&pTarget); }
+    GSL_SUPPRESS(f.6) void RemoveNotifyTarget(NotifyTarget& pTarget) noexcept { m_vNotifyTargets.erase(&pTarget); }
 
 private:
     using NotifyTargetSet = std::set<NotifyTarget*>;

--- a/src/ui/ViewModelBase.hh
+++ b/src/ui/ViewModelBase.hh
@@ -24,13 +24,16 @@ public:
         NotifyTarget(NotifyTarget&&) noexcept = default;
         NotifyTarget& operator=(NotifyTarget&&) noexcept = default;
 
+        [[gsl::suppress(f.6)]] /*Overrides can throw, we should either make this pure or suppress*/
         virtual void OnViewModelBoolValueChanged([[maybe_unused]] const BoolModelProperty::ChangeArgs& args) {}
+        [[gsl::suppress(f.6)]] 
         virtual void OnViewModelStringValueChanged([[maybe_unused]] const StringModelProperty::ChangeArgs& args) {}
+        [[gsl::suppress(f.6)]] 
         virtual void OnViewModelIntValueChanged([[maybe_unused]] const IntModelProperty::ChangeArgs& args) {}
     };
 
     void AddNotifyTarget(NotifyTarget& pTarget) { m_vNotifyTargets.insert(&pTarget); }
-    void RemoveNotifyTarget(NotifyTarget& pTarget) { m_vNotifyTargets.erase(&pTarget); }
+    [[gsl::suppress(f.6)]] void RemoveNotifyTarget(NotifyTarget& pTarget) noexcept { m_vNotifyTargets.erase(&pTarget); }
 
 private:
     using NotifyTargetSet = std::set<NotifyTarget*>;

--- a/src/ui/drawing/ISurface.hh
+++ b/src/ui/drawing/ISurface.hh
@@ -15,9 +15,10 @@ class ISurface
 {
 public:
     virtual ~ISurface() noexcept = default;
-
     ISurface(const ISurface&) noexcept = delete;
+    ISurface& operator=(const ISurface&) noexcept = delete;
     ISurface(ISurface&&) noexcept = delete;
+    ISurface& operator=(ISurface&&) noexcept = delete;
 
     /// <summary>
     /// Gets the width of the surface.

--- a/src/ui/drawing/gdi/GDIBitmapSurface.cpp
+++ b/src/ui/drawing/gdi/GDIBitmapSurface.cpp
@@ -7,7 +7,7 @@ namespace ui {
 namespace drawing {
 namespace gdi {
 
-void GDIAlphaBitmapSurface::FillRectangle(int nX, int nY, int nWidth, int nHeight, Color nColor)
+void GDIAlphaBitmapSurface::FillRectangle(int nX, int nY, int nWidth, int nHeight, Color nColor) noexcept
 {
     assert(nWidth != 0);
     assert(nHeight != 0);
@@ -40,7 +40,7 @@ void GDIAlphaBitmapSurface::FillRectangle(int nX, int nY, int nWidth, int nHeigh
     }
 }
 
-static inline void BlendPixel(UINT32* nTarget, UINT32 nBlend)
+static constexpr void BlendPixel(UINT32* nTarget, UINT32 nBlend) noexcept
 {
     const auto alpha = nBlend >> 24;
 
@@ -125,7 +125,7 @@ void GDIAlphaBitmapSurface::WriteText(int nX, int nY, int nFont, Color nColor, c
     DeleteDC(hMemDC);
 }
 
-void GDIAlphaBitmapSurface::Blend(HDC hTargetDC, int nX, int nY) const
+void GDIAlphaBitmapSurface::Blend(HDC hTargetDC, int nX, int nY) const noexcept
 {
     int nWidth = static_cast<int>(GetWidth());
     int nHeight = static_cast<int>(GetHeight());
@@ -163,11 +163,11 @@ void GDIAlphaBitmapSurface::Blend(HDC hTargetDC, int nX, int nY) const
     DeleteDC(hMemDC);
 }
 
-void GDIAlphaBitmapSurface::SetOpacity(double fAlpha)
+void GDIAlphaBitmapSurface::SetOpacity(double fAlpha) noexcept
 {
     assert(fAlpha >= 0.0 && fAlpha <= 1.0);
     const auto nAlpha = static_cast<UINT8>(255 * fAlpha);
-    assert(nAlpha > 0.0); // setting opacity to 0 is irreversable - caller should just not draw it
+    assert(nAlpha > 0.0); // setting opacity to 0 is irreversible - caller should just not draw it
 
     const UINT8* pEnd = reinterpret_cast<UINT8*>(m_pBits + GetWidth() * GetHeight());
     UINT8* pBits = reinterpret_cast<UINT8*>(m_pBits) + 3;

--- a/src/ui/drawing/gdi/GDIBitmapSurface.cpp
+++ b/src/ui/drawing/gdi/GDIBitmapSurface.cpp
@@ -18,7 +18,7 @@ void GDIAlphaBitmapSurface::FillRectangle(int nX, int nY, int nWidth, int nHeigh
     if (nStride == nWidth)
     {
         // doing full scanlines, just bulk fill
-        auto pEnd = pBits + nWidth * nHeight;
+        const UINT32* pEnd = pBits + nWidth * nHeight;
         do
         {
             *pBits++ = nColor.ARGB;
@@ -29,7 +29,7 @@ void GDIAlphaBitmapSurface::FillRectangle(int nX, int nY, int nWidth, int nHeigh
         // partial scanlines, have to fill in strips
         while (nHeight--)
         {
-            auto pEnd = pBits + nWidth;
+            const UINT32* pEnd = pBits + nWidth;
             do
             {
                 *pBits++ = nColor.ARGB;
@@ -109,11 +109,11 @@ void GDIAlphaBitmapSurface::WriteText(int nX, int nY, int nFont, Color nColor, c
     auto nLines = szText.cy;
     while (nLines--)
     {
-        auto pEnd = pBits + szText.cx;
+        const UINT32* pEnd = pBits + szText.cx;
         do
         {
-            UINT8 nAlpha = 0xFF - ((*pTextBits++) & 0xFF);
-            UINT32 pColor = (nColor.ARGB & 0x00FFFFFF) | ((nAlpha * nColor.Channel.A / 255) << 24);
+            const UINT8 nAlpha = 0xFF - ((*pTextBits++) & 0xFF);
+            const UINT32 pColor = (nColor.ARGB & 0x00FFFFFF) | ((nAlpha * nColor.Channel.A / 255) << 24);
             BlendPixel(pBits, pColor);
             ++pBits;
         } while (pBits < pEnd);
@@ -127,8 +127,8 @@ void GDIAlphaBitmapSurface::WriteText(int nX, int nY, int nFont, Color nColor, c
 
 void GDIAlphaBitmapSurface::Blend(HDC hTargetDC, int nX, int nY) const noexcept
 {
-    int nWidth = static_cast<int>(GetWidth());
-    int nHeight = static_cast<int>(GetHeight());
+    const int nWidth = static_cast<int>(GetWidth());
+    const int nHeight = static_cast<int>(GetHeight());
 
     // copy a portion of the target surface into a buffer
     HDC hMemDC = CreateCompatibleDC(hTargetDC);

--- a/src/ui/drawing/gdi/GDIBitmapSurface.hh
+++ b/src/ui/drawing/gdi/GDIBitmapSurface.hh
@@ -38,7 +38,7 @@ protected:
     UINT32* m_pBits;
 
 private:
-    HDC CreateBitmapHDC(const int nWidth, const int nHeight)
+    HDC CreateBitmapHDC(const int nWidth, const int nHeight) noexcept
     {
         BITMAPINFO bmi{};
         bmi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
@@ -80,12 +80,12 @@ public:
     GDIAlphaBitmapSurface(GDIAlphaBitmapSurface&&) noexcept = delete;
     GDIAlphaBitmapSurface& operator=(GDIAlphaBitmapSurface&&) noexcept = delete;
 
-    void FillRectangle(int nX, int nY, int nWidth, int nHeight, Color nColor) override;
+    void FillRectangle(int nX, int nY, int nWidth, int nHeight, Color nColor) noexcept override;
     void WriteText(int nX, int nY, int nFont, Color nColor, const std::wstring& sText) override;
 
-    void Blend(HDC hTargetDC, int nX, int nY) const;
+    void Blend(HDC hTargetDC, int nX, int nY) const noexcept;
 
-    void SetOpacity(double fAlpha) override;
+    void SetOpacity(double fAlpha) noexcept override;
 };
 
 class GDISurfaceFactory : public ISurfaceFactory

--- a/src/ui/drawing/gdi/GDISurface.cpp
+++ b/src/ui/drawing/gdi/GDISurface.cpp
@@ -15,7 +15,7 @@ GDISurface::GDISurface(HDC hDC, const RECT& rcDEST, ResourceRepository& pResourc
     SelectObject(hDC, GetStockObject(DC_BRUSH));
 }
 
-void GDISurface::FillRectangle(int nX, int nY, int nWidth, int nHeight, Color nColor)
+void GDISurface::FillRectangle(int nX, int nY, int nWidth, int nHeight, Color nColor) noexcept
 {
     assert(nColor.Channel.A == 0xFF);
     SetDCBrushColor(m_hDC, RGB(nColor.Channel.R, nColor.Channel.G, nColor.Channel.B));

--- a/src/ui/drawing/gdi/GDISurface.hh
+++ b/src/ui/drawing/gdi/GDISurface.hh
@@ -24,10 +24,10 @@ public:
 
     ~GDISurface() noexcept = default;
 
-    size_t GetWidth() const override { return m_nWidth; }
-    size_t GetHeight() const override { return m_nHeight; }
+    size_t GetWidth() const noexcept override { return m_nWidth; }
+    size_t GetHeight() const noexcept override { return m_nHeight; }
 
-    void FillRectangle(int nX, int nY, int nWidth, int nHeight, Color nColor) override;
+    void FillRectangle(int nX, int nY, int nWidth, int nHeight, Color nColor) noexcept override;
 
     int LoadFont(const std::string& sFont, int nFontSize, FontStyles nStyle) override;
     ra::ui::Size MeasureText(int nFont, const std::wstring& sText) const override;
@@ -36,7 +36,7 @@ public:
     void DrawImage(int nX, int nY, int nWidth, int nHeight, const ImageReference& pImage) override;
     void DrawSurface(int nX, int nY, const ISurface& pSurface) override;
 
-    void SetOpacity(_UNUSED double) override { assert("This surface does not support opacity"); }
+    void SetOpacity(_UNUSED double) noexcept override { assert("This surface does not support opacity"); }
 
 protected:
     void SwitchFont(int nFont) const;

--- a/src/ui/drawing/gdi/ImageRepository.cpp
+++ b/src/ui/drawing/gdi/ImageRepository.cpp
@@ -343,7 +343,7 @@ HBITMAP ImageRepository::LoadLocalPNG(const std::wstring& sFilename, size_t nWid
     return hBitmap;
 }
 
-ImageRepository::HBitmapMap* ImageRepository::GetBitmapMap(ImageType nType)
+ImageRepository::HBitmapMap* ImageRepository::GetBitmapMap(ImageType nType) noexcept
 {
     switch (nType)
     {
@@ -423,7 +423,7 @@ HBITMAP ImageRepository::GetHBitmap(const ImageReference& pImage)
     return hBitmap;
 }
 
-void ImageRepository::AddReference(ImageReference& pImage) noexcept
+void ImageRepository::AddReference(ImageReference& pImage)
 {
     if (pImage.Name().empty())
         return;
@@ -462,13 +462,13 @@ void ImageRepository::ReleaseReference(ImageReference& pImage) noexcept
     pImage.SetData(0ULL);
 }
 
-bool ImageRepository::HasReferencedImageChanged(ImageReference& pImage) const noexcept
+bool ImageRepository::HasReferencedImageChanged(ImageReference& pImage) const
 {
     if (pImage.Type() == ra::ui::ImageType::None)
         return false;
 
     const auto hBitmapBefore = pImage.GetData();
-    GetHBitmap(pImage);
+    GetHBitmap(pImage); // TBD: Is the return value supposed to be discarded?
     return (pImage.GetData() != hBitmapBefore);
 }
 

--- a/src/ui/drawing/gdi/ImageRepository.hh
+++ b/src/ui/drawing/gdi/ImageRepository.hh
@@ -11,9 +11,21 @@ namespace gdi {
 
 class ImageRepository : public IImageRepository
 {
+    struct HBitmapReference
+    {
+        HBITMAP m_hBitmap{};
+        std::atomic<unsigned int> m_nReferences;
+    };
+
+    using HBitmapMap = std::unordered_map<std::string, HBitmapReference>;
 public:
-    ImageRepository() noexcept {};
-    [[gsl::suppress(f .6)]] ~ImageRepository() noexcept;
+    ImageRepository() noexcept(std::is_nothrow_default_constructible_v<HBitmapMap> &&
+                               std::is_nothrow_default_constructible_v<std::set<std::wstring>>) = default;
+    GSL_SUPPRESS(f.6) ~ImageRepository() noexcept;
+    ImageRepository(const ImageRepository&) = delete;
+    ImageRepository& operator=(const ImageRepository&) = delete;
+    ImageRepository(ImageRepository&&) = delete;
+    ImageRepository& operator=(ImageRepository&&) = delete;
 
     /// <summary>
     /// Initializes the repository.
@@ -28,7 +40,7 @@ public:
     void FetchImage(ImageType nType, const std::string& sName) override;
 
     void AddReference(ImageReference& pImage) override;
-    [[gsl::suppress(f .6)]] void ReleaseReference(ImageReference& pImage) noexcept override;
+    GSL_SUPPRESS(f.6) void ReleaseReference(ImageReference& pImage) noexcept override;
 
     bool HasReferencedImageChanged(ImageReference& pImage) const override;
 
@@ -39,13 +51,6 @@ private:
     HBITMAP GetImage(ImageType nType, const std::string& sName);
     HBITMAP GetDefaultImage(ImageType nType);
 
-    struct HBitmapReference
-    {
-        HBITMAP m_hBitmap{};
-        std::atomic<unsigned int> m_nReferences;
-    };
-
-    using HBitmapMap = std::unordered_map<std::string, HBitmapReference>;
     HBitmapMap m_mBadges;
     HBitmapMap m_mUserPics;
     HBitmapMap m_mLocal;

--- a/src/ui/drawing/gdi/ImageRepository.hh
+++ b/src/ui/drawing/gdi/ImageRepository.hh
@@ -12,14 +12,14 @@ namespace gdi {
 class ImageRepository : public IImageRepository
 {
 public:
-    ImageRepository() = default;
-    ~ImageRepository() noexcept;
+    ImageRepository() noexcept {};
+    [[gsl::suppress(f .6)]] ~ImageRepository() noexcept;
 
     /// <summary>
     /// Initializes the repository.
     /// </summary>
     bool Initialize();
-    
+
     /// <summary>
     /// Gets the <see cref="HBITMAP" /> from an <see cref="ImageReference" />.
     /// </summary>
@@ -27,10 +27,10 @@ public:
 
     void FetchImage(ImageType nType, const std::string& sName) override;
 
-    void AddReference(ImageReference& pImage) noexcept override;
-    void ReleaseReference(ImageReference& pImage) noexcept override;
+    void AddReference(ImageReference& pImage) override;
+    [[gsl::suppress(f .6)]] void ReleaseReference(ImageReference& pImage) noexcept override;
 
-    bool HasReferencedImageChanged(ImageReference& pImage) const noexcept override;
+    bool HasReferencedImageChanged(ImageReference& pImage) const override;
 
 private:
     static std::wstring GetFilename(ImageType nType, const std::string& sName);
@@ -51,7 +51,7 @@ private:
     HBitmapMap m_mLocal;
     HBitmapMap m_mIcons;
 
-    HBitmapMap* GetBitmapMap(ImageType nType);
+    HBitmapMap* GetBitmapMap(ImageType nType) noexcept;
 
     std::mutex m_oMutex;
     std::set<std::wstring> m_vRequestedImages;

--- a/src/ui/drawing/gdi/ResourceRepository.hh
+++ b/src/ui/drawing/gdi/ResourceRepository.hh
@@ -39,10 +39,10 @@ public:
         }
 
         using namespace ra::bitwise_ops;
-        auto nWeight = ((nStyle & FontStyles::Bold) == FontStyles::Bold) ? FW_BOLD : FW_NORMAL;
-        auto nItalic = ((nStyle & FontStyles::Italic) == FontStyles::Italic) ? TRUE : FALSE;
-        auto nUnderline = ((nStyle & FontStyles::Underline) == FontStyles::Underline) ? TRUE : FALSE;
-        auto nStrikeOut = ((nStyle & FontStyles::Strikethrough) == FontStyles::Strikethrough) ? TRUE : FALSE;
+        const auto nWeight = ((nStyle & FontStyles::Bold) == FontStyles::Bold) ? FW_BOLD : FW_NORMAL;
+        const auto nItalic = ((nStyle & FontStyles::Italic) == FontStyles::Italic) ? TRUE : FALSE;
+        const auto nUnderline = ((nStyle & FontStyles::Underline) == FontStyles::Underline) ? TRUE : FALSE;
+        const auto nStrikeOut = ((nStyle & FontStyles::Strikethrough) == FontStyles::Strikethrough) ? TRUE : FALSE;
 
         HFONT hFont = CreateFontA(nFontSize, 0, 0, 0, nWeight, nItalic, nUnderline, nStrikeOut,
             DEFAULT_CHARSET, OUT_DEFAULT_PRECIS, CLIP_CHARACTER_PRECIS, ANTIALIASED_QUALITY, DEFAULT_PITCH, sFont.c_str());

--- a/src/ui/viewmodels/GameChecksumViewModel.hh
+++ b/src/ui/viewmodels/GameChecksumViewModel.hh
@@ -11,7 +11,7 @@ namespace viewmodels {
 class GameChecksumViewModel : public WindowViewModelBase
 {
 public:
-    GameChecksumViewModel() noexcept;
+    [[gsl::suppress(f.6)]] GameChecksumViewModel() noexcept;
 
     /// <summary>
     /// The <see cref="ModelProperty" /> for the message.

--- a/src/ui/viewmodels/GameChecksumViewModel.hh
+++ b/src/ui/viewmodels/GameChecksumViewModel.hh
@@ -11,7 +11,7 @@ namespace viewmodels {
 class GameChecksumViewModel : public WindowViewModelBase
 {
 public:
-    [[gsl::suppress(f.6)]] GameChecksumViewModel() noexcept;
+    GSL_SUPPRESS(f.6) GameChecksumViewModel() noexcept;
 
     /// <summary>
     /// The <see cref="ModelProperty" /> for the message.

--- a/src/ui/viewmodels/RichPresenceMonitorViewModel.cpp
+++ b/src/ui/viewmodels/RichPresenceMonitorViewModel.cpp
@@ -24,7 +24,8 @@ static time_t GetRichPresenceModified()
 {
     const auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::GameContext>();
     auto& pLocalStorage = ra::services::ServiceLocator::GetMutable<ra::services::ILocalStorage>();
-    auto tLastModified = pLocalStorage.GetLastModified(ra::services::StorageItemType::RichPresence, std::to_wstring(pGameContext.GameId()));
+    const auto tLastModified = pLocalStorage.GetLastModified(ra::services::StorageItemType::RichPresence,
+                                                             std::to_wstring(pGameContext.GameId()));
     return std::chrono::system_clock::to_time_t(tLastModified);
 }
 
@@ -97,7 +98,7 @@ void RichPresenceMonitorViewModel::ScheduleUpdateDisplayString()
         else
         {
             // check to see if the script was updated
-            time_t tRichPresenceFileTime = GetRichPresenceModified();
+            const time_t tRichPresenceFileTime = GetRichPresenceModified();
             if (tRichPresenceFileTime != m_tRichPresenceFileTime)
             {
                 ra::services::ServiceLocator::GetMutable<ra::data::GameContext>().ReloadRichPresenceScript();

--- a/src/ui/viewmodels/RichPresenceMonitorViewModel.cpp
+++ b/src/ui/viewmodels/RichPresenceMonitorViewModel.cpp
@@ -57,7 +57,7 @@ void RichPresenceMonitorViewModel::StartMonitoring()
     }
 }
 
-void RichPresenceMonitorViewModel::StopMonitoring()
+void RichPresenceMonitorViewModel::StopMonitoring() noexcept
 {
     switch (m_nState)
     {

--- a/src/ui/viewmodels/RichPresenceMonitorViewModel.hh
+++ b/src/ui/viewmodels/RichPresenceMonitorViewModel.hh
@@ -11,7 +11,7 @@ namespace viewmodels {
 class RichPresenceMonitorViewModel : public WindowViewModelBase
 {
 public:
-    explicit RichPresenceMonitorViewModel() noexcept;
+    [[gsl::suppress(f.6)]] RichPresenceMonitorViewModel() noexcept;
 
     /// <summary>
     /// The <see cref="ModelProperty" /> for the message.
@@ -31,7 +31,7 @@ public:
     /// <summary>
     /// Stops periodically updating the display string.
     /// </summary>
-    void StopMonitoring();
+    void StopMonitoring() noexcept;
 
     /// <summary>
     /// Refreshes the display string.

--- a/src/ui/viewmodels/RichPresenceMonitorViewModel.hh
+++ b/src/ui/viewmodels/RichPresenceMonitorViewModel.hh
@@ -11,7 +11,7 @@ namespace viewmodels {
 class RichPresenceMonitorViewModel : public WindowViewModelBase
 {
 public:
-    [[gsl::suppress(f.6)]] RichPresenceMonitorViewModel() noexcept;
+    GSL_SUPPRESS(f.6) RichPresenceMonitorViewModel() noexcept;
 
     /// <summary>
     /// The <see cref="ModelProperty" /> for the message.

--- a/src/ui/win32/Desktop.cpp
+++ b/src/ui/win32/Desktop.cpp
@@ -14,9 +14,9 @@ namespace win32 {
 
 Desktop::Desktop() noexcept
 {
-    m_vDialogPresenters.emplace_back(new MessageBoxDialog::Presenter());
-    m_vDialogPresenters.emplace_back(new RichPresenceDialog::Presenter());
-    m_vDialogPresenters.emplace_back(new GameChecksumDialog::Presenter());
+    m_vDialogPresenters.emplace_back(new (std::nothrow) MessageBoxDialog::Presenter);
+    m_vDialogPresenters.emplace_back(new (std::nothrow) RichPresenceDialog::Presenter);
+    m_vDialogPresenters.emplace_back(new (std::nothrow) GameChecksumDialog::Presenter);
 }
 
 void Desktop::ShowWindow(WindowViewModelBase& vmViewModel) const
@@ -84,7 +84,7 @@ IDialogPresenter* Desktop::GetDialogPresenter(const WindowViewModelBase& oViewMo
     return nullptr;
 }
 
-void Desktop::Shutdown()
+void Desktop::Shutdown() noexcept
 {
 }
 

--- a/src/ui/win32/Desktop.hh
+++ b/src/ui/win32/Desktop.hh
@@ -11,14 +11,14 @@ namespace win32 {
 class Desktop : public IDesktop
 {
 public:
-    Desktop() noexcept;
+    [[gsl::suppress(f.6)]] Desktop() noexcept;
 
     void ShowWindow(WindowViewModelBase& oViewModel) const override;
     ra::ui::DialogResult ShowModal(WindowViewModelBase& oViewModel) const override;
 
     void GetWorkArea(ra::ui::Position& oUpperLeftCorner, ra::ui::Size& oSize) const override;
 
-    void Shutdown() override;
+    void Shutdown() noexcept override;
 
 private:
     _Success_(return != nullptr)

--- a/src/ui/win32/Desktop.hh
+++ b/src/ui/win32/Desktop.hh
@@ -11,7 +11,7 @@ namespace win32 {
 class Desktop : public IDesktop
 {
 public:
-    [[gsl::suppress(f.6)]] Desktop() noexcept;
+    GSL_SUPPRESS(f.6) Desktop() noexcept;
 
     void ShowWindow(WindowViewModelBase& oViewModel) const override;
     ra::ui::DialogResult ShowModal(WindowViewModelBase& oViewModel) const override;

--- a/src/ui/win32/DialogBase.cpp
+++ b/src/ui/win32/DialogBase.cpp
@@ -7,7 +7,7 @@ namespace ui {
 namespace win32 {
 
 _Use_decl_annotations_
-DialogBase::DialogBase(ra::ui::WindowViewModelBase& vmWindow) noexcept :
+DialogBase::DialogBase(ra::ui::WindowViewModelBase& vmWindow) :
     m_vmWindow{ vmWindow },
     m_bindWindow{ vmWindow }
 {
@@ -38,8 +38,8 @@ _NODISCARD static INT_PTR CALLBACK StaticDialogProc(HWND hDlg, UINT uMsg, WPARAM
     return result;
 }
 
-_Use_decl_annotations_
-HWND DialogBase::CreateDialogWindow(const LPCTSTR sResourceId, IDialogPresenter* const pDialogPresenter)
+_Use_decl_annotations_ HWND DialogBase::CreateDialogWindow(const TCHAR* restrict sResourceId,
+                                                           IDialogPresenter* const restrict pDialogPresenter)
 {
     m_hWnd = ::CreateDialog(g_hThisDLLInst, sResourceId, g_RAMainWnd, StaticDialogProc);
     if (m_hWnd)
@@ -78,8 +78,8 @@ static INT_PTR CALLBACK StaticModalDialogProc(HWND hDlg, UINT uMsg, WPARAM wPara
     return result;
 }
 
-_Use_decl_annotations_
-void DialogBase::CreateModalWindow(LPCTSTR sResourceId, IDialogPresenter* const pDialogPresenter)
+_Use_decl_annotations_ void DialogBase::CreateModalWindow(const TCHAR* restrict sResourceId,
+                                                          IDialogPresenter* const restrict pDialogPresenter) noexcept
 {
     m_pDialogPresenter = pDialogPresenter;
     m_bModal = true;

--- a/src/ui/win32/DialogBase.hh
+++ b/src/ui/win32/DialogBase.hh
@@ -67,12 +67,12 @@ protected:
     /// Called when the window is created, but before it is shown.
     /// </summary>
     /// <returns>Return <c>TRUE</c> if passing the keyboard focus to a default control, otherwise return <c>FALSE</c>.</returns>
-    [[gsl::suppress(f.6)]] virtual BOOL OnInitDialog() { return TRUE; } /*overrides might throw*/
+    virtual BOOL OnInitDialog() noexcept { return TRUE; }
 
     /// <summary>
     /// Called when the window is shown.
     /// </summary>
-    [[gsl::suppress(f.6)]] virtual void OnShown() {}
+    virtual void OnShown() noexcept {}
 
     /// <summary>
     /// Called when the window is destroyed.

--- a/src/ui/win32/DialogBase.hh
+++ b/src/ui/win32/DialogBase.hh
@@ -25,26 +25,27 @@ public:
     /// <param name="sResourceId">The resource identifier defining the dialog.</param>
     /// <param name="pDialogClosed">Callback to call when the dialog is closed.</param>
     /// <returns>Handle of the window.</returns>
-    _NODISCARD HWND CreateDialogWindow(_In_ const LPCTSTR sResourceId,
-        _In_ IDialogPresenter* const pDialogPresenter);
+    _NODISCARD HWND CreateDialogWindow(_In_ const TCHAR* restrict sResourceId,
+                                       _In_ IDialogPresenter* const restrict pDialogPresenter);
 
     /// <summary>
     /// Creates the dialog window and does not return until the window is closed.
     /// </summary>
     /// <param name="sResourceId">The resource identifier defining the dialog.</param>
     /// <param name="pDialogClosed">Callback to call when the dialog is closed.</param>
-    void CreateModalWindow(_In_ LPCTSTR sResourceId, _In_ IDialogPresenter* const pDialogPresenter);
+    void CreateModalWindow(_In_ const TCHAR* restrict sResourceId,
+                           _In_ IDialogPresenter* const restrict pDialogPresenter) noexcept;
 
     /// <summary>
     /// Gets the <see cref="HWND" /> for the dialog.
     /// </summary>
-    _NODISCARD HWND GetHWND() const { return m_hWnd; }
+    _NODISCARD HWND GetHWND() const noexcept { return m_hWnd; }
 
     /// <summary>
     /// Shows the dialog window.
     /// </summary>
     /// <returns><c>true</c> if the window was shown, <c>false</c> if CreateDialogWindow has not been called.</returns>
-    bool ShowDialogWindow() const
+    bool ShowDialogWindow() const noexcept
     {
         if (!m_hWnd)
             return false;
@@ -54,7 +55,7 @@ public:
     }
 
 protected:
-    explicit DialogBase(_Inout_ ra::ui::WindowViewModelBase& vmWindow) noexcept;
+    explicit DialogBase(_Inout_ ra::ui::WindowViewModelBase& vmWindow);
     ~DialogBase() noexcept;
 
     /// <summary>
@@ -66,12 +67,12 @@ protected:
     /// Called when the window is created, but before it is shown.
     /// </summary>
     /// <returns>Return <c>TRUE</c> if passing the keyboard focus to a default control, otherwise return <c>FALSE</c>.</returns>
-    virtual BOOL OnInitDialog() { return TRUE; }
+    [[gsl::suppress(f.6)]] virtual BOOL OnInitDialog() { return TRUE; } /*overrides might throw*/
 
     /// <summary>
     /// Called when the window is shown.
     /// </summary>
-    virtual void OnShown() {}
+    [[gsl::suppress(f.6)]] virtual void OnShown() {}
 
     /// <summary>
     /// Called when the window is destroyed.

--- a/src/ui/win32/GameChecksumDialog.cpp
+++ b/src/ui/win32/GameChecksumDialog.cpp
@@ -8,7 +8,7 @@ namespace ra {
 namespace ui {
 namespace win32 {
 
-bool GameChecksumDialog::Presenter::IsSupported(const ra::ui::WindowViewModelBase& vmViewModel)
+bool GameChecksumDialog::Presenter::IsSupported(const ra::ui::WindowViewModelBase& vmViewModel) noexcept
 {
     return (dynamic_cast<const ra::ui::viewmodels::GameChecksumViewModel*>(&vmViewModel) != nullptr);
 }
@@ -28,10 +28,11 @@ void GameChecksumDialog::Presenter::ShowWindow(ra::ui::WindowViewModelBase& oVie
 
 // ------------------------------------
 
-GameChecksumDialog::GameChecksumDialog(ra::ui::viewmodels::GameChecksumViewModel& vmRichPresenceDisplay) noexcept
+GameChecksumDialog::GameChecksumDialog(ra::ui::viewmodels::GameChecksumViewModel& vmRichPresenceDisplay)
     : DialogBase(vmRichPresenceDisplay)
 {
-    m_bindWindow.SetInitialPosition(ra::ui::win32::bindings::RelativePosition::Center, ra::ui::win32::bindings::RelativePosition::Center);
+    m_bindWindow.SetInitialPosition(ra::ui::win32::bindings::RelativePosition::Center,
+                                    ra::ui::win32::bindings::RelativePosition::Center);
     m_bindWindow.BindLabel(IDC_RA_ROMCHECKSUMTEXT, ra::ui::viewmodels::GameChecksumViewModel::ChecksumProperty);
 }
 

--- a/src/ui/win32/GameChecksumDialog.hh
+++ b/src/ui/win32/GameChecksumDialog.hh
@@ -15,7 +15,7 @@ namespace win32 {
 class GameChecksumDialog : public DialogBase
 {
 public:
-    explicit GameChecksumDialog(ra::ui::viewmodels::GameChecksumViewModel& vmGameChecksum) noexcept;
+    explicit GameChecksumDialog(ra::ui::viewmodels::GameChecksumViewModel& vmGameChecksum);
     virtual ~GameChecksumDialog() noexcept = default;
     GameChecksumDialog(const GameChecksumDialog&) noexcept = delete;
     GameChecksumDialog& operator=(const GameChecksumDialog&) noexcept = delete;
@@ -25,7 +25,7 @@ public:
     class Presenter : public IDialogPresenter
     {
     public:
-        bool IsSupported(const ra::ui::WindowViewModelBase& viewModel) override;
+        bool IsSupported(const ra::ui::WindowViewModelBase& viewModel) noexcept override;
         void ShowWindow(ra::ui::WindowViewModelBase& viewModel) override;
         void ShowModal(ra::ui::WindowViewModelBase& viewModel) override;
     };

--- a/src/ui/win32/MessageBoxDialog.cpp
+++ b/src/ui/win32/MessageBoxDialog.cpp
@@ -21,7 +21,7 @@ MessageBoxDialog::Presenter::Presenter() noexcept
         pTaskDialog = (fnTaskDialog)GetProcAddress(hDll, "TaskDialog");
 }
 
-bool MessageBoxDialog::Presenter::IsSupported(const ra::ui::WindowViewModelBase& oViewModel)
+bool MessageBoxDialog::Presenter::IsSupported(const ra::ui::WindowViewModelBase& oViewModel) noexcept
 {
     return (dynamic_cast<const ra::ui::viewmodels::MessageBoxViewModel*>(&oViewModel) != nullptr);
 }

--- a/src/ui/win32/MessageBoxDialog.hh
+++ b/src/ui/win32/MessageBoxDialog.hh
@@ -16,7 +16,7 @@ public:
     public:
         Presenter() noexcept;
 
-        bool IsSupported(const ra::ui::WindowViewModelBase& viewModel) override;
+        bool IsSupported(const ra::ui::WindowViewModelBase& viewModel) noexcept override;
         void ShowWindow(ra::ui::WindowViewModelBase& viewModel) override;
         void ShowModal(ra::ui::WindowViewModelBase& viewModel) override;
     };

--- a/src/ui/win32/RichPresenceDialog.cpp
+++ b/src/ui/win32/RichPresenceDialog.cpp
@@ -53,13 +53,13 @@ RichPresenceDialog::~RichPresenceDialog() noexcept
 }
 
 
-BOOL RichPresenceDialog::OnInitDialog()
+BOOL RichPresenceDialog::OnInitDialog() noexcept
 {
     SetWindowFont(::GetDlgItem(GetHWND(), IDC_RA_RICHPRESENCERESULTTEXT), m_hFont, FALSE);
     return DialogBase::OnInitDialog();
 }
 
-void RichPresenceDialog::OnShown()
+void RichPresenceDialog::OnShown() noexcept
 {
     auto& vmRichPresence = dynamic_cast<ra::ui::viewmodels::RichPresenceMonitorViewModel&>(m_vmWindow);
     vmRichPresence.StartMonitoring();

--- a/src/ui/win32/RichPresenceDialog.cpp
+++ b/src/ui/win32/RichPresenceDialog.cpp
@@ -8,7 +8,7 @@ namespace ra {
 namespace ui {
 namespace win32 {
 
-bool RichPresenceDialog::Presenter::IsSupported(const ra::ui::WindowViewModelBase& oViewModel)
+bool RichPresenceDialog::Presenter::IsSupported(const ra::ui::WindowViewModelBase& oViewModel) noexcept
 {
     return (dynamic_cast<const ra::ui::viewmodels::RichPresenceMonitorViewModel*>(&oViewModel) != nullptr);
 }
@@ -32,20 +32,19 @@ void RichPresenceDialog::Presenter::ShowWindow(ra::ui::WindowViewModelBase& vmVi
     m_pDialog->ShowDialogWindow();
 }
 
-void RichPresenceDialog::Presenter::OnClosed()
-{
-    m_pDialog.reset();
-}
+void RichPresenceDialog::Presenter::OnClosed() noexcept { m_pDialog.reset(); }
 
 // ------------------------------------
 _Use_decl_annotations_
-RichPresenceDialog::RichPresenceDialog(ra::ui::viewmodels::RichPresenceMonitorViewModel& vmRichPresenceDisplay) noexcept
+RichPresenceDialog::RichPresenceDialog(ra::ui::viewmodels::RichPresenceMonitorViewModel& vmRichPresenceDisplay)
     : DialogBase(vmRichPresenceDisplay)
 {
     m_hFont = CreateFont(15, 0, 0, 0, FW_NORMAL, FALSE, FALSE, FALSE, DEFAULT_CHARSET, OUT_DEFAULT_PRECIS, CLIP_DEFAULT_PRECIS, CLEARTYPE_QUALITY, VARIABLE_PITCH, nullptr);
 
-    m_bindWindow.SetInitialPosition(ra::ui::win32::bindings::RelativePosition::After, ra::ui::win32::bindings::RelativePosition::Far, "Rich Presence Monitor");
-    m_bindWindow.BindLabel(IDC_RA_RICHPRESENCERESULTTEXT, ra::ui::viewmodels::RichPresenceMonitorViewModel::DisplayStringProperty);
+    m_bindWindow.SetInitialPosition(ra::ui::win32::bindings::RelativePosition::After,
+                                    ra::ui::win32::bindings::RelativePosition::Far, "Rich Presence Monitor");
+    m_bindWindow.BindLabel(IDC_RA_RICHPRESENCERESULTTEXT,
+                           ra::ui::viewmodels::RichPresenceMonitorViewModel::DisplayStringProperty);
 }
 
 RichPresenceDialog::~RichPresenceDialog() noexcept

--- a/src/ui/win32/RichPresenceDialog.hh
+++ b/src/ui/win32/RichPresenceDialog.hh
@@ -32,8 +32,8 @@ public:
     };
 
 protected:
-    BOOL OnInitDialog() override;
-    void OnShown() override;
+    BOOL OnInitDialog() noexcept override;
+    void OnShown() noexcept override;
     void OnDestroy() override;
 
 private:

--- a/src/ui/win32/RichPresenceDialog.hh
+++ b/src/ui/win32/RichPresenceDialog.hh
@@ -12,7 +12,7 @@ namespace win32 {
 class RichPresenceDialog : public DialogBase
 {
 public:
-    explicit RichPresenceDialog(_Inout_ ra::ui::viewmodels::RichPresenceMonitorViewModel& vmRichPresenceDisplay) noexcept;
+    explicit RichPresenceDialog(_Inout_ ra::ui::viewmodels::RichPresenceMonitorViewModel& vmRichPresenceDisplay);
     virtual ~RichPresenceDialog() noexcept;
     RichPresenceDialog(const RichPresenceDialog&) noexcept = delete;
     RichPresenceDialog& operator=(const RichPresenceDialog&) noexcept = delete;
@@ -22,10 +22,10 @@ public:
     class Presenter : public IClosableDialogPresenter
     {
     public:
-        bool IsSupported(const ra::ui::WindowViewModelBase& viewModel) override;
+        bool IsSupported(const ra::ui::WindowViewModelBase& viewModel) noexcept override;
         void ShowWindow(ra::ui::WindowViewModelBase& viewModel) override;
         void ShowModal(ra::ui::WindowViewModelBase& viewModel) override;
-        void OnClosed() override;
+        void OnClosed() noexcept override;
 
     private:
         std::unique_ptr<RichPresenceDialog> m_pDialog;

--- a/src/ui/win32/RichPresenceDialog.hh
+++ b/src/ui/win32/RichPresenceDialog.hh
@@ -33,7 +33,7 @@ public:
 
 protected:
     BOOL OnInitDialog() noexcept override;
-    void OnShown() noexcept override;
+    GSL_SUPPRESS(f.6) void OnShown() noexcept override;
     void OnDestroy() override;
 
 private:

--- a/src/ui/win32/bindings/WindowBinding.cpp
+++ b/src/ui/win32/bindings/WindowBinding.cpp
@@ -204,7 +204,7 @@ void WindowBinding::OnPositionChanged(_UNUSED ra::ui::Position oPosition)
     }
 }
 
-void WindowBinding::OnViewModelStringValueChanged(const StringModelProperty::ChangeArgs& args)
+void WindowBinding::OnViewModelStringValueChanged(const StringModelProperty::ChangeArgs& args) noexcept
 {
     if (args.Property == WindowViewModelBase::WindowTitleProperty)
     {

--- a/src/ui/win32/bindings/WindowBinding.hh
+++ b/src/ui/win32/bindings/WindowBinding.hh
@@ -63,7 +63,7 @@ public:
     void OnPositionChanged(ra::ui::Position oPosition);
 
 protected:
-    void OnViewModelStringValueChanged(const StringModelProperty::ChangeArgs& args) noexcept override;
+    GSL_SUPPRESS(f.6) void OnViewModelStringValueChanged(const StringModelProperty::ChangeArgs& args) noexcept override;
 
     void RestoreSizeAndPosition();
 

--- a/src/ui/win32/bindings/WindowBinding.hh
+++ b/src/ui/win32/bindings/WindowBinding.hh
@@ -23,7 +23,7 @@ enum class RelativePosition
 class WindowBinding : protected BindingBase
 {
 public:
-    explicit WindowBinding(WindowViewModelBase& vmWindowViewModel) noexcept
+    explicit WindowBinding(WindowViewModelBase& vmWindowViewModel)
         : BindingBase(vmWindowViewModel)
     {
     }

--- a/src/ui/win32/bindings/WindowBinding.hh
+++ b/src/ui/win32/bindings/WindowBinding.hh
@@ -63,7 +63,7 @@ public:
     void OnPositionChanged(ra::ui::Position oPosition);
 
 protected:
-    void OnViewModelStringValueChanged(const StringModelProperty::ChangeArgs& args) override;
+    void OnViewModelStringValueChanged(const StringModelProperty::ChangeArgs& args) noexcept override;
 
     void RestoreSizeAndPosition();
 

--- a/tests/Exports_Tests.cpp
+++ b/tests/Exports_Tests.cpp
@@ -108,12 +108,12 @@ public:
             return ra::ui::DialogResult::OK;
         });
 
-        mockServer.HandleRequest<api::Login>([](_UNUSED const ra::api::Login::Request& request, ra::api::Login::Response& response)
-        {
-            response.ErrorMessage = "Invalid user/password combination. Please try again.";
-            response.Result = ra::api::ApiResult::Error;
-            return true;
-        });
+        mockServer.HandleRequest<api::Login>(
+            [](_UNUSED const ra::api::Login::Request&/*request*/, ra::api::Login::Response& response) {
+                response.ErrorMessage = "Invalid user/password combination. Please try again.";
+                response.Result = ra::api::ApiResult::Error;
+                return true;
+            });
 
         mockConfiguration.SetUsername("User");
         mockConfiguration.SetApiToken("ApiToken");

--- a/tests/RA_Integration.Tests.vcxproj
+++ b/tests/RA_Integration.Tests.vcxproj
@@ -20,7 +20,7 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>RA_IntegrationTests</RootNamespace>
     <ProjectSubType>NativeUnitTestProject</ProjectSubType>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/tests/RA_Integration.Tests.vcxproj
+++ b/tests/RA_Integration.Tests.vcxproj
@@ -72,7 +72,7 @@
     <LinkIncremental>true</LinkIncremental>
     <OutDir>$(SolutionDir)bin\$(Configuration)\tests\</OutDir>
     <IntDir>$(SolutionDir)obj\$(Configuration)\tests\</IntDir>
-    <CodeAnalysisRuleSet>CppCoreCheckFuncRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>..\src\ra_rules.ruleset</CodeAnalysisRuleSet>
     <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">

--- a/tests/RA_Integration.Tests.vcxproj
+++ b/tests/RA_Integration.Tests.vcxproj
@@ -180,111 +180,11 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\lua\lapi.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="">
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">4115;4244;4702</DisableSpecificWarnings>
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Analysis|Win32'">4115;4244;4702</DisableSpecificWarnings>
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">4115;4244;4702</DisableSpecificWarnings>
-    </ClCompile>
-    <ClCompile Include="..\lua\lauxlib.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="">
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">4244</DisableSpecificWarnings>
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Analysis|Win32'">4244</DisableSpecificWarnings>
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">4244</DisableSpecificWarnings>
-    </ClCompile>
-    <ClCompile Include="..\lua\lcode.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="">
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">4201;4244</DisableSpecificWarnings>
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">4201;4244</DisableSpecificWarnings>
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Analysis|Win32'">4201;4244</DisableSpecificWarnings>
-    </ClCompile>
-    <ClCompile Include="..\lua\lctype.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" />
-    <ClCompile Include="..\lua\ldebug.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="">
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">4201;4244</DisableSpecificWarnings>
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">4201;4244</DisableSpecificWarnings>
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Analysis|Win32'">4201;4244</DisableSpecificWarnings>
-    </ClCompile>
-    <ClCompile Include="..\lua\ldo.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="">
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">4201;4244</DisableSpecificWarnings>
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">4201;4244</DisableSpecificWarnings>
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Analysis|Win32'">4201;4244</DisableSpecificWarnings>
-    </ClCompile>
-    <ClCompile Include="..\lua\ldump.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" />
-    <ClCompile Include="..\lua\lfunc.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" />
-    <ClCompile Include="..\lua\lgc.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="">
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">4201;4244</DisableSpecificWarnings>
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Analysis|Win32'">4201;4244</DisableSpecificWarnings>
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">4201;4244</DisableSpecificWarnings>
-    </ClCompile>
-    <ClCompile Include="..\lua\llex.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="">
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">4201;4310</DisableSpecificWarnings>
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">4201;4310</DisableSpecificWarnings>
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Analysis|Win32'">4201;4310</DisableSpecificWarnings>
-    </ClCompile>
-    <ClCompile Include="..\lua\lmem.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" />
-    <ClCompile Include="..\lua\lobject.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" />
-    <ClCompile Include="..\lua\lopcodes.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" />
-    <ClCompile Include="..\lua\lparser.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="">
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">4201;4224;4244</DisableSpecificWarnings>
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Analysis|Win32'">4201;4224;4244</DisableSpecificWarnings>
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">4201;4224;4244</DisableSpecificWarnings>
-    </ClCompile>
-    <ClCompile Include="..\lua\lstate.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" />
-    <ClCompile Include="..\lua\lstring.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="">
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">4201;4244;4310</DisableSpecificWarnings>
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">4201;4244;4310</DisableSpecificWarnings>
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Analysis|Win32'">4201;4244;4310</DisableSpecificWarnings>
-    </ClCompile>
-    <ClCompile Include="..\lua\ltable.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" />
-    <ClCompile Include="..\lua\ltm.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" />
-    <ClCompile Include="..\lua\lundump.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" />
-    <ClCompile Include="..\lua\lvm.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="">
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">4201;4310</DisableSpecificWarnings>
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Analysis|Win32'">4201;4310</DisableSpecificWarnings>
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">4201;4310</DisableSpecificWarnings>
-    </ClCompile>
-    <ClCompile Include="..\lua\lzio.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" />
-    <ClCompile Include="..\rcheevos\src\rcheevos\alloc.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" />
-    <ClCompile Include="..\rcheevos\src\rcheevos\condition.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="">
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">4201;4115</DisableSpecificWarnings>
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">4201;4115</DisableSpecificWarnings>
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Analysis|Win32'">4201;4115</DisableSpecificWarnings>
-    </ClCompile>
-    <ClCompile Include="..\rcheevos\src\rcheevos\condset.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="">
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">4115;4201;4244</DisableSpecificWarnings>
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">4115;4201;4244</DisableSpecificWarnings>
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Analysis|Win32'">4115;4201;4244</DisableSpecificWarnings>
-    </ClCompile>
-    <ClCompile Include="..\rcheevos\src\rcheevos\expression.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="">
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">4115;4201</DisableSpecificWarnings>
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">4115;4201</DisableSpecificWarnings>
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Analysis|Win32'">4115;4201</DisableSpecificWarnings>
-    </ClCompile>
-    <ClCompile Include="..\rcheevos\src\rcheevos\format.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" />
-    <ClCompile Include="..\rcheevos\src\rcheevos\lboard.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="">
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">4115;4201</DisableSpecificWarnings>
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Analysis|Win32'">4115;4201</DisableSpecificWarnings>
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">4115;4201</DisableSpecificWarnings>
-    </ClCompile>
-    <ClCompile Include="..\rcheevos\src\rcheevos\operand.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" />
-    <ClCompile Include="..\rcheevos\src\rcheevos\term.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="">
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">4115;4201</DisableSpecificWarnings>
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Analysis|Win32'">4115;4201</DisableSpecificWarnings>
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">4115;4201</DisableSpecificWarnings>
-    </ClCompile>
     <ClCompile Include="..\src\api\ApiCall.cpp" />
     <ClCompile Include="..\src\api\impl\ConnectedServer.cpp" />
     <ClCompile Include="..\src\api\impl\DisconnectedServer.cpp" />
     <ClCompile Include="..\src\api\impl\OfflineServer.cpp" />
     <ClCompile Include="..\src\data\SessionTracker.cpp" />
-    <ClCompile Include="..\rcheevos\src\rcheevos\trigger.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="">
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">4115;4201</DisableSpecificWarnings>
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Analysis|Win32'">4115;4201</DisableSpecificWarnings>
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">4115;4201</DisableSpecificWarnings>
-    </ClCompile>
-    <ClCompile Include="..\rcheevos\src\rcheevos\value.c" CompileAs="CompileAsC" PrecompiledHeader="NotUsing" ForcedIncludeFiles="">
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">4115;4201</DisableSpecificWarnings>
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Analysis|Win32'">4115;4201</DisableSpecificWarnings>
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">4115;4201</DisableSpecificWarnings>
-    </ClCompile>
-    <ClCompile Include="..\src\md5.c" PrecompiledHeader="NotUsing" ForcedIncludeFiles="" />
     <ClCompile Include="..\src\data\GameContext.cpp" />
     <ClCompile Include="..\src\pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
@@ -305,7 +205,6 @@
     <ClCompile Include="api\DisconnectedServer_Tests.cpp" />
     <ClCompile Include="data\SessionTracker_Tests.cpp" />
     <ClCompile Include="RA_RichPresence_Tests.cpp" />
-    <ClInclude Include="..\rcheevos\src\rcheevos\internal.h" />
     <ClInclude Include="..\src\RA_Achievement.h" />
     <ClInclude Include="..\src\RA_Defs.h" />
     <ClInclude Include="..\src\RA_Leaderboard.h" />
@@ -355,6 +254,11 @@
     <None Include="base.props">
       <SubType>Designer</SubType>
     </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\rcheevos.vcxproj">
+      <Project>{9d55ebe7-1392-4fa1-a9b9-f022f764ce35}</Project>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/tests/RA_Integration.Tests.vcxproj
+++ b/tests/RA_Integration.Tests.vcxproj
@@ -20,7 +20,7 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>RA_IntegrationTests</RootNamespace>
     <ProjectSubType>NativeUnitTestProject</ProjectSubType>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -72,7 +72,7 @@
     <LinkIncremental>true</LinkIncremental>
     <OutDir>$(SolutionDir)bin\$(Configuration)\tests\</OutDir>
     <IntDir>$(SolutionDir)obj\$(Configuration)\tests\</IntDir>
-    <CodeAnalysisRuleSet>..\src\ra_rules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>CppCoreCheckFuncRules.ruleset</CodeAnalysisRuleSet>
     <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -112,6 +112,7 @@
       <SubSystem>Windows</SubSystem>
       <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
+      <IgnoreSpecificDefaultLibraries>libc.lib, libcmt.lib, libcd.lib, libcmtd.lib, msvcrtd.lib</IgnoreSpecificDefaultLibraries>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">

--- a/tests/RA_Integration.Tests.vcxproj.filters
+++ b/tests/RA_Integration.Tests.vcxproj.filters
@@ -7,12 +7,6 @@
     <Filter Include="Code">
       <UniqueIdentifier>{c09a9464-e27a-4721-8467-626c7f5e3ab0}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Code\rcheevos">
-      <UniqueIdentifier>{633c15ff-4743-416b-9e0b-fa7493d6d969}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Code\lua">
-      <UniqueIdentifier>{ca929deb-dbc0-4ae3-8307-9806dbf4b05f}</UniqueIdentifier>
-    </Filter>
     <Filter Include="Tests\UI">
       <UniqueIdentifier>{4f043333-855f-48b9-b8c2-08e3c5f0d576}</UniqueIdentifier>
     </Filter>
@@ -54,9 +48,6 @@
     <ClCompile Include="..\src\services\SearchResults.cpp">
       <Filter>Code</Filter>
     </ClCompile>
-    <ClCompile Include="..\rcheevos\src\rcheevos\alloc.c">
-      <Filter>Code\rcheevos</Filter>
-    </ClCompile>
     <ClCompile Include="RA_RichPresence_Tests.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
@@ -64,9 +55,6 @@
       <Filter>Code</Filter>
     </ClCompile>
     <ClCompile Include="..\src\RA_Achievement.cpp">
-      <Filter>Code</Filter>
-    </ClCompile>
-    <ClCompile Include="..\src\md5.c">
       <Filter>Code</Filter>
     </ClCompile>
     <ClCompile Include="..\src\RA_md5factory.cpp">
@@ -182,101 +170,11 @@
     <ClCompile Include="RA_Condition_Tests.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
-    <ClCompile Include="..\rcheevos\src\rcheevos\condition.c">
-      <Filter>Code\rcheevos</Filter>
-    </ClCompile>
-    <ClCompile Include="..\rcheevos\src\rcheevos\condset.c">
-      <Filter>Code\rcheevos</Filter>
-    </ClCompile>
-    <ClCompile Include="..\rcheevos\src\rcheevos\expression.c">
-      <Filter>Code\rcheevos</Filter>
-    </ClCompile>
-    <ClCompile Include="..\rcheevos\src\rcheevos\format.c">
-      <Filter>Code\rcheevos</Filter>
-    </ClCompile>
-    <ClCompile Include="..\rcheevos\src\rcheevos\lboard.c">
-      <Filter>Code\rcheevos</Filter>
-    </ClCompile>
-    <ClCompile Include="..\rcheevos\src\rcheevos\operand.c">
-      <Filter>Code\rcheevos</Filter>
-    </ClCompile>
-    <ClCompile Include="..\rcheevos\src\rcheevos\term.c">
-      <Filter>Code\rcheevos</Filter>
-    </ClCompile>
-    <ClCompile Include="..\rcheevos\src\rcheevos\trigger.c">
-      <Filter>Code\rcheevos</Filter>
-    </ClCompile>
-    <ClCompile Include="..\rcheevos\src\rcheevos\value.c">
-      <Filter>Code\rcheevos</Filter>
-    </ClCompile>
     <ClCompile Include="..\src\RA_Achievement.cpp">
       <Filter>Code</Filter>
     </ClCompile>
     <ClCompile Include="RA_Condition_Tests.cpp">
       <Filter>Tests</Filter>
-    </ClCompile>
-    <ClCompile Include="..\lua\lapi.c">
-      <Filter>Code\lua</Filter>
-    </ClCompile>
-    <ClCompile Include="..\lua\lcode.c">
-      <Filter>Code\lua</Filter>
-    </ClCompile>
-    <ClCompile Include="..\lua\lctype.c">
-      <Filter>Code\lua</Filter>
-    </ClCompile>
-    <ClCompile Include="..\lua\ldebug.c">
-      <Filter>Code\lua</Filter>
-    </ClCompile>
-    <ClCompile Include="..\lua\ldo.c">
-      <Filter>Code\lua</Filter>
-    </ClCompile>
-    <ClCompile Include="..\lua\ldump.c">
-      <Filter>Code\lua</Filter>
-    </ClCompile>
-    <ClCompile Include="..\lua\lfunc.c">
-      <Filter>Code\lua</Filter>
-    </ClCompile>
-    <ClCompile Include="..\lua\lgc.c">
-      <Filter>Code\lua</Filter>
-    </ClCompile>
-    <ClCompile Include="..\lua\llex.c">
-      <Filter>Code\lua</Filter>
-    </ClCompile>
-    <ClCompile Include="..\lua\lmem.c">
-      <Filter>Code\lua</Filter>
-    </ClCompile>
-    <ClCompile Include="..\lua\lobject.c">
-      <Filter>Code\lua</Filter>
-    </ClCompile>
-    <ClCompile Include="..\lua\lopcodes.c">
-      <Filter>Code\lua</Filter>
-    </ClCompile>
-    <ClCompile Include="..\lua\lparser.c">
-      <Filter>Code\lua</Filter>
-    </ClCompile>
-    <ClCompile Include="..\lua\lstate.c">
-      <Filter>Code\lua</Filter>
-    </ClCompile>
-    <ClCompile Include="..\lua\lstring.c">
-      <Filter>Code\lua</Filter>
-    </ClCompile>
-    <ClCompile Include="..\lua\ltable.c">
-      <Filter>Code\lua</Filter>
-    </ClCompile>
-    <ClCompile Include="..\lua\ltm.c">
-      <Filter>Code\lua</Filter>
-    </ClCompile>
-    <ClCompile Include="..\lua\lundump.c">
-      <Filter>Code\lua</Filter>
-    </ClCompile>
-    <ClCompile Include="..\lua\lvm.c">
-      <Filter>Code\lua</Filter>
-    </ClCompile>
-    <ClCompile Include="..\lua\lzio.c">
-      <Filter>Code\lua</Filter>
-    </ClCompile>
-    <ClCompile Include="..\lua\lauxlib.c">
-      <Filter>Code\lua</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -312,9 +210,6 @@
     <ClCompile Include="..\src\services\Http.cpp">
       <Filter>Code</Filter>
     </ClCompile>
-    <ClInclude Include="..\rcheevos\src\rcheevos\internal.h">
-      <Filter>Code\rcheevos</Filter>
-    </ClInclude>
     <ClInclude Include="mocks\MockHttpRequester.hh">
       <Filter>Tests\Mocks</Filter>
     </ClInclude>

--- a/tests/RA_Leaderboard_Tests.cpp
+++ b/tests/RA_Leaderboard_Tests.cpp
@@ -10,14 +10,14 @@ namespace tests {
 class LeaderboardHarness : public RA_Leaderboard
 {
 public:
-    LeaderboardHarness() : RA_Leaderboard(1) {}
+    LeaderboardHarness() noexcept : RA_Leaderboard(1) {}
 
-    bool IsActive() const { return m_bActive; }
-    bool IsScoreSubmitted() const { return m_bScoreSubmitted; }
-    unsigned int SubmittedScore() const { return m_nSubmittedScore; }
+    bool IsActive() const noexcept { return m_bActive; }
+    bool IsScoreSubmitted() const noexcept { return m_bScoreSubmitted; }
+    unsigned int SubmittedScore() const noexcept { return m_nSubmittedScore; }
 
 public:
-    void Reset() override
+    void Reset() noexcept override
     {
         RA_Leaderboard::Reset();
 
@@ -26,17 +26,17 @@ public:
         m_nSubmittedScore = 0;
     }
 
-    void Start() override
+    void Start() noexcept override
     {
         m_bActive = true;
     }
 
-    void Cancel() override
+    void Cancel() noexcept override
     {
         m_bActive = false;
     }
 
-    void Submit(unsigned int nScore) override
+    void Submit(unsigned int nScore) noexcept override
     {
         m_bActive = false;
         m_bScoreSubmitted = true;

--- a/tests/RA_StringUtils_Tests.cpp
+++ b/tests/RA_StringUtils_Tests.cpp
@@ -4,7 +4,8 @@ using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
 namespace ra {
 
-_NODISCARD static std::string TrimLineEnding(std::string&& str) noexcept
+[[gsl::suppress(f.6), nodiscard]]
+static std::string TrimLineEnding(std::string&& str) noexcept
 {
     auto sRet{ std::move_if_noexcept(str) };
     return TrimLineEnding(sRet);

--- a/tests/RA_UnitTestHelpers.cpp
+++ b/tests/RA_UnitTestHelpers.cpp
@@ -7,15 +7,15 @@ using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 static unsigned char* g_pMemoryBuffer;
 static size_t g_nMemorySize;
 
-static unsigned char ReadMemory(unsigned int nAddress)
+static constexpr unsigned char ReadMemory(unsigned int nAddress) noexcept
 {
     if (nAddress <= g_nMemorySize)
         return g_pMemoryBuffer[nAddress];
 
-    return '\0';
+    return unsigned char();
 }
 
-static void SetMemory(unsigned int nAddress, unsigned int nValue)
+static constexpr void SetMemory(unsigned int nAddress, unsigned int nValue) noexcept
 {
     if (nAddress <= g_nMemorySize)
         g_pMemoryBuffer[nAddress] = static_cast<unsigned char>(nValue);

--- a/tests/api/ConnectedServer_Tests.cpp
+++ b/tests/api/ConnectedServer_Tests.cpp
@@ -86,7 +86,7 @@ public:
         auto response = server.Login(request);
 
         Assert::AreEqual(ApiResult::Error, response.Result);
-        Assert::AreEqual(std::string("HTTP error code 404"), response.ErrorMessage);
+        Assert::AreEqual(std::string("HTTP error code: 404"), response.ErrorMessage);
         Assert::AreEqual(std::string(""), response.Username);
         Assert::AreEqual(std::string(""), response.ApiToken);
         Assert::AreEqual(0U, response.Score);

--- a/tests/base.props
+++ b/tests/base.props
@@ -9,6 +9,7 @@
     <Lua_Dir>$(RA_DIR)lua\</Lua_Dir>
     <MSTest_IncludePath>$(VCInstallDir)UnitTest\include\</MSTest_IncludePath>
     <RA_IncludePath>$(RA_DIR);$(RA_SourceDir);$(RapidJSON_IncludeDir);$(rcheevos_IncludePath);$(Lua_Dir);$(MSTest_IncludePath)</RA_IncludePath>
+    <XPDeprecationWarning>false</XPDeprecationWarning>
   </PropertyGroup>
   <PropertyGroup>
     <OutDir>$(SolutionDir)bin\$(Configuration)\</OutDir>
@@ -64,6 +65,10 @@
     </BuildMacro>
     <BuildMacro Include="Lua_Dir">
       <Value>$(Lua_Dir)</Value>
+      <EnvironmentVariable>true</EnvironmentVariable>
+    </BuildMacro>
+    <BuildMacro Include="XPDeprecationWarning">
+      <Value>$(XPDeprecationWarning)</Value>
       <EnvironmentVariable>true</EnvironmentVariable>
     </BuildMacro>
   </ItemGroup>

--- a/tests/base.props
+++ b/tests/base.props
@@ -2,13 +2,14 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros">
+    <MSTest_IncludePath>$(VCInstallDir)UnitTest\include\</MSTest_IncludePath>
     <RA_DIR>$(SolutionDir)</RA_DIR>
     <RapidJSON_IncludeDir>$(RA_DIR)rapidjson\include\</RapidJSON_IncludeDir>
-    <RA_SourceDir>$(RA_DIR)src\</RA_SourceDir>
     <rcheevos_IncludePath>$(RA_DIR)rcheevos\include\</rcheevos_IncludePath>
+    <RA_SourceDir>$(RA_DIR)src\</RA_SourceDir>
+    <GSL_IncludeDir>$(RA_DIR)GSL\include\</GSL_IncludeDir>
     <Lua_Dir>$(RA_DIR)lua\</Lua_Dir>
-    <MSTest_IncludePath>$(VCInstallDir)UnitTest\include\</MSTest_IncludePath>
-    <RA_IncludePath>$(RA_DIR);$(RA_SourceDir);$(RapidJSON_IncludeDir);$(rcheevos_IncludePath);$(Lua_Dir);$(MSTest_IncludePath)</RA_IncludePath>
+    <RA_IncludePath>$(RA_DIR);$(RA_SourceDir);$(RapidJSON_IncludeDir);$(rcheevos_IncludePath);$(Lua_Dir);$(MSTest_IncludePath);$(GSL_IncludeDir)</RA_IncludePath>
     <XPDeprecationWarning>false</XPDeprecationWarning>
   </PropertyGroup>
   <PropertyGroup>
@@ -59,12 +60,16 @@
       <Value>$(RA_SourceDir)</Value>
       <EnvironmentVariable>true</EnvironmentVariable>
     </BuildMacro>
-    <BuildMacro Include="RA_IncludePath">
-      <Value>$(RA_IncludePath)</Value>
+    <BuildMacro Include="GSL_IncludeDir">
+      <Value>$(GSL_IncludeDir)</Value>
       <EnvironmentVariable>true</EnvironmentVariable>
     </BuildMacro>
     <BuildMacro Include="Lua_Dir">
       <Value>$(Lua_Dir)</Value>
+      <EnvironmentVariable>true</EnvironmentVariable>
+    </BuildMacro>
+    <BuildMacro Include="RA_IncludePath">
+      <Value>$(RA_IncludePath)</Value>
       <EnvironmentVariable>true</EnvironmentVariable>
     </BuildMacro>
     <BuildMacro Include="XPDeprecationWarning">

--- a/tests/data/SessionTracker_Tests.cpp
+++ b/tests/data/SessionTracker_Tests.cpp
@@ -25,7 +25,7 @@ public:
     class SessionTrackerHarness : public SessionTracker
     {
     public:
-        [[gsl::suppress(f.6)]] SessionTrackerHarness(const char* sUsername = "User") noexcept
+        GSL_SUPPRESS(f.6) SessionTrackerHarness(const char* sUsername = "User") noexcept
             : m_sUsername(sUsername), m_sUsernameWide(ra::Widen(sUsername))
         {
         }

--- a/tests/data/SessionTracker_Tests.cpp
+++ b/tests/data/SessionTracker_Tests.cpp
@@ -25,7 +25,7 @@ public:
     class SessionTrackerHarness : public SessionTracker
     {
     public:
-        SessionTrackerHarness(const char* sUsername = "User") noexcept
+        [[gsl::suppress(f.6)]] SessionTrackerHarness(const char* sUsername = "User") noexcept
             : m_sUsername(sUsername), m_sUsernameWide(ra::Widen(sUsername))
         {
         }
@@ -52,7 +52,7 @@ public:
             mockStorage.MockStoredData(StorageItemType::SessionStats, m_sUsernameWide, sContents);
         }
 
-        void MockInspectingMemory(bool bInspectingMemory)
+        void MockInspectingMemory(bool bInspectingMemory) noexcept 
         {
             m_bInspectingMemory = bInspectingMemory;
         }
@@ -63,7 +63,7 @@ public:
         }
 
     protected:
-        bool IsInspectingMemory() const override { return m_bInspectingMemory; }
+        bool IsInspectingMemory() const noexcept override { return m_bInspectingMemory; }
 
     private:
         bool m_bInspectingMemory{ false };

--- a/tests/mocks/MockClock.hh
+++ b/tests/mocks/MockClock.hh
@@ -12,28 +12,21 @@ namespace mocks {
 class MockClock : public IClock
 {
 public:
-    MockClock() noexcept
-        : m_Override(this)
+    MockClock() noexcept : m_Override(this)
     {
         // force GMT timezone for unit tests
         _putenv("TZ=GMT");
         _tzset();
 
-        m_tNow = std::chrono::system_clock::from_time_t(1534889323); // 16:08:43 08/21/18
+        m_tNow    = std::chrono::system_clock::from_time_t(1534889323); // 16:08:43 08/21/18
         m_tUpTime = std::chrono::steady_clock::time_point();
     }
 
-    std::chrono::system_clock::time_point Now() const override
-    {
-        return m_tNow;
-    }
+    std::chrono::system_clock::time_point Now() const noexcept override { return m_tNow; }
 
-    std::chrono::steady_clock::time_point UpTime() const override
-    {
-        return m_tUpTime;
-    }
+    std::chrono::steady_clock::time_point UpTime() const noexcept override { return m_tUpTime; }
 
-    void AdvanceTime(std::chrono::milliseconds nDuration)
+    void AdvanceTime(std::chrono::milliseconds nDuration) noexcept
     {
         m_tNow += nDuration;
         m_tUpTime += nDuration;

--- a/tests/mocks/MockConfiguration.hh
+++ b/tests/mocks/MockConfiguration.hh
@@ -17,10 +17,10 @@ public:
     {
     }
 
-    const std::string& GetUsername() const override { return m_sUsername; }
+    const std::string& GetUsername() const noexcept override { return m_sUsername; }
     void SetUsername(const std::string& sValue) override { m_sUsername = sValue; }
 
-    const std::string& GetApiToken() const override { return m_sApiToken; }
+    const std::string& GetApiToken() const noexcept override { return m_sApiToken; }
     void SetApiToken(const std::string& sValue) override { m_sApiToken = sValue; }
 
     bool IsFeatureEnabled(Feature nFeature) const override
@@ -36,9 +36,9 @@ public:
             m_vEnabledFeatures.erase(nFeature);
     }
 
-    unsigned int GetNumBackgroundThreads() const override { return m_nBackgroundThreads; }
+    unsigned int GetNumBackgroundThreads() const noexcept override { return m_nBackgroundThreads; }
 
-    const std::string& GetRomDirectory() const override { return m_sRomDirectory; }
+    const std::string& GetRomDirectory() const noexcept override { return m_sRomDirectory; }
     void SetRomDirectory(const std::string& sValue) override { m_sRomDirectory = sValue; }
 
     ra::ui::Position GetWindowPosition([[maybe_unused]] const std::string& /*sPositionKey*/) const override
@@ -47,26 +47,28 @@ public:
         return ra::ui::Position();
     }
 
-    void SetWindowPosition([[maybe_unused]] const std::string& /*sPositionKey*/, [[maybe_unused]] const ra::ui::Position& /*oPosition*/) override
+    void SetWindowPosition([[maybe_unused]] const std::string& /*sPositionKey*/,
+                           [[maybe_unused]] const ra::ui::Position& /*oPosition*/) noexcept override
     {
         assert(!"Not implemented");
     }
 
-    ra::ui::Size GetWindowSize([[maybe_unused]] const std::string& /*sPositionKey*/) const override
+    ra::ui::Size GetWindowSize([[maybe_unused]] const std::string& /*sPositionKey*/) const noexcept override
     {
         assert(!"Not implemented");
         return ra::ui::Size();
     }
 
-    void SetWindowSize([[maybe_unused]] const std::string& /*sPositionKey*/, [[maybe_unused]] const ra::ui::Size& /*oSize*/) override
+    void SetWindowSize([[maybe_unused]] const std::string& /*sPositionKey*/,
+                       [[maybe_unused]] const ra::ui::Size& /*oSize*/) noexcept override
     {
         assert(!"Not implemented");
     }
 
-    const std::string& GetHostName() const override { return m_sHostName; }
+    const std::string& GetHostName() const noexcept override { return m_sHostName; }
     void SetHostName(const std::string& sHostName) { m_sHostName = sHostName; }
 
-    void Save() const override
+    void Save() const noexcept override
     {
         assert(!"Not implemented");
     }

--- a/tests/mocks/MockDesktop.hh
+++ b/tests/mocks/MockDesktop.hh
@@ -32,15 +32,15 @@ public:
         return Handle(vmViewModel);
     }
 
-    bool WasDialogShown() { return m_bDialogShown; }
+    bool WasDialogShown() noexcept { return m_bDialogShown; }
 
-    void GetWorkArea(ra::ui::Position& oUpperLeftCorner, ra::ui::Size& oSize) const override
+    void GetWorkArea(ra::ui::Position& oUpperLeftCorner, ra::ui::Size& oSize) const noexcept override
     {
         oUpperLeftCorner = { 0, 0 };
         oSize = { 1920, 1080 };
     }
 
-    void Shutdown() override {}
+    void Shutdown() noexcept override {}
 
     template<typename T>
     void ExpectWindow(std::function<ra::ui::DialogResult(T&)>&& fnHandler)

--- a/tests/mocks/MockFileSystem.hh
+++ b/tests/mocks/MockFileSystem.hh
@@ -14,7 +14,7 @@ namespace mocks {
 class MockFileSystem : public IFileSystem
 {
 public:
-    [[gsl::suppress(f.6)]] MockFileSystem() noexcept 
+    GSL_SUPPRESS(f.6) MockFileSystem() noexcept 
         : m_Override(this)
     {
     }

--- a/tests/mocks/MockFileSystem.hh
+++ b/tests/mocks/MockFileSystem.hh
@@ -14,12 +14,12 @@ namespace mocks {
 class MockFileSystem : public IFileSystem
 {
 public:
-    MockFileSystem() noexcept 
+    [[gsl::suppress(f.6)]] MockFileSystem() noexcept 
         : m_Override(this)
     {
     }
 
-    const std::wstring& BaseDirectory() const override { return m_sBaseDirectory; }
+    const std::wstring& BaseDirectory() const noexcept override { return m_sBaseDirectory; }
     void SetBaseDirectory(const std::wstring& sBaseDirectory)
     {
         m_sBaseDirectory = sBaseDirectory;

--- a/tests/mocks/MockGameContext.hh
+++ b/tests/mocks/MockGameContext.hh
@@ -44,7 +44,7 @@ public:
     /// </summary>
     void SetHasActiveAchievements(bool bValue) noexcept { m_bHasActiveAchievements = bValue; }
 
-    AchievementSet::Type ActiveAchievementType() const noexcept { return m_nActiveAchievementType; }
+    AchievementSet::Type ActiveAchievementType() const noexcept override { return m_nActiveAchievementType; }
 
     /// <summary>
     /// Sets the value for <see cref="HasActiveAchievements" />

--- a/tests/mocks/MockGameContext.hh
+++ b/tests/mocks/MockGameContext.hh
@@ -21,14 +21,14 @@ public:
     /// <summary>
     /// Sets the unique identifier of the currently loaded game.
     /// </summary>
-    void SetGameId(unsigned int nGameId) { m_nGameId = nGameId; }
+    void SetGameId(unsigned int nGameId) noexcept { m_nGameId = nGameId; }
 
     /// <summary>
     /// Sets the title of the currently loaded game.
     /// </summary>
     void SetGameTitle(const std::wstring& sTitle) { m_sGameTitle = sTitle; }
 
-    bool HasRichPresence() const override { return !m_sRichPresenceDisplayString.empty(); }
+    bool HasRichPresence() const noexcept override { return !m_sRichPresenceDisplayString.empty(); }
 
     std::wstring GetRichPresenceDisplayString() const override { return m_sRichPresenceDisplayString; }
 
@@ -37,19 +37,19 @@ public:
     /// </summary>
     void SetRichPresenceDisplayString(std::wstring sValue) { m_sRichPresenceDisplayString = sValue; }
 
-    bool HasActiveAchievements() const override { return m_bHasActiveAchievements;}
+    bool HasActiveAchievements() const noexcept override { return m_bHasActiveAchievements; }
     
     /// <summary>
     /// Sets the value for <see cref="HasActiveAchievements" />
     /// </summary>
-    void SetHasActiveAchievements(bool bValue) { m_bHasActiveAchievements = bValue; }
+    void SetHasActiveAchievements(bool bValue) noexcept { m_bHasActiveAchievements = bValue; }
 
-    AchievementSet::Type ActiveAchievementType() const { return m_nActiveAchievementType; }
+    AchievementSet::Type ActiveAchievementType() const noexcept { return m_nActiveAchievementType; }
 
     /// <summary>
     /// Sets the value for <see cref="HasActiveAchievements" />
     /// </summary>
-    void SetActiveAchievementType(AchievementSet::Type bValue) { m_nActiveAchievementType = bValue; }
+    void SetActiveAchievementType(AchievementSet::Type bValue) noexcept { m_nActiveAchievementType = bValue; }
 
 private:
     ra::services::ServiceLocator::ServiceOverride<ra::data::GameContext> m_Override;

--- a/tests/mocks/MockHttpRequester.hh
+++ b/tests/mocks/MockHttpRequester.hh
@@ -17,7 +17,7 @@ public:
     {
     }
 
-    void SetUserAgent([[maybe_unused]] const std::string& /*sUserAgent*/) override {}
+    void SetUserAgent([[maybe_unused]] const std::string& /*sUserAgent*/) noexcept override {}
 
     unsigned int Request(const Http::Request& pRequest, TextWriter& pContentWriter) const override
     {

--- a/tests/mocks/MockLocalStorage.hh
+++ b/tests/mocks/MockLocalStorage.hh
@@ -40,7 +40,8 @@ public:
         return sEmpty;
     }
 
-    std::chrono::system_clock::time_point GetLastModified(_UNUSED StorageItemType nType, _UNUSED const std::wstring& sKey) override
+    std::chrono::system_clock::time_point GetLastModified(_UNUSED StorageItemType nType,
+                                                          _UNUSED const std::wstring& sKey) noexcept override
     {
         return std::chrono::system_clock::time_point();
     }

--- a/tests/mocks/MockServer.hh
+++ b/tests/mocks/MockServer.hh
@@ -38,29 +38,29 @@ public:
 
     // === user functions ===
 
-    Login::Response Login(_UNUSED const Login::Request& request) noexcept override
+    Login::Response Login(_UNUSED const Login::Request& request) override
     {
         return HandleRequest<ra::api::Login>(request);
     }
 
-    Logout::Response Logout(_UNUSED const Logout::Request& request) noexcept override
+    Logout::Response Logout(_UNUSED const Logout::Request& request) override
     {
         return HandleRequest<ra::api::Logout>(request);
     }
 
-    StartSession::Response StartSession(_UNUSED const StartSession::Request& request) noexcept override
+    StartSession::Response StartSession(_UNUSED const StartSession::Request& request) override
     {
         return HandleRequest<ra::api::StartSession>(request);
     }
 
-    Ping::Response Ping(_UNUSED const Ping::Request& request) noexcept override
+    Ping::Response Ping(_UNUSED const Ping::Request& request) override
     {
         return HandleRequest<ra::api::Ping>(request);
     }
 
 protected:
     template<typename TApi>
-    inline auto HandleRequest(const ApiRequestBase& pRequest) const noexcept
+    inline auto HandleRequest(const ApiRequestBase& pRequest) const
     {
         typename TApi::Response response;
         std::string sApiName(TApi::Name());

--- a/tests/mocks/MockServer.hh
+++ b/tests/mocks/MockServer.hh
@@ -38,29 +38,30 @@ public:
 
     // === user functions ===
 
-    Login::Response Login(_UNUSED const Login::Request& request) override
+    Login::Response Login(const Login::Request& request) noexcept override
     {
         return HandleRequest<ra::api::Login>(request);
     }
 
-    Logout::Response Logout(_UNUSED const Logout::Request& request) override
+    Logout::Response Logout(const Logout::Request& request) noexcept override
     {
         return HandleRequest<ra::api::Logout>(request);
     }
 
-    StartSession::Response StartSession(_UNUSED const StartSession::Request& request) override
+    StartSession::Response StartSession(const StartSession::Request& request) noexcept override
     {
         return HandleRequest<ra::api::StartSession>(request);
     }
 
-    Ping::Response Ping(_UNUSED const Ping::Request& request) override
+    Ping::Response Ping(const Ping::Request& request) noexcept override
     {
         return HandleRequest<ra::api::Ping>(request);
     }
 
 protected:
     template<typename TApi>
-    inline auto HandleRequest(const ApiRequestBase& pRequest) const
+    GSL_SUPPRESS(f.6)
+    inline auto HandleRequest(const ApiRequestBase& pRequest) const noexcept
     {
         typename TApi::Response response;
         std::string sApiName(TApi::Name());

--- a/tests/mocks/MockSessionTracker.hh
+++ b/tests/mocks/MockSessionTracker.hh
@@ -18,11 +18,11 @@ public:
     {
     }
 
-    void LoadSessions() override
+    void LoadSessions() noexcept override
     {
     }
 
-    const std::wstring& GetUsername() const { return m_sUsername; }
+    const std::wstring& GetUsername() const noexcept { return m_sUsername; }
 
 private:
     ra::services::ServiceLocator::ServiceOverride<ra::data::SessionTracker> m_Override;

--- a/tests/mocks/MockThreadPool.hh
+++ b/tests/mocks/MockThreadPool.hh
@@ -19,12 +19,12 @@ public:
     {
     }
 
-    void RunAsync(std::function<void()>&& f) noexcept override
+    void RunAsync(std::function<void()>&& f) override
     {
         m_vTasks.emplace(f);
     }
 
-    void ScheduleAsync(std::chrono::milliseconds nDelay, std::function<void()>&& f) noexcept override
+    void ScheduleAsync(std::chrono::milliseconds nDelay, std::function<void()>&& f) override
     {
         m_vDelayedTasks.emplace_back(nDelay, f);
     }

--- a/tests/ui/ViewModelBase_Tests.cpp
+++ b/tests/ui/ViewModelBase_Tests.cpp
@@ -36,7 +36,7 @@ TEST_CLASS(ViewModelBase_Tests)
             m_sLastPropertyChanged.clear();
         }
 
-        void OnViewModelBoolValueChanged(const BoolModelProperty::ChangeArgs& args) override
+        void OnViewModelBoolValueChanged(const BoolModelProperty::ChangeArgs& args) noexcept override
         {
             m_sLastPropertyChanged = args.Property.GetPropertyName();
             m_bOldValue = args.tOldValue;
@@ -52,7 +52,7 @@ TEST_CLASS(ViewModelBase_Tests)
             m_sLastPropertyChanged.clear();
         }
 
-        void OnViewModelStringValueChanged(const StringModelProperty::ChangeArgs& args) override
+        void OnViewModelStringValueChanged(const StringModelProperty::ChangeArgs& args) noexcept override
         {
             m_sLastPropertyChanged = args.Property.GetPropertyName();
             m_sOldValue = args.tOldValue;
@@ -68,7 +68,7 @@ TEST_CLASS(ViewModelBase_Tests)
             m_sLastPropertyChanged.clear();
         }
 
-        void OnViewModelIntValueChanged(const IntModelProperty::ChangeArgs& args) override
+        void OnViewModelIntValueChanged(const IntModelProperty::ChangeArgs& args) noexcept override
         {
             m_sLastPropertyChanged = args.Property.GetPropertyName();
             m_nOldValue = args.tOldValue;

--- a/tests/ui/ViewModelBase_Tests.cpp
+++ b/tests/ui/ViewModelBase_Tests.cpp
@@ -36,7 +36,7 @@ TEST_CLASS(ViewModelBase_Tests)
             m_sLastPropertyChanged.clear();
         }
 
-        void OnViewModelBoolValueChanged(const BoolModelProperty::ChangeArgs& args) noexcept override
+        GSL_SUPPRESS(f.6) void OnViewModelBoolValueChanged(const BoolModelProperty::ChangeArgs& args) noexcept override
         {
             m_sLastPropertyChanged = args.Property.GetPropertyName();
             m_bOldValue = args.tOldValue;
@@ -52,6 +52,7 @@ TEST_CLASS(ViewModelBase_Tests)
             m_sLastPropertyChanged.clear();
         }
 
+        GSL_SUPPRESS(f.6)
         void OnViewModelStringValueChanged(const StringModelProperty::ChangeArgs& args) noexcept override
         {
             m_sLastPropertyChanged = args.Property.GetPropertyName();
@@ -68,7 +69,7 @@ TEST_CLASS(ViewModelBase_Tests)
             m_sLastPropertyChanged.clear();
         }
 
-        void OnViewModelIntValueChanged(const IntModelProperty::ChangeArgs& args) noexcept override
+        GSL_SUPPRESS(f.6) void OnViewModelIntValueChanged(const IntModelProperty::ChangeArgs& args) noexcept override
         {
             m_sLastPropertyChanged = args.Property.GetPropertyName();
             m_nOldValue = args.tOldValue;

--- a/tests/ui/viewmodels/GameChecksumViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/GameChecksumViewModel_Tests.cpp
@@ -28,7 +28,7 @@ private:
         }
 
         void SetText(const std::wstring& sValue) const override { m_sText = sValue; }
-        const std::wstring& GetText() const { return m_sText; }
+        const std::wstring& GetText() const noexcept { return m_sText; }
 
     private:
         ra::services::ServiceLocator::ServiceOverride<ra::services::IClipboard> m_Override;


### PR DESCRIPTION
This only addresses one rule but was triggered many times
`F.6: If your function may not throw, declare it noexcept`

Basically this does three things (from order of most to least changes):
- All functions guaranteed not to throw (nothrow exception guarantee) are marked as `noexcept`
- Functions that have a high chance of throwing have `noexcept` removed
  - Some virtual methods had noexcept removed or had a warning where it could be noexcept suppressed because overrides could throw and subclasses can't have a different exception spec than the parent class.
  - I could be wrong, if I am, please say so where so I can suppress the analysis warning
- Functions that have a low chance of throwing have the rule suppressed.
  - Had to analyze these very carefully
  - Made some changes to functions to minimize the chance of exceptions being thrown

If there's any suggestions for improvement, please say so.