### PR TITLE
Always Check Return of CRT Functions

### DIFF
--- a/RA_Integration.sln
+++ b/RA_Integration.sln
@@ -19,7 +19,6 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Analysis|Win32 = Analysis|Win32
-		AnalysisUnicode|Win32 = AnalysisUnicode|Win32
 		Debug|Win32 = Debug|Win32
 		Release|Win32 = Release|Win32
 		ReleaseWithDebug|Win32 = ReleaseWithDebug|Win32
@@ -27,8 +26,6 @@ Global
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{825CB292-F069-4B27-82CF-3417746ACDF3}.Analysis|Win32.ActiveCfg = Analysis|Win32
 		{825CB292-F069-4B27-82CF-3417746ACDF3}.Analysis|Win32.Build.0 = Analysis|Win32
-		{825CB292-F069-4B27-82CF-3417746ACDF3}.AnalysisUnicode|Win32.ActiveCfg = AnalysisUnicode|Win32
-		{825CB292-F069-4B27-82CF-3417746ACDF3}.AnalysisUnicode|Win32.Build.0 = AnalysisUnicode|Win32
 		{825CB292-F069-4B27-82CF-3417746ACDF3}.Debug|Win32.ActiveCfg = Debug|Win32
 		{825CB292-F069-4B27-82CF-3417746ACDF3}.Debug|Win32.Build.0 = Debug|Win32
 		{825CB292-F069-4B27-82CF-3417746ACDF3}.Release|Win32.ActiveCfg = Release|Win32
@@ -37,8 +34,6 @@ Global
 		{825CB292-F069-4B27-82CF-3417746ACDF3}.ReleaseWithDebug|Win32.Build.0 = ReleaseWithDebug|Win32
 		{876DEBDF-C7C8-4713-8CEF-EBDEE65306A7}.Analysis|Win32.ActiveCfg = Analysis|Win32
 		{876DEBDF-C7C8-4713-8CEF-EBDEE65306A7}.Analysis|Win32.Build.0 = Analysis|Win32
-		{876DEBDF-C7C8-4713-8CEF-EBDEE65306A7}.AnalysisUnicode|Win32.ActiveCfg = Analysis|Win32
-		{876DEBDF-C7C8-4713-8CEF-EBDEE65306A7}.AnalysisUnicode|Win32.Build.0 = Analysis|Win32
 		{876DEBDF-C7C8-4713-8CEF-EBDEE65306A7}.Debug|Win32.ActiveCfg = Debug|Win32
 		{876DEBDF-C7C8-4713-8CEF-EBDEE65306A7}.Debug|Win32.Build.0 = Debug|Win32
 		{876DEBDF-C7C8-4713-8CEF-EBDEE65306A7}.Release|Win32.ActiveCfg = Release|Win32
@@ -47,8 +42,6 @@ Global
 		{876DEBDF-C7C8-4713-8CEF-EBDEE65306A7}.ReleaseWithDebug|Win32.Build.0 = Release|Win32
 		{9D55EBE7-1392-4FA1-A9B9-F022F764CE35}.Analysis|Win32.ActiveCfg = Release|Win32
 		{9D55EBE7-1392-4FA1-A9B9-F022F764CE35}.Analysis|Win32.Build.0 = Release|Win32
-		{9D55EBE7-1392-4FA1-A9B9-F022F764CE35}.AnalysisUnicode|Win32.ActiveCfg = Release|Win32
-		{9D55EBE7-1392-4FA1-A9B9-F022F764CE35}.AnalysisUnicode|Win32.Build.0 = Release|Win32
 		{9D55EBE7-1392-4FA1-A9B9-F022F764CE35}.Debug|Win32.ActiveCfg = Debug|Win32
 		{9D55EBE7-1392-4FA1-A9B9-F022F764CE35}.Debug|Win32.Build.0 = Debug|Win32
 		{9D55EBE7-1392-4FA1-A9B9-F022F764CE35}.Release|Win32.ActiveCfg = Release|Win32

--- a/src/RA_AchievementOverlay.cpp
+++ b/src/RA_AchievementOverlay.cpp
@@ -600,8 +600,7 @@ void AchievementOverlay::DrawFriendsPage(HDC hDC, int nDX, _UNUSED int, const RE
             HANDLE hOldObj = SelectObject(hDC, g_hFontDesc);
 
             auto buffer = ra::StringPrintf(" %s (%u) ", pFriend.Username(), pFriend.GetScore());
-            TextOut(hDC, nXOffs + nFriendLeftOffsetText, nYOffs, NativeStr(buffer).c_str(),
-                    buffer.length());
+            TextOut(hDC, nXOffs + nFriendLeftOffsetText, nYOffs, NativeStr(buffer).c_str(), buffer.length());
 
             SelectObject(hDC, g_hFontTiny);
             buffer = ra::StringPrintf(" %s ", pFriend.Activity());
@@ -675,8 +674,6 @@ void AchievementOverlay::DrawAchievementExaminePage(HDC hDC, int nDX, _UNUSED in
     buffer = ra::StringPrintf(" Modified: %s ", _TimeStampToString(tModified));
     TextOut(hDC, nDX + 20, nCoreDetailsY + nCoreDetailsSpacing, NativeStr(buffer).c_str(),
             gsl::narrow<int>(buffer.length()));
-
-            
 
     if (g_AchExamine.HasData())
     {
@@ -754,7 +751,7 @@ void AchievementOverlay::DrawNewsPage(HDC hDC, int nDX, _UNUSED int, const RECT&
 
         SelectObject(hDC, g_hFontDesc2);
 
-        //vSetup initial variables for the rect
+        // vSetup initial variables for the rect
         RECT rcNews{nLeftAlign, nYOffset, nRightAlign, nYOffset};
 
         // Calculate height of rect, fetch bottom for next rect:
@@ -954,29 +951,23 @@ void AchievementOverlay::DrawLeaderboardExaminePage(HDC hDC, int nDX, _UNUSED in
 
         if (g_LBExamine.m_bHasData)
         {
-            for (size_t i = 0; i < pLB->GetRankInfoCount(); ++i)
+            gsl::index i{-1};
+            for (const auto& rEntry : *pLB)
             {
-                const RA_Leaderboard::Entry& rEntry = pLB->GetRankInfo(i);
-                std::string sScoreFormatted = pLB->FormatScore(rEntry.m_nScore);
-
-                char sRankText[256];
-                sprintf_s(sRankText, 256, " %u ", rEntry.m_nRank);
-
-                char sNameText[256];
-                sprintf_s(sNameText, 256, " %s ", rEntry.m_sUsername.c_str());
-
-                char sScoreText[256];
-                sprintf_s(sScoreText, 256, " %s ", sScoreFormatted.c_str());
+                i++;
+                const auto sRankText = ra::StringPrintf(" %u ", rEntry.m_nRank);
+                const auto sNameText = ra::StringPrintf(" %s ", rEntry.m_sUsername);
+                const auto sScoreText = ra::StringPrintf(" %s ", pLB->FormatScore(rEntry.m_nScore));
 
                 //	Draw/Fetch user image? //TBD
                 TextOut(hDC, nDX + nWonByPlayerRankX, nLeaderboardYOffs + (i * nLeaderboardYSpacing),
-                        NativeStr(sRankText).c_str(), strlen(sRankText));
+                        NativeStr(sRankText).c_str(), gsl::narrow_cast<int>(sRankText.length()));
 
                 TextOut(hDC, nDX + nWonByPlayerUserX, nLeaderboardYOffs + (i * nLeaderboardYSpacing),
-                        NativeStr(sNameText).c_str(), strlen(sNameText));
+                        NativeStr(sNameText).c_str(), gsl::narrow_cast<int>(sNameText.length()));
 
                 TextOut(hDC, nDX + nWonByPlayerScoreX, nLeaderboardYOffs + (i * nLeaderboardYSpacing),
-                        NativeStr(sScoreText).c_str(), strlen(sScoreText));
+                        NativeStr(sScoreText).c_str(), gsl::narrow_cast<int>(sScoreText.length()));
             }
         }
         else
@@ -1407,12 +1398,12 @@ void AchievementOverlay::InstallNewsArticlesFromFile()
             };
 
             {
-                std::tm destTime;
-                localtime_s(&destTime, &nNewsItem.m_nPostedAt);
+                std::tm destTime{};
+                Expects(localtime_s(&destTime, &nNewsItem.m_nPostedAt) == 0);
 
-                char buffer[256U]{};
-                strftime(buffer, 256U, "%b %d", &destTime);
-                nNewsItem.m_sPostedAt = buffer;
+                std::ostringstream oss;
+                oss << std::put_time(&destTime, "%b %d");
+                nNewsItem.m_sPostedAt = oss.str();
             }
 
             m_LatestNews.push_back(std::move(nNewsItem));

--- a/src/RA_Core.cpp
+++ b/src/RA_Core.cpp
@@ -50,7 +50,7 @@ std::string g_sROMDirLocation;
 HMODULE g_hThisDLLInst = nullptr;
 HINSTANCE g_hRAKeysDLL = nullptr;
 HWND g_RAMainWnd = nullptr;
-ConsoleID g_ConsoleID = ConsoleID::UnknownConsoleID;	//	Currently active Console ID
+ConsoleID g_ConsoleID = ConsoleID::UnknownConsoleID; //	Currently active Console ID
 bool g_bRAMTamperedWith = false;
 
 BOOL APIENTRY DllMain(HMODULE hModule, DWORD dwReason, _UNUSED LPVOID)
@@ -63,7 +63,7 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD dwReason, _UNUSED LPVOID)
     return TRUE;
 }
 
-static void InitCommon(HWND hMainHWND, /*enum EmulatorID*/int nEmulatorID)
+static void InitCommon(HWND hMainHWND, /*enum EmulatorID*/ int nEmulatorID)
 {
     ra::services::Initialization::RegisterServices(ra::itoe<EmulatorID>(nEmulatorID));
 
@@ -89,13 +89,13 @@ static void InitCommon(HWND hMainHWND, /*enum EmulatorID*/int nEmulatorID)
     g_AchievementOverlay.UpdateImages();
 }
 
-API BOOL CCONV _RA_InitOffline(HWND hMainHWND, /*enum EmulatorID*/int nEmulatorID, const char* /*sClientVer*/)
+API BOOL CCONV _RA_InitOffline(HWND hMainHWND, /*enum EmulatorID*/ int nEmulatorID, const char* /*sClientVer*/)
 {
     InitCommon(hMainHWND, nEmulatorID);
     return TRUE;
 }
 
-API BOOL CCONV _RA_InitI(HWND hMainHWND, /*enum EmulatorID*/int nEmulatorID, const char* sClientVer)
+API BOOL CCONV _RA_InitI(HWND hMainHWND, /*enum EmulatorID*/ int nEmulatorID, const char* sClientVer)
 {
     InitCommon(hMainHWND, nEmulatorID);
 
@@ -110,14 +110,13 @@ API BOOL CCONV _RA_InitI(HWND hMainHWND, /*enum EmulatorID*/int nEmulatorID, con
     RAWeb::CreateThreadedHTTPRequest(RequestNews, args);
 
     // validate version (async call)
-    ra::services::ServiceLocator::GetMutable<ra::services::IThreadPool>().RunAsync([]
-    {
+    ra::services::ServiceLocator::GetMutable<ra::services::IThreadPool>().RunAsync([] {
         if (!ra::services::ServiceLocator::GetMutable<ra::data::EmulatorContext>().ValidateClientVersion())
             ra::services::ServiceLocator::GetMutable<ra::data::UserContext>().Logout();
     });
 
     //	TBD:
-    //if( RAUsers::LocalUser().Username().length() > 0 )
+    // if( RAUsers::LocalUser().Username().length() > 0 )
     //{
     //	args.clear();
     //	args[ 'u' ] = RAUsers::LocalUser().Username();
@@ -195,42 +194,39 @@ API bool CCONV _RA_ConfirmLoadNewRom(bool bQuittingApp)
 
     if (g_pCoreAchievements->HasUnsavedChanges())
     {
-        char buffer[1024];
-        sprintf_s(buffer, 1024,
+        const auto buffer = ra::StringPrintf(
             "You have unsaved changes in the Core Achievements set.\n"
             "If you %s you will lose these changes.\n"
-            "%s", sCurrentAction, sNextAction);
+            "%s",
+            sCurrentAction, sNextAction);
 
         nResult = MessageBox(g_RAMainWnd, NativeStr(buffer).c_str(), TEXT("Warning"), MB_ICONWARNING | MB_YESNO);
     }
     if (g_pUnofficialAchievements->HasUnsavedChanges())
     {
-        char buffer[1024];
-        sprintf_s(buffer, 1024,
+        const auto buffer = ra::StringPrintf(
             "You have unsaved changes in the Unofficial Achievements set.\n"
             "If you %s you will lose these changes.\n"
-            "%s", sCurrentAction, sNextAction);
+            "%s",
+            sCurrentAction, sNextAction);
 
         nResult = MessageBox(g_RAMainWnd, NativeStr(buffer).c_str(), TEXT("Warning"), MB_ICONWARNING | MB_YESNO);
     }
     if (g_pLocalAchievements->HasUnsavedChanges())
     {
-        char buffer[1024];
-        sprintf_s(buffer, 1024,
+        const auto buffer = ra::StringPrintf(
             "You have unsaved changes in the Local Achievements set.\n"
             "If you %s you will lose these changes.\n"
-            "%s", sCurrentAction, sNextAction);
+            "%s",
+            sCurrentAction, sNextAction);
 
         nResult = MessageBox(g_RAMainWnd, NativeStr(buffer).c_str(), TEXT("Warning"), MB_ICONWARNING | MB_YESNO);
     }
 
-    return(nResult == IDYES);
+    return (nResult == IDYES);
 }
 
-API void CCONV _RA_SetConsoleID(unsigned int nConsoleID)
-{
-    g_ConsoleID = static_cast<ConsoleID>(nConsoleID);
-}
+API void CCONV _RA_SetConsoleID(unsigned int nConsoleID) { g_ConsoleID = static_cast<ConsoleID>(nConsoleID); }
 
 API bool CCONV _RA_WarnDisableHardcore(const char* sActivity)
 {
@@ -310,7 +306,8 @@ static void ActivateGame(unsigned int nGameId)
 {
     if (!ra::services::ServiceLocator::Get<ra::data::UserContext>().IsLoggedIn())
     {
-        ra::ui::viewmodels::MessageBoxViewModel::ShowErrorMessage(L"Cannot load achievements",
+        ra::ui::viewmodels::MessageBoxViewModel::ShowErrorMessage(
+            L"Cannot load achievements",
             L"You must be logged in to load achievements. Please reload the game after logging in.");
         return;
     }
@@ -333,8 +330,7 @@ static void ActivateGame(unsigned int nGameId)
 
             ra::services::ServiceLocator::Get<ra::services::IAudioSystem>().PlayAudioFile(L"Overlay\\info.wav");
             ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().QueueMessage(
-                L"Playing in Softcore Mode",
-                bLeaderboardsEnabled ? L"Leaderboard submissions will be canceled." : L"");
+                L"Playing in Softcore Mode", bLeaderboardsEnabled ? L"Leaderboard submissions will be canceled." : L"");
         }
     }
     else
@@ -351,7 +347,8 @@ static void ActivateGame(unsigned int nGameId)
     g_AchievementOverlay.OnLoad_NewRom();
     g_MemBookmarkDialog.OnLoad_NewRom();
 
-    ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::WindowManager>().RichPresenceMonitor.UpdateDisplayString();
+    ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::WindowManager>()
+        .RichPresenceMonitor.UpdateDisplayString();
 }
 
 struct PendingRom
@@ -442,7 +439,8 @@ API void CCONV _RA_OnReset()
 
 API void CCONV _RA_InstallMemoryBank(int nBankID, void* pReader, void* pWriter, int nBankSize)
 {
-    g_MemManager.AddMemoryBank(ra::to_unsigned(nBankID), (_RAMByteReadFn*)pReader, (_RAMByteWriteFn*)pWriter, ra::to_unsigned(nBankSize));
+    g_MemManager.AddMemoryBank(ra::to_unsigned(nBankID), (_RAMByteReadFn*)pReader, (_RAMByteWriteFn*)pWriter,
+                               ra::to_unsigned(nBankSize));
     g_MemoryDialog.AddBank(nBankID);
 }
 
@@ -452,12 +450,11 @@ API void CCONV _RA_ClearMemoryBanks()
     g_MemoryDialog.ClearBanks();
 }
 
-
-//void FetchBinaryFromWeb( const char* sFilename )
+// void FetchBinaryFromWeb( const char* sFilename )
 //{
 //	const unsigned int nBufferSize = (3*1024*1024);	//	3mb enough?
 //
-//	char* buffer = new char[nBufferSize];	
+//	char* buffer = new char[nBufferSize];
 //	if( buffer != nullptr )
 //	{
 //		char sAddr[1024];
@@ -565,23 +562,35 @@ API HMENU CCONV _RA_CreatePopupMenu()
         AppendMenu(hRA, MF_STRING, IDM_RA_OPENUSERPAGE, TEXT("Open my &User Page"));
 
         constexpr auto nGameFlags = ra::to_unsigned(MF_STRING);
-        //if( g_pActiveAchievements->ra::GameID() == 0 )	//	Disabled til I can get this right: Snes9x doesn't call this?
-        //	nGameFlags |= (MF_GRAYED|MF_DISABLED);
+        // if( g_pActiveAchievements->ra::GameID() == 0 )	//	Disabled til I can get this right: Snes9x
+        // doesn't call this? 	nGameFlags |= (MF_GRAYED|MF_DISABLED);
 
         auto& pConfiguration = ra::services::ServiceLocator::Get<ra::services::IConfiguration>();
 
         // TODO: Replace UINT_PTR{} with the _z literal after PR #23 gets accepted
         AppendMenu(hRA, nGameFlags, IDM_RA_OPENGAMEPAGE, TEXT("Open this &Game's Page"));
         AppendMenu(hRA, MF_SEPARATOR, 0U, nullptr);
-        AppendMenu(hRA, pConfiguration.IsFeatureEnabled(ra::services::Feature::Hardcore) ? MF_CHECKED : MF_UNCHECKED, IDM_RA_HARDCORE_MODE, TEXT("&Hardcore Mode"));
+        AppendMenu(hRA, pConfiguration.IsFeatureEnabled(ra::services::Feature::Hardcore) ? MF_CHECKED : MF_UNCHECKED,
+                   IDM_RA_HARDCORE_MODE, TEXT("&Hardcore Mode"));
         AppendMenu(hRA, MF_SEPARATOR, 0U, nullptr);
 
         GSL_SUPPRESS_TYPE1 AppendMenu(hRA, MF_POPUP, reinterpret_cast<UINT_PTR>(hRA_LB), TEXT("Leaderboards"));
-        AppendMenu(hRA_LB, pConfiguration.IsFeatureEnabled(ra::services::Feature::Leaderboards) ? MF_CHECKED : MF_UNCHECKED, IDM_RA_TOGGLELEADERBOARDS, TEXT("Enable &Leaderboards"));
+        AppendMenu(hRA_LB,
+                   pConfiguration.IsFeatureEnabled(ra::services::Feature::Leaderboards) ? MF_CHECKED : MF_UNCHECKED,
+                   IDM_RA_TOGGLELEADERBOARDS, TEXT("Enable &Leaderboards"));
         AppendMenu(hRA_LB, MF_SEPARATOR, 0U, nullptr);
-        AppendMenu(hRA_LB, pConfiguration.IsFeatureEnabled(ra::services::Feature::LeaderboardNotifications) ? MF_CHECKED : MF_UNCHECKED, IDM_RA_TOGGLE_LB_NOTIFICATIONS, TEXT("Display Challenge Notification"));
-        AppendMenu(hRA_LB, pConfiguration.IsFeatureEnabled(ra::services::Feature::LeaderboardCounters) ? MF_CHECKED : MF_UNCHECKED, IDM_RA_TOGGLE_LB_COUNTER, TEXT("Display Time/Score Counter"));
-        AppendMenu(hRA_LB, pConfiguration.IsFeatureEnabled(ra::services::Feature::LeaderboardScoreboards) ? MF_CHECKED : MF_UNCHECKED, IDM_RA_TOGGLE_LB_SCOREBOARD, TEXT("Display Rank Scoreboard"));
+        AppendMenu(hRA_LB,
+                   pConfiguration.IsFeatureEnabled(ra::services::Feature::LeaderboardNotifications) ? MF_CHECKED
+                                                                                                    : MF_UNCHECKED,
+                   IDM_RA_TOGGLE_LB_NOTIFICATIONS, TEXT("Display Challenge Notification"));
+        AppendMenu(hRA_LB,
+                   pConfiguration.IsFeatureEnabled(ra::services::Feature::LeaderboardCounters) ? MF_CHECKED
+                                                                                               : MF_UNCHECKED,
+                   IDM_RA_TOGGLE_LB_COUNTER, TEXT("Display Time/Score Counter"));
+        AppendMenu(hRA_LB,
+                   pConfiguration.IsFeatureEnabled(ra::services::Feature::LeaderboardScoreboards) ? MF_CHECKED
+                                                                                                  : MF_UNCHECKED,
+                   IDM_RA_TOGGLE_LB_SCOREBOARD, TEXT("Display Rank Scoreboard"));
 
         AppendMenu(hRA, MF_SEPARATOR, 0U, nullptr);
         AppendMenu(hRA, MF_STRING, IDM_RA_FILES_ACHIEVEMENTS, TEXT("Achievement &Sets"));
@@ -591,7 +600,7 @@ API HMENU CCONV _RA_CreatePopupMenu()
         AppendMenu(hRA, MF_SEPARATOR, 0U, nullptr);
         AppendMenu(hRA, MF_STRING, IDM_RA_REPORTBROKENACHIEVEMENTS, TEXT("&Report Broken Achievements"));
         AppendMenu(hRA, MF_STRING, IDM_RA_GETROMCHECKSUM, TEXT("Get ROM &Checksum"));
-        //AppendMenu(hRA, MF_STRING, IDM_RA_SCANFORGAMES, TEXT("Scan &for games"));
+        // AppendMenu(hRA, MF_STRING, IDM_RA_SCANFORGAMES, TEXT("Scan &for games"));
     }
     else
     {
@@ -654,9 +663,11 @@ void RestoreWindowPosition(HWND hDlg, const char* sDlgKey, bool bToRight, bool b
     GetWindowRect(g_RAMainWnd, &rcMainWindow);
 
     // determine where the window should be placed
-    rc.left = (oPosition.X != INT32_MIN) ? (rcMainWindow.left + oPosition.X) : bToRight ? rcMainWindow.right : rcMainWindow.left;
+    rc.left = (oPosition.X != INT32_MIN) ? (rcMainWindow.left + oPosition.X)
+                                         : bToRight ? rcMainWindow.right : rcMainWindow.left;
     rc.right = (oSize.Width != INT32_MIN) ? (rc.left + oSize.Width) : (rc.left + nDlgWidth);
-    rc.top = (oPosition.Y != INT32_MIN) ? (rcMainWindow.top + oPosition.Y) : bToBottom ? rcMainWindow.bottom : rcMainWindow.top;
+    rc.top = (oPosition.Y != INT32_MIN) ? (rcMainWindow.top + oPosition.Y)
+                                        : bToBottom ? rcMainWindow.bottom : rcMainWindow.top;
     rc.bottom = (oSize.Height != INT32_MIN) ? (rc.top + oSize.Height) : (rc.top + nDlgHeight);
 
     // make sure the window is on screen
@@ -705,7 +716,8 @@ void RememberWindowPosition(HWND hDlg, const char* sDlgKey)
     oPosition.X = rc.left - rcMainWindow.left;
     oPosition.Y = rc.top - rcMainWindow.top;
 
-    ra::services::ServiceLocator::GetMutable<ra::services::IConfiguration>().SetWindowPosition(std::string(sDlgKey), oPosition);
+    ra::services::ServiceLocator::GetMutable<ra::services::IConfiguration>().SetWindowPosition(std::string(sDlgKey),
+                                                                                               oPosition);
 }
 
 void RememberWindowSize(HWND hDlg, const char* sDlgKey)
@@ -726,21 +738,25 @@ API void CCONV _RA_InvokeDialog(LPARAM nID)
     {
         case IDM_RA_FILES_ACHIEVEMENTS:
             if (g_AchievementsDialog.GetHWND() == nullptr)
-                g_AchievementsDialog.InstallHWND(CreateDialog(g_hThisDLLInst, MAKEINTRESOURCE(IDD_RA_ACHIEVEMENTS), g_RAMainWnd, g_AchievementsDialog.s_AchievementsProc));
+                g_AchievementsDialog.InstallHWND(CreateDialog(g_hThisDLLInst, MAKEINTRESOURCE(IDD_RA_ACHIEVEMENTS),
+                                                              g_RAMainWnd, g_AchievementsDialog.s_AchievementsProc));
             if (g_AchievementsDialog.GetHWND() != nullptr)
                 ShowWindow(g_AchievementsDialog.GetHWND(), SW_SHOW);
             break;
 
         case IDM_RA_FILES_ACHIEVEMENTEDITOR:
             if (g_AchievementEditorDialog.GetHWND() == nullptr)
-                g_AchievementEditorDialog.InstallHWND(CreateDialog(g_hThisDLLInst, MAKEINTRESOURCE(IDD_RA_ACHIEVEMENTEDITOR), g_RAMainWnd, g_AchievementEditorDialog.s_AchievementEditorProc));
+                g_AchievementEditorDialog.InstallHWND(
+                    CreateDialog(g_hThisDLLInst, MAKEINTRESOURCE(IDD_RA_ACHIEVEMENTEDITOR), g_RAMainWnd,
+                                 g_AchievementEditorDialog.s_AchievementEditorProc));
             if (g_AchievementEditorDialog.GetHWND() != nullptr)
                 ShowWindow(g_AchievementEditorDialog.GetHWND(), SW_SHOW);
             break;
 
         case IDM_RA_FILES_MEMORYFINDER:
             if (g_MemoryDialog.GetHWND() == nullptr)
-                g_MemoryDialog.InstallHWND(CreateDialog(g_hThisDLLInst, MAKEINTRESOURCE(IDD_RA_MEMORY), g_RAMainWnd, g_MemoryDialog.s_MemoryProc));
+                g_MemoryDialog.InstallHWND(CreateDialog(g_hThisDLLInst, MAKEINTRESOURCE(IDD_RA_MEMORY), g_RAMainWnd,
+                                                        g_MemoryDialog.s_MemoryProc));
             if (g_MemoryDialog.GetHWND() != nullptr)
                 ShowWindow(g_MemoryDialog.GetHWND(), SW_SHOW);
             break;
@@ -803,12 +819,7 @@ API void CCONV _RA_InvokeDialog(LPARAM nID)
             {
                 std::ostringstream oss;
                 oss << "http://" << _RA_HostName() << "/User/" << pUserContext.GetUsername();
-                ShellExecute(nullptr,
-                    TEXT("open"),
-                    NativeStr(oss.str()).c_str(),
-                    nullptr,
-                    nullptr,
-                    SW_SHOWNORMAL);
+                ShellExecute(nullptr, TEXT("open"), NativeStr(oss.str()).c_str(), nullptr, nullptr, SW_SHOWNORMAL);
             }
             break;
         }
@@ -820,12 +831,7 @@ API void CCONV _RA_InvokeDialog(LPARAM nID)
             {
                 std::ostringstream oss;
                 oss << "http://" << _RA_HostName() << "/Game/" << pGameContext.GameId();
-                ShellExecute(nullptr,
-                    TEXT("open"),
-                    NativeStr(oss.str()).c_str(),
-                    nullptr,
-                    nullptr,
-                    SW_SHOWNORMAL);
+                ShellExecute(nullptr, TEXT("open"), NativeStr(oss.str()).c_str(), nullptr, nullptr, SW_SHOWNORMAL);
             }
             else
             {
@@ -845,11 +851,12 @@ API void CCONV _RA_InvokeDialog(LPARAM nID)
             {
                 if (g_GameLibrary.GetHWND() == nullptr)
                 {
-                    _FetchGameHashLibraryFromWeb();		//	##BLOCKING##
-                    _FetchGameTitlesFromWeb();			//	##BLOCKING##
-                    _FetchMyProgressFromWeb();			//	##BLOCKING##
+                    _FetchGameHashLibraryFromWeb(); //	##BLOCKING##
+                    _FetchGameTitlesFromWeb();      //	##BLOCKING##
+                    _FetchMyProgressFromWeb();      //	##BLOCKING##
 
-                    g_GameLibrary.InstallHWND(CreateDialog(g_hThisDLLInst, MAKEINTRESOURCE(IDD_RA_GAMELIBRARY), g_RAMainWnd, &Dlg_GameLibrary::s_GameLibraryProc));
+                    g_GameLibrary.InstallHWND(CreateDialog(g_hThisDLLInst, MAKEINTRESOURCE(IDD_RA_GAMELIBRARY),
+                                                           g_RAMainWnd, &Dlg_GameLibrary::s_GameLibraryProc));
                 }
 
                 if (g_GameLibrary.GetHWND() != nullptr)
@@ -895,7 +902,8 @@ API void CCONV _RA_InvokeDialog(LPARAM nID)
         case IDM_RA_TOGGLE_LB_NOTIFICATIONS:
         {
             auto& pConfiguration = ra::services::ServiceLocator::GetMutable<ra::services::IConfiguration>();
-            pConfiguration.SetFeatureEnabled(ra::services::Feature::LeaderboardNotifications,
+            pConfiguration.SetFeatureEnabled(
+                ra::services::Feature::LeaderboardNotifications,
                 !pConfiguration.IsFeatureEnabled(ra::services::Feature::LeaderboardNotifications));
 
             _RA_RebuildMenu();
@@ -905,7 +913,8 @@ API void CCONV _RA_InvokeDialog(LPARAM nID)
         case IDM_RA_TOGGLE_LB_COUNTER:
         {
             auto& pConfiguration = ra::services::ServiceLocator::GetMutable<ra::services::IConfiguration>();
-            pConfiguration.SetFeatureEnabled(ra::services::Feature::LeaderboardCounters,
+            pConfiguration.SetFeatureEnabled(
+                ra::services::Feature::LeaderboardCounters,
                 !pConfiguration.IsFeatureEnabled(ra::services::Feature::LeaderboardCounters));
 
             _RA_RebuildMenu();
@@ -915,7 +924,8 @@ API void CCONV _RA_InvokeDialog(LPARAM nID)
         case IDM_RA_TOGGLE_LB_SCOREBOARD:
         {
             auto& pConfiguration = ra::services::ServiceLocator::GetMutable<ra::services::IConfiguration>();
-            pConfiguration.SetFeatureEnabled(ra::services::Feature::LeaderboardScoreboards,
+            pConfiguration.SetFeatureEnabled(
+                ra::services::Feature::LeaderboardScoreboards,
                 !pConfiguration.IsFeatureEnabled(ra::services::Feature::LeaderboardScoreboards));
 
             _RA_RebuildMenu();
@@ -954,7 +964,8 @@ API void CCONV _RA_OnLoadState(const char* sFilename)
         auto& pConfiguration = ra::services::ServiceLocator::GetMutable<ra::services::IConfiguration>();
         if (pConfiguration.IsFeatureEnabled(ra::services::Feature::Hardcore))
         {
-            ra::ui::viewmodels::MessageBoxViewModel::ShowWarningMessage(L"Disabling Hardcore mode.", L"Loading save states is not allowed in Hardcore mode.");
+            ra::ui::viewmodels::MessageBoxViewModel::ShowWarningMessage(
+                L"Disabling Hardcore mode.", L"Loading save states is not allowed in Hardcore mode.");
             ra::services::ServiceLocator::GetMutable<ra::data::EmulatorContext>().DisableHardcoreMode();
         }
 
@@ -978,13 +989,19 @@ API void CCONV _RA_DoAchievementsFrame()
     }
 }
 
-void CCONV _RA_InstallSharedFunctions(bool(*fpIsActive)(void), void(*fpCauseUnpause)(void), void(*fpRebuildMenu)(void), void(*fpEstimateTitle)(char*), void(*fpResetEmulation)(void), void(*fpLoadROM)(const char*))
+void CCONV _RA_InstallSharedFunctions(bool (*fpIsActive)(void), void (*fpCauseUnpause)(void),
+                                      void (*fpRebuildMenu)(void), void (*fpEstimateTitle)(char*),
+                                      void (*fpResetEmulation)(void), void (*fpLoadROM)(const char*))
 {
-    void(*fpCausePause)(void) = nullptr;
-    _RA_InstallSharedFunctionsExt(fpIsActive, fpCauseUnpause, fpCausePause, fpRebuildMenu, fpEstimateTitle, fpResetEmulation, fpLoadROM);
+    void (*fpCausePause)(void) = nullptr;
+    _RA_InstallSharedFunctionsExt(fpIsActive, fpCauseUnpause, fpCausePause, fpRebuildMenu, fpEstimateTitle,
+                                  fpResetEmulation, fpLoadROM);
 }
 
-void CCONV _RA_InstallSharedFunctionsExt(bool(*fpIsActive)(void), void(*fpCauseUnpause)(void), void(*fpCausePause)(void), void(*fpRebuildMenu)(void), void(*fpEstimateTitle)(char*), void(*fpResetEmulation)(void), void(*fpLoadROM)(const char*))
+void CCONV _RA_InstallSharedFunctionsExt(bool (*fpIsActive)(void), void (*fpCauseUnpause)(void),
+                                         void (*fpCausePause)(void), void (*fpRebuildMenu)(void),
+                                         void (*fpEstimateTitle)(char*), void (*fpResetEmulation)(void),
+                                         void (*fpLoadROM)(const char*))
 {
     //	NB. Must be called from within DLL
     _RA_GameIsActive = fpIsActive;
@@ -996,11 +1013,10 @@ void CCONV _RA_InstallSharedFunctionsExt(bool(*fpIsActive)(void), void(*fpCauseU
     _RA_LoadROM = fpLoadROM;
 }
 
-
 //////////////////////////////////////////////////////////////////////////
 
 BOOL _ReadTil(const char nChar, char* restrict buffer, unsigned int nSize,
-              gsl::not_null<DWORD* restrict> pCharsReadOut, gsl::not_null<FILE* restrict> pFile)
+              gsl::not_null<DWORD * restrict> pCharsReadOut, gsl::not_null<FILE * restrict> pFile)
 {
     Expects(buffer != nullptr);
     char pNextChar = '\0';
@@ -1015,7 +1031,7 @@ BOOL _ReadTil(const char nChar, char* restrict buffer, unsigned int nSize,
 
         buffer[(*pCharsReadOut)++] = pNextChar;
     } while (pNextChar != nChar && (*pCharsReadOut) < nSize && !feof(pFile));
-    
+
     Ensures(buffer != nullptr);
     return ((*pCharsReadOut) > 0);
 }
@@ -1049,7 +1065,7 @@ void _ReadStringTil(std::string& value, char nChar, const char* restrict& pSourc
 
 void _WriteBufferToFile(const std::wstring& sFileName, const std::string& raw)
 {
-    std::ofstream ofile{ sFileName, std::ios::binary };
+    std::ofstream ofile{sFileName, std::ios::binary};
     if (!ofile.is_open())
         return;
     ofile.write(raw.c_str(), ra::to_signed(raw.length()));
@@ -1071,53 +1087,47 @@ _Use_decl_annotations_ bool _ReadBufferFromFile(std::string& buffer, const wchar
     return true;
 }
 
-_Use_decl_annotations_
-char* _MallocAndBulkReadFileToBuffer(const wchar_t* sFilename, long& nFileSizeOut) noexcept
+_Use_decl_annotations_ char* _MallocAndBulkReadFileToBuffer(const wchar_t* sFilename,
+                                                            std::streamsize& nFileSize) noexcept
 {
-    nFileSizeOut = 0L;
-    FILE* pf = nullptr;
-    _wfopen_s(&pf, sFilename, L"r");
-    if (pf == nullptr)
+    nFileSize = 0LL;
+    std::ifstream ifile{sFilename, std::ios::binary};
+    if (!ifile.is_open())
         return nullptr;
 
     // Calculate filesize
-    fseek(pf, 0L, SEEK_END);
-    nFileSizeOut = ftell(pf);
-    fseek(pf, 0L, SEEK_SET);
+    nFileSize = ra::to_signed(std::filesystem::file_size(sFilename));
 
-    if (nFileSizeOut <= 0)
-    {
-        //	No good content in this file.
-        fclose(pf);
+    // No good content in this file.
+    if (nFileSize <= 0)
         return nullptr;
-    }
 
-    //	malloc() must be managed!
-    //	NB. By adding +1, we allow for a single \0 character :)
-    char* pRawFileOut = static_cast<char*>(std::malloc((nFileSizeOut + 1) * sizeof(char)));
+    // malloc() must be managed!
+    // NB. By adding +1, we allow for a single \0 character :)
+    auto pRawFileOut = static_cast<char*>(std::malloc((nFileSize + 1) * sizeof(char)));
     if (pRawFileOut)
     {
-        ZeroMemory(pRawFileOut, nFileSizeOut + 1);
-        fread(pRawFileOut, nFileSizeOut, sizeof(char), pf);
+        ZeroMemory(pRawFileOut, nFileSize + 1);
+        ifile.read(pRawFileOut, nFileSize);
     }
-
-    fclose(pf);
 
     return pRawFileOut;
 }
 
 std::string _TimeStampToString(time_t nTime)
 {
-    char buffer[64];
-    ctime_s(buffer, 64, &nTime);
-    return std::string(buffer);
+    std::tm tm{};
+    Expects(localtime_s(&tm, &nTime));
+
+    std::ostringstream oss;
+    oss << std::put_time(&tm, "%c");
+    return oss.str();
 }
 
 namespace ra {
 
-_Success_(return == 0)
-_NODISCARD static auto CALLBACK
-BrowseCallbackProc(_In_ HWND hwnd, _In_ UINT uMsg, _In_ LPARAM /*lParam*/, _In_ LPARAM lpData) noexcept // it might
+_Success_(return == 0) _NODISCARD static auto CALLBACK
+    BrowseCallbackProc(_In_ HWND hwnd, _In_ UINT uMsg, _In_ LPARAM /*lParam*/, _In_ LPARAM lpData) noexcept // it might
 {
     ASSERT(uMsg != BFFM_VALIDATEFAILED);
     if (uMsg == BFFM_INITIALIZED)
@@ -1125,7 +1135,6 @@ BrowseCallbackProc(_In_ HWND hwnd, _In_ UINT uMsg, _In_ LPARAM /*lParam*/, _In_ 
         LPCTSTR path{};
         GSL_SUPPRESS_TYPE1 path = reinterpret_cast<LPCTSTR>(lpData);
         GSL_SUPPRESS_TYPE1 ::SendMessage(hwnd, ra::to_unsigned(BFFM_SETSELECTION), 0U, reinterpret_cast<LPARAM>(path));
-
     }
     return 0;
 }
@@ -1145,19 +1154,19 @@ std::string GetFolderFromDialog()
         return std::string();
 
     bi.ulFlags = BIF_USENEWUI | BIF_VALIDATE;
-    bi.lpfn    = ra::BrowseCallbackProc;
+    bi.lpfn = ra::BrowseCallbackProc;
     GSL_SUPPRESS_TYPE1 bi.lParam = reinterpret_cast<LPARAM>(g_sHomeDir.c_str());
-    
+
     std::string ret;
     {
-        const auto idlist_deleter =[](LPITEMIDLIST lpItemIdList) noexcept
+        const auto idlist_deleter = [](LPITEMIDLIST lpItemIdList) noexcept
         {
             ::CoTaskMemFree(lpItemIdList);
             lpItemIdList = nullptr;
         };
 
         using ItemListOwner = std::unique_ptr<ITEMIDLIST, decltype(idlist_deleter)>;
-        ItemListOwner owner{ ::SHBrowseForFolder(&bi), idlist_deleter };
+        ItemListOwner owner{::SHBrowseForFolder(&bi), idlist_deleter};
         if (!owner)
         {
             ::OleUninitialize();
@@ -1175,7 +1184,4 @@ std::string GetFolderFromDialog()
     return ret;
 }
 
-BOOL CanCausePause() noexcept
-{
-    return (_RA_CausePause != nullptr);
-}
+BOOL CanCausePause() noexcept { return (_RA_CausePause != nullptr); }

--- a/src/RA_Core.cpp
+++ b/src/RA_Core.cpp
@@ -1117,7 +1117,7 @@ namespace ra {
 
 _Success_(return == 0)
 _NODISCARD static auto CALLBACK
-BrowseCallbackProc(_In_ HWND hwnd, _In_ UINT uMsg, _In_ _UNUSED LPARAM lParam, _In_ LPARAM lpData) noexcept // it might
+BrowseCallbackProc(_In_ HWND hwnd, _In_ UINT uMsg, _In_ LPARAM /*lParam*/, _In_ LPARAM lpData) noexcept // it might
 {
     ASSERT(uMsg != BFFM_VALIDATEFAILED);
     if (uMsg == BFFM_INITIALIZED)

--- a/src/RA_Core.cpp
+++ b/src/RA_Core.cpp
@@ -1104,10 +1104,10 @@ _Use_decl_annotations_ char* _MallocAndBulkReadFileToBuffer(const wchar_t* sFile
 
     // malloc() must be managed!
     // NB. By adding +1, we allow for a single \0 character :)
-    auto pRawFileOut = static_cast<char*>(std::malloc((nFileSize + 1) * sizeof(char)));
+    auto pRawFileOut = static_cast<char*>(std::malloc((gsl::narrow_cast<std::size_t>(nFileSize) + 1) * sizeof(char)));
     if (pRawFileOut)
     {
-        ZeroMemory(pRawFileOut, nFileSize + 1);
+        ZeroMemory(pRawFileOut, gsl::narrow_cast<std::size_t>(nFileSize) + 1);
         ifile.read(pRawFileOut, nFileSize);
     }
 

--- a/src/RA_Core.h
+++ b/src/RA_Core.h
@@ -17,10 +17,11 @@ extern ConsoleID g_ConsoleID;
 extern bool g_bRAMTamperedWith;
 
 // Read a file to a malloc'd buffer. Returns nullptr on error. Owner MUST free() buffer if not nullptr.
-extern char* _MallocAndBulkReadFileToBuffer(_In_z_ const wchar_t* sFilename, std::streamsize& nFileSize) noexcept;
+_NODISCARD GSL_SUPPRESS_F6 char* _MallocAndBulkReadFileToBuffer(_In_z_ const wchar_t* sFilename,
+                                                                _Out_ std::streamsize& nFileSize) noexcept;
 
 // Read a file to a std::string. Returns false on error.
-_Success_(return ) _NODISCARD bool _ReadBufferFromFile(_Out_ std::string& buffer, _In_ const wchar_t* restrict sFile);
+_Success_(return ) _NODISCARD bool _ReadBufferFromFile(_Out_ std::string& buffer, _In_z_ const wchar_t* restrict sFile);
 
 // Read file until reaching the end of the file, or the specified char.
 extern BOOL _ReadTil(const char nChar, char* restrict buffer, unsigned int nSize,

--- a/src/RA_Core.h
+++ b/src/RA_Core.h
@@ -17,7 +17,7 @@ extern ConsoleID g_ConsoleID;
 extern bool g_bRAMTamperedWith;
 
 // Read a file to a malloc'd buffer. Returns nullptr on error. Owner MUST free() buffer if not nullptr.
-extern char* _MallocAndBulkReadFileToBuffer(_In_z_ const wchar_t* sFilename, _Out_ long& nFileSizeOut) noexcept;
+extern char* _MallocAndBulkReadFileToBuffer(_In_z_ const wchar_t* sFilename, std::streamsize& nFileSize) noexcept;
 
 // Read a file to a std::string. Returns false on error.
 _Success_(return ) _NODISCARD bool _ReadBufferFromFile(_Out_ std::string& buffer, _In_ const wchar_t* restrict sFile);

--- a/src/RA_Dlg_AchEditor.cpp
+++ b/src/RA_Dlg_AchEditor.cpp
@@ -242,7 +242,7 @@ LRESULT CALLBACK EditProc(HWND hwnd, UINT nMsg, WPARAM wParam, LPARAM lParam) no
             // inline suppression not working, and by function not working, have to disable it by code
 
 #pragma warning(suppress : 26454)
-            GSL_SUPPRESS(io .5) lvDispinfo.hdr.code = LVN_ENDLABELEDIT;
+            GSL_SUPPRESS_IO5 lvDispinfo.hdr.code = LVN_ENDLABELEDIT;
 
             lvDispinfo.item.mask = LVIF_TEXT;
             lvDispinfo.item.iItem = nSelItem;
@@ -305,7 +305,7 @@ LRESULT CALLBACK DropDownProc(HWND hwnd, UINT nMsg, WPARAM wParam, LPARAM lParam
             lvDispinfo.hdr.hwndFrom = hwnd;
             lvDispinfo.hdr.idFrom = GetDlgCtrlID(hwnd);
 #pragma warning(suppress : 26454)
-            GSL_SUPPRESS(io .5) lvDispinfo.hdr.code = LVN_ENDLABELEDIT;
+            GSL_SUPPRESS_IO5 lvDispinfo.hdr.code = LVN_ENDLABELEDIT;
             lvDispinfo.item.mask = LVIF_TEXT;
             lvDispinfo.item.iItem = nSelItem;
             lvDispinfo.item.iSubItem = nSelSubItem;
@@ -336,7 +336,7 @@ LRESULT CALLBACK DropDownProc(HWND hwnd, UINT nMsg, WPARAM wParam, LPARAM lParam
             lvDispinfo.hdr.hwndFrom = hwnd;
             lvDispinfo.hdr.idFrom = GetDlgCtrlID(hwnd);
 #pragma warning(suppress : 26454)
-            GSL_SUPPRESS(io .5) lvDispinfo.hdr.code = LVN_ENDLABELEDIT;
+            GSL_SUPPRESS_IO5 lvDispinfo.hdr.code = LVN_ENDLABELEDIT;
             lvDispinfo.item.mask = LVIF_TEXT;
             lvDispinfo.item.iItem = nSelItem;
             lvDispinfo.item.iSubItem = nSelSubItem;
@@ -1434,7 +1434,7 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
                         lvDispinfo.hdr.hwndFrom = g_hIPEEdit;
                         lvDispinfo.hdr.idFrom = GetDlgCtrlID(g_hIPEEdit);
 #pragma warning(suppress : 26454)
-                        GSL_SUPPRESS(io .5) lvDispinfo.hdr.code = LVN_ENDLABELEDIT;
+                        GSL_SUPPRESS_IO5 lvDispinfo.hdr.code = LVN_ENDLABELEDIT;
                         lvDispinfo.item.mask = LVIF_TEXT;
                         lvDispinfo.item.iItem = nSelItem;
                         lvDispinfo.item.iSubItem = nSelSubItem;

--- a/src/RA_Dlg_AchEditor.cpp
+++ b/src/RA_Dlg_AchEditor.cpp
@@ -83,10 +83,15 @@ INT_PTR CALLBACK AchProgressProc(HWND hDlg, UINT nMsg, WPARAM wParam, _UNUSED LP
 Dlg_AchievementEditor::Dlg_AchievementEditor() noexcept
 {
     m_lbxGroupNames.front() = _T("Core");
-    for (auto it = std::next(m_lbxGroupNames.begin()); it != m_lbxGroupNames.end(); ++it)
+
+    gsl::index i = -1;
+    for (auto& name : m_lbxGroupNames)
     {
-        const auto i = std::distance(std::next(m_lbxGroupNames.begin()), it);
-        *it = ra::StringPrintf(_T("Alt %02t"), i);
+        i++;
+        if (i == 0)
+            continue;
+        else
+            name = ra::StringPrintf(_T("Alt %02t"), i);
     }
 }
 
@@ -177,7 +182,8 @@ void Dlg_AchievementEditor::UpdateCondition(HWND hList, LV_ITEM& item, const Con
         sMemSizeStrDst = ra::Narrow(MEMSIZE_STR.at(ra::etoi(Cond.CompTarget().GetSize())));
     }
 
-    LbxDataAt(nRow, CondSubItems::Id) = std::to_string(nRow + 1);;
+    LbxDataAt(nRow, CondSubItems::Id) = std::to_string(nRow + 1);
+    ;
     LbxDataAt(nRow, CondSubItems::Group) = ra::Narrow(Condition::TYPE_STR.at(ra::etoi(Cond.GetConditionType())));
     LbxDataAt(nRow, CondSubItems::Type_Src) = ra::Narrow(sMemTypStrSrc);
     LbxDataAt(nRow, CondSubItems::Size_Src) = ra::Narrow(sMemSizeStrSrc);
@@ -235,8 +241,8 @@ LRESULT CALLBACK EditProc(HWND hwnd, UINT nMsg, WPARAM wParam, LPARAM lParam) no
             lvDispinfo.hdr.idFrom = GetDlgCtrlID(hwnd);
             // inline suppression not working, and by function not working, have to disable it by code
 
-#pragma warning(suppress: 26454)
-            GSL_SUPPRESS(io.5) lvDispinfo.hdr.code = LVN_ENDLABELEDIT;
+#pragma warning(suppress : 26454)
+            GSL_SUPPRESS(io .5) lvDispinfo.hdr.code = LVN_ENDLABELEDIT;
 
             lvDispinfo.item.mask = LVIF_TEXT;
             lvDispinfo.item.iItem = nSelItem;
@@ -253,7 +259,8 @@ LRESULT CALLBACK EditProc(HWND hwnd, UINT nMsg, WPARAM wParam, LPARAM lParam) no
             // the LV ID and the LVs Parent window's HWND
             FORWARD_WM_NOTIFY(GetParent(hList), IDC_RA_LBX_CONDITIONS, &lvDispinfo, SendMessage); // ##reinterpret? ##SD
 
-            if (g_AchievementEditorDialog.LbxDataAt(lvDispinfo.item.iItem, CondSubItems::Type_Tgt).compare("Value") == 0)
+            if (g_AchievementEditorDialog.LbxDataAt(lvDispinfo.item.iItem, CondSubItems::Type_Tgt).compare("Value") ==
+                0)
             {
                 // Remove the associated 'size' entry
                 if ((lvDispinfo.item.iItem >= 0) && (lvDispinfo.item.iSubItem >= 1))
@@ -297,8 +304,8 @@ LRESULT CALLBACK DropDownProc(HWND hwnd, UINT nMsg, WPARAM wParam, LPARAM lParam
             ZeroMemory(&lvDispinfo, sizeof(LV_DISPINFO));
             lvDispinfo.hdr.hwndFrom = hwnd;
             lvDispinfo.hdr.idFrom = GetDlgCtrlID(hwnd);
-#pragma warning(suppress: 26454)
-            GSL_SUPPRESS(io.5) lvDispinfo.hdr.code = LVN_ENDLABELEDIT;
+#pragma warning(suppress : 26454)
+            GSL_SUPPRESS(io .5) lvDispinfo.hdr.code = LVN_ENDLABELEDIT;
             lvDispinfo.item.mask = LVIF_TEXT;
             lvDispinfo.item.iItem = nSelItem;
             lvDispinfo.item.iSubItem = nSelSubItem;
@@ -328,8 +335,8 @@ LRESULT CALLBACK DropDownProc(HWND hwnd, UINT nMsg, WPARAM wParam, LPARAM lParam
             ZeroMemory(&lvDispinfo, sizeof(LV_DISPINFO));
             lvDispinfo.hdr.hwndFrom = hwnd;
             lvDispinfo.hdr.idFrom = GetDlgCtrlID(hwnd);
-#pragma warning(suppress: 26454)
-            GSL_SUPPRESS(io.5) lvDispinfo.hdr.code = LVN_ENDLABELEDIT;
+#pragma warning(suppress : 26454)
+            GSL_SUPPRESS(io .5) lvDispinfo.hdr.code = LVN_ENDLABELEDIT;
             lvDispinfo.item.mask = LVIF_TEXT;
             lvDispinfo.item.iItem = nSelItem;
             lvDispinfo.item.iSubItem = nSelSubItem;
@@ -608,10 +615,11 @@ BOOL CreateIPE(int nItem, CondSubItems nSubItem)
                     break;
             }
 
-            g_hIPEEdit = CreateWindowEx(WS_EX_CLIENTEDGE, TEXT("EDIT"), TEXT(""),
-                                        WS_CHILD | WS_VISIBLE | WS_POPUPWINDOW | WS_BORDER | ES_WANTRETURN,
-                                        rcSubItem.left, rcSubItem.top, nWidth, ra::ftoi(1.5f * nHeight),
-                                        g_AchievementEditorDialog.GetHWND(), nullptr, GetModuleHandle(nullptr), nullptr);
+            g_hIPEEdit =
+                CreateWindowEx(WS_EX_CLIENTEDGE, TEXT("EDIT"), TEXT(""),
+                               WS_CHILD | WS_VISIBLE | WS_POPUPWINDOW | WS_BORDER | ES_WANTRETURN, rcSubItem.left,
+                               rcSubItem.top, nWidth, ra::ftoi(1.5f * nHeight), g_AchievementEditorDialog.GetHWND(),
+                               nullptr, GetModuleHandle(nullptr), nullptr);
 
             if (g_hIPEEdit == nullptr)
             {
@@ -632,7 +640,6 @@ BOOL CreateIPE(int nItem, CondSubItems nSubItem)
                 {
                     const size_t nGrp = g_AchievementEditorDialog.GetSelectedConditionGroup();
                     const Condition& Cond = g_AchievementEditorDialog.ActiveAchievement()->GetCondition(nGrp, nItem);
-
 
                     const auto buffer = std::to_string(Cond.RequiredHits());
                     SetWindowText(g_hIPEEdit, NativeStr(buffer).c_str());
@@ -1126,7 +1133,8 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
                         {
                             const unsigned int uSelectedCount = ListView_GetSelectedCount(hList);
 
-                            const auto buffer = ra::StringPrintf("Are you sure you wish to delete %u condition(s)?", uSelectedCount);
+                            const auto buffer =
+                                ra::StringPrintf("Are you sure you wish to delete %u condition(s)?", uSelectedCount);
                             if (MessageBox(hDlg, NativeStr(buffer).c_str(), TEXT("Warning"), MB_YESNO) == IDYES)
                             {
                                 nSel = -1;
@@ -1425,8 +1433,8 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
                         ZeroMemory(&lvDispinfo, sizeof(LV_DISPINFO));
                         lvDispinfo.hdr.hwndFrom = g_hIPEEdit;
                         lvDispinfo.hdr.idFrom = GetDlgCtrlID(g_hIPEEdit);
-#pragma warning(suppress: 26454)
-                        GSL_SUPPRESS(io.5) lvDispinfo.hdr.code = LVN_ENDLABELEDIT;
+#pragma warning(suppress : 26454)
+                        GSL_SUPPRESS(io .5) lvDispinfo.hdr.code = LVN_ENDLABELEDIT;
                         lvDispinfo.item.mask = LVIF_TEXT;
                         lvDispinfo.item.iItem = nSelItem;
                         lvDispinfo.item.iSubItem = nSelSubItem;
@@ -1452,7 +1460,7 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
         case WM_NOTIFY:
         {
 #pragma warning(push)
-#pragma warning(disable: 26490)
+#pragma warning(disable : 26490)
             GSL_SUPPRESS_TYPE1
             switch (((reinterpret_cast<LPNMHDR>(lParam))->code))
 #pragma warning(pop)
@@ -1576,7 +1584,7 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
                         g_AchievementsDialog.OnEditAchievement(*pActiveAch);
                     }
 
-                    // Inject the new text into the lbx 
+                    // Inject the new text into the lbx
                     ListView_SetItemText(::GetDlgItem(hDlg, IDC_RA_LBX_CONDITIONS), lvItem.iItem, lvItem.iSubItem,
                                          lvItem.pszText); // put new text
 
@@ -1751,21 +1759,20 @@ unsigned int Dlg_AchievementEditor::ParseValue(const std::string& sData, CompVar
     try
     {
         size_t nRead{};
-        const auto nVal = std::stoul(sData, &nRead, nBase); 
+        const auto nVal = std::stoul(sData, &nRead, nBase);
         if (nRead < sData.length())
             bInvalid = true;
         else if (nRead > 0 && sData.at(0) == '-')
-            ra::ui::viewmodels::MessageBoxViewModel::ShowWarningMessage(L"Invalid Input", L"Value must be non-negative.");
+            ra::ui::viewmodels::MessageBoxViewModel::ShowWarningMessage(L"Invalid Input",
+                                                                        L"Value must be non-negative.");
         else if (nVal > nMax)
             bTooLarge = true;
         else
             return nVal;
-    }
-    catch (const std::invalid_argument&)
+    } catch (const std::invalid_argument&)
     {
         bInvalid = true;
-    }
-    catch (const std::out_of_range&)
+    } catch (const std::out_of_range&)
     {
         bTooLarge = true;
     }
@@ -1774,27 +1781,28 @@ unsigned int Dlg_AchievementEditor::ParseValue(const std::string& sData, CompVar
     {
         if (nBase == 10)
         {
-            ra::ui::viewmodels::MessageBoxViewModel::ShowWarningMessage(L"Invalid Input",
+            ra::ui::viewmodels::MessageBoxViewModel::ShowWarningMessage(
+                L"Invalid Input",
                 L"Only values that can be represented as decimal are allowed while the "
                 L"'show decimal values' checkbox is checked.");
         }
         else
         {
-            ra::ui::viewmodels::MessageBoxViewModel::ShowWarningMessage(L"Invalid Input",
-                L"Only values that can be represented as hexadecimal are allowed.");
+            ra::ui::viewmodels::MessageBoxViewModel::ShowWarningMessage(
+                L"Invalid Input", L"Only values that can be represented as hexadecimal are allowed.");
         }
     }
     else if (bTooLarge)
     {
         if (nBase == 10)
         {
-            ra::ui::viewmodels::MessageBoxViewModel::ShowWarningMessage(L"Too Large",
-                ra::StringPrintf(L"Value cannot exceed %lu", nMax));
+            ra::ui::viewmodels::MessageBoxViewModel::ShowWarningMessage(
+                L"Too Large", ra::StringPrintf(L"Value cannot exceed %lu", nMax));
         }
         else
         {
-            ra::ui::viewmodels::MessageBoxViewModel::ShowWarningMessage(L"Too Large",
-                ra::StringPrintf(L"Value cannot exceed 0x%x", nMax));
+            ra::ui::viewmodels::MessageBoxViewModel::ShowWarningMessage(
+                L"Too Large", ra::StringPrintf(L"Value cannot exceed 0x%x", nMax));
         }
     }
 
@@ -1868,7 +1876,7 @@ void Dlg_AchievementEditor::UpdateSelectedBadgeImage(const std::string& sBackupB
 
     m_hAchievementBadge.ChangeReference(ra::ui::ImageType::Badge, sAchievementBadgeURI);
     GSL_SUPPRESS_CON4 // inline suppression for this currently not working
-    const auto hBitmap = ra::ui::drawing::gdi::ImageRepository::GetHBitmap(m_hAchievementBadge);
+        const auto hBitmap = ra::ui::drawing::gdi::ImageRepository::GetHBitmap(m_hAchievementBadge);
 
     if (hBitmap != nullptr)
     {
@@ -2011,7 +2019,8 @@ void Dlg_AchievementEditor::LoadAchievement(Achievement* pCheevo, _UNUSED BOOL)
         if (m_pSelectedAchievement->Category() == ra::etoi(AchievementSet::Type::Local))
             SetDlgItemTextA(m_hAchievementEditorDlg, IDC_RA_ACH_ID, "0");
         else
-            SetDlgItemTextA(m_hAchievementEditorDlg, IDC_RA_ACH_ID, std::to_string(m_pSelectedAchievement->ID()).c_str());
+            SetDlgItemTextA(m_hAchievementEditorDlg, IDC_RA_ACH_ID,
+                            std::to_string(m_pSelectedAchievement->ID()).c_str());
 
         const auto buffer = std::to_string(m_pSelectedAchievement->Points());
         SetDlgItemText(m_hAchievementEditorDlg, IDC_RA_ACH_POINTS, NativeStr(buffer).c_str());
@@ -2061,7 +2070,8 @@ void Dlg_AchievementEditor::LoadAchievement(Achievement* pCheevo, _UNUSED BOOL)
             if (m_pSelectedAchievement->Category() == ra::etoi(AchievementSet::Type::Local))
                 SetDlgItemTextA(m_hAchievementEditorDlg, IDC_RA_ACH_ID, "0");
             else
-                SetDlgItemTextA(m_hAchievementEditorDlg, IDC_RA_ACH_ID, std::to_string(m_pSelectedAchievement->ID()).c_str());
+                SetDlgItemTextA(m_hAchievementEditorDlg, IDC_RA_ACH_ID,
+                                std::to_string(m_pSelectedAchievement->ID()).c_str());
         }
         if (ra::etoi(pCheevo->GetDirtyFlags() & Achievement::DirtyFlags::Points) && !bPointsSelected)
             SetDlgItemText(m_hAchievementEditorDlg, IDC_RA_ACH_POINTS,

--- a/src/RA_Dlg_AchEditor.cpp
+++ b/src/RA_Dlg_AchEditor.cpp
@@ -633,8 +633,8 @@ BOOL CreateIPE(int nItem, CondSubItems nSubItem)
                     const size_t nGrp = g_AchievementEditorDialog.GetSelectedConditionGroup();
                     const Condition& Cond = g_AchievementEditorDialog.ActiveAchievement()->GetCondition(nGrp, nItem);
 
-                    char buffer[256];
-                    sprintf_s(buffer, 256, "%u", Cond.RequiredHits());
+
+                    const auto buffer = std::to_string(Cond.RequiredHits());
                     SetWindowText(g_hIPEEdit, NativeStr(buffer).c_str());
                 }
             }
@@ -1126,8 +1126,7 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
                         {
                             const unsigned int uSelectedCount = ListView_GetSelectedCount(hList);
 
-                            char buffer[256];
-                            sprintf_s(buffer, 256, "Are you sure you wish to delete %u condition(s)?", uSelectedCount);
+                            const auto buffer = ra::StringPrintf("Are you sure you wish to delete %u condition(s)?", uSelectedCount);
                             if (MessageBox(hDlg, NativeStr(buffer).c_str(), TEXT("Warning"), MB_YESNO) == IDYES)
                             {
                                 nSel = -1;
@@ -1509,8 +1508,7 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
                                 SendMessage(g_RAMainWnd, WM_COMMAND, IDM_RA_FILES_MEMORYFINDER, 0);
 
                                 // Update the text to match
-                                char buffer[16];
-                                sprintf_s(buffer, 16, "0x%06x", rCond.CompSource().GetValue());
+                                const auto buffer = ra::StringPrintf("0x%06x", rCond.CompSource().GetValue());
                                 SetDlgItemText(g_MemoryDialog.GetHWND(), IDC_RA_WATCHING, NativeStr(buffer).c_str());
 
                                 // Nudge the ComboBox to update the mem note
@@ -1526,8 +1524,7 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
                                 SendMessage(g_RAMainWnd, WM_COMMAND, IDM_RA_FILES_MEMORYFINDER, 0);
 
                                 // Update the text to match
-                                char buffer[16];
-                                sprintf_s(buffer, 16, "0x%06x", rCond.CompTarget().GetValue());
+                                const auto buffer = ra::StringPrintf("0x%06x", rCond.CompTarget().GetValue());
                                 SetDlgItemText(g_MemoryDialog.GetHWND(), IDC_RA_WATCHING, NativeStr(buffer).c_str());
 
                                 // Nudge the ComboBox to update the mem note
@@ -1753,8 +1750,8 @@ unsigned int Dlg_AchievementEditor::ParseValue(const std::string& sData, CompVar
     bool bInvalid = false;
     try
     {
-        size_t nRead;
-        auto nVal = std::stoul(sData, &nRead, nBase);
+        size_t nRead{};
+        const auto nVal = std::stoul(sData, &nRead, nBase); 
         if (nRead < sData.length())
             bInvalid = true;
         else if (nRead > 0 && sData.at(0) == '-')

--- a/src/RA_Dlg_Achievement.cpp
+++ b/src/RA_Dlg_Achievement.cpp
@@ -1092,7 +1092,7 @@ void Dlg_Achievements::OnLoad_NewRom(unsigned int nGameID)
         // SetupColumns( hList );
         LoadAchievements(hList);
 
-        const auto buffer = ra::StringPrintf(_T(" %u"), nGameID);
+        auto buffer = ra::StringPrintf(_T(" %u"), nGameID);
         SetDlgItemText(m_hAchievementsDlg, IDC_RA_GAMEHASH, NativeStr(buffer).c_str());
 
         if (nGameID != 0)
@@ -1104,7 +1104,7 @@ void Dlg_Achievements::OnLoad_NewRom(unsigned int nGameID)
             EnableWindow(GetDlgItem(m_hAchievementsDlg, IDC_RA_PROMOTE_ACH), TRUE);
         }
 
-        _stprintf_s(buffer, _T(" %u"), g_pActiveAchievements->NumAchievements());
+        buffer = ra::StringPrintf(_T(" %u"), g_pActiveAchievements->NumAchievements());
         SetDlgItemText(m_hAchievementsDlg, IDC_RA_NUMACH, NativeStr(buffer).c_str());
         SetDlgItemText(m_hAchievementsDlg, IDC_RA_POINT_TOTAL,
                        NativeStr(std::to_string(g_pActiveAchievements->PointTotal())).c_str());

--- a/src/RA_Dlg_Achievement.cpp
+++ b/src/RA_Dlg_Achievement.cpp
@@ -135,10 +135,9 @@ void Dlg_Achievements::RemoveAchievement(HWND hList, int nIter)
 {
     ASSERT(nIter < ListView_GetItemCount(hList));
     ListView_DeleteItem(hList, nIter);
-    m_lbxData.erase(m_lbxData.begin() + nIter);
+    m_lbxData.erase(std::next(m_lbxData.begin(), nIter));
 
-    char buffer[16];
-    sprintf_s(buffer, 16, " %u", g_pActiveAchievements->NumAchievements());
+    const auto buffer = ra::StringPrintf(" %u", g_pActiveAchievements->NumAchievements());
     SetDlgItemText(m_hAchievementsDlg, IDC_RA_NUMACH, NativeStr(buffer).c_str());
     SetDlgItemText(m_hAchievementsDlg, IDC_RA_POINT_TOTAL,
                    NativeStr(std::to_string(g_pActiveAchievements->PointTotal())).c_str());
@@ -201,36 +200,36 @@ void Dlg_Achievements::AddAchievementRow(const Achievement& Ach)
 _Success_(return ) _NODISCARD BOOL
     LocalValidateAchievementsBeforeCommit(_In_reads_(1) const std::array<int, 1> nLbxItems)
 {
-    char buffer[2048];
     for (auto& nIter : nLbxItems)
     {
         const Achievement& Ach = g_pActiveAchievements->GetAchievement(nIter);
         if (Ach.Title().length() < 2)
         {
-            sprintf_s(buffer, 2048, "Achievement title too short:\n%s\nMust be greater than 2 characters.",
-                      Ach.Title().c_str());
+            const auto buffer =
+                ra::StringPrintf("Achievement title too short:\n%s\nMust be greater than 2 characters.", Ach.Title());
             MessageBox(nullptr, NativeStr(buffer).c_str(), TEXT("Error!"), MB_OK);
             return FALSE;
         }
         if (Ach.Title().length() > 63)
         {
-            sprintf_s(buffer, 2048, "Achievement title too long:\n%s\nMust be fewer than 80 characters.",
-                      Ach.Title().c_str());
+            const auto buffer =
+                ra::StringPrintf("Achievement title too long:\n%s\nMust be fewer than 80 characters.",
+                      Ach.Title());
             MessageBox(nullptr, NativeStr(buffer).c_str(), TEXT("Error!"), MB_OK);
             return FALSE;
         }
 
         if (Ach.Description().length() < 2)
         {
-            sprintf_s(buffer, 2048, "Achievement description too short:\n%s\nMust be greater than 2 characters.",
-                      Ach.Description().c_str());
+            const auto buffer = ra::StringPrintf(
+                "Achievement description too short:\n%s\nMust be greater than 2 characters.", Ach.Description());
             MessageBox(nullptr, NativeStr(buffer).c_str(), TEXT("Error!"), MB_OK);
             return FALSE;
         }
         if (Ach.Description().length() > 255)
         {
-            sprintf_s(buffer, 2048, "Achievement description too long:\n%s\nMust be fewer than 255 characters.",
-                      Ach.Description().c_str());
+            const auto buffer = ra::StringPrintf(
+                "Achievement description too long:\n%s\nMust be fewer than 255 characters.", Ach.Description());
             MessageBox(nullptr, NativeStr(buffer).c_str(), TEXT("Error!"), MB_OK);
             return FALSE;
         }
@@ -567,8 +566,7 @@ INT_PTR Dlg_Achievements::AchievementsProc(HWND hDlg, UINT nMsg, WPARAM wParam, 
                     ListView_SetItemState(hList, nNewID, LVIS_FOCUSED | LVIS_SELECTED, ra::to_unsigned(-1));
                     ListView_EnsureVisible(hList, nNewID, FALSE);
 
-                    char buffer[16];
-                    sprintf_s(buffer, 16, " %u", g_pActiveAchievements->NumAchievements());
+                    const auto buffer = ra::StringPrintf(" %u", g_pActiveAchievements->NumAchievements());
                     SetDlgItemText(m_hAchievementsDlg, IDC_RA_NUMACH, NativeStr(buffer).c_str());
 
                     Cheevo.SetModified(TRUE);
@@ -606,8 +604,7 @@ INT_PTR Dlg_Achievements::AchievementsProc(HWND hDlg, UINT nMsg, WPARAM wParam, 
                                           LVIS_FOCUSED | LVIS_SELECTED, ra::to_unsigned(-1));
                     ListView_EnsureVisible(hList, g_pLocalAchievements->NumAchievements() - 1, FALSE);
 
-                    char buffer2[16];
-                    sprintf_s(buffer2, 16, " %u", g_pActiveAchievements->NumAchievements());
+                    const auto buffer2 = ra::StringPrintf(" %u", g_pActiveAchievements->NumAchievements());
                     SetDlgItemText(m_hAchievementsDlg, IDC_RA_NUMACH, NativeStr(buffer2).c_str());
                     SetDlgItemText(m_hAchievementsDlg, IDC_RA_POINT_TOTAL,
                                    NativeStr(std::to_string(g_pActiveAchievements->PointTotal())).c_str());
@@ -941,12 +938,11 @@ INT_PTR Dlg_Achievements::CommitAchievements(HWND hDlg)
     //  title = std::string("Upload ") + std::to_string( nNumChecked ) + std::string(" Achievements");
     //}
 
-    char message[1024];
-    sprintf_s(message, 1024,
-              "Uploading the selected %u achievement(s).\n"
-              "Are you sure? This will update the server with your new achievements\n"
-              "and players will be able to download them into their games immediately.",
-              nNumChecked);
+    const auto message = ra::StringPrintf(
+        "Uploading the selected %u achievement(s).\n"
+        "Are you sure? This will update the server with your new achievements\n"
+        "and players will be able to download them into their games immediately.",
+        nNumChecked);
 
     BOOL bErrorsEncountered = FALSE;
 
@@ -1014,8 +1010,7 @@ INT_PTR Dlg_Achievements::CommitAchievements(HWND hDlg)
                 }
                 else
                 {
-                    char buffer[1024];
-                    sprintf_s(buffer, 1024, "Error!!\n%s", std::string(response["Error"].GetString()).c_str());
+                    const auto buffer = ra::StringPrintf("Error!!\n%s", response["Error"].GetString());
                     MessageBox(hDlg, NativeStr(buffer).c_str(), TEXT("Error!"), MB_OK);
                     bErrorsEncountered = TRUE;
                 }
@@ -1029,8 +1024,7 @@ INT_PTR Dlg_Achievements::CommitAchievements(HWND hDlg)
         }
         else
         {
-            char buffer[512];
-            sprintf_s(buffer, 512, "Successfully uploaded data for %u achievements!", nNumChecked);
+            const auto buffer = ra::StringPrintf("Successfully uploaded data for %u achievements!", nNumChecked);
             MessageBox(hDlg, NativeStr(buffer).c_str(), TEXT("Success!"), MB_OK);
 
             RECT rcBounds;
@@ -1098,8 +1092,7 @@ void Dlg_Achievements::OnLoad_NewRom(unsigned int nGameID)
         // SetupColumns( hList );
         LoadAchievements(hList);
 
-        TCHAR buffer[256];
-        _stprintf_s(buffer, 256, _T(" %u"), nGameID);
+        const auto buffer = ra::StringPrintf(_T(" %u"), nGameID);
         SetDlgItemText(m_hAchievementsDlg, IDC_RA_GAMEHASH, NativeStr(buffer).c_str());
 
         if (nGameID != 0)

--- a/src/RA_Dlg_AchievementsReporter.cpp
+++ b/src/RA_Dlg_AchievementsReporter.cpp
@@ -202,7 +202,7 @@ INT_PTR CALLBACK Dlg_AchievementsReporter::AchievementsReporterProc(HWND hDlg, U
                                 "The development team will investigate this bug as soon as possible\n"
                                 "and we will send you a message on RetroAchievements.org\n"
                                 "as soon as we have a solution.\n\n"
-                                "Thanks again!\0"
+                                "Thanks again!"
                             };
 
                             MessageBox(hDlg, NativeStr(buffer.data()).c_str(), TEXT("Success!"), MB_OK);

--- a/src/RA_Dlg_GameLibrary.cpp
+++ b/src/RA_Dlg_GameLibrary.cpp
@@ -273,7 +273,7 @@ void Dlg_GameLibrary::ThreadedScanProc()
             auto pBuf = std::make_unique<unsigned char[]>(6 * 1024 * 1024);
 
             ifile.read(pBuf.get(), nSize); // Check
-            Results.insert_or_assign(FilesToScan.front(), RAGenerateMD5(pBuf.get(), nSize));
+            Results.insert_or_assign(FilesToScan.front(), RAGenerateMD5(pBuf.get(), gsl::narrow_cast<std::size_t>(nSize)));
             pBuf.reset();
 
             SendMessage(g_GameLibrary.GetHWND(), WM_TIMER, 0U, 0L);

--- a/src/RA_Dlg_MemBookmark.cpp
+++ b/src/RA_Dlg_MemBookmark.cpp
@@ -761,7 +761,7 @@ void Dlg_MemBookmark::ImportFromFile(std::wstring&& sFilename)
     if (!ifile.is_open())
     {
         std::array<char, 2048> buf{};
-        strerror_s(buf.data(), sizeof(buf), errno);
+        Ensures(strerror_s(buf.data(), sizeof(buf), errno) == 0);
         RA_LOG("%s: %s", ra::Narrow(sFilename).c_str(), buf.data());
         return;
     }

--- a/src/RA_Dlg_Memory.h
+++ b/src/RA_Dlg_Memory.h
@@ -106,7 +106,7 @@ private:
 
     bool GetSelectedMemoryRange(ra::ByteAddress& start, ra::ByteAddress& end);
 
-    void UpdateSearchResult(const ra::services::SearchResults::Result& result, _Out_ unsigned int& nMemVal, TCHAR(&buffer)[1024]);
+    ra::tstring UpdateSearchResult(const ra::services::SearchResults::Result& result, _Out_ unsigned int& nMemVal);
     bool CompareSearchResult(unsigned int nCurVal, unsigned int nPrevVal);
 
     static CodeNotes m_CodeNotes;

--- a/src/RA_Integration.vcxproj
+++ b/src/RA_Integration.vcxproj
@@ -409,7 +409,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Analysis|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_DEBUG;RA_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;RA_EXPORTS;_PREFAST_;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -462,7 +462,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='AnalysisUnicode|Win32'">
     <ClCompile>
-      <PreprocessorDefinitions>_DEBUG;RA_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;RA_EXPORTS;_PREFAST_;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>

--- a/src/RA_Leaderboard.h
+++ b/src/RA_Leaderboard.h
@@ -59,6 +59,11 @@ public:
     size_t GetRankInfoCount() const noexcept { return m_RankInfo.size(); }
     void SortRankInfo();
 
+    inline auto begin() noexcept { return m_RankInfo.begin(); }
+    inline auto begin() const noexcept { return m_RankInfo.begin(); }
+    inline auto end() noexcept { return m_RankInfo.end(); }
+    inline auto end() const noexcept { return m_RankInfo.end(); }
+
 protected:
     virtual void Start();
     virtual void Cancel();

--- a/src/RA_httpthread.cpp
+++ b/src/RA_httpthread.cpp
@@ -3,11 +3,11 @@
 #include "RA_Core.h"
 #include "RA_User.h"
 
-#include "RA_BuildVer.h"
 #include "RA_AchievementSet.h"
+#include "RA_BuildVer.h"
 #include "RA_Dlg_AchEditor.h"
-#include "RA_Dlg_Memory.h"
 #include "RA_Dlg_MemBookmark.h"
+#include "RA_Dlg_Memory.h"
 #include "RA_RichPresence.h"
 
 #include "data\EmulatorContext.hh"
@@ -21,8 +21,7 @@
 
 #include <winhttp.h>
 
-const char* RequestTypeToString[] =
-{
+const char* RequestTypeToString[] = {
     "RequestScore",
     "RequestNews",
     "RequestRichPresence",
@@ -43,36 +42,20 @@ const char* RequestTypeToString[] =
 };
 static_assert(SIZEOF_ARRAY(RequestTypeToString) == NumRequestTypes, "Must match up!");
 
-const char* RequestTypeToPost[] =
-{
-    "score",
-    "news",
-    "richpresencepatch",
-    "achievementwondata",
-    "lbinfo",
-    "codenotes2",
-    "getfriendlist",
-    "badgeiter",
-    "hashlibrary",
-    "gameslist",
-    "allprogress",
+const char* RequestTypeToPost[] = {
+    "score",          "news",          "richpresencepatch", "achievementwondata", "lbinfo",          "codenotes2",
+    "getfriendlist",  "badgeiter",     "hashlibrary",       "gameslist",          "allprogress",
 
-    "submitcodenote",
-    "submitlbentry",
-    "uploadachievement",
-    "submitticket",
-    "submitgametitle",
+    "submitcodenote", "submitlbentry", "uploadachievement", "submitticket",       "submitgametitle",
 };
 static_assert(SIZEOF_ARRAY(RequestTypeToPost) == NumRequestTypes, "Must match up!");
 
-const char* UploadTypeToString[] =
-{
+const char* UploadTypeToString[] = {
     "RequestUploadBadgeImage",
 };
 static_assert(SIZEOF_ARRAY(UploadTypeToString) == NumUploadTypes, "Must match up!");
 
-const char* UploadTypeToPost[] =
-{
+const char* UploadTypeToPost[] = {
     "uploadbadgeimage",
 };
 static_assert(SIZEOF_ARRAY(UploadTypeToPost) == NumUploadTypes, "Must match up!");
@@ -100,13 +83,13 @@ BOOL RequestObject::ParseResponseToJSON(rapidjson::Document& rDocOut)
 
 static void AppendIntegrationVersion(_Inout_ std::string& sUserAgent)
 {
-    sUserAgent.append(ra::StringPrintf("%d.%d.%d.%d", RA_INTEGRATION_VERSION_MAJOR,
-                                       RA_INTEGRATION_VERSION_MINOR, RA_INTEGRATION_VERSION_REVISION,
-                                       RA_INTEGRATION_VERSION_MODIFIED));
-    
-    if constexpr (_CONSTANT_LOC pos{ std::string_view{ RA_INTEGRATION_VERSION_PRODUCT }.find('-') }; pos != std::string_view::npos)
+    sUserAgent.append(ra::StringPrintf("%d.%d.%d.%d", RA_INTEGRATION_VERSION_MAJOR, RA_INTEGRATION_VERSION_MINOR,
+                                       RA_INTEGRATION_VERSION_REVISION, RA_INTEGRATION_VERSION_MODIFIED));
+
+    if constexpr (_CONSTANT_LOC pos{std::string_view{RA_INTEGRATION_VERSION_PRODUCT}.find('-')};
+                  pos != std::string_view::npos)
     {
-        constexpr std::string_view sAppend{ RA_INTEGRATION_VERSION_PRODUCT };
+        constexpr std::string_view sAppend{RA_INTEGRATION_VERSION_PRODUCT};
         sUserAgent.append(sAppend, pos);
     }
 }
@@ -119,9 +102,9 @@ static void AppendNTVersion(_Inout_ std::string& sUserAgent)
 #ifndef NTSTATUS
     using NTSTATUS = __success(return >= 0) LONG;
 #endif
-    if (const auto ntModule{ ::GetModuleHandleW(L"ntdll.dll") }; ntModule)
+    if (const auto ntModule{::GetModuleHandleW(L"ntdll.dll")}; ntModule)
     {
-        RTL_OSVERSIONINFOEXW osVersion{ sizeof(RTL_OSVERSIONINFOEXW) };
+        RTL_OSVERSIONINFOEXW osVersion{sizeof(RTL_OSVERSIONINFOEXW)};
         using fnRtlGetVersion = NTSTATUS(NTAPI*)(PRTL_OSVERSIONINFOEXW);
 
         fnRtlGetVersion RtlGetVersion{};
@@ -133,8 +116,8 @@ static void AppendNTVersion(_Inout_ std::string& sUserAgent)
             RtlGetVersion(&osVersion);
             if (osVersion.dwMajorVersion > 0UL)
             {
-                sUserAgent.append(ra::StringPrintf("WindowsNT %lu.%lu", osVersion.dwMajorVersion,
-                                                   osVersion.dwMinorVersion));
+                sUserAgent.append(
+                    ra::StringPrintf("WindowsNT %lu.%lu", osVersion.dwMajorVersion, osVersion.dwMinorVersion));
             }
         }
     }
@@ -178,14 +161,14 @@ BOOL RAWeb::DoBlockingRequest(RequestType nType, const PostArgs& PostData, rapid
         if (response.size() > 0)
         {
             JSONResponseOut.Parse(response.c_str());
-            //LogJSON( JSONResponseOut );   //  Already logged during DoBlockingRequest()?
+            // LogJSON( JSONResponseOut );   //  Already logged during DoBlockingRequest()?
 
             if (JSONResponseOut.HasParseError())
             {
                 RA_LOG("JSON Parse Error encountered!\n");
             }
 
-            return(!JSONResponseOut.HasParseError());
+            return (!JSONResponseOut.HasParseError());
         }
     }
 
@@ -246,7 +229,7 @@ BOOL DoBlockingImageUpload(UploadType nType, const std::string& sFilename, std::
 
     // Use WinHttpOpen to obtain a session handle.
 #pragma warning(push)
-#pragma warning(disable: 26477)
+#pragma warning(disable : 26477)
     GSL_SUPPRESS_ES47 HINTERNET hSession = WinHttpOpen(RAWeb::GetUserAgent().c_str(), WINHTTP_ACCESS_TYPE_DEFAULT_PROXY,
                                                        WINHTTP_NO_PROXY_NAME, WINHTTP_NO_PROXY_BYPASS, 0);
 #pragma warning(pop)
@@ -259,23 +242,23 @@ BOOL DoBlockingImageUpload(UploadType nType, const std::string& sFilename, std::
 
     if (hConnect != nullptr)
     {
-        WCHAR wBuffer[1024];
-        mbstowcs_s(&nTemp, wBuffer, 1024, sRequestedPage.c_str(), strlen(sRequestedPage.c_str()) + 1);
+        std::array<wchar_t, 1024> wBuffer{};
+        // TBD: This seems like ra::Widen, the CRT on Windows can only do ASCII (native) or UTF-16 (Managed), UTF-8
+        // doesn't seem to work
+        Expects(mbstowcs_s(&nTemp, wBuffer.data(), 1024, sRequestedPage.c_str(), sRequestedPage.length() + 1) == 0);
+        constexpr auto rsize_max = ra::to_unsigned(-1) >> 1; // RSIZE_MAX == PTRDIFF_MAX (indexing limits)
+        Ensures((nTemp > 0) && (nTemp < rsize_max));
 
-        hRequest = WinHttpOpenRequest(hConnect,
-            L"POST",
-            wBuffer,
-            nullptr,
-            WINHTTP_NO_REFERER,
-            WINHTTP_DEFAULT_ACCEPT_TYPES,
-            0);
+        GSL_SUPPRESS_ES47 hRequest = WinHttpOpenRequest(hConnect, L"POST", wBuffer.data(), nullptr, WINHTTP_NO_REFERER,
+                                                        WINHTTP_DEFAULT_ACCEPT_TYPES, 0);
     }
 
     if (hRequest != nullptr)
     {
         //---------------------------41184676334
         const char* mimeBoundary = "---------------------------41184676334";
-        const wchar_t* contentType = L"Content-Type: multipart/form-data; boundary=---------------------------41184676334\r\n";
+        const wchar_t* contentType =
+            L"Content-Type: multipart/form-data; boundary=---------------------------41184676334\r\n";
 
         const int nResult =
             WinHttpAddRequestHeaders(hRequest, contentType, ra::to_unsigned(-1), WINHTTP_ADDREQ_FLAG_ADD_IF_NEW);
@@ -287,38 +270,38 @@ BOOL DoBlockingImageUpload(UploadType nType, const std::string& sFilename, std::
             std::string sRTargetAndExtension = sRTarget + sFilename.substr(sFilename.length() - 4);
 
             std::ostringstream sb_ascii;
-            //sb_ascii << str;                                  
-            sb_ascii << "--" << mimeBoundary << "\r\n";                                                         //  --Boundary
-            sb_ascii << "Content-Disposition: form-data; name=\"file\"; filename=\"" << sRTargetAndExtension << "\"\r\n";   //  Item header    'file' - Hijacking to determine request type!
-            sb_ascii << "\r\n";                                                                                 //  Spacing
-            sb_ascii << f.rdbuf();                                                                              //  Binary content
-            sb_ascii << "\r\n";                                                                                 //  Spacing
-            sb_ascii << "--" << mimeBoundary << "--\r\n";                                                       //  --Boundary--
+            // sb_ascii << str;
+            sb_ascii << "--" << mimeBoundary << "\r\n"; //  --Boundary
+            sb_ascii << "Content-Disposition: form-data; name=\"file\"; filename=\"" << sRTargetAndExtension
+                     << "\"\r\n";  //  Item header    'file' - Hijacking to determine request type!
+            sb_ascii << "\r\n";    //  Spacing
+            sb_ascii << f.rdbuf(); //  Binary content
+            sb_ascii << "\r\n";    //  Spacing
+            sb_ascii << "--" << mimeBoundary << "--\r\n"; //  --Boundary--
 
-                                                                                                                //  ## EXPERIMENTAL ##
-                                                                                                                //sb_ascii << "Content-Disposition: form-data; name=\"r\"\r\n";                                     //  Item header    'r'
-                                                                                                                //sb_ascii << "\r\n";                                                                                   //  Spacing
-                                                                                                                //sb_ascii << sRTarget << "\r\n";                                                                       //  Binary content
-                                                                                                                //sb_ascii << "\r\n";                                                                                   //  Spacing
-                                                                                                                //sb_ascii << "--" << mimeBoundary << "--\r\n";                                                     //  --Boundary--
+            //  ## EXPERIMENTAL ##
+            // sb_ascii << "Content-Disposition: form-data; name=\"r\"\r\n";                                     // Item
+            // header    'r' sb_ascii << "\r\n"; //  Spacing sb_ascii << sRTarget << "\r\n"; //  Binary content sb_ascii
+            // << "\r\n";                                                                                   //  Spacing
+            // sb_ascii << "--" << mimeBoundary << "--\r\n";                                                     //
+            // --Boundary--
 
-            const std::string str = sb_ascii.str();
+            std::string str = sb_ascii.str();
 
             //  Inject type of request
 
-            bSuccess = WinHttpSendRequest(
-                hRequest,
-                WINHTTP_NO_ADDITIONAL_HEADERS,
-                0,
-                (void*)str.c_str(),
-                static_cast<unsigned long>(str.length()),
-                static_cast<unsigned long>(str.length()),
-                0);
+            GSL_SUPPRESS_ES47 bSuccess = WinHttpSendRequest(hRequest,
+                                                            WINHTTP_NO_ADDITIONAL_HEADERS,
+                                                            0,
+                                                            str.data(),
+                                                            gsl::narrow_cast<unsigned long>(str.length()),
+                                                            gsl::narrow_cast<unsigned long>(str.length()),
+                                                            0);
         }
 
         if (WinHttpReceiveResponse(hRequest, nullptr))
         {
-            //BYTE* sDataDestOffset = &pBufferOut[0];
+            // BYTE* sDataDestOffset = &pBufferOut[0];
 
             DWORD nBytesToRead = 0;
             WinHttpQueryDataAvailable(hRequest, &nBytesToRead);
@@ -334,7 +317,7 @@ BOOL DoBlockingImageUpload(UploadType nType, const std::string& sFilename, std::
                 {
                     DWORD nBytesFetched = 0;
 
-                    auto pData{ std::make_unique<char[]>(nBytesToRead) };
+                    auto pData{std::make_unique<char[]>(nBytesToRead)};
                     if (WinHttpReadData(hRequest, pData.get(), nBytesToRead, &nBytesFetched))
                     {
                         ASSERT(nBytesToRead == nBytesFetched);
@@ -346,7 +329,7 @@ BOOL DoBlockingImageUpload(UploadType nType, const std::string& sFilename, std::
             }
 
             if (ResponseOut.size() > 0)
-                ResponseOut.push_back('\0');    //  EOS for parsing
+                ResponseOut.push_back('\0'); //  EOS for parsing
 
             RA_LOG(__FUNCTION__ ": success! Returned %u bytes.", ResponseOut.size());
         }
@@ -367,7 +350,8 @@ BOOL RAWeb::DoBlockingImageUpload(UploadType nType, const std::string& sFilename
         }
         else
         {
-            RA_LOG(__FUNCTION__ " (%d, %s) has parse error: %s\n", nType, sFilename.c_str(), GetParseError_En(ResponseOut.GetParseError()));
+            RA_LOG(__FUNCTION__ " (%d, %s) has parse error: %s\n", nType, sFilename.c_str(),
+                   GetParseError_En(ResponseOut.GetParseError()));
             return FALSE;
         }
     }
@@ -381,8 +365,7 @@ BOOL RAWeb::DoBlockingImageUpload(UploadType nType, const std::string& sFilename
 //  Adds items to the httprequest queue
 void RAWeb::CreateThreadedHTTPRequest(RequestType nType, const PostArgs& PostData, const std::string& sData)
 {
-    ra::services::ServiceLocator::GetMutable<ra::services::IThreadPool>().RunAsync([nType, PostData, sData]() mutable
-    {
+    ra::services::ServiceLocator::GetMutable<ra::services::IThreadPool>().RunAsync([nType, PostData, sData]() mutable {
         auto pObj = std::make_unique<RequestObject>(nType, PostData, sData);
         std::string sResponse;
         DoBlockingRequest(pObj->GetRequestType(), pObj->GetPostArgs(), sResponse);

--- a/src/RA_md5factory.cpp
+++ b/src/RA_md5factory.cpp
@@ -2,65 +2,56 @@
 
 #include "RA_Defs.h"
 
-namespace {
-const static unsigned int MD5_STRING_LEN = 32;
-}
+_CONSTANT_VAR MD5_STRING_LEN = 32;
 
 std::string RAGenerateMD5(const std::string& sStringToMD5)
 {
-    static char buffer[33];
-
     md5_state_t pms{};
-    md5_byte_t digest[16]{};
+    std::array<md5_byte_t, 16> digest{};
 
-    md5_byte_t* pDataBuffer = new md5_byte_t[sStringToMD5.length()];
+    auto pDataBuffer = std::make_unique<md5_byte_t[]>(sStringToMD5.length());
     ASSERT(pDataBuffer != nullptr);
     if (pDataBuffer == nullptr)
-        return "";
+        return {};
 
-    memcpy(pDataBuffer, sStringToMD5.c_str(), sStringToMD5.length());
+    std::memcpy(pDataBuffer.get(), sStringToMD5.c_str(), sStringToMD5.length());
 
     md5_init(&pms);
-    md5_append(&pms, pDataBuffer, sStringToMD5.length());
-    md5_finish(&pms, digest);
+    md5_append(&pms, pDataBuffer.get(), sStringToMD5.length());
+    md5_finish(&pms, digest.data());
 
-    memset(buffer, 0, MD5_STRING_LEN + 1);
-    sprintf_s(buffer, MD5_STRING_LEN + 1,
-        "%02x%02x%02x%02x%02x%02x%02x%02x"
-        "%02x%02x%02x%02x%02x%02x%02x%02x",
-        digest[0], digest[1], digest[2], digest[3], digest[4], digest[5], digest[6], digest[7],
-        digest[8], digest[9], digest[10], digest[11], digest[12], digest[13], digest[14], digest[15]);
+    std::array<char, MD5_STRING_LEN + 1> buffer{};
+    Ensures(sprintf_s(buffer.data(), buffer.size(),
+                      "%02x%02x%02x%02x%02x%02x%02x%02x"
+                      "%02x%02x%02x%02x%02x%02x%02x%02x",
+                      digest.at(0), digest.at(1), digest.at(2), digest.at(3), digest.at(4), digest.at(5), digest.at(6),
+                      digest.at(7), digest.at(8), digest.at(9), digest.at(10), digest.at(11), digest.at(12),
+                      digest.at(13), digest.at(14), digest.at(15)) >= 0);
 
-    delete[] pDataBuffer;
-    pDataBuffer = nullptr;
-
-    return buffer;
+    pDataBuffer.reset();
+    return buffer.data();
 }
 
 std::string RAGenerateMD5(const BYTE* pRawData, size_t nDataLen)
 {
-    static char buffer[33];
+    md5_state_t pms{};
+    std::array<md5_byte_t, 16> digest{};
 
-    md5_state_t pms;
-    md5_byte_t digest[16];
-
-    static_assert(sizeof(md5_byte_t) == sizeof(BYTE), "Must be equivalent for the MD5 to work!");
+    static_assert(ra::is_same_size_v<md5_byte_t, BYTE>, "Must be equivalent for the MD5 to work!");
 
     md5_init(&pms);
     md5_append(&pms, pRawData, nDataLen);
-    md5_finish(&pms, digest);
+    md5_finish(&pms, digest.data());
 
-    memset(buffer, 0, MD5_STRING_LEN + 1);
-    sprintf_s(buffer, MD5_STRING_LEN + 1,
-        "%02x%02x%02x%02x%02x%02x%02x%02x"
-        "%02x%02x%02x%02x%02x%02x%02x%02x",
-        digest[0], digest[1], digest[2], digest[3], digest[4], digest[5], digest[6], digest[7],
-        digest[8], digest[9], digest[10], digest[11], digest[12], digest[13], digest[14], digest[15]);
+    std::array<char, MD5_STRING_LEN + 1> buffer{};
+    Ensures(sprintf_s(buffer.data(), buffer.size(),
+                      "%02x%02x%02x%02x%02x%02x%02x%02x"
+                      "%02x%02x%02x%02x%02x%02x%02x%02x",
+                      digest.at(0), digest.at(1), digest.at(2), digest.at(3), digest.at(4), digest.at(5), digest.at(6),
+                      digest.at(7), digest.at(8), digest.at(9), digest.at(10), digest.at(11), digest.at(12),
+                      digest.at(13), digest.at(14), digest.at(15)) >= 0);
 
-    return buffer;	//	Implicit promotion to std::string
+    return buffer.data(); //	Implicit promotion to std::string
 }
 
-std::string RAGenerateMD5(const std::vector<BYTE> DataIn)
-{
-    return RAGenerateMD5(DataIn.data(), DataIn.size());
-}
+std::string RAGenerateMD5(const std::vector<BYTE> DataIn) { return RAGenerateMD5(DataIn.data(), DataIn.size()); }

--- a/src/pch.h
+++ b/src/pch.h
@@ -9,7 +9,7 @@
     We don't care about warnings for library files.
 */
 
-#ifdef _PREFAST_ // code analysis on
+#ifdef _PREFAST_                // code analysis on
 #define _CA_SHOULD_CHECK_RETURN // always check, functions with these that fail can be catastrophic
 #define _CA_SHOULD_CHECK_RETURN_WER
 #endif // _PREFAST_
@@ -45,6 +45,7 @@
 /* STL Stuff */
 #include <array> // algorithm, iterator, tuple
 #include <atomic>
+#include <filesystem>
 #include <fstream>
 #include <iomanip>
 #include <map>

--- a/src/pch.h
+++ b/src/pch.h
@@ -8,6 +8,12 @@
 
     We don't care about warnings for library files.
 */
+
+#ifdef _PREFAST_ // code analysis on
+#define _CA_SHOULD_CHECK_RETURN // always check, functions with these that fail can be catastrophic
+#define _CA_SHOULD_CHECK_RETURN_WER
+#endif // _PREFAST_
+
 #pragma warning(push)
 #pragma warning(disable : 4091 4191 4365 4464 4571 4619 4623 4625 4626 4768 4774 5026 5027 5039 5045)
 /* Windows Stuff */

--- a/src/ra_utility.h
+++ b/src/ra_utility.h
@@ -37,11 +37,10 @@ _NODISCARD _CONSTANT_VAR itoe(_In_ Integral i) noexcept
     return static_cast<Enum>(i);
 }
 
+
 // function alias templates for etoi (EnumToIntegral) and itoe (IntegralToEnum)
-template<typename Enum>
-_CONSTANT_VAR to_integral{etoi<Enum>};
-template<typename Enum, typename Integral = std::underlying_type_t<Enum>>
-_CONSTANT_VAR to_enum{itoe<Enum, Integral>};
+template<typename Enum> _CONSTANT_VAR to_integral{etoi<Enum>};
+template<typename Enum, typename Integral = std::underlying_type_t<Enum>> _CONSTANT_VAR to_enum{itoe<Enum, Integral>};
 
 /// <summary>Calculates the size of any standard fstream.</summary>
 /// <param name="filename">The filename.</param>

--- a/src/ra_utility.h
+++ b/src/ra_utility.h
@@ -37,10 +37,11 @@ _NODISCARD _CONSTANT_VAR itoe(_In_ Integral i) noexcept
     return static_cast<Enum>(i);
 }
 
-
 // function alias templates for etoi (EnumToIntegral) and itoe (IntegralToEnum)
-template<typename Enum> _CONSTANT_VAR to_integral{etoi<Enum>};
-template<typename Enum, typename Integral = std::underlying_type_t<Enum>> _CONSTANT_VAR to_enum{itoe<Enum, Integral>};
+template<typename Enum>
+_CONSTANT_VAR to_integral{etoi<Enum>};
+template<typename Enum, typename Integral = std::underlying_type_t<Enum>>
+_CONSTANT_VAR to_enum{itoe<Enum, Integral>};
 
 /// <summary>Calculates the size of any standard fstream.</summary>
 /// <param name="filename">The filename.</param>

--- a/src/rcheevos.vcxproj
+++ b/src/rcheevos.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{9D55EBE7-1392-4FA1-A9B9-F022F764CE35}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>RAIntegrationRcheevos</RootNamespace>
-    <WindowsTargetPlatformVersion>7.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
     <ProjectName>rcheevos</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -27,7 +27,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141_xp</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/src/rcheevos.vcxproj
+++ b/src/rcheevos.vcxproj
@@ -27,7 +27,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v141_xp</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/src/services/impl/LeaderboardManager.cpp
+++ b/src/services/impl/LeaderboardManager.cpp
@@ -72,9 +72,8 @@ void LeaderboardManager::SubmitLeaderboardEntry(const RA_Leaderboard& lb, unsign
     }
     else
     {
-        char sValidationSig[50];
-        sprintf_s(sValidationSig, 50, "%u%s%u", lb.ID(), RAUsers::LocalUser().Username().c_str(), lb.ID());
-        std::string sValidationMD5 = RAGenerateMD5(sValidationSig);
+        const auto sValidationSig = StringPrintf("%u%s%u", lb.ID(), RAUsers::LocalUser().Username(), lb.ID());
+        const auto sValidationMD5 = RAGenerateMD5(sValidationSig);
 
         PostArgs args;
         args['u'] = RAUsers::LocalUser().Username();


### PR DESCRIPTION
This addresses a lot of different things, but not completely (bounds/ranges/errors).
This basically just tells the compiler to tell us that a return value was ignored even if it was optional in the C library. In C11, the safe functions call a constraint handler (function pointer callback) to handle any runtime errors that happen (similar to exception handling).

Even though the "safe" functions are somewhat similar to the C11 spec, it doesn't handle the error at all and just crashes a module/app if not handled (usually leading to segmentation faults).

Most of the time there are functions being replaced but sometimes we just checked the value since it didn't make sense to replace it.