### PR TITLE
provide default game name in RP ping when hash doesn't resolve

### DIFF
--- a/src/RA_AchievementOverlay.cpp
+++ b/src/RA_AchievementOverlay.cpp
@@ -476,10 +476,10 @@ void AchievementOverlay::DrawAchievementsPage(HDC hDC, int nDX, int nDY, const R
     const size_t nNumberOfAchievements = g_pActiveAchievements->NumAchievements();
     if (nNumberOfAchievements == 0)
     {
-        if (!RA_GameIsActive())
+        if (pGameContext.GameId() == 0)
             sSubtitle = "No achievements present";
         else
-            sSubtitle = ra::StringPrintf("No achievements present - %lh%02lm", nPlayTime / 3600, (nPlayTime / 60) % 60);
+            sSubtitle = ra::StringPrintf("No achievements present - %dh%02dm", nPlayTime / 3600, (nPlayTime / 60) % 60);
     }
     else if (g_nActiveAchievementSet == AchievementSet::Type::Core)
     {

--- a/src/data/GameContext.hh
+++ b/src/data/GameContext.hh
@@ -36,6 +36,11 @@ public:
     const std::wstring& GameTitle() const noexcept { return m_sGameTitle; }
 
     /// <summary>
+    /// Sets the game title.
+    /// </summary>
+    void SetGameTitle(const std::wstring& sGameTitle) { m_sGameTitle = sGameTitle; }
+
+    /// <summary>
     /// Gets the hash of the currently loaded game.
     /// </summary>
     const std::string& GameHash() const noexcept { return m_sGameHash; }

--- a/src/data/SessionTracker.cpp
+++ b/src/data/SessionTracker.cpp
@@ -109,17 +109,20 @@ void SessionTracker::BeginSession(unsigned int nGameId)
     m_tpSessionStart = pClock.UpTime();
     m_tSessionStart = std::chrono::system_clock::to_time_t(pClock.Now());
 
-    ra::api::StartSession::Request request;
-    request.GameId = nGameId;
-    request.CallAsync([](const ra::api::StartSession::Response&) {});
-
     auto& pThreadPool = ra::services::ServiceLocator::GetMutable<ra::services::IThreadPool>();
     pThreadPool.ScheduleAsync(std::chrono::seconds(30), [this, tSessionStart = m_tSessionStart]() { UpdateSession(tSessionStart); });
 
-    // make sure a persisted play entry exists for the game and is first in the list
-    AddSession(nGameId, m_tSessionStart, std::chrono::seconds(0));
-    if (m_vGameStats.begin()->GameId != nGameId)
-        SortSessions();
+    if (nGameId != 0)
+    {
+        ra::api::StartSession::Request request;
+        request.GameId = nGameId;
+        request.CallAsync([](const ra::api::StartSession::Response&) {});
+
+        // make sure a persisted play entry exists for the game and is first in the list
+        AddSession(nGameId, m_tSessionStart, std::chrono::seconds(0));
+        if (m_vGameStats.begin()->GameId != nGameId)
+            SortSessions();
+    }
 }
 
 void SessionTracker::EndSession()
@@ -159,7 +162,7 @@ void SessionTracker::UpdateSession(time_t tSessionStart)
     const auto tSessionDuration = std::chrono::duration_cast<std::chrono::seconds>(pClock.UpTime() - m_tpSessionStart);
 
     // ignore sessions less than one minute
-    if (tSessionDuration > std::chrono::seconds(60))
+    if (m_nCurrentGameId != 0 && tSessionDuration > std::chrono::seconds(60))
         WriteSessionStats(tSessionDuration);
 
     // schedule next ping


### PR DESCRIPTION
* Restores Ping functionality when hash does not resolve
* Sends "Playing [estimated_name]" or "Playing Unknown" instead of "Playing " as was sent in 0.74.