### PR TITLE
prevent exception if server sends 'null' as a username

### DIFF
--- a/src/services/impl/LeaderboardManager.cpp
+++ b/src/services/impl/LeaderboardManager.cpp
@@ -128,7 +128,7 @@ void LeaderboardManager::OnSubmitEntry(const rapidjson::Document& doc)
     for (auto& NextEntry : TopEntries.GetArray())
     {
         const auto nRank{ NextEntry["Rank"].GetUint() };
-        const std::string& sUser{ NextEntry["User"].GetString() };
+        const std::string& sUser{ NextEntry["User"].IsString() ? NextEntry["User"].GetString() : "?????" };
         const auto nUserScore{ NextEntry["Score"].GetInt() };
         const auto nSubmitted{ static_cast<std::time_t>(ra::to_signed(NextEntry["DateSubmitted"].GetUint())) };
 


### PR DESCRIPTION
`submitlbentry` API response was returning a null user for a specific leaderboard, causing the client to crash because it wasn't being properly handled.
```
...
{"User":null,"Score":1474,"DateSubmitted":1410450054,"Rank":10}
...
```
If detected, the client will now display "?????"