### PR TITLE
disable filter button when opening memory viewer after loading game

### DIFF
--- a/src/RA_Dlg_Memory.cpp
+++ b/src/RA_Dlg_Memory.cpp
@@ -809,17 +809,10 @@ INT_PTR Dlg_Memory::MemoryProc(HWND hDlg, UINT nMsg, WPARAM wParam, LPARAM lPara
             SetWindowFont(GetDlgItem(hDlg, IDC_RA_MEMBITS), GetStockObject(SYSTEM_FIXED_FONT), TRUE);
             SetWindowFont(GetDlgItem(hDlg, IDC_RA_MEMBITS_TITLE), GetStockObject(SYSTEM_FIXED_FONT), TRUE);
 
-            //	8-bit by default:
-            CheckDlgButton(hDlg, IDC_RA_CBO_4BIT, BST_UNCHECKED);
-            CheckDlgButton(hDlg, IDC_RA_CBO_8BIT, BST_CHECKED);
-            CheckDlgButton(hDlg, IDC_RA_CBO_16BIT, BST_UNCHECKED);
-            CheckDlgButton(hDlg, IDC_RA_CBO_32BIT, BST_UNCHECKED);
-
             CheckDlgButton(hDlg, IDC_RA_MEMVIEW8BIT, BST_CHECKED);
             CheckDlgButton(hDlg, IDC_RA_MEMVIEW16BIT, BST_UNCHECKED);
             CheckDlgButton(hDlg, IDC_RA_MEMVIEW32BIT, BST_UNCHECKED);
 
-            MemoryProc(hDlg, WM_COMMAND, IDC_RA_CBO_8BIT, 0); //	Imitate a buttonpress of '8-bit'
             g_MemoryDialog.OnLoad_NewRom();
 
             // Add a single column for list view
@@ -1066,6 +1059,7 @@ INT_PTR Dlg_Memory::MemoryProc(HWND hDlg, UINT nMsg, WPARAM wParam, LPARAM lPara
                     EnableWindow(GetDlgItem(hDlg, IDC_RA_RESULTS_BACK), TRUE);
                     EnableWindow(GetDlgItem(hDlg, IDC_RA_RESULTS_FORWARD), FALSE);
 
+                    assert(m_SearchResults.size() >= 2); // expect at least initial search and new filter holder
                     SearchResult& srPrevious = *(m_SearchResults.end() - 2);
                     SearchResult& sr = m_SearchResults.back();
                     sr.m_nCompareType = nCmpType;
@@ -1584,7 +1578,10 @@ void Dlg_Memory::OnLoad_NewRom()
 
     MemoryViewerControl::destroyEditCaret();
     MemoryViewerControl::Invalidate();
+
     m_SearchResults.clear();
+    ClearLogOutput();
+    EnableWindow(GetDlgItem(g_MemoryDialog.m_hWnd, IDC_RA_DOTEST), FALSE);
 }
 
 void Dlg_Memory::Invalidate()

--- a/src/services/SearchResults.cpp
+++ b/src/services/SearchResults.cpp
@@ -37,7 +37,10 @@ void SearchResults::Initialize(unsigned int nAddress, unsigned int nBytes, MemSi
         nBytes = g_MemManager.TotalBankSize() - nAddress;
 
     const unsigned int nPadding = Padding(nSize);
-    nBytes -= nPadding;
+    if (nPadding >= nBytes)
+        nBytes = 0;
+    else
+        nBytes -= nPadding;
 
     m_sSummary.reserve(64);
     m_sSummary.append("Cleared: (");

--- a/tests/services/SearchResults_Tests.cpp
+++ b/tests/services/SearchResults_Tests.cpp
@@ -771,6 +771,18 @@ public:
         Assert::AreEqual(MemSize::SixteenBit, result.nSize);
         Assert::AreEqual(0xFFFEU, result.nValue);
     }
+
+    TEST_METHOD(TestInitializeFromMemorySixteenBitZeroBytes)
+    {
+        std::array<unsigned char, 5> memory{ 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        InitializeMemory(memory);
+
+        SearchResults results;
+        results.Initialize(0U, 0U, MemSize::SixteenBit);
+
+        Assert::AreEqual(0U, results.MatchingAddressCount());
+        Assert::AreEqual(std::string("Cleared: (16-bit) mode. Aware of 0 RAM locations."), results.Summary());
+    }
 };
 
 } // namespace tests


### PR DESCRIPTION
When opening the memory viewer after loading a game, the "Filter" button is enabled, but no initial search has been performed. Clicking on "Filter" without first starting a search causes an exception.

This change ensures the "Filter" button is disabled, and removes the code that tries to run an initial search when opening the dialog.