### PR TITLE
don't start animation timer until first call to Update

### DIFF
--- a/src/ui/viewmodels/PopupMessageViewModel.hh
+++ b/src/ui/viewmodels/PopupMessageViewModel.hh
@@ -92,6 +92,14 @@ public:
     void UpdateRenderImage(double fElapsed) override;
     
     /// <summary>
+    /// Determines whether the animation cycle has started.
+    /// </summary>
+    bool IsAnimationStarted() const noexcept
+    {
+        return (m_fAnimationProgress >= 0.0);
+    }
+
+    /// <summary>
     /// Determines whether the animation cycle has completed.
     /// </summary>
     bool IsAnimationComplete() const noexcept
@@ -102,7 +110,7 @@ public:
 private:
     void CreateRenderImage();
 
-    double m_fAnimationProgress = 0.0;
+    double m_fAnimationProgress = -1.0;
     int m_nInitialY = 0;
     int m_nTargetY = 0;
 


### PR DESCRIPTION
Prevents issue where popups queued during an expensive operation (like loading a ROM) would already be partially or completely through their animation cycle before the first frame where they're rendered.