### PR TITLE
only update list view subitems that change

### DIFF
--- a/src/RA_Dlg_AchEditor.cpp
+++ b/src/RA_Dlg_AchEditor.cpp
@@ -185,7 +185,7 @@ void Dlg_AchievementEditor::SetCell(HWND hList, LV_ITEM& lvItem, int nRow, CondS
     }
 }
 
-void Dlg_AchievementEditor::SetCell(HWND hList, LV_ITEM& lvItem, int nRow, CondSubItems nColumn, const std::string&& sNewValue)
+void Dlg_AchievementEditor::SetCell(HWND hList, LV_ITEM& lvItem, int nRow, CondSubItems nColumn, std::string&& sNewValue)
 {
     std::string& sCell = LbxDataAt(nRow, nColumn);
     if (sCell != sNewValue)
@@ -1794,7 +1794,7 @@ unsigned int Dlg_AchievementEditor::ParseValue(const std::string& sData, CompVar
     try
     {
         size_t nRead;
-        auto nVal = std::stoul(sData, &nRead, nBase);
+        const auto nVal = std::stoul(sData, &nRead, nBase);
         if (nRead < sData.length())
             bInvalid = true;
         else if (nRead > 0 && sData.at(0) == '-')

--- a/src/RA_Dlg_AchEditor.cpp
+++ b/src/RA_Dlg_AchEditor.cpp
@@ -148,12 +148,53 @@ const int Dlg_AchievementEditor::AddCondition(HWND hList, const Condition& Cond,
     item.pszText = sData.data();
     item.iItem = ListView_InsertItem(hList, &item);
 
+    auto& pRow = m_lbxData.at(m_nNumOccupiedRows);
+    if (pRow.at(0).capacity() == 0)
+    {
+        // not sure exactly why, but the std::string objects in the LbxData nested array
+        // aren't constructed properly (they're just zeroed out memory). a std::string
+        // should never have 0 capacity - if it does, call reserve to initialize it 
+        // properly before trying to assign anything to it.
+        for (auto& pCell : pRow)
+            pCell.reserve(8);
+    }
+    else
+    {
+        // reconstructing the row - clear out any stored strings so the subitems get repopulated
+        for (auto& pCell : pRow)
+            pCell.clear();
+    }
+
     UpdateCondition(hList, item, Cond, nCurrentHits);
 
     Ensures(item.iItem == m_nNumOccupiedRows);
 
     m_nNumOccupiedRows++;
     return item.iItem;
+}
+
+void Dlg_AchievementEditor::SetCell(HWND hList, LV_ITEM& lvItem, int nRow, CondSubItems nColumn, const std::string& sNewValue)
+{
+    std::string& sCell = LbxDataAt(nRow, nColumn);
+    if (sCell != sNewValue)
+    {
+        sCell.assign(sNewValue);
+        lvItem.iSubItem = ra::etoi(nColumn);
+        lvItem.pszText = sCell.data();
+        ListView_SetItem(hList, &lvItem);
+    }
+}
+
+void Dlg_AchievementEditor::SetCell(HWND hList, LV_ITEM& lvItem, int nRow, CondSubItems nColumn, const std::string&& sNewValue)
+{
+    std::string& sCell = LbxDataAt(nRow, nColumn);
+    if (sCell != sNewValue)
+    {
+        sCell = std::move(sNewValue);
+        lvItem.iSubItem = ra::etoi(nColumn);
+        lvItem.pszText = sCell.data();
+        ListView_SetItem(hList, &lvItem);
+    }
 }
 
 void Dlg_AchievementEditor::UpdateCondition(HWND hList, LV_ITEM& item, const Condition& Cond, unsigned int nCurrentHits)
@@ -169,48 +210,47 @@ void Dlg_AchievementEditor::UpdateCondition(HWND hList, LV_ITEM& item, const Con
         sMemSizeStrSrc = ra::Narrow(MEMSIZE_STR.at(ra::etoi(Cond.CompSource().GetSize())));
     }
 
-    const char* sMemTypStrDst = "Value";
-    std::string sMemSizeStrDst;
-    if (Cond.CompTarget().GetType() != CompVariable::Type::ValueComparison)
-    {
-        sMemTypStrDst = (Cond.CompTarget().GetType() == CompVariable::Type::Address) ? "Mem" : "Delta";
-        sMemSizeStrDst = ra::Narrow(MEMSIZE_STR.at(ra::etoi(Cond.CompTarget().GetSize())));
-    }
-
-    LbxDataAt(nRow, CondSubItems::Id) = std::to_string(nRow + 1);;
-    LbxDataAt(nRow, CondSubItems::Group) = ra::Narrow(Condition::TYPE_STR.at(ra::etoi(Cond.GetConditionType())));
-    LbxDataAt(nRow, CondSubItems::Type_Src) = ra::Narrow(sMemTypStrSrc);
-    LbxDataAt(nRow, CondSubItems::Size_Src) = ra::Narrow(sMemSizeStrSrc);
-    LbxDataAt(nRow, CondSubItems::Value_Src) = ra::StringPrintf("0x%06x", Cond.CompSource().GetValue());
-    LbxDataAt(nRow, CondSubItems::Comparison) = ra::Narrow(COMPARISONTYPE_STR.at(ra::etoi(Cond.CompareType())));
-    LbxDataAt(nRow, CondSubItems::Type_Tgt) = ra::Narrow(sMemTypStrDst);
-    LbxDataAt(nRow, CondSubItems::Size_Tgt) = ra::Narrow(sMemSizeStrDst);
-    LbxDataAt(nRow, CondSubItems::Value_Tgt) = ra::StringPrintf("0x%02x", Cond.CompTarget().GetValue());
-    LbxDataAt(nRow, CondSubItems::Hitcount) = ra::StringPrintf("%u (%u)", Cond.RequiredHits(), nCurrentHits);
-
-    auto& pConfiguration = ra::services::ServiceLocator::Get<ra::services::IConfiguration>();
-    if (pConfiguration.IsFeatureEnabled(ra::services::Feature::PreferDecimal))
-    {
-        if (Cond.CompTarget().GetType() == CompVariable::Type::ValueComparison)
-            LbxDataAt(nRow, CondSubItems::Value_Tgt) = std::to_string(Cond.CompTarget().GetValue());
-    }
+    SetCell(hList, item, nRow, CondSubItems::Id, std::to_string(nRow + 1));
+    SetCell(hList, item, nRow, CondSubItems::Group, ra::Narrow(Condition::TYPE_STR.at(ra::etoi(Cond.GetConditionType()))));
+    SetCell(hList, item, nRow, CondSubItems::Type_Src, ra::Narrow(sMemTypStrSrc));
+    SetCell(hList, item, nRow, CondSubItems::Size_Src, ra::Narrow(sMemSizeStrSrc));
+    SetCell(hList, item, nRow, CondSubItems::Value_Src, ra::StringPrintf("0x%06x", Cond.CompSource().GetValue()));
 
     if (Cond.IsAddCondition() || Cond.IsSubCondition())
     {
-        LbxDataAt(nRow, CondSubItems::Comparison).clear();
-        LbxDataAt(nRow, CondSubItems::Type_Tgt).clear();
-        LbxDataAt(nRow, CondSubItems::Size_Tgt).clear();
-        LbxDataAt(nRow, CondSubItems::Value_Tgt).clear();
-        LbxDataAt(nRow, CondSubItems::Hitcount).clear();
+        SetCell(hList, item, nRow, CondSubItems::Comparison, "");
+        SetCell(hList, item, nRow, CondSubItems::Type_Tgt, "");
+        SetCell(hList, item, nRow, CondSubItems::Size_Tgt, "");
+        SetCell(hList, item, nRow, CondSubItems::Value_Tgt, "");
+        SetCell(hList, item, nRow, CondSubItems::Hitcount, "");
     }
-
-    for (auto it = COLUMN_TITLE.cbegin(); it != COLUMN_TITLE.cend(); ++it)
+    else
     {
-        const auto i = gsl::narrow<int>(std::distance(COLUMN_TITLE.cbegin(), it));
-        item.iSubItem = i;
-        ra::tstring sData{NativeStr(LbxDataAt(nRow, ra::itoe<CondSubItems>(i)))};
-        item.pszText = sData.data();
-        ListView_SetItem(hList, &item);
+        const char* sMemTypStrDst = "Value";
+        std::string sMemSizeStrDst;
+        if (Cond.CompTarget().GetType() != CompVariable::Type::ValueComparison)
+        {
+            sMemTypStrDst = (Cond.CompTarget().GetType() == CompVariable::Type::Address) ? "Mem" : "Delta";
+            sMemSizeStrDst = ra::Narrow(MEMSIZE_STR.at(ra::etoi(Cond.CompTarget().GetSize())));
+        }
+
+        SetCell(hList, item, nRow, CondSubItems::Comparison, ra::Narrow(COMPARISONTYPE_STR.at(ra::etoi(Cond.CompareType()))));
+        SetCell(hList, item, nRow, CondSubItems::Type_Tgt, ra::Narrow(sMemTypStrDst));
+        SetCell(hList, item, nRow, CondSubItems::Size_Tgt, ra::Narrow(sMemSizeStrDst));
+        SetCell(hList, item, nRow, CondSubItems::Hitcount, ra::StringPrintf("%u (%u)", Cond.RequiredHits(), nCurrentHits));
+
+        bool bValueInDecimal = false;
+        if (Cond.CompTarget().GetType() == CompVariable::Type::ValueComparison)
+        {
+            auto& pConfiguration = ra::services::ServiceLocator::Get<ra::services::IConfiguration>();
+            if (pConfiguration.IsFeatureEnabled(ra::services::Feature::PreferDecimal))
+                bValueInDecimal = true;
+        }
+
+        if (bValueInDecimal)
+            SetCell(hList, item, nRow, CondSubItems::Value_Tgt, std::to_string(Cond.CompTarget().GetValue()));
+        else
+            SetCell(hList, item, nRow, CondSubItems::Value_Tgt, ra::StringPrintf("0x%02x", Cond.CompTarget().GetValue()));
     }
 }
 

--- a/src/RA_Dlg_AchEditor.h
+++ b/src/RA_Dlg_AchEditor.h
@@ -69,7 +69,7 @@ private:
     const int AddCondition(HWND hList, const Condition& Cond, unsigned int nCurrentHits);
     void UpdateCondition(HWND hList, LV_ITEM& item, const Condition& Cond, unsigned int nCurrentHits);
     void SetCell(HWND hList, LV_ITEM& item, int nRow, CondSubItems nColumn, const std::string& sNewValue);
-    void SetCell(HWND hList, LV_ITEM& item, int nRow, CondSubItems nColumn, const std::string&& sNewValue);
+    void SetCell(HWND hList, LV_ITEM& item, int nRow, CondSubItems nColumn, std::string&& sNewValue);
 
     unsigned int ParseValue(const std::string& sData, CompVariable::Type nType) const;
 

--- a/src/RA_Dlg_AchEditor.h
+++ b/src/RA_Dlg_AchEditor.h
@@ -68,6 +68,8 @@ private:
 
     const int AddCondition(HWND hList, const Condition& Cond, unsigned int nCurrentHits);
     void UpdateCondition(HWND hList, LV_ITEM& item, const Condition& Cond, unsigned int nCurrentHits);
+    void SetCell(HWND hList, LV_ITEM& item, int nRow, CondSubItems nColumn, const std::string& sNewValue);
+    void SetCell(HWND hList, LV_ITEM& item, int nRow, CondSubItems nColumn, const std::string&& sNewValue);
 
     unsigned int ParseValue(const std::string& sData, CompVariable::Type nType) const;
 


### PR DESCRIPTION
Reported by @kdecks: 
>While an achievement is active and the window is open various conditions flicker white without pattern 2-3 times per second.
> About performance, the game is where the performance struggles. There is noticeable slowdown even with 15 conditions, and it increases from there.

Something between 0.74 and 0.75 significantly increased the time spent updating the achievement editor listview when the selected achievement was active. The editor was blindly repainting the listview for every frame in case the achievement's hitcounts changed.

In 0.74, the average time to repaint the listview (on my machine, release build) with 40 conditions was 10.8ms. In 0.75, it's 23.7ms (119% slower). 

Assuming an emulator runs at 60fps, that only gives us 16ms per frame to do whatever needs to be done for each frame, and that includes everything the emulator is doing for that frame as well. As we start to exceed that threshhold, we actually slow down the emulator.

I couldn't narrow down exactly which change introduced the overhead - I think it was a combination of several: spectre mitigation, don't use std library functions that aren't bounds checked, and replacing sprintf(buffer) with StringPrintf are the top contenders.

With these changes, it only takes 0.4ms to update the listview (96% faster than 0.74). The basic principal is we already keep a copy of the stringified data in memory, so we can tell when the string changes, and the UI should only be notified to repaint when that occurs.