### PR TITLE
Add RAOricutron to the emulator list

### DIFF
--- a/src/RA_Interface.h
+++ b/src/RA_Interface.h
@@ -33,6 +33,7 @@ enum EmulatorID
     RA_Meka = 8,
     RA_QUASI88 = 9,
     RA_AppleWin = 10,
+    RA_Oricutron = 11,
 
     NumEmulatorIDs,
     UnknownEmulator = NumEmulatorIDs

--- a/src/RA_Interface.h
+++ b/src/RA_Interface.h
@@ -73,7 +73,7 @@ enum ConsoleID
     MSX = 29,
     C64 = 30,
     ZX81 = 31,
-    // unused32 = 32,
+    Oric = 32,
     SG1000 = 33,
     VIC20 = 34,
     Amiga = 35,

--- a/src/data/EmulatorContext.cpp
+++ b/src/data/EmulatorContext.cpp
@@ -81,6 +81,11 @@ void EmulatorContext::Initialize(EmulatorID nEmulatorId)
             m_sClientName = "RAppleWin";
             _RA_SetConsoleID(ConsoleID::AppleII);
             break;
+
+        case RA_Oricutron:
+            m_sClientName = "RAOricutron";
+            _RA_SetConsoleID(ConsoleID::Oric);
+            break;
     }
 }
 


### PR DESCRIPTION
Also use the unused console ID of 32 for the Oric platforms.