### PR TITLE
Refresh unlocked achievements when switching between hardcore and non-hardcore mode

### DIFF
--- a/src/RA_StringUtils.h
+++ b/src/RA_StringUtils.h
@@ -181,7 +181,6 @@ public:
             m_vPending.emplace_back(std::wstring{ra::ToWString(arg)});
         else
             m_vPending.emplace_back(std::string{ra::ToString(arg)});
-        
     }
 
     template<>

--- a/src/data/EmulatorContext.cpp
+++ b/src/data/EmulatorContext.cpp
@@ -254,6 +254,8 @@ void EmulatorContext::DisableHardcoreMode()
         auto& pLeaderboardManager = ra::services::ServiceLocator::GetMutable<ra::services::ILeaderboardManager>();
         pLeaderboardManager.Reset();
 #endif
+
+        ra::services::ServiceLocator::GetMutable<ra::data::GameContext>().RefreshUnlocks();
     }
 }
 
@@ -310,6 +312,8 @@ bool EmulatorContext::EnableHardcoreMode()
     _RA_ResetEmulation();
     _RA_OnReset();
 #endif
+
+    ra::services::ServiceLocator::GetMutable<ra::data::GameContext>().RefreshUnlocks();
 
     return true;
 }

--- a/src/data/GameContext.cpp
+++ b/src/data/GameContext.cpp
@@ -90,7 +90,6 @@ void GameContext::LoadGame(unsigned int nGameId)
 #ifndef RA_UTEST
     auto& pImageRepository = ra::services::ServiceLocator::GetMutable<ra::ui::IImageRepository>();
 #endif
-    auto& pConfiguration = ra::services::ServiceLocator::Get<ra::services::IConfiguration>();
 
     // game properties
     m_sGameTitle = response.Title;
@@ -154,10 +153,24 @@ void GameContext::LoadGame(unsigned int nGameId)
     MergeLocalAchievements();
 
     // get user unlocks asynchronously
-    ra::api::FetchUserUnlocks::Request request2;
-    request2.GameId = nGameId;
-    request2.Hardcore = pConfiguration.IsFeatureEnabled(ra::services::Feature::Hardcore);
-    request2.CallAsync([this, bWasPaused](const ra::api::FetchUserUnlocks::Response& response)
+    RefreshUnlocks(!bWasPaused);
+
+    // show "game loaded" popup
+    ra::services::ServiceLocator::Get<ra::services::IAudioSystem>().PlayAudioFile(L"Overlay\\info.wav");
+    ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().QueueMessage(
+        ra::StringPrintf(L"Loaded %s", response.Title),
+        ra::StringPrintf(L"%u achievements, Total Score %u", nNumCoreAchievements, nTotalCoreAchievementPoints),
+        ra::ui::ImageType::Icon, response.ImageIcon);
+}
+
+void GameContext::RefreshUnlocks(bool bUnpause)
+{
+    const auto& pConfiguration = ra::services::ServiceLocator::Get<ra::services::IConfiguration>();
+
+    ra::api::FetchUserUnlocks::Request request;
+    request.GameId = m_nGameId;
+    request.Hardcore = pConfiguration.IsFeatureEnabled(ra::services::Feature::Hardcore);
+    request.CallAsync([this, bUnpause](const ra::api::FetchUserUnlocks::Response& response)
     {
         std::set<unsigned int> vLockedAchievements;
         for (auto& pAchievement : m_vAchievements)
@@ -187,24 +200,17 @@ void GameContext::LoadGame(unsigned int nGameId)
             }
         }
 
-        ra::services::ServiceLocator::GetMutable<ra::services::AchievementRuntime>().SetPaused(bWasPaused);
+        if (bUnpause)
+            ra::services::ServiceLocator::GetMutable<ra::services::AchievementRuntime>().SetPaused(false);
 
 #ifndef RA_UTEST
         for (int nIndex = 0; nIndex < ra::to_signed(g_pActiveAchievements->NumAchievements()); ++nIndex)
         {
             const Achievement& Ach = g_pActiveAchievements->GetAchievement(nIndex);
-            if (Ach.Active())
-                g_AchievementsDialog.OnEditData(nIndex, Dlg_Achievements::Column::Achieved, "No");
+            g_AchievementsDialog.OnEditData(nIndex, Dlg_Achievements::Column::Achieved, Ach.Active() ? "No" : "Yes");
         }
 #endif
     });
-
-    // show "game loaded" popup
-    ra::services::ServiceLocator::Get<ra::services::IAudioSystem>().PlayAudioFile(L"Overlay\\info.wav");
-    ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().QueueMessage(
-        ra::StringPrintf(L"Loaded %s", response.Title),
-        ra::StringPrintf(L"%u achievements, Total Score %u", nNumCoreAchievements, nTotalCoreAchievementPoints),
-        ra::ui::ImageType::Icon, response.ImageIcon);
 }
 
 void GameContext::MergeLocalAchievements()

--- a/src/data/GameContext.hh
+++ b/src/data/GameContext.hh
@@ -95,6 +95,11 @@ public:
     void AwardAchievement(unsigned int nAchievementId) const;
 
     /// <summary>
+    /// Updates the set of unlocked achievements from the server.
+    /// </summary>
+    void RefreshUnlocks() { RefreshUnlocks(false); }
+
+    /// <summary>
     /// Gets whether or not the loaded game has a rich presence script.
     /// </summary>
     virtual bool HasRichPresence() const noexcept;
@@ -124,6 +129,7 @@ public:
 protected:
     void MergeLocalAchievements();
     bool ReloadAchievement(Achievement& pAchievement);
+    void RefreshUnlocks(bool bWasPaused);
 
     unsigned int m_nGameId = 0;
     std::wstring m_sGameTitle;

--- a/tests/services/AchievementRuntime_Tests.cpp
+++ b/tests/services/AchievementRuntime_Tests.cpp
@@ -358,6 +358,36 @@ public:
         Assert::AreEqual(pAchievement2.ID(), vChanges.at(1).nId);
         Assert::AreEqual(AchievementRuntime::ChangeType::AchievementTriggered, vChanges.at(1).nType);
     }
+
+    TEST_METHOD(TestReactivateAchievement)
+    {
+        AchievementRuntime runtime;
+        auto* pTrigger = ParseTrigger("1=1_1=0");
+
+        std::vector<AchievementRuntime::Change> vChanges;
+        runtime.ActivateAchievement(6U, pTrigger);
+        runtime.Process(vChanges);
+        runtime.Process(vChanges);
+        runtime.Process(vChanges);
+        Assert::AreEqual(3U, pTrigger->requirement->conditions->current_hits);
+
+        // deactivating achievement should not reset hit count
+        runtime.DeactivateAchievement(6U);
+        Assert::AreEqual(3U, pTrigger->requirement->conditions->current_hits);
+
+        runtime.Process(vChanges);
+        Assert::AreEqual(3U, pTrigger->requirement->conditions->current_hits);
+
+        // reactivating achievement should not reset hit count
+        // this behavior is important for GameContext.RefreshUnlocks - when switching from hardcore to non-hardcore,
+        // the achievement is deactivated and reactivated (if not unlocked). since the emulator is not reset, the
+        // hit count shouldn't be reset either.
+        runtime.ActivateAchievement(6U, pTrigger);
+        Assert::AreEqual(3U, pTrigger->requirement->conditions->current_hits);
+
+        runtime.Process(vChanges);
+        Assert::AreEqual(4U, pTrigger->requirement->conditions->current_hits);
+    }
 };
 
 } // namespace tests


### PR DESCRIPTION
If a user only has the non-hardcore version of a badge, this will properly enabled/disable the hardcore trigger when toggling hardcore on and off.