### PR TITLE
render messages over leaderboard counter

### DIFF
--- a/src/ui/viewmodels/OverlayManager.cpp
+++ b/src/ui/viewmodels/OverlayManager.cpp
@@ -48,6 +48,10 @@ static int GetAbsolutePosition(int nValue, RelativePosition nRelativePosition, s
 
 void OverlayManager::Render(ra::ui::drawing::ISurface& pSurface) const
 {
+#ifndef RA_UTEST
+    g_LeaderboardPopups.Render(pSurface);
+#endif
+
     if (!m_vPopupMessages.empty())
     {
         const auto& pActiveMessage = m_vPopupMessages.front();
@@ -55,10 +59,6 @@ void OverlayManager::Render(ra::ui::drawing::ISurface& pSurface) const
         const int nY = GetAbsolutePosition(pActiveMessage.GetRenderLocationY(), pActiveMessage.GetRenderLocationYRelativePosition(), pSurface.GetHeight());
         pSurface.DrawSurface(nX, nY, pActiveMessage.GetRenderImage());
     }
-
-#ifndef RA_UTEST
-    g_LeaderboardPopups.Render(pSurface);
-#endif
 }
 
 int OverlayManager::QueueMessage(PopupMessageViewModel&& pMessage)


### PR DESCRIPTION
The counter is static and will persist after the popup leaves. It makes sense for the popup to appear in front of the counter. Also, the message text is more important than the counter, and should be given display preference.

Before:
![image](https://user-images.githubusercontent.com/32680403/51484832-ca030080-1d59-11e9-898c-11876374831b.png)

After:
![image](https://user-images.githubusercontent.com/32680403/51484842-cf604b00-1d59-11e9-9d45-31f88b44ab9a.png)
