### PR TITLE
improve performance of GdiAlphaBitmapSurface::Blend

### DIFF
--- a/src/ui/drawing/gdi/GDIBitmapSurface.hh
+++ b/src/ui/drawing/gdi/GDIBitmapSurface.hh
@@ -71,6 +71,9 @@ private:
     // explicitly setting an initial value causes the constructor calculated values to be overridden.
     HBITMAP m_hBitmap;
     HDC m_hMemDC;
+
+    // allow GDIAlphaBitmapSurface direct access to m_hMemDC for Blending
+    friend class GDIAlphaBitmapSurface;
 };
 
 class GDIAlphaBitmapSurface : public GDIBitmapSurface
@@ -78,10 +81,12 @@ class GDIAlphaBitmapSurface : public GDIBitmapSurface
 public:
     explicit GDIAlphaBitmapSurface(const int nWidth, const int nHeight,
                                    ResourceRepository& pResourceRepository) noexcept :
-        GDIBitmapSurface(nWidth, nHeight, pResourceRepository)
+        GDIBitmapSurface(nWidth, nHeight, pResourceRepository), m_pBlendBuffer(nWidth, nHeight, pResourceRepository)
     {}
 
-    explicit GDIAlphaBitmapSurface(const int nWidth, const int nHeight) noexcept : GDIBitmapSurface(nWidth, nHeight) {}
+    explicit GDIAlphaBitmapSurface(const int nWidth, const int nHeight) noexcept
+        : GDIBitmapSurface(nWidth, nHeight), m_pBlendBuffer(nWidth, nHeight)
+    {}
 
     GDIAlphaBitmapSurface(const GDIAlphaBitmapSurface&) noexcept = delete;
     GDIAlphaBitmapSurface& operator=(const GDIAlphaBitmapSurface&) noexcept = delete;
@@ -91,9 +96,12 @@ public:
     void FillRectangle(int nX, int nY, int nWidth, int nHeight, Color nColor) noexcept override;
     void WriteText(int nX, int nY, int nFont, Color nColor, const std::wstring& sText) override;
 
-    void Blend(HDC hTargetDC, int nX, int nY) const;
+    void Blend(HDC hTargetDC, int nX, int nY) const noexcept;
 
     void SetOpacity(double fAlpha) override;
+
+private:
+    GDIBitmapSurface m_pBlendBuffer;
 };
 
 class GDISurfaceFactory : public ISurfaceFactory


### PR DESCRIPTION
There have been some reports of performance concerns with the new library that are attributed to drawing the popup windows in RASnes9x. The problem seems to be that RASnes9x aggressively dispatches `WM_PAINT` messages and each `WM_PAINT` causes the screen to be refreshed (including the popups). I've seen it called as many as three times per frame just watching a game boot. 

The DLL uses GDI for all of the overlay drawing, and prior to 0.75, drew directly onto the `HDC` provided by the emulator. In 0.75 the drawing is done once into a bitmap and that's transferred to the `HDC` for each call to `_RA_RenderPopups`. However, since GDI doesn't implicitly handle transparent bitmaps, the popup has to be merged with a section of the `HDC` in a third buffer, then that is blitted back to the `HDC`. The merging process is all done in software, so is relatively slow (0.864ms per call on average for rendering the welcome and game loaded messages). To reach 60 frames per second, each frame can only use 16ms, so that's roughly 5% of the per-frame time spent rendering the popup. If you extend that to two or three calls per frame, you can see that we're quickly eating up the time allocated per frame that should be used for more important things (like emulating).

My machine is pretty beefy, so some users have much higher average times, which makes the emulator seems laggy when rendering the popups. This PR aggressively optimizes the merging logic, lowering my average time to 0.462ms per call (47% faster). This is just a temporary solution to help users of the 0.75 DLL. A better solution will be implemented in 0.76.

Raw data using Release build (average is calculated after discarding the highest and lowest values): 
```
before:  908us  786us [786us][913us] 820us  858us  870us  902us  905us => 864us
after : [535us][407us] 530us  414us  439us  503us  411us  523us  414us => 464us
```

Summary of changes:
* store a second buffer for the lifetime of the popup instead of reallocating it for every render
* avoid function call for pixels where alpha is 0 or 255
* shrink function to a single line - expect it to be inlined
* eliminate pointer null checks for every pixel - do once before the loop
