### PR TITLE
Add QUASI88 to the emulators list

### DIFF
--- a/src/RA_Core.cpp
+++ b/src/RA_Core.cpp
@@ -134,6 +134,13 @@ static void InitCommon(HWND hMainHWND, /*enum EmulatorID*/int nEmulatorID, const
             g_sClientDownloadURL = "RAMeka.zip";
             g_sClientEXEName = "RAMeka.exe";
             break;
+        case RA_QUASI88:
+            g_ConsoleID = PC8800;
+            g_sClientVersion = sClientVer;
+            g_sClientName = "RAQUASI88";
+            g_sClientDownloadURL = "RAQUASI88.zip";
+            g_sClientEXEName = "RAQUASI88.exe";
+            break;
         default:
             g_ConsoleID = UnknownConsoleID;
             g_sClientVersion = sClientVer;

--- a/src/RA_Interface.h
+++ b/src/RA_Interface.h
@@ -31,6 +31,7 @@ enum EmulatorID
     RA_PCE = 6,
     RA_Libretro = 7,
     RA_Meka = 8,
+    RA_QUASI88 = 9,
 
     NumEmulatorIDs,
     UnknownEmulator = NumEmulatorIDs


### PR DESCRIPTION
Requires website updates to access the required URLs.

Related: https://github.com/RetroAchievements/RAEmus/pull/21