### PR TITLE
fixes for empty alt groups

### DIFF
--- a/src/RA_Condition.cpp
+++ b/src/RA_Condition.cpp
@@ -141,10 +141,6 @@ void ConditionSet::Serialize(std::string& buffer) const
     m_vConditionGroups.front().SerializeAppend(buffer);
     for (auto it = std::next(m_vConditionGroups.begin()); it != m_vConditionGroups.end(); ++it)
     {
-        // ignore empty groups when serializing
-        if (it->Count() == 0)
-            continue;
-
         buffer.append(1, 'S');
         it->SerializeAppend(buffer);
     }

--- a/src/RA_Dlg_AchEditor.cpp
+++ b/src/RA_Dlg_AchEditor.cpp
@@ -85,7 +85,7 @@ Dlg_AchievementEditor::Dlg_AchievementEditor() noexcept
     m_lbxGroupNames.front() = _T("Core");
     for (auto it = std::next(m_lbxGroupNames.begin()); it != m_lbxGroupNames.end(); ++it)
     {
-        const auto i = std::distance(std::next(m_lbxGroupNames.begin()), it);
+        const auto i = std::distance(m_lbxGroupNames.begin(), it);
         *it = ra::StringPrintf(_T("Alt %02t"), i);
     }
 }
@@ -1392,6 +1392,7 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
                     {
                         MessageBox(m_hAchievementEditorDlg, TEXT("Cannot remove Core Condition Group!"),
                                    TEXT("Warning"), MB_OK);
+                        break;
                     }
 
                     RepopulateGroupList(ActiveAchievement());


### PR DESCRIPTION
Four fixes in one:
* Alt group numbering starts at 1 again
* Attempting to delete an empty alt group doesn't display the "cannot delete core group" warning
* Empty alt groups are no longer "lost" when selecting another achievement and coming back
* HitCounts are remembered on conditions other than the one being edited.

The general problem is that when an achievement is edited, the trigger has to be rebuilt so rcheevos will honor the changes. Adding a new alt group counts as modifying the achievement, so the trigger has to be rebuilt. rcheevos didn't support an achievement with empty alt group, so the alt group was discarded, even though it still appeared to be present in the UI. As a result, attempting to remove the empty alt group generated a "cannot delete core group" warning. Adding a condition to the empty alt group reactivated it as the trigger was once again rebuilt. 

The primary fix here is to support empty alt groups when rebuilding the achievement. 

A secondary fix is to copy the HitCount data from the old achievement to the new achievement. This is particularly important when creating achievements that have some start condition that should remain "started" while modifying the end conditions for the achievement.