### PR TITLE
don't rely on a ID of 0 for detecting local achievements

### DIFF
--- a/src/RA_AchievementOverlay.cpp
+++ b/src/RA_AchievementOverlay.cpp
@@ -1451,7 +1451,7 @@ void AchievementExamine::Initialize(const Achievement* pAch)
     {
         //	Do nothing.
     }
-    else if (m_pSelectedAchievement->ID() == 0)
+    else if (m_pSelectedAchievement->Category() == ra::etoi(AchievementSet::Type::Local))
     {
         //	Uncommitted/Exempt ID
         //	NB. Don't attempt to get anything

--- a/src/RA_Dlg_Achievement.cpp
+++ b/src/RA_Dlg_Achievement.cpp
@@ -639,7 +639,7 @@ INT_PTR Dlg_Achievements::AchievementsProc(HWND hDlg, UINT nMsg, WPARAM wParam, 
                     {
                         const Achievement& Ach = g_pActiveAchievements->GetAchievement(nSel);
 
-                        if (Ach.ID() == 0)
+                        if (Ach.Category() == ra::etoi(AchievementSet::Type::Local))
                         {
                             //  Local achievement
                             if (MessageBox(hDlg, TEXT("Are you sure that you want to remove this achievement?"), TEXT("Remove Achievement"), MB_YESNO | MB_ICONWARNING) == IDYES)


### PR DESCRIPTION
fixes ability to delete local achievements and display errors looking at local achievement details