### PR TITLE
Ensure paths are absolute when interacting with file system

### DIFF
--- a/src/services/Http.cpp
+++ b/src/services/Http.cpp
@@ -34,6 +34,7 @@ Http::Response Http::Request::Download(const std::wstring& sFilename) const
 {
     auto& pFileSystem = ra::services::ServiceLocator::Get<ra::services::IFileSystem>();
     auto pFile = pFileSystem.CreateTextFile(sFilename);
+    Ensures(pFile != nullptr);
 
     const auto& pHttpRequester = ra::services::ServiceLocator::Get<ra::services::IHttpRequester>();
     const auto nStatusCode = ra::itoe<Http::StatusCode>(pHttpRequester.Request(*this, *pFile));

--- a/src/services/impl/FileLogger.hh
+++ b/src/services/impl/FileLogger.hh
@@ -29,6 +29,12 @@ public:
             pFileSystem.DeleteFile(sOldLogFilePath);
             pFileSystem.MoveFile(sLogFilePath, sOldLogFilePath);
         }
+        else if (nLogSize < 0)
+        {
+            std::wstring sCacheDirectory = pFileSystem.BaseDirectory() + L"RACache";
+            if (!pFileSystem.DirectoryExists(sCacheDirectory))
+                pFileSystem.CreateDirectory(sCacheDirectory);
+        }
 
         m_pWriter = pFileSystem.AppendTextFile(sLogFilePath);
         if (m_pWriter != nullptr)

--- a/src/services/impl/FileLogger.hh
+++ b/src/services/impl/FileLogger.hh
@@ -19,19 +19,19 @@ class FileLogger : public ra::services::ILogger
 public:
     explicit FileLogger(const ra::services::IFileSystem& pFileSystem)
     {
-        std::wstring sLogFilePath = pFileSystem.BaseDirectory() + L"RACache\\RALog.txt";
+        const std::wstring sLogFilePath = ra::BuildWString(pFileSystem.BaseDirectory().c_str(), L"RACache\\RALog.txt");
 
         // if the file is over 1MB, rename it and start a new one
         const int64_t nLogSize = pFileSystem.GetFileSize(sLogFilePath);
         if (nLogSize > 1024 * 1024)
         {
-            std::wstring sOldLogFilePath = pFileSystem.BaseDirectory() + L"RACache\\RALog-old.txt";
+            const std::wstring sOldLogFilePath = ra::BuildWString(pFileSystem.BaseDirectory().c_str(), L"RACache\\RALog-old.txt");
             pFileSystem.DeleteFile(sOldLogFilePath);
             pFileSystem.MoveFile(sLogFilePath, sOldLogFilePath);
         }
         else if (nLogSize < 0)
         {
-            std::wstring sCacheDirectory = pFileSystem.BaseDirectory() + L"RACache";
+            const std::wstring sCacheDirectory = ra::BuildWString(pFileSystem.BaseDirectory().c_str(), L"RACache");
             if (!pFileSystem.DirectoryExists(sCacheDirectory))
                 pFileSystem.CreateDirectory(sCacheDirectory);
         }

--- a/src/services/impl/WindowsFileSystem.cpp
+++ b/src/services/impl/WindowsFileSystem.cpp
@@ -26,20 +26,36 @@ WindowsFileSystem::WindowsFileSystem() noexcept
     }
 }
 
+const std::wstring& WindowsFileSystem::MakeAbsolute(std::wstring& sBuffer, const std::wstring& sPath) const
+{
+    if (!PathIsRelativeW(sPath.c_str()))
+        return sPath;
+
+    sBuffer.reserve(m_sBaseDirectory.length() + sPath.length());
+    sBuffer.assign(m_sBaseDirectory);
+    sBuffer.append(sPath);
+    return sBuffer;
+}
+
 bool WindowsFileSystem::DirectoryExists(const std::wstring& sDirectory) const noexcept
 {
-    const DWORD nAttrib = GetFileAttributesW(sDirectory.c_str());
+    std::wstring sBuffer;
+    const auto& sAbsolutePath = MakeAbsolute(sBuffer, sDirectory);
+    const DWORD nAttrib = GetFileAttributesW(sAbsolutePath.c_str());
     return (nAttrib != INVALID_FILE_ATTRIBUTES) && (nAttrib & FILE_ATTRIBUTE_DIRECTORY);
 }
 
 bool WindowsFileSystem::CreateDirectory(const std::wstring& sDirectory) const noexcept
 {
-    return static_cast<bool>(CreateDirectoryW(sDirectory.c_str(), nullptr));
+    std::wstring sBuffer;
+    const auto& sAbsolutePath = MakeAbsolute(sBuffer, sDirectory);
+    return static_cast<bool>(CreateDirectoryW(sAbsolutePath.c_str(), nullptr));
 }
 
 size_t WindowsFileSystem::GetFilesInDirectory(const std::wstring& sDirectory, _Inout_ std::vector<std::wstring>& vResults) const
 {
-    std::wstring sSearchString = sDirectory;
+    std::wstring sBuffer;
+    std::wstring sSearchString = MakeAbsolute(sBuffer, sDirectory);
     sSearchString += L"\\*";
 
     WIN32_FIND_DATAW ffdFile;
@@ -60,18 +76,26 @@ size_t WindowsFileSystem::GetFilesInDirectory(const std::wstring& sDirectory, _I
 
 bool WindowsFileSystem::DeleteFile(const std::wstring& sPath) const noexcept
 {
-    return static_cast<bool>(DeleteFileW(sPath.c_str()));
+    std::wstring sBuffer;
+    const auto& sAbsolutePath = MakeAbsolute(sBuffer, sPath);
+    return static_cast<bool>(DeleteFileW(sAbsolutePath.c_str()));
 }
 
 bool WindowsFileSystem::MoveFile(const std::wstring& sOldPath, const std::wstring& sNewPath) const noexcept
 {
-    return static_cast<bool>(MoveFileW(sOldPath.c_str(), sNewPath.c_str()));
+    std::wstring sBufferNew, sBufferOld;
+    const auto& sAbsolutePathNew = MakeAbsolute(sBufferNew, sNewPath);
+    const auto& sAbsolutePathOld = MakeAbsolute(sBufferOld, sOldPath);
+    return static_cast<bool>(MoveFileW(sAbsolutePathOld.c_str(), sAbsolutePathNew.c_str()));
 }
 
 int64_t WindowsFileSystem::GetFileSize(const std::wstring& sPath) const
 {
+    std::wstring sBuffer;
+    const auto& sAbsolutePath = MakeAbsolute(sBuffer, sPath);
+
     WIN32_FILE_ATTRIBUTE_DATA fadFile;
-    if (!GetFileAttributesExW(sPath.c_str(), GET_FILEEX_INFO_LEVELS::GetFileExInfoStandard, &fadFile))
+    if (!GetFileAttributesExW(sAbsolutePath.c_str(), GET_FILEEX_INFO_LEVELS::GetFileExInfoStandard, &fadFile))
     {
         if (GetLastError() != ERROR_FILE_NOT_FOUND && ra::services::ServiceLocator::Exists<ra::services::ILogger>())
         {
@@ -97,8 +121,11 @@ int64_t WindowsFileSystem::GetFileSize(const std::wstring& sPath) const
 
 std::chrono::system_clock::time_point WindowsFileSystem::GetLastModified(const std::wstring& sPath) const
 {
+    std::wstring sBuffer;
+    const auto& sAbsolutePath = MakeAbsolute(sBuffer, sPath);
+
     WIN32_FILE_ATTRIBUTE_DATA fadFile;
-    if (!GetFileAttributesExW(sPath.c_str(), GET_FILEEX_INFO_LEVELS::GetFileExInfoStandard, &fadFile))
+    if (!GetFileAttributesExW(sAbsolutePath.c_str(), GET_FILEEX_INFO_LEVELS::GetFileExInfoStandard, &fadFile))
     {
         RA_LOG_ERR("Error %d getting last modified for file: %s", GetLastError(), ra::Narrow(sPath).c_str());
         return std::chrono::system_clock::time_point();
@@ -115,7 +142,10 @@ std::chrono::system_clock::time_point WindowsFileSystem::GetLastModified(const s
 
 std::unique_ptr<TextReader> WindowsFileSystem::OpenTextFile(const std::wstring& sPath) const
 {
-    auto pReader = std::make_unique<FileTextReader>(sPath);
+    std::wstring sBuffer;
+    const auto& sAbsolutePath = MakeAbsolute(sBuffer, sPath);
+
+    auto pReader = std::make_unique<FileTextReader>(sAbsolutePath);
     if (!pReader->GetFStream().is_open())
     {
         RA_LOG("Failed to open \"%s\": %d", ra::Narrow(sPath).c_str(), errno);
@@ -127,7 +157,10 @@ std::unique_ptr<TextReader> WindowsFileSystem::OpenTextFile(const std::wstring& 
 
 std::unique_ptr<TextWriter> WindowsFileSystem::CreateTextFile(const std::wstring& sPath) const
 {
-    auto pWriter = std::make_unique<FileTextWriter>(sPath);
+    std::wstring sBuffer;
+    const auto& sAbsolutePath = MakeAbsolute(sBuffer, sPath);
+
+    auto pWriter = std::make_unique<FileTextWriter>(sAbsolutePath);
     if (!pWriter->GetFStream().is_open())
     {
         RA_LOG("Failed to create \"%s\": %d", ra::Narrow(sPath).c_str(), errno);
@@ -139,9 +172,12 @@ std::unique_ptr<TextWriter> WindowsFileSystem::CreateTextFile(const std::wstring
 
 std::unique_ptr<TextWriter> WindowsFileSystem::AppendTextFile(const std::wstring& sPath) const
 {
+    std::wstring sBuffer;
+    const auto& sAbsolutePath = MakeAbsolute(sBuffer, sPath);
+
     // cannot use std::ios::app, or the SetPosition method doesn't work
     // have to specify std::ios::in or the previous contents are lost
-    auto pWriter = std::make_unique<FileTextWriter>(sPath, std::ios::ate | std::ios::in | std::ios::out);
+    auto pWriter = std::make_unique<FileTextWriter>(sAbsolutePath, std::ios::ate | std::ios::in | std::ios::out);
     const gsl::not_null<const std::ofstream*> oStream{gsl::make_not_null(&pWriter->GetFStream())};
     if (!oStream->is_open())
     {

--- a/src/services/impl/WindowsFileSystem.cpp
+++ b/src/services/impl/WindowsFileSystem.cpp
@@ -26,7 +26,8 @@ WindowsFileSystem::WindowsFileSystem() noexcept
     }
 }
 
-const std::wstring& WindowsFileSystem::MakeAbsolute(std::wstring& sBuffer, const std::wstring& sPath) const
+GSL_SUPPRESS_F6
+const std::wstring& WindowsFileSystem::MakeAbsolute(std::wstring& sBuffer, const std::wstring& sPath) const noexcept
 {
     if (!PathIsRelativeW(sPath.c_str()))
         return sPath;

--- a/src/services/impl/WindowsFileSystem.hh
+++ b/src/services/impl/WindowsFileSystem.hh
@@ -33,7 +33,7 @@ public:
     std::unique_ptr<TextWriter> AppendTextFile(const std::wstring& sPath) const override;
 
 private:
-    const std::wstring& MakeAbsolute(std::wstring& sBuffer, const std::wstring& sPath) const;
+    const std::wstring& MakeAbsolute(std::wstring& sBuffer, const std::wstring& sPath) const noexcept;
 
     std::wstring m_sBaseDirectory;
 };

--- a/src/services/impl/WindowsFileSystem.hh
+++ b/src/services/impl/WindowsFileSystem.hh
@@ -33,6 +33,8 @@ public:
     std::unique_ptr<TextWriter> AppendTextFile(const std::wstring& sPath) const override;
 
 private:
+    const std::wstring& MakeAbsolute(std::wstring& sBuffer, const std::wstring& sPath) const;
+
     std::wstring m_sBaseDirectory;
 };
 


### PR DESCRIPTION
Addresses #253. The RACache directory was created with a full path, but the images were being written with a relative path. Since the relative RACache directory doesn't exist, an exception occurred.