### PR TITLE
Retry achievement unlock on network error

### DIFF
--- a/src/Exports.cpp
+++ b/src/Exports.cpp
@@ -105,11 +105,16 @@ API void CCONV _RA_AttemptLogin(bool bBlocking)
         if (bBlocking)
         {
             ra::api::Login::Response response = request.Call();
+
+            // if we're blocking, we can't keep retrying on network failure, but we can retry at least once
+            if (response.Result == ra::api::ApiResult::Incomplete)
+                response = request.Call();
+
             HandleLoginResponse(response);
         }
         else
         {
-            request.CallAsync(HandleLoginResponse);
+            request.CallAsyncWithRetry(HandleLoginResponse);
         }
     }
 }

--- a/src/RA_httpthread.cpp
+++ b/src/RA_httpthread.cpp
@@ -19,6 +19,8 @@
 #include "services\IThreadPool.hh"
 #include "services\ServiceLocator.hh"
 
+#include <winhttp.h>
+
 const char* RequestTypeToString[] =
 {
     "RequestScore",

--- a/src/api/ApiCall.hh
+++ b/src/api/ApiCall.hh
@@ -42,7 +42,7 @@ protected:
 
 private:
     template<class TRequest, class TCallback>
-    static void DoAsyncWithRetry(const TRequest&& request, TCallback&& callback, std::chrono::milliseconds delay)
+    static void DoAsyncWithRetry(const TRequest& request, TCallback&& callback, std::chrono::milliseconds delay)
     {
         auto response = request.Call();
         if (response.Result != ApiResult::Incomplete)
@@ -97,7 +97,7 @@ struct ApiResponseBase
     /// <returns><c>true</c> if the call was unsuccessful, <c>false</c> if not.</returns>
     bool Failed() const noexcept
     {
-        return (!Succeeded() && Result != ApiResult::None);
+        return !Succeeded() && (Result != ApiResult::None);
     }
 };
 

--- a/src/api/ApiCall.hh
+++ b/src/api/ApiCall.hh
@@ -11,21 +11,62 @@ namespace ra {
 namespace api {
 
 enum class ApiResult
-{    
+{
     None = 0,       // unspecified
     Success,        // call was successful
     Error,          // an error occurred
     Failed,         // call was unsuccessful, but didn't error
     Unsupported,    // call is not supported and was not made
+    Incomplete,     // call could not be made at this time
 };
 
 struct ApiRequestBase
 {
+protected:
     template<class TRequest, class TCallback>
     static void CallAsync(const TRequest& request, TCallback&& callback)
     {
         ra::services::ServiceLocator::GetMutable<ra::services::IThreadPool>().RunAsync(
-            [request, callback = std::move(callback)] { callback(request.Call()); });
+            [request, callback = std::move(callback)]{ callback(request.Call()); });
+    }
+
+    template<class TRequest, class TCallback>
+    static void CallAsyncWithRetry(const TRequest& request, TCallback&& callback)
+    {
+        ra::services::ServiceLocator::GetMutable<ra::services::IThreadPool>().RunAsync(
+            [request, callback = std::move(callback)]
+        {
+            DoAsyncWithRetry(std::move(request), std::move(callback), std::chrono::milliseconds(0));
+        });
+    }
+
+private:
+    template<class TRequest, class TCallback>
+    static void DoAsyncWithRetry(const TRequest&& request, TCallback&& callback, std::chrono::milliseconds delay)
+    {
+        auto response = request.Call();
+        if (response.Result != ApiResult::Incomplete)
+        {
+            callback(response);
+            return;
+        }
+
+        if (delay < std::chrono::milliseconds(500))
+        {
+            delay = std::chrono::milliseconds(500);
+        }
+        else
+        {
+            delay += delay;
+            if (delay > std::chrono::minutes(2))
+                delay = std::chrono::minutes(2);
+        }
+
+        ra::services::ServiceLocator::GetMutable<ra::services::IThreadPool>().ScheduleAsync(delay,
+            [request = std::move(request), callback = std::move(callback), delay]
+        {
+            DoAsyncWithRetry(std::move(request), std::move(callback), delay);
+        });
     }
 };
 
@@ -56,7 +97,7 @@ struct ApiResponseBase
     /// <returns><c>true</c> if the call was unsuccessful, <c>false</c> if not.</returns>
     bool Failed() const noexcept
     {
-        return (Result == ApiResult::Error || Result == ApiResult::Unsupported || Result == ApiResult::Failed);
+        return (!Succeeded() && Result != ApiResult::None);
     }
 };
 

--- a/src/api/AwardAchievement.hh
+++ b/src/api/AwardAchievement.hh
@@ -31,6 +31,11 @@ public:
         {
             ApiRequestBase::CallAsync<Request, Callback>(*this, std::move(callback));
         }
+
+        void CallAsyncWithRetry(Callback&& callback) const
+        {
+            ApiRequestBase::CallAsyncWithRetry<Request, Callback>(*this, std::move(callback));
+        }
     };
 };
 

--- a/src/api/Login.hh
+++ b/src/api/Login.hh
@@ -34,6 +34,11 @@ public:
         {
             ApiRequestBase::CallAsync<Request, Callback>(*this, std::move(callback));
         }
+
+        void CallAsyncWithRetry(Callback&& callback) const
+        {
+            ApiRequestBase::CallAsyncWithRetry<Request, Callback>(*this, std::move(callback));
+        }
     };
 };
 

--- a/src/api/impl/ConnectedServer.cpp
+++ b/src/api/impl/ConnectedServer.cpp
@@ -6,6 +6,7 @@
 #include "RA_User.h"
 
 #include "services\Http.hh"
+#include "services\IHttpRequester.hh"
 #include "services\ILocalStorage.hh"
 #include "services\ServiceLocator.hh"
 
@@ -22,7 +23,9 @@ _NODISCARD static bool HandleHttpError(_In_ const ra::services::Http::Response& 
 {
     if (httpResponse.StatusCode() != ra::services::Http::StatusCode::OK)
     {
-        pResponse.Result = ApiResult::Error;
+        const auto& pHttpRequester = ra::services::ServiceLocator::Get<ra::services::IHttpRequester>();
+        const bool bRetry = pHttpRequester.IsRetryable(ra::etoi(httpResponse.StatusCode()));
+        pResponse.Result = bRetry ? ApiResult::Incomplete : ApiResult::Error;
         pResponse.ErrorMessage = ra::StringPrintf("HTTP error code: %d", ra::etoi(httpResponse.StatusCode()));
         return true;
     }

--- a/src/data/GameContext.cpp
+++ b/src/data/GameContext.cpp
@@ -379,7 +379,7 @@ void GameContext::AwardAchievement(unsigned int nAchievementId) const
     request.AchievementId = nAchievementId;
     request.Hardcore = _RA_HardcoreModeIsActive();
     request.GameHash = GameHash();
-    request.CallAsync([nPopupId](const ra::api::AwardAchievement::Response& response)
+    request.CallAsyncWithRetry([nPopupId](const ra::api::AwardAchievement::Response& response)
     {
         if (response.Succeeded())
         {

--- a/src/pch.h
+++ b/src/pch.h
@@ -18,7 +18,6 @@
 #include <direct.h>
 #include <io.h>
 #include <wincodec.h>
-#include <winhttp.h>
 
 #if WIN32_LEAN_AND_MEAN
 #include <CommDlg.h>

--- a/src/services/IHttpRequester.hh
+++ b/src/services/IHttpRequester.hh
@@ -30,6 +30,11 @@ public:
     /// <returns>The status code from the server, or an error code if the request failed before reaching the server.</returns>
     virtual unsigned int Request(const Http::Request& pRequest, TextWriter& pContentWriter) const = 0;
 
+    /// <summary>
+    /// Determines whether or not it would be reasonable to retry the request for the provided error code.
+    /// </summary>
+    virtual bool IsRetryable(unsigned int nStatusCode) const noexcept = 0;
+
 protected:
     IHttpRequester() noexcept = default;
 };

--- a/src/services/IHttpRequester.hh
+++ b/src/services/IHttpRequester.hh
@@ -33,7 +33,7 @@ public:
     /// <summary>
     /// Determines whether or not it would be reasonable to retry the request for the provided error code.
     /// </summary>
-    virtual bool IsRetryable(unsigned int nStatusCode) const noexcept = 0;
+    _NODISCARD virtual bool IsRetryable(unsigned int nStatusCode) const noexcept = 0;
 
 protected:
     IHttpRequester() noexcept = default;

--- a/src/services/impl/WindowsHttpRequester.hh
+++ b/src/services/impl/WindowsHttpRequester.hh
@@ -19,6 +19,8 @@ public:
 
     unsigned int Request(const Http::Request& pRequest, TextWriter& pContentWriter) const override;
 
+    bool IsRetryable(unsigned int nStatusCode) const noexcept override;
+
 private:
     std::wstring m_sUserAgent;
 };

--- a/tests/RA_UnitTestHelpers.h
+++ b/tests/RA_UnitTestHelpers.h
@@ -27,6 +27,12 @@ namespace CppUnitTestFramework {
 #pragma warning(push)
 #pragma warning(disable : 4505) // unreferenced inline functions, they are referenced. Must be a bug.
 template<>
+std::wstring ToString<std::chrono::milliseconds>(const std::chrono::milliseconds& t)
+{
+    return std::to_wstring(t.count()) + L"ms";
+}
+
+template<>
 std::wstring ToString<MemSize>(const MemSize& t)
 {
     return MEMSIZE_STR.at(ra::etoi(t));
@@ -133,6 +139,8 @@ std::wstring ToString<ra::api::ApiResult>(const ra::api::ApiResult& result)
             return L"Failed";
         case ra::api::ApiResult::Unsupported:
             return L"Unsupported";
+        case ra::api::ApiResult::Incomplete:
+            return L"Incomplete";
         default:
             return std::to_wstring(ra::etoi(result));
     }

--- a/tests/api/ConnectedServer_Tests.cpp
+++ b/tests/api/ConnectedServer_Tests.cpp
@@ -6,11 +6,15 @@
 
 #include "tests\RA_UnitTestHelpers.h"
 #include "tests\mocks\MockHttpRequester.hh"
+#include "tests\mocks\MockServer.hh"
+#include "tests\mocks\MockThreadPool.hh"
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
 using ra::api::impl::ConnectedServer;
+using ra::api::mocks::MockServer;
 using ra::services::mocks::MockHttpRequester;
+using ra::services::mocks::MockThreadPool;
 using ra::services::Http;
 
 namespace ra {
@@ -20,6 +24,100 @@ namespace tests {
 TEST_CLASS(ConnectedServer_Tests)
 {
 public:
+    // ConnectedServer manages converting the Http error codes to Incomplete responses, this just tests the handling
+    // of Incomplete responses by the ApiRequestBase.
+    TEST_METHOD(TestCallAsyncWithRetry)
+    {
+        MockThreadPool mockThreadPool;
+        MockServer mockServer;
+        bool bHandlerCalled = false;
+        mockServer.HandleRequest<ra::api::AwardAchievement>([&bHandlerCalled](const ra::api::AwardAchievement::Request& request, ra::api::AwardAchievement::Response& response)
+        {
+            bHandlerCalled = true;
+            Assert::AreEqual(1234U, request.AchievementId);
+            Assert::AreEqual(std::string("HASH"), request.GameHash);
+            Assert::IsTrue(request.Hardcore);
+
+            response.Result = ra::api::ApiResult::Incomplete;
+            return true;
+        });
+
+        AwardAchievement::Request request;
+        request.GameHash = "HASH";
+        request.AchievementId = 1234U;
+        request.Hardcore = true;
+
+        bool bCallbackCalled = false;
+        request.CallAsyncWithRetry([&bCallbackCalled](const ra::api::AwardAchievement::Response& response)
+        {
+            Assert::AreEqual(ra::api::ApiResult::Success, response.Result);
+            bCallbackCalled = true;
+        });
+
+        // call should be async
+        Assert::IsFalse(bCallbackCalled);
+        Assert::IsFalse(bHandlerCalled);
+        Assert::AreEqual(1U, mockThreadPool.PendingTasks());
+
+        // async call should be incomplete and requeued
+        mockThreadPool.ExecuteNextTask();
+        Assert::IsFalse(bCallbackCalled);
+        Assert::IsTrue(bHandlerCalled);
+        Assert::AreEqual(1U, mockThreadPool.PendingTasks());
+        Assert::AreEqual(std::chrono::milliseconds(500), mockThreadPool.NextTaskDelay());
+
+        // callback called again, still incomplete, requeue with longer delay
+        bHandlerCalled = false;
+        mockThreadPool.AdvanceTime(std::chrono::milliseconds(500));
+        Assert::IsFalse(bCallbackCalled);
+        Assert::IsTrue(bHandlerCalled);
+        Assert::AreEqual(1U, mockThreadPool.PendingTasks());
+        Assert::AreEqual(std::chrono::milliseconds(1000), mockThreadPool.NextTaskDelay());
+
+        // response succeeded, should complete transaction
+        mockServer.HandleRequest<ra::api::AwardAchievement>([&bHandlerCalled](const ra::api::AwardAchievement::Request& request, ra::api::AwardAchievement::Response& response)
+        {
+            bHandlerCalled = true;
+            Assert::AreEqual(1234U, request.AchievementId);
+            Assert::AreEqual(std::string("HASH"), request.GameHash);
+            Assert::IsTrue(request.Hardcore);
+
+            response.Result = ra::api::ApiResult::Success;
+            return true;
+        });
+
+        bHandlerCalled = false;
+        mockThreadPool.AdvanceTime(std::chrono::milliseconds(1000));
+        Assert::IsTrue(bCallbackCalled);
+        Assert::IsTrue(bHandlerCalled);
+        Assert::AreEqual(0U, mockThreadPool.PendingTasks());
+    }
+
+    TEST_METHOD(TestCallAsyncWithRetryMaxDelay)
+    {
+        MockThreadPool mockThreadPool;
+        MockServer mockServer;
+        mockServer.HandleRequest<ra::api::AwardAchievement>([](const ra::api::AwardAchievement::Request&, ra::api::AwardAchievement::Response& response)
+        {
+            response.Result = ra::api::ApiResult::Incomplete;
+            return true;
+        });
+
+        AwardAchievement::Request request;
+        request.GameHash = "HASH";
+        request.AchievementId = 1234U;
+        request.Hardcore = true;
+
+        request.CallAsyncWithRetry([](const ra::api::AwardAchievement::Response&) {});
+
+        // call should be async
+        mockThreadPool.ExecuteNextTask();
+        for (int i = 0; i < 100; i++)
+            mockThreadPool.AdvanceTime(mockThreadPool.NextTaskDelay());
+
+        Assert::AreEqual(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::minutes(2)), mockThreadPool.NextTaskDelay());
+    }
+
     // ====================================================
     // These tests validate the generic handling of errors - they just happen to be written using the Login API
 

--- a/tests/mocks/MockHttpRequester.hh
+++ b/tests/mocks/MockHttpRequester.hh
@@ -26,7 +26,7 @@ public:
         return ra::etoi(response.StatusCode());
     }
 
-    bool IsRetryable(_UNUSED unsigned int nStatusCode) const noexcept
+    bool IsRetryable(unsigned int) const noexcept
     {
         return false;
     }

--- a/tests/mocks/MockHttpRequester.hh
+++ b/tests/mocks/MockHttpRequester.hh
@@ -26,6 +26,11 @@ public:
         return ra::etoi(response.StatusCode());
     }
 
+    bool IsRetryable(_UNUSED unsigned int nStatusCode) const noexcept
+    {
+        return false;
+    }
+
 private:
     ServiceLocator::ServiceOverride<IHttpRequester> m_Override;
 

--- a/tests/mocks/MockThreadPool.hh
+++ b/tests/mocks/MockThreadPool.hh
@@ -53,6 +53,20 @@ public:
     }
 
     /// <summary>
+    /// Gets the delay until the next task would be executed.
+    /// </summary>
+    std::chrono::milliseconds NextTaskDelay() const
+    {
+        if (!m_vTasks.empty())
+            return std::chrono::milliseconds(0);
+
+        if (!m_vDelayedTasks.empty())
+            return m_vDelayedTasks.front().nDelay;
+
+        return std::chrono::hours(10000);
+    }
+
+    /// <summary>
     /// Gets the number of outstanding asynchronous tasks are queued
     /// </summary>
     size_t PendingTasks() const { return m_vTasks.size() + m_vDelayedTasks.size(); }


### PR DESCRIPTION
* If the WinHttp library returns one of several identified error codes (three of which I've experienced), the API call with fail with an Incomplete state.
* If the Incomplete state is detected on login, a second login attempt will be made immediately. If that also fails, the error will be reported to the user as the login process is synchronous.
* If the Incomplete state is detected when unlocking an achievement, the request will be made again until it is successful or the application is closed. The first retry will occur 500ms after the failed attempt, then the delay will double up to 2 minutes between attempts: 1s, 2s, 4s, 8s, 16s, 32s, 64s, 120s, 120s, 120s...
* Changes made in #242 ensure the popup is displayed even if the server doesn't acknowledge the unlock.
* In the unlikely event that connectivity is not restored before the application is closed, the unlock will be lost. 
  - This is no different than the current application, which silently swallows the network error.
    - Because the popup does not currently display in this situation, the player may not realize they triggered the achievement and may submit a ticket indicating the achievement did not work. It is impossible for the developer to know the problem was network related without looking at the player's local log file.
  - Because the popup does display now, the player will see that they triggered the achievement, but may not realize the server did not acknowledge it. The assumption is that the client will eventually reach the server and the achievement will be unlocked. 
    - Because the popup does display now, the player may take a screenshot to use as proof (although, doing that for every achievement just in case their network goes out seems inefficient).