### PR TITLE
Require latest emulator version for hardcore mode

### DIFF
--- a/src/Exports.cpp
+++ b/src/Exports.cpp
@@ -6,6 +6,7 @@
 
 #include "api\Login.hh"
 
+#include "data\EmulatorContext.hh"
 #include "data\SessionTracker.hh"
 #include "data\UserContext.hh"
 
@@ -35,10 +36,13 @@ API int CCONV _RA_HardcoreModeIsActive()
 
 static void HandleLoginResponse(const ra::api::Login::Response& response)
 {
+    auto& pUserContext = ra::services::ServiceLocator::GetMutable<ra::data::UserContext>();
+    if (pUserContext.IsLoginDisabled())
+        return;
+
     if (response.Succeeded())
     {
         // initialize the user context
-        auto& pUserContext = ra::services::ServiceLocator::GetMutable<ra::data::UserContext>();
         pUserContext.Initialize(response.Username, response.ApiToken);
         pUserContext.SetScore(response.Score);
 
@@ -81,6 +85,10 @@ static void HandleLoginResponse(const ra::api::Login::Response& response)
 
 API void CCONV _RA_AttemptLogin(bool bBlocking)
 {
+    auto& pUserContext = ra::services::ServiceLocator::GetMutable<ra::data::UserContext>();
+    if (pUserContext.IsLoginDisabled())
+        return;
+
     const auto& pConfiguration = ra::services::ServiceLocator::Get<ra::services::IConfiguration>();
     if (pConfiguration.GetApiToken().empty() || pConfiguration.GetUsername().empty())
     {
@@ -105,6 +113,14 @@ API void CCONV _RA_AttemptLogin(bool bBlocking)
         }
     }
 }
+
+#ifndef RA_UTEST
+API void CCONV _RA_UpdateAppTitle(const char* sMessage)
+{
+    std::string sTitle = ra::services::ServiceLocator::Get<ra::data::EmulatorContext>().GetAppTitle(sMessage ? sMessage : "");
+    SetWindowText(g_RAMainWnd, NativeStr(sTitle).c_str());
+}
+#endif
 
 _Use_decl_annotations_
 API int _RA_UpdatePopups(ControllerInput*, float fElapsedSeconds, bool, bool bPaused)

--- a/src/RA_AchievementOverlay.cpp
+++ b/src/RA_AchievementOverlay.cpp
@@ -6,6 +6,7 @@
 
 #include "ra_math.h"
 
+#include "data\EmulatorContext.hh"
 #include "data\GameContext.hh"
 #include "data\SessionTracker.hh"
 #include "data\UserContext.hh"
@@ -1156,7 +1157,7 @@ _Use_decl_annotations_ void AchievementOverlay::Render(HDC hRealDC, const RECT* 
         auto ctSelectChar{_T('A')};
 
         //	Genesis wouldn't use 'A' for select
-        if (g_EmulatorID == RA_Gens)
+        if (ra::services::ServiceLocator::Get<ra::data::EmulatorContext>().GetEmulatorId() == RA_Gens)
             ctSelectChar = _T('C');
 
         {

--- a/src/RA_AchievementSet.cpp
+++ b/src/RA_AchievementSet.cpp
@@ -248,7 +248,7 @@ void AchievementSet::Test()
                         ra::services::ServiceLocator::Get<ra::services::IAudioSystem>().PlayAudioFile(L"Overlay\\unlock.wav");
                         ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().QueueMessage(
                             L"Modified: Achievement Unlocked",
-                            ra::StringPrintf(L"%s (%u) (Unofficial)", pAchievement->Title(), pAchievement->Points()),
+                            ra::StringPrintf(L"%s (%u)", pAchievement->Title(), pAchievement->Points()),
                             ra::ui::ImageType::Badge, pAchievement->BadgeImageURI());
                     }
                     else if (g_bRAMTamperedWith)
@@ -256,7 +256,7 @@ void AchievementSet::Test()
                         ra::services::ServiceLocator::Get<ra::services::IAudioSystem>().PlayAudioFile(L"Overlay\\acherror.wav");
                         ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().QueueMessage(
                             L"(RAM tampered with!): Achievement Unlocked",
-                            ra::StringPrintf(L"%s (%u) (Unofficial)", pAchievement->Title(), pAchievement->Points()),
+                            ra::StringPrintf(L"%s (%u)", pAchievement->Title(), pAchievement->Points()),
                             ra::ui::ImageType::Badge, pAchievement->BadgeImageURI());
                     }
                     else

--- a/src/RA_Core.cpp
+++ b/src/RA_Core.cpp
@@ -20,6 +20,7 @@
 #include "api\Logout.hh"
 #include "api\ResolveHash.hh"
 
+#include "data\EmulatorContext.hh"
 #include "data\GameContext.hh"
 #include "data\SessionTracker.hh"
 #include "data\UserContext.hh"
@@ -49,12 +50,7 @@ std::string g_sROMDirLocation;
 HMODULE g_hThisDLLInst = nullptr;
 HINSTANCE g_hRAKeysDLL = nullptr;
 HWND g_RAMainWnd = nullptr;
-EmulatorID g_EmulatorID = EmulatorID::UnknownEmulator;	//	Uniquely identifies the emulator
 ConsoleID g_ConsoleID = ConsoleID::UnknownConsoleID;	//	Currently active Console ID
-const char* g_sClientVersion = nullptr;
-const char* g_sClientName = nullptr;
-const char* g_sClientDownloadURL = nullptr;
-const char* g_sClientEXEName = nullptr;
 bool g_bRAMTamperedWith = false;
 
 inline static constexpr unsigned int PROCESS_WAIT_TIME{ 100U };
@@ -70,91 +66,15 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD dwReason, _UNUSED LPVOID)
     return TRUE;
 }
 
-static void InitCommon(HWND hMainHWND, /*enum EmulatorID*/int nEmulatorID, const char* sClientVer)
+static void InitCommon(HWND hMainHWND, /*enum EmulatorID*/int nEmulatorID)
 {
+    ra::services::Initialization::RegisterServices(ra::itoe<EmulatorID>(nEmulatorID));
+
     // initialize global state
-    g_EmulatorID = static_cast<EmulatorID>(nEmulatorID);
     g_RAMainWnd = hMainHWND;
-
-    switch (g_EmulatorID)
-    {
-        case RA_Gens:
-            g_ConsoleID = MegaDrive;
-            g_sClientVersion = sClientVer;
-            g_sClientName = "RAGens_REWiND";
-            g_sClientDownloadURL = "RAGens.zip";
-            g_sClientEXEName = "RAGens.exe";
-            break;
-        case RA_Project64:
-            g_ConsoleID = N64;
-            g_sClientVersion = sClientVer;
-            g_sClientName = "RAP64";
-            g_sClientDownloadURL = "RAP64.zip";
-            g_sClientEXEName = "RAP64.exe";
-            break;
-        case RA_Snes9x:
-            g_ConsoleID = SNES;
-            g_sClientVersion = sClientVer;
-            g_sClientName = "RASnes9X";
-            g_sClientDownloadURL = "RASnes9X.zip";
-            g_sClientEXEName = "RASnes9X.exe";
-            break;
-        case RA_VisualboyAdvance:
-            g_ConsoleID = GB;
-            g_sClientVersion = sClientVer;
-            g_sClientName = "RAVisualBoyAdvance";
-            g_sClientDownloadURL = "RAVBA.zip";
-            g_sClientEXEName = "RAVisualBoyAdvance.exe";
-            break;
-        case RA_Nester:
-        case RA_FCEUX:
-            g_ConsoleID = NES;
-            g_sClientVersion = sClientVer;
-            g_sClientName = "RANes";
-            g_sClientDownloadURL = "RANes.zip";
-            g_sClientEXEName = "RANes.exe";
-            break;
-        case RA_PCE:
-            g_ConsoleID = PCEngine;
-            g_sClientVersion = sClientVer;
-            g_sClientName = "RAPCE";
-            g_sClientDownloadURL = "RAPCE.zip";
-            g_sClientEXEName = "RAPCE.exe";
-            break;
-        case RA_Libretro:
-            g_ConsoleID = Atari2600;
-            g_sClientVersion = sClientVer;
-            g_sClientName = "RALibretro";
-            g_sClientDownloadURL = "RALibretro.zip";
-            g_sClientEXEName = "RALibretro.exe";
-            break;
-        case RA_Meka:
-            g_ConsoleID = MasterSystem;
-            g_sClientVersion = sClientVer;
-            g_sClientName = "RAMeka";
-            g_sClientDownloadURL = "RAMeka.zip";
-            g_sClientEXEName = "RAMeka.exe";
-            break;
-        case RA_QUASI88:
-            g_ConsoleID = PC8800;
-            g_sClientVersion = sClientVer;
-            g_sClientName = "RAQUASI88";
-            g_sClientDownloadURL = "RAQUASI88.zip";
-            g_sClientEXEName = "RAQUASI88.exe";
-            break;
-        default:
-            g_ConsoleID = UnknownConsoleID;
-            g_sClientVersion = sClientVer;
-            g_sClientName = "";
-            break;
-    }
-
-    ra::services::Initialization::RegisterServices(g_sClientName);
 
     auto& pFileSystem = ra::services::ServiceLocator::Get<ra::services::IFileSystem>();
     g_sHomeDir = pFileSystem.BaseDirectory();
-
-    RAWeb::SetUserAgentString();
 
     //////////////////////////////////////////////////////////////////////////
     //	Dialogs:
@@ -172,15 +92,19 @@ static void InitCommon(HWND hMainHWND, /*enum EmulatorID*/int nEmulatorID, const
     g_AchievementOverlay.UpdateImages();
 }
 
-API BOOL CCONV _RA_InitOffline(HWND hMainHWND, /*enum EmulatorID*/int nEmulatorID, const char* sClientVer)
+API BOOL CCONV _RA_InitOffline(HWND hMainHWND, /*enum EmulatorID*/int nEmulatorID, const char* /*sClientVer*/)
 {
-    InitCommon(hMainHWND, nEmulatorID, sClientVer);
+    InitCommon(hMainHWND, nEmulatorID);
     return TRUE;
 }
 
 API BOOL CCONV _RA_InitI(HWND hMainHWND, /*enum EmulatorID*/int nEmulatorID, const char* sClientVer)
 {
-    InitCommon(hMainHWND, nEmulatorID, sClientVer);
+    InitCommon(hMainHWND, nEmulatorID);
+
+    // Set the client version and User-Agent string
+    ra::services::ServiceLocator::GetMutable<ra::data::EmulatorContext>().SetClientVersion(sClientVer);
+    RAWeb::SetUserAgentString();
 
     //////////////////////////////////////////////////////////////////////////
     //	Update news:
@@ -188,11 +112,12 @@ API BOOL CCONV _RA_InitI(HWND hMainHWND, /*enum EmulatorID*/int nEmulatorID, con
     args['c'] = std::to_string(6);
     RAWeb::CreateThreadedHTTPRequest(RequestNews, args);
 
-    //////////////////////////////////////////////////////////////////////////
-    //	Attempt to fetch latest client version:
-    args.clear();
-    args['e'] = std::to_string(nEmulatorID);
-    RAWeb::CreateThreadedHTTPRequest(RequestLatestClientPage, args);	//	g_sGetLatestClientPage
+    // validate version (async call)
+    ra::services::ServiceLocator::GetMutable<ra::services::IThreadPool>().RunAsync([]
+    {
+        if (!ra::services::ServiceLocator::GetMutable<ra::data::EmulatorContext>().ValidateClientVersion())
+            ra::services::ServiceLocator::GetMutable<ra::data::UserContext>().Logout();
+    });
 
     //	TBD:
     //if( RAUsers::LocalUser().Username().length() > 0 )
@@ -308,17 +233,6 @@ API void CCONV _RA_SetConsoleID(unsigned int nConsoleID)
     g_ConsoleID = static_cast<ConsoleID>(nConsoleID);
 }
 
-static void DisableHardcoreMode()
-{
-    auto& pConfiguration = ra::services::ServiceLocator::GetMutable<ra::services::IConfiguration>();
-    pConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, false);
-
-    _RA_RebuildMenu();
-
-    auto& pLeaderboardManager = ra::services::ServiceLocator::GetMutable<ra::services::ILeaderboardManager>();
-    pLeaderboardManager.Reset();
-}
-
 API bool CCONV _RA_WarnDisableHardcore(const char* sActivity)
 {
     // already disabled, just return success
@@ -336,7 +250,7 @@ API bool CCONV _RA_WarnDisableHardcore(const char* sActivity)
         return false;
 
     // user consented, switch to non-hardcore mode
-    DisableHardcoreMode();
+    ra::services::ServiceLocator::GetMutable<ra::data::EmulatorContext>().DisableHardcoreMode();
 
     // return success
     return true;
@@ -494,93 +408,6 @@ API void CCONV _RA_ClearMemoryBanks()
 //	}
 //}
 
-static unsigned long long ParseVersion(const char* sVersion)
-{
-    char* pPart{};
-    const auto major = strtoull(sVersion, &pPart, 10);
-    Expects(pPart != nullptr);
-    if (*pPart == '.')
-        ++pPart;
-
-    const auto minor = strtoul(pPart, &pPart, 10);
-    if (*pPart == '.')
-        ++pPart;
-
-    const auto patch = strtoul(pPart, &pPart, 10);
-    if (*pPart == '.')
-        ++pPart;
-
-    const auto revision = strtoul(pPart, &pPart, 10);
-    // 64-bit max signed value is 9223 37203 68547 75807
-    auto version = (major * 100000) + minor;
-    version = (version * 100000) + patch;
-    version = (version * 100000) + revision;
-    return version;
-}
-
-static bool RA_OfferNewRAUpdate(const char* sNewVer)
-{
-    std::string sClientVersion = g_sClientVersion;
-    while (sClientVersion[sClientVersion.length() - 1] == '0' && sClientVersion[sClientVersion.length() - 2] == '.')
-        sClientVersion.resize(sClientVersion.length() - 2);
-
-    std::wostringstream oss;
-    oss << L"A new version of " << ra::Widen(g_sClientName) << L" is available for download at " << ra::Widen(_RA_HostName()) << L".\n\n"
-        << L"Current version: " << ra::Widen(sClientVersion) << L"\n"
-        << L"New version: " << ra::Widen(sNewVer);
-
-    ra::ui::viewmodels::MessageBoxViewModel vmMessageBox;
-    vmMessageBox.SetHeader(L"Would you like to update?");
-    vmMessageBox.SetMessage(oss.str());
-    vmMessageBox.SetIcon(ra::ui::viewmodels::MessageBoxViewModel::Icon::Info);
-    vmMessageBox.SetButtons(ra::ui::viewmodels::MessageBoxViewModel::Buttons::YesNo);
-
-    if (vmMessageBox.ShowModal() == ra::ui::DialogResult::Yes)
-    {
-        //FetchBinaryFromWeb( g_sClientEXEName );
-        //
-        //char sBatchUpdater[2048];
-        //sprintf_s( sBatchUpdater, 2048,
-        //	"@echo off\r\n"
-        //	"taskkill /IM %s\r\n"
-        //	"del /f %s\r\n"
-        //	"rename %s.new %s%s.exe\r\n"
-        //	"start %s%s.exe\r\n"
-        //	"del \"%%~f0\"\r\n",
-        //	g_sClientEXEName,
-        //	g_sClientEXEName,
-        //	g_sClientEXEName,
-        //	g_sClientName,
-        //	sNewVer,
-        //	g_sClientName,
-        //	sNewVer );
-
-        //_WriteBufferToFile( "BatchUpdater.bat", sBatchUpdater, strlen( sBatchUpdater ) );
-
-        //ShellExecute( nullptr,
-        //	"open",
-        //	"BatchUpdater.bat",
-        //	nullptr,
-        //	nullptr,
-        //	SW_SHOWNORMAL ); 
-
-        std::ostringstream oss2;
-        oss2 << "http://" << _RA_HostName() << "/download.php";
-        ShellExecute(nullptr,
-            TEXT("open"),
-            NativeStr(oss2.str()).c_str(),
-            nullptr,
-            nullptr,
-            SW_SHOWNORMAL);
-
-        return TRUE;
-    }
-    else
-    {
-        return FALSE;
-    }
-}
-
 API int CCONV _RA_HandleHTTPResults()
 {
     WaitForSingleObject(RAWeb::Mutex(), INFINITE);
@@ -625,32 +452,6 @@ API int CCONV _RA_HandleHTTPResults()
                     {
                         ASSERT(!"RequestScore bad response!?");
                         RA_LOG("RequestScore bad response!?");
-                    }
-                }
-                break;
-
-                case RequestLatestClientPage:
-                {
-                    if (doc.HasMember("LatestVersion"))
-                    {
-                        const std::string& sReply = doc["LatestVersion"].GetString();
-                        const unsigned long long nServerVersion = ParseVersion(sReply.c_str());
-                        const unsigned long long nLocalVersion = ParseVersion(g_sClientVersion);
-
-                        if (nLocalVersion < nServerVersion)
-                        {
-                            //	Update available:
-                            RA_OfferNewRAUpdate(sReply.c_str());
-                        }
-                        else
-                        {
-                            RA_LOG("Latest Client already up to date: server %s, current %s\n", sReply.c_str(), g_sClientVersion);
-                        }
-                    }
-                    else
-                    {
-                        ASSERT(!"RequestLatestClientPage responded, but 'LatestVersion' cannot be found!");
-                        RA_LOG("RequestLatestClientPage responded, but 'LatestVersion' cannot be found?");
                     }
                 }
                 break;
@@ -769,91 +570,14 @@ API HMENU CCONV _RA_CreatePopupMenu()
         AppendMenu(hRA, MF_SEPARATOR, 0U, nullptr);
         AppendMenu(hRA, MF_STRING, IDM_RA_REPORTBROKENACHIEVEMENTS, TEXT("&Report Broken Achievements"));
         AppendMenu(hRA, MF_STRING, IDM_RA_GETROMCHECKSUM, TEXT("Get ROM &Checksum"));
-        AppendMenu(hRA, MF_STRING, IDM_RA_SCANFORGAMES, TEXT("Scan &for games"));
+        //AppendMenu(hRA, MF_STRING, IDM_RA_SCANFORGAMES, TEXT("Scan &for games"));
     }
     else
     {
         AppendMenu(hRA, MF_STRING, IDM_RA_FILES_LOGIN, TEXT("&Login to RA"));
     }
 
-    AppendMenu(hRA, MF_SEPARATOR, 0U, nullptr);
-    AppendMenu(hRA, MF_STRING, IDM_RA_FILES_CHECKFORUPDATE, TEXT("&Check for Emulator Update"));
-
     return hRA;
-}
-
-API void CCONV _RA_UpdateAppTitle(const char* sMessage)
-{
-    std::ostringstream sstr;
-    sstr << std::string(g_sClientName) << " - ";
-
-    // only copy the first two parts of the version string to the title bar: 0.12.7.1 => 0.12
-    const char* ptr = g_sClientVersion;
-    while (*ptr && *ptr != '.')
-        sstr << *ptr++;
-    if (*ptr)
-    {
-        do
-        {
-            sstr << *ptr++;
-        } while (*ptr && *ptr != '.');
-    }
-
-    if (sMessage != nullptr && *sMessage)
-        sstr << " - " << sMessage;
-
-    const auto& pUserContext = ra::services::ServiceLocator::Get<ra::data::UserContext>();
-    if (pUserContext.IsLoggedIn())
-        sstr << " - " << pUserContext.GetUsername();
-
-    if (strcmp(_RA_HostName(), "retroachievements.org") != 0)
-        sstr << " [" << _RA_HostName() << "]";
-
-    SetWindowText(g_RAMainWnd, NativeStr(sstr.str()).c_str());
-}
-
-//	##BLOCKING##
-static void RA_CheckForUpdate()
-{
-    PostArgs args;
-    args['e'] = std::to_string(g_EmulatorID);
-
-    rapidjson::Document doc;
-    if (RAWeb::DoBlockingRequest(RequestLatestClientPage, args, doc))
-    {
-        if (doc.HasMember("LatestVersion"))
-        {
-            const std::string& sReply = doc["LatestVersion"].GetString();
-            const unsigned long long nServerVersion = ParseVersion(sReply.c_str());
-            const unsigned long long nLocalVersion = ParseVersion(g_sClientVersion);
-
-            if (nLocalVersion < nServerVersion)
-            {
-                RA_OfferNewRAUpdate(sReply.c_str());
-            }
-            else
-            {
-                //	Up to date
-                std::wstring sMessage = L"You already have the latest version of " + ra::Widen(g_sClientName) + L": " + ra::Widen(sReply);
-                ra::ui::viewmodels::MessageBoxViewModel::ShowInfoMessage(sMessage);
-            }
-        }
-        else
-        {
-            //	Error in download
-            std::ostringstream oss;
-            oss << "Unexpected response from " << _RA_HostName() << ".";
-            MessageBox(g_RAMainWnd, NativeStr(oss.str()).c_str(), TEXT("Error!"), MB_OK | MB_ICONERROR);
-        }
-    }
-    else
-    {
-        //	Could not connect
-        std::ostringstream oss;
-        oss << "Could not connect to " << _RA_HostName() << ".\n" <<
-            "Please check your connection settings or RA forums!";
-        MessageBox(g_RAMainWnd, NativeStr(oss.str()).c_str(), TEXT("Error!"), MB_OK | MB_ICONERROR);
-    }
 }
 
 void _FetchGameHashLibraryFromWeb()
@@ -1002,68 +726,43 @@ API void CCONV _RA_InvokeDialog(LPARAM nID)
 
         case IDM_RA_FILES_LOGIN:
         {
+            const auto& pConfiguration = ra::services::ServiceLocator::Get<ra::services::IConfiguration>();
+            if (pConfiguration.IsFeatureEnabled(ra::services::Feature::Hardcore))
+            {
+                auto& pEmulatorContext = ra::services::ServiceLocator::GetMutable<ra::data::EmulatorContext>();
+                if (!pEmulatorContext.ValidateClientVersion())
+                {
+                    // The version could not be validated, or the user has chosen to update. Don't login.
+                    break;
+                }
+            }
+
             ra::ui::viewmodels::LoginViewModel vmLogin;
             vmLogin.ShowModal();
             break;
         }
 
         case IDM_RA_FILES_LOGOUT:
-        {
-            const ra::api::Logout::Request request;
-            const auto response = request.Call();
-            if (response.Succeeded())
-            {
-                ra::services::ServiceLocator::GetMutable<ra::data::UserContext>().Initialize("", "");
-                ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().ClearPopups();
-                ra::services::ServiceLocator::Get<ra::services::IConfiguration>().Save();
-                _RA_UpdateAppTitle();
-                RA_RebuildMenu();
-
-                ra::ui::viewmodels::MessageBoxViewModel::ShowInfoMessage(L"You are now logged out.");
-            }
-            else
-            {
-                ra::ui::viewmodels::MessageBoxViewModel::ShowErrorMessage(L"Logout failed", ra::Widen(response.ErrorMessage));
-            }
-            break;
-        }
-
-        case IDM_RA_FILES_CHECKFORUPDATE:
-            RA_CheckForUpdate();
+            ra::services::ServiceLocator::GetMutable<ra::data::UserContext>().Logout();
             break;
 
         case IDM_RA_HARDCORE_MODE:
         {
-            auto& pConfiguration = ra::services::ServiceLocator::GetMutable<ra::services::IConfiguration>();
+            auto& pEmulatorContext = ra::services::ServiceLocator::GetMutable<ra::data::EmulatorContext>();
+            const auto& pConfiguration = ra::services::ServiceLocator::Get<ra::services::IConfiguration>();
             if (pConfiguration.IsFeatureEnabled(ra::services::Feature::Hardcore))
             {
-                DisableHardcoreMode();
+                pEmulatorContext.DisableHardcoreMode();
             }
             else
             {
-                const auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::GameContext>();
-                if (pGameContext.GameId() != 0)
+                if (pEmulatorContext.EnableHardcoreMode())
                 {
-                    ra::ui::viewmodels::MessageBoxViewModel vmMessageBox;
-                    vmMessageBox.SetHeader(L"Enable Hardcore mode?");
-                    vmMessageBox.SetMessage(L"Enabling Hardcore mode will reset the emulator. You will lose any progress that has not been saved through the game.");
-                    vmMessageBox.SetIcon(ra::ui::viewmodels::MessageBoxViewModel::Icon::Warning);
-                    vmMessageBox.SetButtons(ra::ui::viewmodels::MessageBoxViewModel::Buttons::YesNo);
-
-                    if (vmMessageBox.ShowModal() == ra::ui::DialogResult::No)
-                        break;
+                    // if a game was loaded, redownload the associated data
+                    const auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::GameContext>();
+                    if (pGameContext.GameId() != 0)
+                        DownloadAndActivateAchievementData(pGameContext.GameId());
                 }
-
-                pConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, true);
-                _RA_RebuildMenu();
-
-                // when enabling hardcore mode, force a system reset
-                _RA_ResetEmulation();
-                _RA_OnReset();
-
-                // if a game was loaded, redownload the associated data
-                if (pGameContext.GameId() != 0)
-                    DownloadAndActivateAchievementData(pGameContext.GameId());
             }
 
             ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().ClearPopups();
@@ -1240,7 +939,7 @@ API void CCONV _RA_OnLoadState(const char* sFilename)
         if (pConfiguration.IsFeatureEnabled(ra::services::Feature::Hardcore))
         {
             ra::ui::viewmodels::MessageBoxViewModel::ShowWarningMessage(L"Disabling Hardcore mode.", L"Loading save states is not allowed in Hardcore mode.");
-            DisableHardcoreMode();
+            ra::services::ServiceLocator::GetMutable<ra::data::EmulatorContext>().DisableHardcoreMode();
         }
 
         ra::services::ServiceLocator::Get<ra::services::AchievementRuntime>().LoadProgress(sFilename);

--- a/src/RA_Core.cpp
+++ b/src/RA_Core.cpp
@@ -274,6 +274,13 @@ void DownloadAndActivateAchievementData(unsigned int nGameID)
 
 API int CCONV _RA_OnLoadNewRom(const BYTE* pROM, unsigned int nROMSize)
 {
+    if (!ra::services::ServiceLocator::Get<ra::data::UserContext>().IsLoggedIn())
+    {
+        ra::ui::viewmodels::MessageBoxViewModel::ShowErrorMessage(L"Cannot load achievements",
+            L"You must be logged in to load achievements. Please reload the game after logging in.");
+        return 0;
+    }
+
     static std::string sMD5NULL = RAGenerateMD5(nullptr, 0);
 
     std::string sCurrentROMMD5 = RAGenerateMD5(pROM, nROMSize);

--- a/src/RA_Core.h
+++ b/src/RA_Core.h
@@ -13,10 +13,7 @@ extern std::wstring g_sHomeDir;
 extern HINSTANCE g_hRAKeysDLL;
 extern HMODULE g_hThisDLLInst;
 extern HWND g_RAMainWnd;
-extern EmulatorID g_EmulatorID;
 extern ConsoleID g_ConsoleID;
-extern const char* g_sClientVersion;
-extern const char* g_sClientName;
 extern bool g_bRAMTamperedWith;
 
 // Read a file to a malloc'd buffer. Returns nullptr on error. Owner MUST free() buffer if not nullptr.

--- a/src/RA_Dlg_Memory.cpp
+++ b/src/RA_Dlg_Memory.cpp
@@ -239,7 +239,7 @@ void MemoryViewerControl::setAddress(unsigned int address)
     Invalidate();
 }
 
-void MemoryViewerControl::setWatchedAddress(unsigned int address) noexcept
+void MemoryViewerControl::setWatchedAddress(unsigned int address)
 {
     if (m_nWatchedAddress != address)
     {
@@ -248,7 +248,7 @@ void MemoryViewerControl::setWatchedAddress(unsigned int address) noexcept
     }
 }
 
-void MemoryViewerControl::Invalidate() noexcept
+void MemoryViewerControl::Invalidate()
 {
     HWND hOurDlg = GetDlgItem(g_MemoryDialog.GetHWND(), IDC_RA_MEMTEXTVIEWER);
     if (hOurDlg != nullptr)

--- a/src/RA_Dlg_Memory.cpp
+++ b/src/RA_Dlg_Memory.cpp
@@ -7,6 +7,7 @@
 #include "RA_User.h"
 #include "RA_httpthread.h"
 
+#include "data\EmulatorContext.hh"
 #include "data\GameContext.hh"
 
 #ifndef ID_OK
@@ -258,7 +259,7 @@ void MemoryViewerControl::Invalidate() noexcept
         // the render by calling UpdateWindow
         // TODO: figure out why this is necessary and remove it. There's a similar check in Dlg_Memory::Invalidate for
         // the search results
-        if (g_EmulatorID == RA_Libretro)
+        if (ra::services::ServiceLocator::Get<ra::data::EmulatorContext>().GetEmulatorId() == RA_Libretro)
             UpdateWindow(hOurDlg);
     }
 }
@@ -1577,7 +1578,7 @@ void Dlg_Memory::Invalidate()
     if (hList != nullptr)
     {
         InvalidateRect(hList, nullptr, FALSE);
-        if (g_EmulatorID == RA_Libretro)
+        if (ra::services::ServiceLocator::Get<ra::data::EmulatorContext>().GetEmulatorId() == RA_Libretro)
             UpdateWindow(hList);
     }
 }

--- a/src/RA_Dlg_Memory.h
+++ b/src/RA_Dlg_Memory.h
@@ -23,13 +23,13 @@ public:
     static bool OnEditInput(UINT c);
 
     static void setAddress(unsigned int nAddr);
-    static void setWatchedAddress(unsigned int nAddr) noexcept;
+    static void setWatchedAddress(unsigned int nAddr);
     static unsigned int getWatchedAddress() noexcept { return m_nWatchedAddress; }
     static void moveAddress(int offset, int nibbleOff);
     static void editData(unsigned int nByteAddress, bool bLowerNibble, unsigned int value);
-    static void Invalidate() noexcept;
+    static void Invalidate();
 
-    static void SetDataSize(MemSize value) noexcept
+    static void SetDataSize(MemSize value)
     {
         m_nDataSize = value;
         Invalidate();

--- a/src/RA_Integration.vcxproj
+++ b/src/RA_Integration.vcxproj
@@ -39,7 +39,9 @@
     <ClCompile Include="api\impl\ConnectedServer.cpp" />
     <ClCompile Include="api\impl\DisconnectedServer.cpp" />
     <ClCompile Include="api\impl\OfflineServer.cpp" />
+    <ClCompile Include="data\EmulatorContext.cpp" />
     <ClCompile Include="data\SessionTracker.cpp" />
+    <ClCompile Include="data\UserContext.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='DebugUnicode|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='AnalysisUnicode|Win32'">Create</PrecompiledHeader>
@@ -114,11 +116,13 @@
     <ClInclude Include="api\impl\OfflineServer.hh" />
     <ClInclude Include="api\impl\ServerBase.hh" />
     <ClInclude Include="api\IServer.hh" />
+    <ClInclude Include="api\LatestClient.hh" />
     <ClInclude Include="api\Login.hh" />
     <ClInclude Include="api\Logout.hh" />
     <ClInclude Include="api\Ping.hh" />
     <ClInclude Include="api\ResolveHash.hh" />
     <ClInclude Include="api\StartSession.hh" />
+    <ClInclude Include="data\EmulatorContext.hh" />
     <ClInclude Include="data\GameContext.hh" />
     <ClInclude Include="data\SessionTracker.hh" />
     <ClInclude Include="data\UserContext.hh" />

--- a/src/RA_Integration.vcxproj.filters
+++ b/src/RA_Integration.vcxproj.filters
@@ -234,6 +234,12 @@
     <ClCompile Include="ui\win32\LoginDialog.cpp">
       <Filter>UI\Win32</Filter>
     </ClCompile>
+    <ClCompile Include="data\EmulatorContext.cpp">
+      <Filter>Data</Filter>
+    </ClCompile>
+    <ClCompile Include="data\UserContext.cpp">
+      <Filter>Data</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="RA_Achievement.h">
@@ -571,6 +577,12 @@
     </ClInclude>
     <ClInclude Include="ui\win32\bindings\CheckBoxBinding.hh">
       <Filter>UI\Win32\Bindings</Filter>
+    </ClInclude>
+    <ClInclude Include="api\LatestClient.hh">
+      <Filter>API</Filter>
+    </ClInclude>
+    <ClInclude Include="data\EmulatorContext.hh">
+      <Filter>Data</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/RA_Resource.h
+++ b/src/RA_Resource.h
@@ -129,7 +129,7 @@
 #define IDM_RA_RETROACHIEVEMENTS        1700
 #define IDM_RA_FILES_TEST1              1701
 #define IDM_RA_FILES_TEST2              1702
-#define IDM_RA_FILES_CHECKFORUPDATE     1703
+#define IDM_RA_FILES_CHECKFORUPDATE     1703    // available
 #define IDM_RA_FILES_ACHIEVEMENTS       1704
 #define IDM_RA_FILES_MEMORYFINDER       1705
 #define IDM_RA_FILES_LOGIN              1706

--- a/src/RA_httpthread.cpp
+++ b/src/RA_httpthread.cpp
@@ -10,6 +10,7 @@
 #include "RA_Dlg_MemBookmark.h"
 #include "RA_RichPresence.h"
 
+#include "data\EmulatorContext.hh"
 #include "data\GameContext.hh"
 
 #include "services\Http.hh"
@@ -23,7 +24,6 @@ const char* RequestTypeToString[] =
     "RequestScore",
     "RequestNews",
     "RequestPatch",
-    "RequestLatestClientPage",
     "RequestRichPresence",
     "RequestAchievementInfo",
     "RequestLeaderboardInfo",
@@ -49,7 +49,6 @@ const char* RequestTypeToPost[] =
     "score",
     "news",
     "patch",
-    "latestclient",
     "richpresencepatch",
     "achievementwondata",
     "lbinfo",
@@ -147,16 +146,18 @@ void RAWeb::SetUserAgentString()
     std::string sUserAgent;
     sUserAgent.reserve(128U);
 
-    if (g_sClientName != nullptr)
+    const auto& pEmulatorContext = ra::services::ServiceLocator::Get<ra::data::EmulatorContext>();
+    const auto& sClientName = pEmulatorContext.GetClientName();
+    if (!sClientName.empty())
     {
-        sUserAgent.append(g_sClientName);
+        sUserAgent.append(sClientName);
         sUserAgent.append("/");
     }
     else
     {
         sUserAgent.append("UnknownClient/");
     }
-    sUserAgent.append(g_sClientVersion);
+    sUserAgent.append(pEmulatorContext.GetClientVersion());
     sUserAgent.append(" (");
 
     AppendNTVersion(sUserAgent);

--- a/src/RA_httpthread.h
+++ b/src/RA_httpthread.h
@@ -20,7 +20,6 @@ enum RequestType
     RequestScore,
     RequestNews,
     RequestPatch,
-    RequestLatestClientPage,
     RequestRichPresence,
     RequestAchievementInfo,
     RequestLeaderboardInfo,

--- a/src/api/ApiCall.cpp
+++ b/src/api/ApiCall.cpp
@@ -20,6 +20,7 @@ Logout::Response Logout::Request::Call() const noexcept { return Server().Logout
 StartSession::Response StartSession::Request::Call() const noexcept { return Server().StartSession(*this); }
 Ping::Response Ping::Request::Call() const noexcept { return Server().Ping(*this); }
 ResolveHash::Response ResolveHash::Request::Call() const noexcept { return Server().ResolveHash(*this); }
+LatestClient::Response LatestClient::Request::Call() const noexcept { return Server().LatestClient(*this); }
 
 } // namespace api
 } // namespace ra

--- a/src/api/IServer.hh
+++ b/src/api/IServer.hh
@@ -2,6 +2,7 @@
 #define RA_API_ISERVER_HH
 #pragma once
 
+#include "api/LatestClient.hh"
 #include "api/Login.hh"
 #include "api/Logout.hh"
 #include "api/Ping.hh"
@@ -24,6 +25,9 @@ public:
 
     // === game functions ===
     virtual ResolveHash::Response ResolveHash(const ResolveHash::Request& request) noexcept = 0;
+
+    // === other functions ===
+    virtual LatestClient::Response LatestClient(const LatestClient::Request& request) noexcept = 0;
 
 protected:
     IServer() noexcept = default;

--- a/src/api/LatestClient.hh
+++ b/src/api/LatestClient.hh
@@ -1,0 +1,38 @@
+#ifndef RA_API_LATESTCLIENT_HH
+#define RA_API_LATESTCLIENT_HH
+#pragma once
+
+#include "ApiCall.hh"
+
+namespace ra {
+namespace api {
+
+class LatestClient
+{
+public:
+    static constexpr const char* const Name() noexcept { return "LatestClient"; }
+
+    struct Response : ApiResponseBase
+    {
+        std::string LatestVersion;
+    };
+
+    struct Request : ApiRequestBase
+    {
+        unsigned int EmulatorId;
+
+        using Callback = std::function<void(const Response& response)>;
+
+        Response Call() const noexcept;
+
+        void CallAsync(Callback&& callback) const
+        {
+            ApiRequestBase::CallAsync<Request, Callback>(*this, std::move(callback));
+        }
+    };
+};
+
+} // namespace api
+} // namespace ra
+
+#endif // !RA_API_LATESTCLIENT_HH

--- a/src/api/impl/ConnectedServer.cpp
+++ b/src/api/impl/ConnectedServer.cpp
@@ -275,6 +275,30 @@ ResolveHash::Response ConnectedServer::ResolveHash(const ResolveHash::Request& r
     return std::move(response);
 }
 
+LatestClient::Response ConnectedServer::LatestClient(const LatestClient::Request& request) noexcept
+{
+    LatestClient::Response response;
+    rapidjson::Document document;
+    std::string sPostData;
+
+    // LatestClient doesn't require User/Password, so the next few lines are a subset of DoRequest
+    AppendUrlParam(sPostData, "r", "latestclient");
+    AppendUrlParam(sPostData, "e", std::to_string(request.EmulatorId));
+    RA_LOG_INFO("%s Request: %s", LatestClient::Name(), sPostData.c_str());
+
+    ra::services::Http::Request httpRequest(ra::StringPrintf("%s/dorequest.php", m_sHost));
+    httpRequest.SetPostData(sPostData);
+
+    const auto httpResponse = httpRequest.Call();
+    if (GetJson(LatestClient::Name(), httpResponse, response, document))
+    {
+        response.Result = ApiResult::Success;
+        GetRequiredJsonField(response.LatestVersion, document, "LatestVersion", response);
+    }
+
+    return std::move(response);
+}
+
 } // namespace impl
 } // namespace api
 } // namespace ra

--- a/src/api/impl/ConnectedServer.hh
+++ b/src/api/impl/ConnectedServer.hh
@@ -18,7 +18,8 @@ public:
     GSL_SUPPRESS_F6 StartSession::Response StartSession(const StartSession::Request& request) noexcept override;
     GSL_SUPPRESS_F6 Ping::Response Ping(const Ping::Request& request) noexcept override;
     GSL_SUPPRESS_F6 ResolveHash::Response ResolveHash(const ResolveHash::Request& request) noexcept override;
-
+    GSL_SUPPRESS_F6 LatestClient::Response LatestClient(const LatestClient::Request& request) noexcept override;
+    
 private:
     const std::string m_sHost;
 };

--- a/src/api/impl/DisconnectedServer.cpp
+++ b/src/api/impl/DisconnectedServer.cpp
@@ -12,7 +12,7 @@ Login::Response DisconnectedServer::Login(const Login::Request& request) noexcep
 {
     // use the normal ServerApi to attempt to connect
     auto serverApi = std::make_unique<ConnectedServer>(m_sHost);
-    Login::Response response = serverApi->Login(request);
+    auto response = serverApi->Login(request);
 
     // if successful, update the global IServer instance to the connected API
     if (response.Result == ApiResult::Success)
@@ -20,6 +20,13 @@ Login::Response DisconnectedServer::Login(const Login::Request& request) noexcep
 
     // pass the server API response back to the caller
     return response;
+}
+
+LatestClient::Response DisconnectedServer::LatestClient(const LatestClient::Request& request) noexcept
+{
+    // LatestClient call doesn't require being logged in. Dispatch to the ConnectedServer::LatestClient method.
+    ConnectedServer serverApi(m_sHost);
+    return serverApi.LatestClient(request);
 }
 
 } // namespace impl

--- a/src/api/impl/DisconnectedServer.hh
+++ b/src/api/impl/DisconnectedServer.hh
@@ -16,6 +16,8 @@ public:
     GSL_SUPPRESS_F6 Login::Response Login(const Login::Request& request) noexcept override;
     const std::string& Host() const noexcept { return m_sHost; }
 
+    GSL_SUPPRESS_F6 LatestClient::Response LatestClient(const LatestClient::Request& request) noexcept override;
+
 private:
     const std::string m_sHost;
 };

--- a/src/api/impl/ServerBase.hh
+++ b/src/api/impl/ServerBase.hh
@@ -45,6 +45,14 @@ public:
         return UnsupportedApi<ResolveHash::Response>(ResolveHash::Name());
     }
 
+    // === other functions ===
+
+    LatestClient::Response LatestClient(_UNUSED const LatestClient::Request& /*request*/) noexcept override
+    {
+        GSL_SUPPRESS_F6
+        return UnsupportedApi<LatestClient::Response>(LatestClient::Name());
+    }
+
 protected:
     template<typename TResponse>
     inline typename TResponse UnsupportedApi(const char* const restrict apiName) const

--- a/src/data/EmulatorContext.cpp
+++ b/src/data/EmulatorContext.cpp
@@ -1,0 +1,326 @@
+#include "EmulatorContext.hh"
+
+#include "Exports.hh"
+#include "RA_Log.h"
+#include "RA_StringUtils.h"
+
+#include "api\LatestClient.hh"
+
+#include "data\GameContext.hh"
+#include "data\UserContext.hh"
+
+#include "services\IConfiguration.hh"
+#include "services\ILeaderboardManager.hh"
+
+#include "ui\IDesktop.hh"
+
+#include "ui\viewmodels\MessageBoxViewModel.hh"
+
+namespace ra {
+namespace data {
+
+void EmulatorContext::Initialize(EmulatorID nEmulatorId)
+{
+    m_nEmulatorId = nEmulatorId;
+
+    switch (nEmulatorId)
+    {
+        case RA_Gens:
+            m_sClientName = "RAGens_REWiND";
+            break;
+        case RA_Project64:
+            m_sClientName = "RAP64";
+            break;
+        case RA_Snes9x:
+            m_sClientName = "RASnes9X";
+            break;
+        case RA_VisualboyAdvance:
+            m_sClientName = "RAVisualBoyAdvance";
+            break;
+        case RA_Nester:
+        case RA_FCEUX:
+            m_sClientName = "RANes";
+            break;
+        case RA_PCE:
+            m_sClientName = "RAPCE";
+            break;
+        case RA_Libretro:
+            m_sClientName = "RALibRetro";
+            break;
+        case RA_Meka:
+            m_sClientName = "RAMeka";
+            break;
+        case RA_QUASI88:
+            m_sClientName = "RAQUASI88";
+            break;
+    }
+}
+
+static unsigned long long ParseVersion(const char* sVersion)
+{
+    char* pPart{};
+    const auto major = strtoull(sVersion, &pPart, 10);
+    Expects(pPart != nullptr);
+    if (*pPart == '.')
+        ++pPart;
+
+    const auto minor = strtoul(pPart, &pPart, 10);
+    if (*pPart == '.')
+        ++pPart;
+
+    const auto patch = strtoul(pPart, &pPart, 10);
+    if (*pPart == '.')
+        ++pPart;
+
+    const auto revision = strtoul(pPart, &pPart, 10);
+    // 64-bit max signed value is 9223 37203 68547 75807
+    auto version = (major * 100000) + minor;
+    version = (version * 100000) + patch;
+    version = (version * 100000) + revision;
+    return version;
+}
+
+bool EmulatorContext::ValidateClientVersion()
+{
+    if (m_sLatestVersion.empty())
+    {
+        ra::api::LatestClient::Request request;
+        request.EmulatorId = ra::etoi(m_nEmulatorId);
+        auto response = request.Call();
+        if (!response.Succeeded())
+        {
+            m_sLatestVersion = "Unknown";
+            m_sLatestVersionError = response.ErrorMessage;
+        }
+        else
+        {
+            m_sLatestVersion = response.LatestVersion;
+
+            const unsigned long long nServerVersion = ParseVersion(m_sLatestVersion.c_str());
+            const unsigned long long nLocalVersion = ParseVersion(m_sVersion.c_str());
+            RA_LOG("Client %s date: server %s, current %s",
+                   (nLocalVersion >= nServerVersion) ? "up to" : "out of",
+                   m_sLatestVersion,
+                   m_sVersion);
+        }
+    }
+
+    if (m_sLatestVersion == "Unknown")
+    {
+        const auto& pConfiguration = ra::services::ServiceLocator::Get<ra::services::IConfiguration>();
+
+        std::wstring sError;
+        if (pConfiguration.IsFeatureEnabled(ra::services::Feature::Hardcore))
+        {
+            sError = L"The latest client is required for hardcore mode.";
+            auto& pUserContext = ra::services::ServiceLocator::GetMutable<ra::data::UserContext>();
+            if (pUserContext.IsLoggedIn())
+            {
+                sError += L" You will be logged out.";
+                pUserContext.Logout();
+            }
+            else
+            {
+                if (!pUserContext.IsLoginDisabled() && !pConfiguration.GetApiToken().empty())
+                    sError += L" Login canceled.";
+            }
+
+            pUserContext.DisableLogin();
+        }
+
+        if (!m_sLatestVersionError.empty())
+        {
+            if (!sError.empty())
+                sError += L"\n";
+            sError += ra::Widen(m_sLatestVersionError);
+        }
+
+        ra::ui::viewmodels::MessageBoxViewModel::ShowErrorMessage(L"Could not retrieve latest client version.", sError);
+        return false;
+    }
+
+    const unsigned long long nServerVersion = ParseVersion(m_sLatestVersion.c_str());
+    const unsigned long long nLocalVersion = ParseVersion(m_sVersion.c_str());
+
+    if (nLocalVersion >= nServerVersion)
+        return true;
+
+    // remove any trailing ".0"s off the client version
+    std::string sClientVersion = m_sVersion;
+    while (sClientVersion[sClientVersion.length() - 1] == '0' && sClientVersion[sClientVersion.length() - 2] == '.')
+        sClientVersion.resize(sClientVersion.length() - 2);
+
+    std::string sNewVersion = m_sLatestVersion;
+    while (sNewVersion[sNewVersion.length() - 1] == '0' && sNewVersion[sNewVersion.length() - 2] == '.')
+        sNewVersion.resize(sNewVersion.length() - 2);
+
+    bool bUpdate = false;
+    bool bResult = true;
+
+    std::wstring sMessage;
+    const auto& pConfiguration = ra::services::ServiceLocator::Get<ra::services::IConfiguration>();
+    if (pConfiguration.IsFeatureEnabled(ra::services::Feature::Hardcore))
+    {
+        ra::ui::viewmodels::MessageBoxViewModel vmMessageBox;
+        vmMessageBox.SetHeader(L"The latest client is required for hardcore mode.");
+        vmMessageBox.SetMessage(ra::StringPrintf(
+            L"A new version of %s is available to download at %s.\n\n- Current version: %s\n- New version: %s\n\n"
+            L"Press OK to logout and download the new version, or Cancel to disable hardcore mode and proceed.",
+            m_sClientName,
+            pConfiguration.GetHostName(),
+            sClientVersion,
+            sNewVersion));
+        vmMessageBox.SetIcon(ra::ui::viewmodels::MessageBoxViewModel::Icon::Warning);
+        vmMessageBox.SetButtons(ra::ui::viewmodels::MessageBoxViewModel::Buttons::OKCancel);
+
+        if (vmMessageBox.ShowModal() == ra::ui::DialogResult::Cancel)
+        {
+            DisableHardcoreMode();
+        }
+        else
+        {
+            bUpdate = true;
+            bResult = false;
+        }
+    }
+    else
+    {
+        ra::ui::viewmodels::MessageBoxViewModel vmMessageBox;
+        vmMessageBox.SetHeader(L"Would you like to update?");
+        vmMessageBox.SetMessage(ra::StringPrintf(
+            L"A new version of %s is available to download at %s.\n\n- Current version: %s\n- New version: %s",
+            m_sClientName,
+            pConfiguration.GetHostName(),
+            sClientVersion,
+            sNewVersion));
+        vmMessageBox.SetIcon(ra::ui::viewmodels::MessageBoxViewModel::Icon::Info);
+        vmMessageBox.SetButtons(ra::ui::viewmodels::MessageBoxViewModel::Buttons::YesNo);
+
+        bUpdate = (vmMessageBox.ShowModal() == ra::ui::DialogResult::Yes);
+    }
+
+    if (bUpdate)
+    {
+        ra::services::ServiceLocator::Get<ra::ui::IDesktop>().OpenUrl(
+            ra::StringPrintf("http://%s/download.php", pConfiguration.GetHostName()));
+    }
+
+    return bResult;
+}
+
+void EmulatorContext::DisableHardcoreMode()
+{
+    auto& pConfiguration = ra::services::ServiceLocator::GetMutable<ra::services::IConfiguration>();
+    if (pConfiguration.IsFeatureEnabled(ra::services::Feature::Hardcore))
+    {
+        pConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, false);
+
+#ifndef RA_UTEST
+        _RA_RebuildMenu();
+
+        auto& pLeaderboardManager = ra::services::ServiceLocator::GetMutable<ra::services::ILeaderboardManager>();
+        pLeaderboardManager.Reset();
+#endif
+    }
+}
+
+bool EmulatorContext::EnableHardcoreMode()
+{
+    auto& pConfiguration = ra::services::ServiceLocator::GetMutable<ra::services::IConfiguration>();
+    if (pConfiguration.IsFeatureEnabled(ra::services::Feature::Hardcore))
+        return true;
+
+    // Enable the hardcore flag before calling ValidateClientVersion so it does the hardcore validation
+    // correctly.
+    pConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, true);
+    if (!ValidateClientVersion())
+    {
+        // The version could not be validated, or the user has chosen to update. Log them out.
+        auto& pUserContext = ra::services::ServiceLocator::GetMutable<ra::data::UserContext>();
+        pUserContext.Logout();
+
+        // hardcore is still enabled, which is okay. if the user isn't logged in, they'll have to log in again,
+        // at which point they'll go through the version validation logic again.
+        return true; 
+    }
+
+    if (!pConfiguration.IsFeatureEnabled(ra::services::Feature::Hardcore))
+    {
+        // The user has chosen to abort the switch to hardcore mode.
+        return false;
+    }
+
+    // The user is on the latest verion
+    const auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::GameContext>();
+    if (pGameContext.GameId() != 0)
+    {
+        ra::ui::viewmodels::MessageBoxViewModel vmMessageBox;
+        vmMessageBox.SetHeader(L"Enable hardcore mode?");
+        vmMessageBox.SetMessage(
+            L"Enabling hardcore mode will reset the emulator. You will lose any progress that has not been saved "
+            L"through the game.");
+        vmMessageBox.SetIcon(ra::ui::viewmodels::MessageBoxViewModel::Icon::Warning);
+        vmMessageBox.SetButtons(ra::ui::viewmodels::MessageBoxViewModel::Buttons::YesNo);
+
+        if (vmMessageBox.ShowModal() == ra::ui::DialogResult::No)
+        {
+            pConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, false);
+            return false;
+        }
+    }
+
+#ifndef RA_UTEST
+    // TODO: move these into EmulatorContext
+    _RA_RebuildMenu();
+
+    // when enabling hardcore mode, force a system reset
+    _RA_ResetEmulation();
+    _RA_OnReset();
+#endif
+
+    return true;
+}
+
+std::string EmulatorContext::GetAppTitle(const std::string& sMessage) const
+{
+    ra::StringBuilder builder;
+    builder.Append(m_sClientName);
+    builder.Append(" - ");
+
+    // only copy the first two parts of the version string to the title bar: 0.12.7.1 => 0.12
+    std::string sClientVersion = m_sVersion;
+    auto nIndex = sClientVersion.find('.');
+    if (nIndex != std::string::npos)
+    {
+        nIndex = sClientVersion.find('.', nIndex + 1);
+        if (nIndex != std::string::npos)
+            sClientVersion.erase(nIndex);
+    }
+    builder.Append(sClientVersion);
+
+    if (!sMessage.empty())
+    {
+        builder.Append(" - ");
+        builder.Append(sMessage);
+    }
+
+    const auto& pUserContext = ra::services::ServiceLocator::Get<ra::data::UserContext>();
+    if (pUserContext.IsLoggedIn())
+    {
+        builder.Append(" - ");
+        builder.Append(pUserContext.GetUsername());
+    }
+
+    const auto& sHostName = ra::services::ServiceLocator::Get<ra::services::IConfiguration>().GetHostName();
+    if (sHostName != "retroachievements.org")
+    {
+        builder.Append(" [");
+        builder.Append(sHostName);
+        builder.Append("]");
+    }
+
+    return builder.ToString();
+}
+
+} // namespace data
+} // namespace ra

--- a/src/data/EmulatorContext.cpp
+++ b/src/data/EmulatorContext.cpp
@@ -16,6 +16,12 @@
 
 #include "ui\viewmodels\MessageBoxViewModel.hh"
 
+#ifdef RA_UTEST
+API void CCONV _RA_SetConsoleID(unsigned int)
+{
+}
+#endif
+
 namespace ra {
 namespace data {
 
@@ -27,31 +33,48 @@ void EmulatorContext::Initialize(EmulatorID nEmulatorId)
     {
         case RA_Gens:
             m_sClientName = "RAGens_REWiND";
+            _RA_SetConsoleID(ConsoleID::MegaDrive);
             break;
+
         case RA_Project64:
             m_sClientName = "RAP64";
+            _RA_SetConsoleID(ConsoleID::N64);
             break;
+
         case RA_Snes9x:
             m_sClientName = "RASnes9X";
+            _RA_SetConsoleID(ConsoleID::SNES);
             break;
+
         case RA_VisualboyAdvance:
             m_sClientName = "RAVisualBoyAdvance";
+            _RA_SetConsoleID(ConsoleID::GB);
             break;
+
         case RA_Nester:
         case RA_FCEUX:
             m_sClientName = "RANes";
+            _RA_SetConsoleID(ConsoleID::NES);
             break;
+
         case RA_PCE:
             m_sClientName = "RAPCE";
+            _RA_SetConsoleID(ConsoleID::PCEngine);
             break;
+
         case RA_Libretro:
             m_sClientName = "RALibRetro";
+            // don't provide a default console - wait for user to load core
             break;
+
         case RA_Meka:
             m_sClientName = "RAMeka";
+            _RA_SetConsoleID(ConsoleID::MasterSystem);
             break;
+
         case RA_QUASI88:
             m_sClientName = "RAQUASI88";
+            _RA_SetConsoleID(ConsoleID::PC8800);
             break;
     }
 }

--- a/src/data/EmulatorContext.hh
+++ b/src/data/EmulatorContext.hh
@@ -24,20 +24,55 @@ public:
     /// </summary>
     void Initialize(EmulatorID nEmulatorId);
 
+    /// <summary>
+    /// Sets the client version.
+    /// </summary>
     void SetClientVersion(const std::string& sVersion) { m_sVersion = sVersion; }
 
-    bool ValidateClientVersion();
-
-    EmulatorID GetEmulatorId() const noexcept { return m_nEmulatorId; }
-
-    const std::string& GetClientName() const noexcept { return m_sClientName; }
-
+    /// <summary>
+    /// Gets the version of the emulator this context was initialized with.
+    /// </summary>
     const std::string& GetClientVersion() const noexcept { return m_sVersion; }
 
+    /// <summary>
+    /// Validates the client version against the latest version known by the server
+    /// </summary>
+    /// <remarks>
+    /// May show dialogs prompting the user to acknowledge their version is out of date.
+    /// The first time this is called, it makes a synchronous server call.
+    /// </remarks>
+    /// <returns>
+    /// <c>true</c> if client version is sufficient for the current configuration, 
+    /// <c>false</c> if not.
+    /// </returns>
+    bool ValidateClientVersion();
+
+    /// <summary>
+    /// Gets the unique identifier of the emulator this context was initialized with.
+    /// </summary>
+    EmulatorID GetEmulatorId() const noexcept { return m_nEmulatorId; }
+
+    /// <summary>
+    /// Gets the client name for the emulator this context was initialized with.
+    /// </summary>
+    const std::string& GetClientName() const noexcept { return m_sClientName; }
+
+    /// <summary>
+    /// Disables hardcore mode and notifies other services of that fact.
+    /// </summary>
     void DisableHardcoreMode();
 
+    /// <summary>
+    /// Enables hardcore mode and notifies other services of that fact.
+    /// </summary>
+    /// <returns><c>true</c> if hardcore mode was enabled, <c>false</c> if the user chose not to based on prompts they
+    /// were given.</returns>
     bool EnableHardcoreMode();
 
+    /// <summary>
+    /// Builds a string for displaying in the title bar of the emulator.
+    /// </summary>
+    /// <param name="sMessage">A custom message provided by the emulator to also display in the title bar.</param>
     std::string GetAppTitle(const std::string& sMessage) const;
 
 protected:

--- a/src/data/EmulatorContext.hh
+++ b/src/data/EmulatorContext.hh
@@ -1,0 +1,54 @@
+#ifndef RA_DATA_EMULATORCONTEXT_HH
+#define RA_DATA_EMULATORCONTEXT_HH
+#pragma once
+
+#include "RA_Interface.h"
+
+#include <string>
+
+namespace ra {
+namespace data {
+
+class EmulatorContext
+{
+public:
+    EmulatorContext() noexcept = default;
+    virtual ~EmulatorContext() noexcept = default;
+    EmulatorContext(const EmulatorContext&) noexcept = delete;
+    EmulatorContext& operator=(const EmulatorContext&) noexcept = delete;
+    EmulatorContext(EmulatorContext&&) noexcept = delete;
+    EmulatorContext& operator=(EmulatorContext&&) noexcept = delete;
+
+    /// <summary>
+    /// Initializes the emulator context.
+    /// </summary>
+    void Initialize(EmulatorID nEmulatorId);
+
+    void SetClientVersion(const std::string& sVersion) { m_sVersion = sVersion; }
+
+    bool ValidateClientVersion();
+
+    EmulatorID GetEmulatorId() const noexcept { return m_nEmulatorId; }
+
+    const std::string& GetClientName() const noexcept { return m_sClientName; }
+
+    const std::string& GetClientVersion() const noexcept { return m_sVersion; }
+
+    void DisableHardcoreMode();
+
+    bool EnableHardcoreMode();
+
+    std::string GetAppTitle(const std::string& sMessage) const;
+
+protected:
+    EmulatorID m_nEmulatorId = EmulatorID::UnknownEmulator;
+    std::string m_sVersion;
+    std::string m_sLatestVersion;
+    std::string m_sLatestVersionError;
+    std::string m_sClientName;
+};
+
+} // namespace data
+} // namespace ra
+
+#endif // !RA_DATA_EMULATORCONTEXT_HH

--- a/src/data/UserContext.cpp
+++ b/src/data/UserContext.cpp
@@ -1,0 +1,44 @@
+#include "UserContext.hh"
+
+#include "RA_Core.h"
+
+#include "api\Logout.hh"
+
+#include "services\IConfiguration.hh"
+
+#include "ui\viewmodels\MessageBoxViewModel.hh"
+#include "ui\viewmodels\OverlayManager.hh"
+
+namespace ra {
+namespace data {
+
+void UserContext::Logout()
+{
+    if (!IsLoggedIn())
+        return;
+
+    const ra::api::Logout::Request request;
+    const auto response = request.Call();
+    if (response.Succeeded())
+    {
+        m_sUsername.clear();
+        m_sApiToken.clear();
+        m_nScore = 0U;
+
+        ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().ClearPopups();
+        ra::services::ServiceLocator::Get<ra::services::IConfiguration>().Save();
+#ifndef RA_UTEST
+        _RA_UpdateAppTitle();
+        RA_RebuildMenu();
+#endif
+
+        ra::ui::viewmodels::MessageBoxViewModel::ShowInfoMessage(L"You are now logged out.");
+    }
+    else
+    {
+        ra::ui::viewmodels::MessageBoxViewModel::ShowErrorMessage(L"Logout failed", ra::Widen(response.ErrorMessage));
+    }
+}
+
+} // namespace data
+} // namespace ra

--- a/src/data/UserContext.hh
+++ b/src/data/UserContext.hh
@@ -52,10 +52,26 @@ public:
     /// </summary>
     void SetScore(unsigned int nValue) noexcept { m_nScore = nValue; }
 
+    /// <summary>
+    /// Gets whether login has been disabled.
+    /// </summary>
+    bool IsLoginDisabled() const noexcept { return m_bDisableLogin; }
+
+    /// <summary>
+    /// Disables the ability to login.
+    /// </summary>
+    void DisableLogin() noexcept { m_bDisableLogin = true; }
+
+    /// <summary>
+    /// Logs the user out.
+    /// </summary>
+    virtual void Logout();
+
 protected:
     std::string m_sUsername;
     std::string m_sApiToken;
-    unsigned int m_nScore{0U};
+    unsigned int m_nScore{ 0U };
+    bool m_bDisableLogin{ false };
 };
 
 } // namespace data

--- a/src/services/Initialization.hh
+++ b/src/services/Initialization.hh
@@ -2,6 +2,8 @@
 #define RA_SERVICES_INITIALIZATION_HH
 #pragma once
 
+#include "RA_Interface.h"
+
 namespace ra {
 namespace services {
 
@@ -10,7 +12,7 @@ class Initialization
 public:
     static void RegisterCoreServices();
 
-    static void RegisterServices(const std::string& sClientName);
+    static void RegisterServices(EmulatorID nEmulatorId);
 
     static void Shutdown();
 };

--- a/src/ui/IDesktop.hh
+++ b/src/ui/IDesktop.hh
@@ -32,6 +32,12 @@ public:
     /// <param name="oSize">The size of the work area.</param>
     virtual void GetWorkArea(_Out_ ra::ui::Position& oUpperLeftCorner, _Out_ ra::ui::Size& oSize) const = 0;
 
+    /// <summary>
+    /// Opens the specified URL using the default browser.
+    /// </summary>
+    /// <param name="sUrl">The URL to open.</param>
+    virtual void OpenUrl(const std::string& sUrl) const = 0;
+
     virtual void Shutdown() = 0;
 
 protected:

--- a/src/ui/viewmodels/LoginViewModel.cpp
+++ b/src/ui/viewmodels/LoginViewModel.cpp
@@ -1,5 +1,6 @@
 #include "LoginViewModel.hh"
 
+#include "RA_Interface.h"
 #include "RA_StringUtils.h"
 
 #include "api\Login.hh"
@@ -67,6 +68,10 @@ bool LoginViewModel::Login() const
 
     ra::ui::viewmodels::MessageBoxViewModel::ShowInfoMessage(
         std::wstring(L"Successfully logged in as ") + ra::Widen(response.Username));
+
+#ifndef RA_UTEST
+    RA_RebuildMenu();
+#endif
 
     return true;
 }

--- a/src/ui/win32/Desktop.cpp
+++ b/src/ui/win32/Desktop.cpp
@@ -87,7 +87,7 @@ IDialogPresenter* Desktop::GetDialogPresenter(const WindowViewModelBase& oViewMo
     return nullptr;
 }
 
-void Desktop::OpenUrl(const std::string& sUrl) const
+void Desktop::OpenUrl(const std::string& sUrl) const noexcept
 {
     ShellExecute(nullptr, TEXT("open"), sUrl.c_str(), nullptr, nullptr, SW_SHOWNORMAL);
 }

--- a/src/ui/win32/Desktop.cpp
+++ b/src/ui/win32/Desktop.cpp
@@ -87,6 +87,11 @@ IDialogPresenter* Desktop::GetDialogPresenter(const WindowViewModelBase& oViewMo
     return nullptr;
 }
 
+void Desktop::OpenUrl(const std::string& sUrl) const
+{
+    ShellExecute(nullptr, TEXT("open"), sUrl.c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+}
+
 void Desktop::Shutdown() noexcept
 {
 }

--- a/src/ui/win32/Desktop.hh
+++ b/src/ui/win32/Desktop.hh
@@ -18,6 +18,8 @@ public:
 
     void GetWorkArea(ra::ui::Position& oUpperLeftCorner, ra::ui::Size& oSize) const override;
 
+    void OpenUrl(const std::string& sUrl) const override;
+
     void Shutdown() noexcept override;
 
 private:

--- a/src/ui/win32/Desktop.hh
+++ b/src/ui/win32/Desktop.hh
@@ -18,7 +18,7 @@ public:
 
     void GetWorkArea(ra::ui::Position& oUpperLeftCorner, ra::ui::Size& oSize) const override;
 
-    void OpenUrl(const std::string& sUrl) const override;
+    void OpenUrl(const std::string& sUrl) const noexcept override;
 
     void Shutdown() noexcept override;
 

--- a/src/ui/win32/MessageBoxDialog.cpp
+++ b/src/ui/win32/MessageBoxDialog.cpp
@@ -4,6 +4,8 @@
 
 #include "ui/viewmodels/MessageBoxViewModel.hh"
 
+extern HWND g_RAMainWnd;
+
 namespace ra {
 namespace ui {
 namespace win32 {
@@ -69,7 +71,7 @@ void MessageBoxDialog::Presenter::ShowModal(ra::ui::WindowViewModelBase& oViewMo
             case MessageBoxViewModel::Buttons::RetryCancel: uType |= MB_RETRYCANCEL; break;
         }
 
-        nButton = MessageBoxW(GetActiveWindow(), pMessage->c_str(), oMessageBoxViewModel.GetWindowTitle().c_str(), uType);
+        nButton = MessageBoxW(g_RAMainWnd, pMessage->c_str(), oMessageBoxViewModel.GetWindowTitle().c_str(), uType);
     }
     else
     {
@@ -94,7 +96,7 @@ void MessageBoxDialog::Presenter::ShowModal(ra::ui::WindowViewModelBase& oViewMo
             case MessageBoxViewModel::Buttons::RetryCancel: dwCommonButtons = TDCBF_RETRY_BUTTON | TDCBF_CANCEL_BUTTON; break;
         }
 
-        const HRESULT result = pTaskDialog(GetActiveWindow(), nullptr, oMessageBoxViewModel.GetWindowTitle().c_str(),
+        const HRESULT result = pTaskDialog(g_RAMainWnd, nullptr, oMessageBoxViewModel.GetWindowTitle().c_str(),
             oMessageBoxViewModel.GetHeader().c_str(), oMessageBoxViewModel.GetMessage().c_str(), dwCommonButtons, pszIcon, &nButton);
 
         if (!SUCCEEDED(result))

--- a/tests/RA_Integration.Tests.vcxproj
+++ b/tests/RA_Integration.Tests.vcxproj
@@ -185,8 +185,10 @@
     <ClCompile Include="..\src\api\impl\ConnectedServer.cpp" />
     <ClCompile Include="..\src\api\impl\DisconnectedServer.cpp" />
     <ClCompile Include="..\src\api\impl\OfflineServer.cpp" />
+    <ClCompile Include="..\src\data\EmulatorContext.cpp" />
     <ClCompile Include="..\src\data\SessionTracker.cpp" />
     <ClCompile Include="..\src\data\GameContext.cpp" />
+    <ClCompile Include="..\src\data\UserContext.cpp" />
     <ClCompile Include="..\src\pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Analysis|Win32'">Create</PrecompiledHeader>
@@ -208,6 +210,7 @@
     <ClCompile Include="..\src\ui\viewmodels\LoginViewModel.cpp" />
     <ClCompile Include="api\ConnectedServer_Tests.cpp" />
     <ClCompile Include="api\DisconnectedServer_Tests.cpp" />
+    <ClCompile Include="data\EmulatorContext_Tests.cpp" />
     <ClCompile Include="data\SessionTracker_Tests.cpp" />
     <ClCompile Include="RA_RichPresence_Tests.cpp" />
     <ClInclude Include="..\src\RA_Achievement.h" />

--- a/tests/RA_Integration.Tests.vcxproj.filters
+++ b/tests/RA_Integration.Tests.vcxproj.filters
@@ -183,6 +183,15 @@
     <ClCompile Include="..\src\ui\viewmodels\LoginViewModel.cpp">
       <Filter>Code</Filter>
     </ClCompile>
+    <ClCompile Include="data\EmulatorContext_Tests.cpp">
+      <Filter>Tests\Data</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\data\EmulatorContext.cpp">
+      <Filter>Code</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\data\UserContext.cpp">
+      <Filter>Code</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="RA_Condition_Tests.cpp">

--- a/tests/data/EmulatorContext_Tests.cpp
+++ b/tests/data/EmulatorContext_Tests.cpp
@@ -1,0 +1,515 @@
+#include "CppUnitTest.h"
+
+#include "data\EmulatorContext.hh"
+
+#include "tests\RA_UnitTestHelpers.h"
+
+#include "tests\mocks\MockConfiguration.hh"
+#include "tests\mocks\MockDesktop.hh"
+#include "tests\mocks\MockGameContext.hh"
+#include "tests\mocks\MockServer.hh"
+#include "tests\mocks\MockThreadPool.hh"
+#include "tests\mocks\MockUserContext.hh"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace ra {
+namespace data {
+namespace tests {
+
+TEST_CLASS(EmulatorContext_Tests)
+{
+private:
+    class EmulatorContextHarness : public EmulatorContext
+    {
+    public:
+        ra::api::mocks::MockServer mockServer;
+        ra::data::mocks::MockGameContext mockGameContext;
+        ra::data::mocks::MockUserContext mockUserContext;
+        ra::services::mocks::MockConfiguration mockConfiguration;
+        ra::services::mocks::MockThreadPool mockThreadPool;
+        ra::ui::mocks::MockDesktop mockDesktop;
+
+        void MockVersions(const std::string& sClientVersion, const std::string& sServerVersion)
+        {
+            SetClientVersion(sClientVersion);
+            mockServer.HandleRequest<ra::api::LatestClient>([sServerVersion](const ra::api::LatestClient::Request&, ra::api::LatestClient::Response& response)
+            {
+                response.LatestVersion = sServerVersion;
+                response.Result = ra::api::ApiResult::Success;
+                return true;
+            });
+        }
+    };
+
+public:
+    TEST_METHOD(TestClientName)
+    {
+        EmulatorContextHarness emulator;
+
+        emulator.Initialize(EmulatorID::RA_FCEUX);
+        Assert::AreEqual(std::string("RANes"), emulator.GetClientName());
+
+        emulator.Initialize(EmulatorID::RA_Gens);
+        Assert::AreEqual(std::string("RAGens_REWiND"), emulator.GetClientName());
+
+        emulator.Initialize(EmulatorID::RA_Libretro);
+        Assert::AreEqual(std::string("RALibRetro"), emulator.GetClientName());
+
+        emulator.Initialize(EmulatorID::RA_Meka);
+        Assert::AreEqual(std::string("RAMeka"), emulator.GetClientName());
+
+        emulator.Initialize(EmulatorID::RA_Nester);
+        Assert::AreEqual(std::string("RANes"), emulator.GetClientName());
+
+        emulator.Initialize(EmulatorID::RA_PCE);
+        Assert::AreEqual(std::string("RAPCE"), emulator.GetClientName());
+
+        emulator.Initialize(EmulatorID::RA_Project64);
+        Assert::AreEqual(std::string("RAP64"), emulator.GetClientName());
+
+        emulator.Initialize(EmulatorID::RA_QUASI88);
+        Assert::AreEqual(std::string("RAQUASI88"), emulator.GetClientName());
+
+        emulator.Initialize(EmulatorID::RA_Snes9x);
+        Assert::AreEqual(std::string("RASnes9X"), emulator.GetClientName());
+
+        emulator.Initialize(EmulatorID::RA_VisualboyAdvance);
+        Assert::AreEqual(std::string("RAVisualBoyAdvance"), emulator.GetClientName());
+    }
+
+    TEST_METHOD(TestValidateClientVersionCurrent)
+    {
+        EmulatorContextHarness emulator;
+        emulator.Initialize(EmulatorID::RA_Snes9x);
+        emulator.SetClientVersion("0.56");
+        emulator.mockServer.HandleRequest<ra::api::LatestClient>([](const ra::api::LatestClient::Request& request, ra::api::LatestClient::Response& response)
+        {
+            Assert::AreEqual(static_cast<unsigned int>(EmulatorID::RA_Snes9x), request.EmulatorId);
+            response.LatestVersion = "0.56";
+            response.Result = ra::api::ApiResult::Success;
+            return true;
+        });
+
+        Assert::IsTrue(emulator.ValidateClientVersion());
+        Assert::IsFalse(emulator.mockDesktop.WasDialogShown());
+    }
+
+    TEST_METHOD(TestValidateClientVersionNewer)
+    {
+        EmulatorContextHarness emulator;
+        emulator.Initialize(EmulatorID::RA_Snes9x);
+        emulator.MockVersions("0.57", "0.56");
+
+        Assert::IsTrue(emulator.ValidateClientVersion());
+        Assert::IsFalse(emulator.mockDesktop.WasDialogShown());
+    }
+
+    TEST_METHOD(TestValidateClientVersionApiErrorNonHardcore)
+    {
+        EmulatorContextHarness emulator;
+        emulator.Initialize(EmulatorID::RA_Snes9x);
+        emulator.SetClientVersion("0.57");
+        emulator.mockServer.HandleRequest<ra::api::LatestClient>([](const ra::api::LatestClient::Request&, ra::api::LatestClient::Response& response)
+        {
+            response.ErrorMessage = "Could not communicate with server.";
+            response.Result = ra::api::ApiResult::Error;
+            return true;
+        });
+        emulator.mockDesktop.ExpectWindow<ra::ui::viewmodels::MessageBoxViewModel>([](ra::ui::viewmodels::MessageBoxViewModel& vmMessageBox)
+        {
+            Assert::AreEqual(std::wstring(L"Could not retrieve latest client version."), vmMessageBox.GetHeader());
+            Assert::AreEqual(std::wstring(L"Could not communicate with server."), vmMessageBox.GetMessage());
+            return ra::ui::DialogResult::OK;
+        });
+
+        Assert::IsFalse(emulator.ValidateClientVersion());
+        Assert::IsTrue(emulator.mockDesktop.WasDialogShown());
+    }
+
+    TEST_METHOD(TestValidateClientVersionApiErrorNonHardcoreLoggedIn)
+    {
+        EmulatorContextHarness emulator;
+        emulator.Initialize(EmulatorID::RA_Snes9x);
+        emulator.SetClientVersion("0.57");
+        emulator.mockUserContext.Initialize("User", "Token");
+        emulator.mockServer.HandleRequest<ra::api::LatestClient>([](const ra::api::LatestClient::Request&, ra::api::LatestClient::Response& response)
+        {
+            response.ErrorMessage = "Could not communicate with server.";
+            response.Result = ra::api::ApiResult::Error;
+            return true;
+        });
+        emulator.mockDesktop.ExpectWindow<ra::ui::viewmodels::MessageBoxViewModel>([](ra::ui::viewmodels::MessageBoxViewModel& vmMessageBox)
+        {
+            Assert::AreEqual(std::wstring(L"Could not retrieve latest client version."), vmMessageBox.GetHeader());
+            Assert::AreEqual(std::wstring(L"Could not communicate with server."), vmMessageBox.GetMessage());
+            return ra::ui::DialogResult::OK;
+        });
+
+        Assert::IsFalse(emulator.ValidateClientVersion());
+        Assert::IsTrue(emulator.mockDesktop.WasDialogShown());
+        Assert::IsTrue(emulator.mockUserContext.IsLoggedIn());
+    }
+
+    TEST_METHOD(TestValidateClientVersionApiErrorHardcore)
+    {
+        EmulatorContextHarness emulator;
+        emulator.Initialize(EmulatorID::RA_Snes9x);
+        emulator.SetClientVersion("0.57");
+        emulator.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, true);
+        emulator.mockConfiguration.SetApiToken("Token");
+        emulator.mockServer.HandleRequest<ra::api::LatestClient>([](const ra::api::LatestClient::Request&, ra::api::LatestClient::Response& response)
+        {
+            response.ErrorMessage = "Could not communicate with server.";
+            response.Result = ra::api::ApiResult::Error;
+            return true;
+        });
+        emulator.mockDesktop.ExpectWindow<ra::ui::viewmodels::MessageBoxViewModel>([](ra::ui::viewmodels::MessageBoxViewModel& vmMessageBox)
+        {
+            Assert::AreEqual(std::wstring(L"Could not retrieve latest client version."), vmMessageBox.GetHeader());
+            Assert::AreEqual(std::wstring(L"The latest client is required for hardcore mode. Login canceled.\nCould not communicate with server."), vmMessageBox.GetMessage());
+            return ra::ui::DialogResult::OK;
+        });
+
+        Assert::IsFalse(emulator.ValidateClientVersion());
+        Assert::IsTrue(emulator.mockDesktop.WasDialogShown());
+    }
+
+    TEST_METHOD(TestValidateClientVersionApiErrorHardcoreLoginDisabled)
+    {
+        EmulatorContextHarness emulator;
+        emulator.Initialize(EmulatorID::RA_Snes9x);
+        emulator.SetClientVersion("0.57");
+        emulator.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, true);
+        emulator.mockUserContext.DisableLogin();
+        emulator.mockServer.HandleRequest<ra::api::LatestClient>([](const ra::api::LatestClient::Request&, ra::api::LatestClient::Response& response)
+        {
+            response.ErrorMessage = "Could not communicate with server.";
+            response.Result = ra::api::ApiResult::Error;
+            return true;
+        });
+        emulator.mockDesktop.ExpectWindow<ra::ui::viewmodels::MessageBoxViewModel>([](ra::ui::viewmodels::MessageBoxViewModel& vmMessageBox)
+        {
+            Assert::AreEqual(std::wstring(L"Could not retrieve latest client version."), vmMessageBox.GetHeader());
+            Assert::AreEqual(std::wstring(L"The latest client is required for hardcore mode.\nCould not communicate with server."), vmMessageBox.GetMessage());
+            return ra::ui::DialogResult::OK;
+        });
+
+        Assert::IsFalse(emulator.ValidateClientVersion());
+        Assert::IsTrue(emulator.mockDesktop.WasDialogShown());
+    }
+
+    TEST_METHOD(TestValidateClientVersionApiErrorHardcoreLoggedIn)
+    {
+        EmulatorContextHarness emulator;
+        emulator.Initialize(EmulatorID::RA_Snes9x);
+        emulator.SetClientVersion("0.57");
+        emulator.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, true);
+        emulator.mockUserContext.Initialize("User", "Token");
+        emulator.mockServer.HandleRequest<ra::api::LatestClient>([](const ra::api::LatestClient::Request&, ra::api::LatestClient::Response& response)
+        {
+            response.ErrorMessage = "Could not communicate with server.";
+            response.Result = ra::api::ApiResult::Error;
+            return true;
+        });
+        emulator.mockDesktop.ExpectWindow<ra::ui::viewmodels::MessageBoxViewModel>([](ra::ui::viewmodels::MessageBoxViewModel& vmMessageBox)
+        {
+            Assert::AreEqual(std::wstring(L"Could not retrieve latest client version."), vmMessageBox.GetHeader());
+            Assert::AreEqual(std::wstring(L"The latest client is required for hardcore mode. You will be logged out.\nCould not communicate with server."), vmMessageBox.GetMessage());
+            return ra::ui::DialogResult::OK;
+        });
+
+        Assert::IsFalse(emulator.ValidateClientVersion());
+        Assert::IsTrue(emulator.mockDesktop.WasDialogShown());
+        Assert::IsFalse(emulator.mockUserContext.IsLoggedIn());
+    }
+
+    TEST_METHOD(TestValidateClientVersionOlderNonHardcoreIgnore)
+    {
+        EmulatorContextHarness emulator;
+        emulator.Initialize(EmulatorID::RA_Snes9x);
+        emulator.mockConfiguration.SetHostName("host");
+        emulator.MockVersions("0.57.0.0", "0.58.0.0");
+        emulator.mockDesktop.ExpectWindow<ra::ui::viewmodels::MessageBoxViewModel>([](ra::ui::viewmodels::MessageBoxViewModel& vmMessageBox)
+        {
+            Assert::AreEqual(std::wstring(L"Would you like to update?"), vmMessageBox.GetHeader());
+            Assert::AreEqual(std::wstring(L"A new version of RASnes9X is available to download at host.\n\n- Current version: 0.57\n- New version: 0.58"), vmMessageBox.GetMessage());
+            return ra::ui::DialogResult::No;
+        });
+
+        Assert::IsTrue(emulator.ValidateClientVersion());
+        Assert::IsTrue(emulator.mockDesktop.WasDialogShown());
+        Assert::AreEqual(std::string(), emulator.mockDesktop.LastOpenedUrl());
+    }
+
+    TEST_METHOD(TestValidateClientVersionOlderNonHardcoreAcknowledge)
+    {
+        EmulatorContextHarness emulator;
+        emulator.Initialize(EmulatorID::RA_Snes9x);
+        emulator.mockConfiguration.SetHostName("host");
+        emulator.MockVersions("0.57.0.0", "0.58.0.0");
+        emulator.mockDesktop.ExpectWindow<ra::ui::viewmodels::MessageBoxViewModel>([](ra::ui::viewmodels::MessageBoxViewModel& vmMessageBox)
+        {
+            Assert::AreEqual(std::wstring(L"Would you like to update?"), vmMessageBox.GetHeader());
+            Assert::AreEqual(std::wstring(L"A new version of RASnes9X is available to download at host.\n\n- Current version: 0.57\n- New version: 0.58"), vmMessageBox.GetMessage());
+            return ra::ui::DialogResult::Yes;
+        });
+
+        Assert::IsTrue(emulator.ValidateClientVersion());
+        Assert::IsTrue(emulator.mockDesktop.WasDialogShown());
+        Assert::AreEqual(std::string("http://host/download.php"), emulator.mockDesktop.LastOpenedUrl());
+    }
+
+    TEST_METHOD(TestValidateClientVersionOlderHardcoreProceed)
+    {
+        EmulatorContextHarness emulator;
+        emulator.Initialize(EmulatorID::RA_Snes9x);
+        emulator.mockConfiguration.SetHostName("host");
+        emulator.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, true);
+        emulator.MockVersions("0.57.0.0", "0.58.0.0");
+        emulator.mockDesktop.ExpectWindow<ra::ui::viewmodels::MessageBoxViewModel>([](ra::ui::viewmodels::MessageBoxViewModel& vmMessageBox)
+        {
+            Assert::AreEqual(std::wstring(L"The latest client is required for hardcore mode."), vmMessageBox.GetHeader());
+            Assert::AreEqual(std::wstring(L"A new version of RASnes9X is available to download at host.\n\n- Current version: 0.57\n- New version: 0.58\n\nPress OK to logout and download the new version, or Cancel to disable hardcore mode and proceed."), vmMessageBox.GetMessage());
+            return ra::ui::DialogResult::Cancel;
+        });
+
+        Assert::IsTrue(emulator.ValidateClientVersion());
+        Assert::IsTrue(emulator.mockDesktop.WasDialogShown());
+        Assert::AreEqual(std::string(), emulator.mockDesktop.LastOpenedUrl());
+        Assert::IsFalse(emulator.mockConfiguration.IsFeatureEnabled(ra::services::Feature::Hardcore));
+    }
+
+    TEST_METHOD(TestValidateClientVersionOlderHardcoreAcknowledge)
+    {
+        EmulatorContextHarness emulator;
+        emulator.Initialize(EmulatorID::RA_Snes9x);
+        emulator.mockConfiguration.SetHostName("host");
+        emulator.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, true);
+        emulator.MockVersions("0.57.0.0", "0.58.0.0");
+        emulator.mockDesktop.ExpectWindow<ra::ui::viewmodels::MessageBoxViewModel>([](ra::ui::viewmodels::MessageBoxViewModel& vmMessageBox)
+        {
+            Assert::AreEqual(std::wstring(L"The latest client is required for hardcore mode."), vmMessageBox.GetHeader());
+            Assert::AreEqual(std::wstring(L"A new version of RASnes9X is available to download at host.\n\n- Current version: 0.57\n- New version: 0.58\n\nPress OK to logout and download the new version, or Cancel to disable hardcore mode and proceed."), vmMessageBox.GetMessage());
+            return ra::ui::DialogResult::OK;
+        });
+
+        Assert::IsFalse(emulator.ValidateClientVersion());
+        Assert::IsTrue(emulator.mockDesktop.WasDialogShown());
+        Assert::AreEqual(std::string("http://host/download.php"), emulator.mockDesktop.LastOpenedUrl());
+        Assert::IsTrue(emulator.mockConfiguration.IsFeatureEnabled(ra::services::Feature::Hardcore));
+    }
+
+    TEST_METHOD(TestDisableHardcoreMode)
+    {
+        EmulatorContextHarness emulator;
+        emulator.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, true);
+
+        emulator.DisableHardcoreMode();
+
+        Assert::IsFalse(emulator.mockConfiguration.IsFeatureEnabled(ra::services::Feature::Hardcore));
+    }
+
+    TEST_METHOD(TestEnableHardcoreModeVersionCurrentNoGame)
+    {
+        EmulatorContextHarness emulator;
+        emulator.MockVersions("0.57", "0.57");
+
+        Assert::IsTrue(emulator.EnableHardcoreMode());
+
+        Assert::IsTrue(emulator.mockConfiguration.IsFeatureEnabled(ra::services::Feature::Hardcore));
+        Assert::IsFalse(emulator.mockDesktop.WasDialogShown());
+    }
+
+    TEST_METHOD(TestEnableHardcoreModeAlreadyEnabled)
+    {
+        EmulatorContextHarness emulator;
+        emulator.MockVersions("0.57", "0.57");
+        emulator.mockGameContext.SetGameId(1U); // would normally show a dialog
+        emulator.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, true);
+
+        Assert::IsTrue(emulator.EnableHardcoreMode());
+
+        Assert::IsTrue(emulator.mockConfiguration.IsFeatureEnabled(ra::services::Feature::Hardcore));
+        Assert::IsFalse(emulator.mockDesktop.WasDialogShown());
+    }
+
+    TEST_METHOD(TestEnableHardcoreModeVersionCurrentGameLoadedAccept)
+    {
+        EmulatorContextHarness emulator;
+        emulator.MockVersions("0.57", "0.57");
+        emulator.mockGameContext.SetGameId(1U);
+        emulator.mockDesktop.ExpectWindow<ra::ui::viewmodels::MessageBoxViewModel>([](ra::ui::viewmodels::MessageBoxViewModel& vmMessageBox)
+        {
+            Assert::AreEqual(std::wstring(L"Enable hardcore mode?"), vmMessageBox.GetHeader());
+            Assert::AreEqual(std::wstring(L"Enabling hardcore mode will reset the emulator. You will lose any progress that has not been saved through the game."), vmMessageBox.GetMessage());
+            return ra::ui::DialogResult::Yes;
+        });
+
+        Assert::IsTrue(emulator.EnableHardcoreMode());
+
+        Assert::IsTrue(emulator.mockConfiguration.IsFeatureEnabled(ra::services::Feature::Hardcore));
+        Assert::IsTrue(emulator.mockDesktop.WasDialogShown());
+    }
+
+    TEST_METHOD(TestEnableHardcoreModeVersionCurrentGameLoadedCancel)
+    {
+        EmulatorContextHarness emulator;
+        emulator.MockVersions("0.57", "0.57");
+        emulator.mockGameContext.SetGameId(1U);
+        emulator.mockDesktop.ExpectWindow<ra::ui::viewmodels::MessageBoxViewModel>([](ra::ui::viewmodels::MessageBoxViewModel& vmMessageBox)
+        {
+            Assert::AreEqual(std::wstring(L"Enable hardcore mode?"), vmMessageBox.GetHeader());
+            Assert::AreEqual(std::wstring(L"Enabling hardcore mode will reset the emulator. You will lose any progress that has not been saved through the game."), vmMessageBox.GetMessage());
+            return ra::ui::DialogResult::No;
+        });
+
+        Assert::IsFalse(emulator.EnableHardcoreMode());
+
+        Assert::IsFalse(emulator.mockConfiguration.IsFeatureEnabled(ra::services::Feature::Hardcore));
+        Assert::IsTrue(emulator.mockDesktop.WasDialogShown());
+    }
+
+    TEST_METHOD(TestEnableHardcoreModeVersionNewerGameLoadedAccept)
+    {
+        EmulatorContextHarness emulator;
+        emulator.MockVersions("0.58", "0.57");
+        emulator.mockGameContext.SetGameId(1U);
+        emulator.mockDesktop.ExpectWindow<ra::ui::viewmodels::MessageBoxViewModel>([](ra::ui::viewmodels::MessageBoxViewModel& vmMessageBox)
+        {
+            Assert::AreEqual(std::wstring(L"Enable hardcore mode?"), vmMessageBox.GetHeader());
+            Assert::AreEqual(std::wstring(L"Enabling hardcore mode will reset the emulator. You will lose any progress that has not been saved through the game."), vmMessageBox.GetMessage());
+            return ra::ui::DialogResult::Yes;
+        });
+
+        Assert::IsTrue(emulator.EnableHardcoreMode());
+
+        Assert::IsTrue(emulator.mockConfiguration.IsFeatureEnabled(ra::services::Feature::Hardcore));
+        Assert::IsTrue(emulator.mockDesktop.WasDialogShown());
+    }
+
+    TEST_METHOD(TestEnableHardcoreModeVersionOlderGameLoadedAccept)
+    {
+        EmulatorContextHarness emulator;
+        emulator.Initialize(EmulatorID::RA_Snes9x);
+        emulator.mockConfiguration.SetHostName("host");
+        emulator.mockUserContext.Initialize("User", "Token");
+        emulator.mockGameContext.SetGameId(1U);
+        emulator.MockVersions("0.57.0.0", "0.58.0.0");
+        emulator.mockDesktop.ExpectWindow<ra::ui::viewmodels::MessageBoxViewModel>([](ra::ui::viewmodels::MessageBoxViewModel& vmMessageBox)
+        {
+            Assert::AreEqual(std::wstring(L"The latest client is required for hardcore mode."), vmMessageBox.GetHeader());
+            Assert::AreEqual(std::wstring(L"A new version of RASnes9X is available to download at host.\n\n- Current version: 0.57\n- New version: 0.58\n\nPress OK to logout and download the new version, or Cancel to disable hardcore mode and proceed."), vmMessageBox.GetMessage());
+            return ra::ui::DialogResult::OK;
+        });
+        Assert::IsTrue(emulator.mockUserContext.IsLoggedIn());
+
+        Assert::IsTrue(emulator.EnableHardcoreMode());
+
+        Assert::IsTrue(emulator.mockConfiguration.IsFeatureEnabled(ra::services::Feature::Hardcore));
+        Assert::IsTrue(emulator.mockDesktop.WasDialogShown());
+        Assert::AreEqual(std::string("http://host/download.php"), emulator.mockDesktop.LastOpenedUrl());
+
+        // user should be logged out if hardcore was enabled on an older version
+        Assert::IsFalse(emulator.mockUserContext.IsLoggedIn());
+    }
+
+    TEST_METHOD(TestEnableHardcoreModeVersionOlderGameLoadedCancel)
+    {
+        EmulatorContextHarness emulator;
+        emulator.Initialize(EmulatorID::RA_Snes9x);
+        emulator.mockConfiguration.SetHostName("host");
+        emulator.mockUserContext.Initialize("User", "Token");
+        emulator.mockGameContext.SetGameId(1U);
+        emulator.MockVersions("0.57.0.0", "0.58.0.0");
+        emulator.mockDesktop.ExpectWindow<ra::ui::viewmodels::MessageBoxViewModel>([](ra::ui::viewmodels::MessageBoxViewModel& vmMessageBox)
+        {
+            Assert::AreEqual(std::wstring(L"The latest client is required for hardcore mode."), vmMessageBox.GetHeader());
+            Assert::AreEqual(std::wstring(L"A new version of RASnes9X is available to download at host.\n\n- Current version: 0.57\n- New version: 0.58\n\nPress OK to logout and download the new version, or Cancel to disable hardcore mode and proceed."), vmMessageBox.GetMessage());
+            return ra::ui::DialogResult::Cancel;
+        });
+        Assert::IsTrue(emulator.mockUserContext.IsLoggedIn());
+
+        Assert::IsFalse(emulator.EnableHardcoreMode());
+
+        Assert::IsFalse(emulator.mockConfiguration.IsFeatureEnabled(ra::services::Feature::Hardcore));
+        Assert::IsTrue(emulator.mockDesktop.WasDialogShown());
+        Assert::AreEqual(std::string(""), emulator.mockDesktop.LastOpenedUrl());
+        Assert::IsTrue(emulator.mockUserContext.IsLoggedIn());
+    }
+
+    TEST_METHOD(TestGetAppTitleDefault)
+    {
+        EmulatorContextHarness emulator;
+        Assert::AreEqual(std::string(" -  []"), emulator.GetAppTitle(""));
+
+        emulator.Initialize(EmulatorID::RA_Snes9x);
+        emulator.SetClientVersion("0.57.0.0");
+        emulator.mockConfiguration.SetHostName("retroachievements.org");
+        Assert::AreEqual(std::string("RASnes9X - 0.57"), emulator.GetAppTitle(""));
+    }
+
+    TEST_METHOD(TestGetAppTitleVersion)
+    {
+        EmulatorContextHarness emulator;
+        emulator.Initialize(EmulatorID::RA_Snes9x);
+        emulator.mockConfiguration.SetHostName("retroachievements.org");
+
+        emulator.SetClientVersion("0.57.1.1");
+        Assert::AreEqual(std::string("RASnes9X - 0.57"), emulator.GetAppTitle(""));
+
+        emulator.SetClientVersion("0.99");
+        Assert::AreEqual(std::string("RASnes9X - 0.99"), emulator.GetAppTitle(""));
+
+        emulator.SetClientVersion("1.0.12.0");
+        Assert::AreEqual(std::string("RASnes9X - 1.0"), emulator.GetAppTitle(""));
+    }
+
+    TEST_METHOD(TestGetAppTitleUserName)
+    {
+        EmulatorContextHarness emulator;
+        emulator.Initialize(EmulatorID::RA_Snes9x);
+        emulator.mockConfiguration.SetHostName("retroachievements.org");
+        emulator.SetClientVersion("0.57");
+
+        Assert::AreEqual(std::string("RASnes9X - 0.57"), emulator.GetAppTitle(""));
+
+        emulator.mockUserContext.Initialize("User", "Token");
+        Assert::AreEqual(std::string("RASnes9X - 0.57 - User"), emulator.GetAppTitle(""));
+
+        emulator.mockUserContext.Logout();
+        Assert::AreEqual(std::string("RASnes9X - 0.57"), emulator.GetAppTitle(""));
+    }
+
+    TEST_METHOD(TestGetAppTitleCustomMessage)
+    {
+        EmulatorContextHarness emulator;
+        emulator.Initialize(EmulatorID::RA_Snes9x);
+        emulator.mockConfiguration.SetHostName("retroachievements.org");
+        emulator.SetClientVersion("0.57");
+        Assert::AreEqual(std::string("RASnes9X - 0.57 - Test"), emulator.GetAppTitle("Test"));
+    }
+
+    TEST_METHOD(TestGetAppTitleCustomHost)
+    {
+        EmulatorContextHarness emulator;
+        emulator.Initialize(EmulatorID::RA_Snes9x);
+        emulator.mockConfiguration.SetHostName("localhost");
+        emulator.SetClientVersion("0.57");
+        Assert::AreEqual(std::string("RASnes9X - 0.57 [localhost]"), emulator.GetAppTitle(""));
+    }
+
+    TEST_METHOD(TestGetAppTitleEverything)
+    {
+        EmulatorContextHarness emulator;
+        emulator.Initialize(EmulatorID::RA_Snes9x);
+        emulator.mockConfiguration.SetHostName("localhost");
+        emulator.mockUserContext.Initialize("User", "Token");
+        emulator.SetClientVersion("0.57");
+        Assert::AreEqual(std::string("RASnes9X - 0.57 - Test - User [localhost]"), emulator.GetAppTitle("Test"));
+    }
+};
+
+} // namespace tests
+} // namespace data
+} // namespace ra

--- a/tests/mocks/MockDesktop.hh
+++ b/tests/mocks/MockDesktop.hh
@@ -45,7 +45,7 @@ public:
         m_sLastOpenedUrl = sUrl;
     }
 
-    const std::string& LastOpenedUrl() const { return m_sLastOpenedUrl; }
+    const std::string& LastOpenedUrl() const noexcept { return m_sLastOpenedUrl; }
 
     void Shutdown() noexcept override {}
 

--- a/tests/mocks/MockDesktop.hh
+++ b/tests/mocks/MockDesktop.hh
@@ -40,6 +40,13 @@ public:
         oSize = { 1920, 1080 };
     }
 
+    void OpenUrl(const std::string& sUrl) const override
+    {
+        m_sLastOpenedUrl = sUrl;
+    }
+
+    const std::string& LastOpenedUrl() const { return m_sLastOpenedUrl; }
+
     void Shutdown() noexcept override {}
 
     template<typename T>
@@ -73,6 +80,7 @@ private:
     ra::services::ServiceLocator::ServiceOverride<IDesktop> m_Override;
     std::vector<DialogHandler> m_vHandlers;
     mutable bool m_bDialogShown = false;
+    mutable std::string m_sLastOpenedUrl;
 };
 
 } // namespace mocks

--- a/tests/mocks/MockServer.hh
+++ b/tests/mocks/MockServer.hh
@@ -65,6 +65,13 @@ public:
         return HandleRequest<ra::api::ResolveHash>(request);
     }
 
+    // === other functions ===
+
+    LatestClient::Response LatestClient(const LatestClient::Request& request) noexcept override
+    {
+        return HandleRequest<ra::api::LatestClient>(request);
+    }
+
 protected:
     template<typename TApi>
     GSL_SUPPRESS_F6

--- a/tests/mocks/MockUserContext.hh
+++ b/tests/mocks/MockUserContext.hh
@@ -18,6 +18,13 @@ public:
     {
     }
 
+    void Logout() override
+    {
+        m_sUsername.clear();
+        m_sApiToken.clear();
+        m_nScore = 0U;
+    }
+
 private:
     ra::services::ServiceLocator::ServiceOverride<ra::data::UserContext> m_Override;
 };

--- a/tests/mocks/MockUserContext.hh
+++ b/tests/mocks/MockUserContext.hh
@@ -18,7 +18,7 @@ public:
     {
     }
 
-    void Logout() override
+    void Logout() noexcept override
     {
         m_sUsername.clear();
         m_sApiToken.clear();


### PR DESCRIPTION
* Version is validated when the user logs in, and when switching to hardcore mode.

* On initial startup, if the emulator version is not current, and the user is not in hardcore mode, they are presented with this dialog:
![image](https://user-images.githubusercontent.com/32680403/50487798-e0b57200-09bc-11e9-9688-9d9134a9836f.png)
  * Pressing Yes opens the download page and closes the dialog.
  * Pressing No just closes the dialog.
  * In both cases, the user is allowed to open games and proceed in non-hardcore mode.
* On initial startup, if the emulator version is not current, and the user is in hardcore mode, they are presented with this dialog:
![image](https://user-images.githubusercontent.com/32680403/50488625-acdc4b80-09c0-11e9-9f5b-e61718cc9714.png)
  * Pressing OK opens the download page, logs the user out, and closes the dialog. Since the user is logged out, achievements will not load.
  * Pressing Cancel closes the dialog and disables hardcore mode. The player is allowed to proceed in non-hardcore mode.
* When switching to hardcore mode, if the emulator version is not current, the user is presented with the second dialog.
  * Pressing OK opens the download page, logs the user out, and closes the dialog. Since the user is logged out, achievements will not trigger.
  * Pressing Cancel closes the dialog and leaves the user in non-hardcode mode.
* If the user chooses to log in after initial startup, and the emulator version is not current, and hardcore mode is enabled, the user is presented with the second dialog.
  * Pressing OK opens the download page, cancels the login, and closes the dialog. Since the user is logged out, achievements will not trigger.
  * Pressing Cancel closes the dialog, disables hardcore, and completes the login.
* If the emulator version is current, no dialog is shown for any of the above scenarios.

* `g_EmulatorId`, `g_sClientVersion`, and `g_sClientName` are now properties on `EmulatorContext`.
* `g_sClientDownloadURL` and `g_sClientEXEName` were removed. They were only referenced in commented out code.

* This PR also removes the "Check for Emulator Updates" menu item and hides the "Scan for Games" menu item (addresses #178).