### PR TITLE
force lost focus binding before triggering command via keyboard

### DIFF
--- a/src/ui/win32/DialogBase.cpp
+++ b/src/ui/win32/DialogBase.cpp
@@ -126,7 +126,13 @@ INT_PTR CALLBACK DialogBase::DialogProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPA
 
                 case 0:
                 {
-                    auto* pControlBinding = FindControlBinding((HWND)(lParam));
+                    // a command triggered by the keyboard will not move focus to the associated button. ensure any
+                    // lostfocus logic is applied for the currently focused control before executing the command.
+                    auto* pControlBinding = FindControlBinding(GetFocus());
+                    if (pControlBinding)
+                        pControlBinding->LostFocus();
+
+                    pControlBinding = FindControlBinding((HWND)(lParam));
                     if (pControlBinding)
                         pControlBinding->OnCommand();
                     break;


### PR DESCRIPTION
Fixes issue where pressing Enter in the password field would trigger the login without first pushing the password to the viewmodel.