### PR TITLE
fix Game Memory label

### DIFF
--- a/src/RA_Dlg_Memory.cpp
+++ b/src/RA_Dlg_Memory.cpp
@@ -1560,9 +1560,9 @@ void Dlg_Memory::OnLoad_NewRom()
         {
             TCHAR label[64]{};
             if (g_MemManager.TotalBankSize() > 0x10000)
-                _stprintf_s(label, 64, TEXT("System Memory (0x%06X-0x%06X)"), start, end);
+                _stprintf_s(label, 64, TEXT("Game Memory (0x%06X-0x%06X)"), start, end);
             else
-                _stprintf_s(label, 64, TEXT("System Memory (0x%06X-0x%06X)"), start, end);
+                _stprintf_s(label, 64, TEXT("Game Memory (0x%04X-0x%04X)"), start, end);
 
             SetDlgItemText(g_MemoryDialog.m_hWnd, IDC_RA_CBO_SEARCHGAMERAM, label);
             EnableWindow(GetDlgItem(g_MemoryDialog.m_hWnd, IDC_RA_CBO_SEARCHGAMERAM), TRUE);


### PR DESCRIPTION
See notes in #293 

Label was unexpectedly modified by #161. This reverts that change.