### PR TITLE
Fix Active display for non-core achievements

### DIFF
--- a/src/data/GameContext.cpp
+++ b/src/data/GameContext.cpp
@@ -204,10 +204,21 @@ void GameContext::RefreshUnlocks(bool bUnpause)
             ra::services::ServiceLocator::GetMutable<ra::services::AchievementRuntime>().SetPaused(false);
 
 #ifndef RA_UTEST
-        for (int nIndex = 0; nIndex < ra::to_signed(g_pActiveAchievements->NumAchievements()); ++nIndex)
+        if (ActiveAchievementType() == AchievementSet::Type::Core)
         {
-            const Achievement& Ach = g_pActiveAchievements->GetAchievement(nIndex);
-            g_AchievementsDialog.OnEditData(nIndex, Dlg_Achievements::Column::Achieved, Ach.Active() ? "No" : "Yes");
+            for (int nIndex = 0; nIndex < ra::to_signed(g_pActiveAchievements->NumAchievements()); ++nIndex)
+            {
+                const Achievement& Ach = g_pActiveAchievements->GetAchievement(nIndex);
+                g_AchievementsDialog.OnEditData(nIndex, Dlg_Achievements::Column::Achieved, Ach.Active() ? "No" : "Yes");
+            }
+        }
+        else
+        {
+            for (int nIndex = 0; nIndex < ra::to_signed(g_pActiveAchievements->NumAchievements()); ++nIndex)
+            {
+                const Achievement& Ach = g_pActiveAchievements->GetAchievement(nIndex);
+                g_AchievementsDialog.OnEditData(nIndex, Dlg_Achievements::Column::Active, Ach.Active() ? "Yes" : "No");
+            }
         }
 #endif
     });


### PR DESCRIPTION
Only an issue if a set other than core is selected before loading the game. The code that updates the active achievements after determining which ones the user has already earned was setting "Yes" for earned and "No" for unearned, but for non-core achievements, the "earned" column becomes the "active" column, and the labels have to be reversed.