### PR TITLE
rebuild trigger when reordering conditions

### DIFF
--- a/src/RA_Dlg_AchEditor.cpp
+++ b/src/RA_Dlg_AchEditor.cpp
@@ -1193,6 +1193,7 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
 
                             // Set this achievement as 'modified'
                             pActiveAch->SetModified(TRUE);
+                            pActiveAch->RebuildTrigger();
                             g_AchievementsDialog.OnEditAchievement(*pActiveAch);
 
                             // Refresh:
@@ -1256,6 +1257,7 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
 
                             // Set this achievement as 'modified'
                             pActiveAch->SetModified(TRUE);
+                            pActiveAch->RebuildTrigger();
                             g_AchievementsDialog.OnEditAchievement(*pActiveAch);
 
                             // Refresh:


### PR DESCRIPTION
fixes an issue where hitcounts appeared to be incrementing on the wrong condition when they were reordered.