### PR TITLE
prevent exception if trigger has empty group

### DIFF
--- a/src/RA_Achievement.cpp
+++ b/src/RA_Achievement.cpp
@@ -132,6 +132,9 @@ inline static constexpr void SetOperand(CompVariable& var, const rc_operand_t& o
 static void MakeConditionGroup(ConditionSet& vConditions, rc_condset_t* pCondSet)
 {
     vConditions.AddGroup();
+    if (!pCondSet)
+        return;
+
     ConditionGroup& group = vConditions.GetGroup(vConditions.GroupCount() - 1);
 
     rc_condition_t* pCondition = pCondSet->conditions;


### PR DESCRIPTION
Contra has an achievement (Who Ordered Fries) that has an empty core group. When wrapping the rcheevos trigger for the UI, the causes a null reference exception. Added a null check to prevent the exception.