### PR TITLE
use strtoul instead of stoul because we don't handle exceptions very well

### DIFF
--- a/src/RA_CodeNotes.cpp
+++ b/src/RA_CodeNotes.cpp
@@ -36,7 +36,7 @@ size_t CodeNotes::Load(unsigned int nID)
             continue;
 
         const std::string& sAddr{note["Address"].GetString()};
-        const ra::ByteAddress nAddr{std::stoul(sAddr, nullptr, 16)};
+        const ra::ByteAddress nAddr = ra::ByteAddressFromString(sAddr);
         const std::string& sAuthor{note["User"].GetString()}; // Author?
 
         m_CodeNotes.try_emplace(nAddr, CodeNoteObj(sAuthor, sNote));

--- a/src/RA_Defs.cpp
+++ b/src/RA_Defs.cpp
@@ -18,41 +18,25 @@ std::string ByteAddressToString(ByteAddress nAddr)
 _Use_decl_annotations_
 ByteAddress ByteAddressFromString(const std::string& sByteAddress)
 {
-    try
+    ra::ByteAddress address{};
+
+    if (!ra::StringStartsWith(sByteAddress, "-")) // negative addresses not supported
     {
-        if (ra::StringStartsWith(sByteAddress, "0x") || ra::StringStartsWith(sByteAddress, "0X"))
+        char* pEnd;
+        address = std::strtoul(sByteAddress.c_str(), &pEnd, 10);
+        if (*pEnd)
         {
-            if (sByteAddress.length() > 2)
-                return ra::ByteAddress{ std::stoul(&sByteAddress.at(2), nullptr, 16) };
-        }
-        else if (ra::StringStartsWith(sByteAddress, "-"))
-        {
-            // negative addresses not supported
-            return ra::ByteAddress{};
-        }
-        else if (!sByteAddress.empty())
-        {
-            try
+            // decimal parse failed, try hex
+            address = std::strtoul(sByteAddress.c_str(), &pEnd, 16);
+            if (*pEnd)
             {
-                return ra::ByteAddress{ std::stoul(sByteAddress.c_str()) };
-            }
-            catch (const std::invalid_argument&)
-            {
-                // try hex conversion
-                return ra::ByteAddress{ std::stoul(sByteAddress.c_str(), nullptr, 16) };
+                // hex parse failed
+                address = {};
             }
         }
-    }
-    catch (const std::invalid_argument&)
-    {
-        // ignore and return default
-    }
-    catch (const std::out_of_range&)
-    {
-        // ignore and return default
     }
 
-    return ra::ByteAddress{};
+    return address;
 }
 
 } /* namespace ra */

--- a/src/RA_Defs.cpp
+++ b/src/RA_Defs.cpp
@@ -16,7 +16,7 @@ std::string ByteAddressToString(ByteAddress nAddr)
 }
 
 _Use_decl_annotations_
-ByteAddress ByteAddressFromString(const std::string& sByteAddress)
+ByteAddress ByteAddressFromString(const std::string& sByteAddress) noexcept
 {
     ra::ByteAddress address{};
 
@@ -24,10 +24,12 @@ ByteAddress ByteAddressFromString(const std::string& sByteAddress)
     {
         char* pEnd;
         address = std::strtoul(sByteAddress.c_str(), &pEnd, 10);
+        assert(pEnd != nullptr);
         if (*pEnd)
         {
             // decimal parse failed, try hex
             address = std::strtoul(sByteAddress.c_str(), &pEnd, 16);
+            assert(pEnd != nullptr);
             if (*pEnd)
             {
                 // hex parse failed

--- a/src/RA_Defs.h
+++ b/src/RA_Defs.h
@@ -183,7 +183,7 @@ public:
 
 namespace ra {
 _NODISCARD std::string ByteAddressToString(_In_ ByteAddress nAddr);
-_NODISCARD ByteAddress ByteAddressFromString(_In_ const std::string& sByteAddress);
+_NODISCARD ByteAddress ByteAddressFromString(_In_ const std::string& sByteAddress) noexcept;
 } // namespace ra
 
 #if _MBCS

--- a/src/RA_RichPresence.cpp
+++ b/src/RA_RichPresence.cpp
@@ -266,9 +266,9 @@ bool RA_RichPresenceInterpreter::Load(ra::services::TextReader& pReader)
 
                 unsigned int nVal{};
                 if (ra::StringStartsWith(sLine, "0x"))
-                    nVal = std::stoul(sLine.substr(2), nullptr, 16);
+                    nVal = std::strtoul(&sLine.at(2), nullptr, 16);
                 else
-                    nVal = std::stoul(sLine);
+                    nVal = std::strtoul(sLine.c_str(), nullptr, 10);
 
                 newLookup.AddLookupData(nVal, sLabel);
             } while (true);

--- a/src/RA_User.cpp
+++ b/src/RA_User.cpp
@@ -57,7 +57,7 @@ void LocalRAUser::OnFriendListResponse(const rapidjson::Document& doc)
     for (auto& NextFriend : FriendData.GetArray())
     {
         auto& pUser{RAUsers::GetUser(NextFriend["Friend"].GetString())};
-        pUser.SetScore(std::stoul(NextFriend["RAPoints"].GetString()));
+        pUser.SetScore(std::strtoul(NextFriend["RAPoints"].GetString(), nullptr, 10));
         pUser.UpdateActivity(NextFriend["LastSeen"].GetString());
 
         AddFriend(pUser.Username(), pUser.GetScore());

--- a/src/data/GameContext.cpp
+++ b/src/data/GameContext.cpp
@@ -515,7 +515,7 @@ Achievement& GameContext::NewAchievement(AchievementSet::Type nType)
     return pAchievement;
 }
 
-bool GameContext::RemoveAchievement(unsigned int nAchievementId) noexcept
+bool GameContext::RemoveAchievement(unsigned int nAchievementId)
 {
     for (auto pIter = m_vAchievements.begin(); pIter != m_vAchievements.end(); ++pIter)
     {

--- a/src/data/GameContext.hh
+++ b/src/data/GameContext.hh
@@ -94,7 +94,7 @@ public:
 
     Achievement& NewAchievement(AchievementSet::Type nType);
 
-    bool RemoveAchievement(unsigned int nAchievementId) noexcept;
+    bool RemoveAchievement(unsigned int nAchievementId);
 
     /// <summary>
     /// Shows the popup for earning an achievement and notifies the server if legitimate.

--- a/src/data/SessionTracker.cpp
+++ b/src/data/SessionTracker.cpp
@@ -48,18 +48,18 @@ void SessionTracker::LoadSessions()
             if (nIndex == std::string::npos)
                 continue;
 
-            const auto nGameId = std::stoul(sLine);
+            const auto nGameId = std::strtoul(sLine.c_str(), nullptr, 10);
 
             auto nIndex2 = sLine.find(':', ++nIndex);
             if (nIndex2 == std::string::npos)
                 continue;
 
-            const auto nSessionStart = std::stoul(&sLine.at(nIndex));
+            const auto nSessionStart = std::strtoul(&sLine.at(nIndex), nullptr, 10);
 
             nIndex = sLine.find(':', ++nIndex2);
             if (nIndex == std::string::npos)
                 continue;
-            const auto nSessionLength = std::stoul(&sLine.at(nIndex2));
+            const auto nSessionLength = std::strtoul(&sLine.at(nIndex2), nullptr, 10);
 
             std::string md5;
             GSL_SUPPRESS_TYPE1 md5 = RAGenerateMD5(reinterpret_cast<const unsigned char*>(sLine.c_str()), nIndex + 1);

--- a/tests/mocks/MockGameContext.hh
+++ b/tests/mocks/MockGameContext.hh
@@ -23,11 +23,6 @@ public:
     /// </summary>
     void SetGameId(unsigned int nGameId) noexcept { m_nGameId = nGameId; }
 
-    /// <summary>
-    /// Sets the title of the currently loaded game.
-    /// </summary>
-    void SetGameTitle(const std::wstring& sTitle) { m_sGameTitle = sTitle; }
-
     bool HasRichPresence() const noexcept override { return !m_sRichPresenceDisplayString.empty(); }
 
     std::wstring GetRichPresenceDisplayString() const override { return m_sRichPresenceDisplayString; }

--- a/tests/mocks/MockHttpRequester.hh
+++ b/tests/mocks/MockHttpRequester.hh
@@ -26,7 +26,7 @@ public:
         return ra::etoi(response.StatusCode());
     }
 
-    bool IsRetryable(unsigned int) const noexcept
+    bool IsRetryable(unsigned int) const noexcept override
     {
         return false;
     }


### PR DESCRIPTION
Legend of Zelda: Link's Awakening DX rich presence contained an invalid lookup entry:
```
oxda=Martha's Bay
```
The letter 'o' is not a valid hex prefix, so `stoul` threw an exception that was not caught. 

This PR replaces most of the instances of `std::stoul` with `std::strtoul`, which does not throw exceptions on parse error. Instead '0' is returned.