### PR TITLE
Prevent matching alternate nibble on same byte in 4-bit mode

### DIFF
--- a/src/services/SearchResults.cpp
+++ b/src/services/SearchResults.cpp
@@ -163,6 +163,15 @@ bool SearchResults::ContainsAddress(unsigned int nAddress) const
     return false;
 }
 
+bool SearchResults::ContainsNibble(unsigned int nAddress) const
+{
+    if (!m_bUnfiltered)
+        return std::binary_search(m_vMatchingAddresses.begin(), m_vMatchingAddresses.end(), nAddress);
+
+    // an unfiltered collection implicitly contains both nibbles of an address
+    return ContainsAddress(nAddress >> 1);
+}
+
 void SearchResults::AddMatches(unsigned int nAddressBase, const unsigned char pMemory[], const std::vector<unsigned int>& vMatches)
 {
     const unsigned int nBlockSize = vMatches.back() - vMatches.front() + Padding(m_nSize) + 1;
@@ -246,7 +255,7 @@ void SearchResults::ProcessBlocksNibbles(const SearchResults& srSource, unsigned
             if (Compare(nValue1 & 0x0F, nValue2, nCompareType))
             {
                 const unsigned int nAddress = (block.GetAddress() + i) << 1;
-                if (srSource.ContainsAddress(nAddress >> 1))
+                if (srSource.ContainsNibble(nAddress))
                 {
                     if (!vMatches.empty() && (i - (vMatches.back() >> 1)) > 16)
                     {
@@ -264,7 +273,7 @@ void SearchResults::ProcessBlocksNibbles(const SearchResults& srSource, unsigned
             if (Compare(nValue1 >> 4, nValue2, nCompareType))
             {
                 const unsigned int nAddress = ((block.GetAddress() + i) << 1) | 1;
-                if (srSource.ContainsAddress(nAddress >> 1))
+                if (srSource.ContainsNibble(nAddress))
                 {
                     if (!vMatches.empty() && (i - (vMatches.back() >> 1)) > 16)
                     {

--- a/src/services/SearchResults.cpp
+++ b/src/services/SearchResults.cpp
@@ -242,7 +242,7 @@ void SearchResults::ProcessBlocksNibbles(const SearchResults& srSource, unsigned
 
     for (auto& block : srSource.m_vBlocks)
     {
-        if (block.GetSize() > vMemory.capacity())
+        if (block.GetSize() > vMemory.size())
             vMemory.resize(block.GetSize());
 
         g_MemManager.ActiveBankRAMRead(vMemory.data(), block.GetAddress(), block.GetSize());

--- a/src/services/SearchResults.h
+++ b/src/services/SearchResults.h
@@ -142,6 +142,7 @@ private:
     void ProcessBlocksNibbles(const SearchResults& srSource, unsigned int nTestValue, ComparisonType nCompareType);
     void AddMatches(unsigned int nAddressBase, const unsigned char pMemory[], const std::vector<unsigned int>& vMatches);
     void AddMatchesNibbles(unsigned int nAddressBase, const unsigned char pMemory[], const std::vector<unsigned int>& vMatches);
+    bool ContainsNibble(unsigned int nAddress) const;
 
     std::string m_sSummary;
     std::vector<MemBlock> m_vBlocks;

--- a/tests/services/SearchResults_Tests.cpp
+++ b/tests/services/SearchResults_Tests.cpp
@@ -585,6 +585,43 @@ public:
         Assert::AreEqual(5U, result.nValue);
     }
 
+    TEST_METHOD(TestInitializeFromResultsFourBitEqualsSameByte)
+    {
+        unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory, 5);
+
+        SearchResults results;
+        results.Initialize(1U, 3U, MemSize::Nibble_Lower);
+        Assert::AreEqual(6U, results.MatchingAddressCount());
+
+        SearchResults filtered1;
+        filtered1.Initialize(results, ComparisonType::Equals, 1);
+        Assert::AreEqual(1U, filtered1.MatchingAddressCount());
+
+        SearchResults::Result result;
+        Assert::IsTrue(filtered1.GetMatchingAddress(0U, result));
+        Assert::AreEqual(1U, result.nAddress);
+        Assert::AreEqual(MemSize::Nibble_Upper, result.nSize);
+        Assert::AreEqual(1U, result.nValue);
+
+        // Nibble_Upper no longer matches, but Nibble_Lower does. Neither should not be returned.
+        memory[1] = 0x21;
+        SearchResults filtered2;
+        filtered2.Initialize(filtered1, ComparisonType::Equals, 1);
+        Assert::AreEqual(0U, filtered2.MatchingAddressCount());
+
+        // Both nibbles match, only previously matched one should be returned
+        memory[1] = 0x11;
+        SearchResults filtered3;
+        filtered3.Initialize(filtered1, ComparisonType::Equals, 1);
+        Assert::AreEqual(1U, filtered3.MatchingAddressCount());
+
+        Assert::IsTrue(filtered3.GetMatchingAddress(0U, result));
+        Assert::AreEqual(1U, result.nAddress);
+        Assert::AreEqual(MemSize::Nibble_Upper, result.nSize);
+        Assert::AreEqual(1U, result.nValue);
+    }
+
     TEST_METHOD(TestExcludeAddressEightBit)
     {
         unsigned char memory[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };


### PR DESCRIPTION
Fixes an issue where performing a 4-bit search would add new matches when filtering.

Given the memory `01 23 45 67`, a filter on "4-bit = 2" would match the upper nibble of the second byte. If the memory then changed to `02 02 02 02`, filtering the results on "=2" should result in no matches because the upper nibble of the second byte is no longer 2. Instead, it would report that the lower nibble of the second byte was 2.

This was caused by the logic checking to see if a match existed in the previous set of filtered results was only checking the address, not the nibble. I've extended the logic to also check the nibble.