### PR TITLE
Create ConsoleContext for console-specific logic

### DIFF
--- a/src/Exports.cpp
+++ b/src/Exports.cpp
@@ -21,6 +21,10 @@
 #include "ui\viewmodels\MessageBoxViewModel.hh"
 #include "ui\viewmodels\OverlayManager.hh"
 
+#ifndef RA_UTEST
+#include "RA_Dlg_Memory.h"
+#endif
+
 API const char* CCONV _RA_IntegrationVersion() { return RA_INTEGRATION_VERSION; }
 
 API const char* CCONV _RA_HostName()
@@ -127,6 +131,10 @@ API void CCONV _RA_SetConsoleID(unsigned int nConsoleId)
     auto pContext = ra::data::ConsoleContext::GetContext(ra::itoe<ConsoleID>(nConsoleId));
     RA_LOG("Console set to %u (%s)", pContext->Id(), pContext->Name());
     ra::services::ServiceLocator::Provide<ra::data::ConsoleContext>(std::move(pContext));
+
+#ifndef RA_UTEST
+    g_MemoryDialog.UpdateMemoryRegions();
+#endif
 }
 
 #ifndef RA_UTEST

--- a/src/Exports.cpp
+++ b/src/Exports.cpp
@@ -6,6 +6,7 @@
 
 #include "api\Login.hh"
 
+#include "data\ConsoleContext.hh"
 #include "data\EmulatorContext.hh"
 #include "data\SessionTracker.hh"
 #include "data\UserContext.hh"
@@ -119,6 +120,12 @@ API void CCONV _RA_AttemptLogin(bool bBlocking)
             request.CallAsyncWithRetry(HandleLoginResponse);
         }
     }
+}
+
+API void CCONV _RA_SetConsoleID(unsigned int nConsoleId)
+{
+    auto pContext = ra::data::ConsoleContext::GetContext(ra::itoe<ConsoleID>(nConsoleId));
+    ra::services::ServiceLocator::Provide<ra::data::ConsoleContext>(std::move(pContext));
 }
 
 #ifndef RA_UTEST

--- a/src/Exports.cpp
+++ b/src/Exports.cpp
@@ -125,6 +125,7 @@ API void CCONV _RA_AttemptLogin(bool bBlocking)
 API void CCONV _RA_SetConsoleID(unsigned int nConsoleId)
 {
     auto pContext = ra::data::ConsoleContext::GetContext(ra::itoe<ConsoleID>(nConsoleId));
+    RA_LOG("Console set to %u (%s)", pContext->Id(), pContext->Name());
     ra::services::ServiceLocator::Provide<ra::data::ConsoleContext>(std::move(pContext));
 }
 

--- a/src/RA_Core.cpp
+++ b/src/RA_Core.cpp
@@ -20,6 +20,7 @@
 #include "api\Logout.hh"
 #include "api\ResolveHash.hh"
 
+#include "data\ConsoleContext.hh"
 #include "data\EmulatorContext.hh"
 #include "data\GameContext.hh"
 #include "data\SessionTracker.hh"
@@ -50,7 +51,6 @@ std::string g_sROMDirLocation;
 HMODULE g_hThisDLLInst = nullptr;
 HINSTANCE g_hRAKeysDLL = nullptr;
 HWND g_RAMainWnd = nullptr;
-ConsoleID g_ConsoleID = ConsoleID::UnknownConsoleID;	//	Currently active Console ID
 bool g_bRAMTamperedWith = false;
 
 BOOL APIENTRY DllMain(HMODULE hModule, DWORD dwReason, _UNUSED LPVOID)
@@ -229,11 +229,6 @@ API bool CCONV _RA_ConfirmLoadNewRom(bool bQuittingApp)
     }
 
     return(nResult == IDYES);
-}
-
-API void CCONV _RA_SetConsoleID(unsigned int nConsoleID)
-{
-    g_ConsoleID = static_cast<ConsoleID>(nConsoleID);
 }
 
 API bool CCONV _RA_WarnDisableHardcore(const char* sActivity)
@@ -608,7 +603,7 @@ API HMENU CCONV _RA_CreatePopupMenu()
 void _FetchGameHashLibraryFromWeb()
 {
     PostArgs args;
-    args['c'] = std::to_string(g_ConsoleID);
+    args['c'] = std::to_string(ra::services::ServiceLocator::Get<ra::data::ConsoleContext>().Id());
     args['u'] = RAUsers::LocalUser().Username();
     args['t'] = RAUsers::LocalUser().Token();
     std::string Response;
@@ -619,7 +614,7 @@ void _FetchGameHashLibraryFromWeb()
 void _FetchGameTitlesFromWeb()
 {
     PostArgs args;
-    args['c'] = std::to_string(g_ConsoleID);
+    args['c'] = std::to_string(ra::services::ServiceLocator::Get<ra::data::ConsoleContext>().Id());
     args['u'] = RAUsers::LocalUser().Username();
     args['t'] = RAUsers::LocalUser().Token();
     std::string Response;
@@ -630,7 +625,7 @@ void _FetchGameTitlesFromWeb()
 void _FetchMyProgressFromWeb()
 {
     PostArgs args;
-    args['c'] = std::to_string(g_ConsoleID);
+    args['c'] = std::to_string(ra::services::ServiceLocator::Get<ra::data::ConsoleContext>().Id());
     args['u'] = RAUsers::LocalUser().Username();
     args['t'] = RAUsers::LocalUser().Token();
     std::string Response;

--- a/src/RA_Core.h
+++ b/src/RA_Core.h
@@ -13,7 +13,6 @@ extern std::wstring g_sHomeDir;
 extern HINSTANCE g_hRAKeysDLL;
 extern HMODULE g_hThisDLLInst;
 extern HWND g_RAMainWnd;
-extern ConsoleID g_ConsoleID;
 extern bool g_bRAMTamperedWith;
 
 // Read a file to a malloc'd buffer. Returns nullptr on error. Owner MUST free() buffer if not nullptr.

--- a/src/RA_Dlg_GameTitle.cpp
+++ b/src/RA_Dlg_GameTitle.cpp
@@ -6,6 +6,7 @@
 #include "RA_User.h"
 #include "RA_httpthread.h"
 
+#include "data\ConsoleContext.hh"
 #include "data\UserContext.hh"
 
 Dlg_GameTitle g_GameTitleDialog;
@@ -36,7 +37,7 @@ INT_PTR Dlg_GameTitle::GameTitleProc(HWND hDlg, UINT uMsg, WPARAM wParam, _UNUSE
             ComboBox_SetCurSel(hKnownGamesCbo, nSel);
 
             PostArgs args;
-            args['c'] = std::to_string(g_ConsoleID);
+            args['c'] = std::to_string(ra::services::ServiceLocator::Get<ra::data::ConsoleContext>().Id());
 
             rapidjson::Document doc;
             if (RAWeb::DoBlockingRequest(RequestGamesList, args, doc))
@@ -115,7 +116,7 @@ INT_PTR Dlg_GameTitle::GameTitleProc(HWND hDlg, UINT uMsg, WPARAM wParam, _UNUSE
                     args['t'] = RAUsers::LocalUser().Token();
                     args['m'] = m_sMD5;
                     args['i'] = ra::Narrow(sSelectedTitle);
-                    args['c'] = std::to_string(g_ConsoleID);
+                    args['c'] = std::to_string(ra::services::ServiceLocator::Get<ra::data::ConsoleContext>().Id());
 
                     rapidjson::Document doc;
                     if (RAWeb::DoBlockingRequest(RequestSubmitNewTitle, args, doc) && 

--- a/src/RA_Dlg_Memory.cpp
+++ b/src/RA_Dlg_Memory.cpp
@@ -1537,18 +1537,42 @@ void Dlg_Memory::OnLoad_NewRom()
     else
         SetDlgItemText(g_MemoryDialog.m_hWnd, IDC_RA_WATCHING, TEXT("Loading..."));
 
+    m_nGameRamStart = m_nGameRamEnd = m_nSystemRamStart = m_nSystemRamEnd = 0U;
+
     if (g_MemManager.TotalBankSize() > 0)
     {
-        ra::ByteAddress start, end;
-        if (GetSystemMemoryRange(start, end))
+        for (const auto& pRegion : ra::services::ServiceLocator::Get<ra::data::ConsoleContext>().MemoryRegions())
         {
-            TCHAR label[64]{};
-            if (g_MemManager.TotalBankSize() > 0x10000)
-                _stprintf_s(label, 64, TEXT("System Memory (0x%06X-0x%06X)"), start, end);
-            else
-                _stprintf_s(label, 64, TEXT("System Memory (0x%04X-0x%04X)"), start, end);
+            if (pRegion.Type == ra::data::ConsoleContext::AddressType::SystemRAM)
+            {
+                if (m_nSystemRamEnd == 0U)
+                {
+                    m_nSystemRamStart = pRegion.StartAddress;
+                    m_nSystemRamEnd = pRegion.EndAddress;
+                }
+                else if (pRegion.StartAddress == m_nSystemRamEnd + 1)
+                {
+                    m_nSystemRamEnd = pRegion.EndAddress;
+                }
+            }
+            else if (pRegion.Type == ra::data::ConsoleContext::AddressType::SaveRAM)
+            {
+                if (m_nGameRamEnd == 0U)
+                {
+                    m_nGameRamStart = pRegion.StartAddress;
+                    m_nGameRamEnd = pRegion.EndAddress;
+                }
+                else if (pRegion.StartAddress == m_nGameRamEnd + 1)
+                {
+                    m_nGameRamEnd = pRegion.EndAddress;
+                }
+            }
+        }
 
-            SetDlgItemText(g_MemoryDialog.m_hWnd, IDC_RA_CBO_SEARCHSYSTEMRAM, label);
+        if (m_nSystemRamEnd != 0U)
+        {
+            const auto sLabel = ra::StringPrintf("System Memory (%s-%s)", ra::ByteAddressToString(m_nSystemRamStart), ra::ByteAddressToString(m_nSystemRamEnd));
+            SetDlgItemText(g_MemoryDialog.m_hWnd, IDC_RA_CBO_SEARCHSYSTEMRAM, NativeStr(sLabel).c_str());
             EnableWindow(GetDlgItem(g_MemoryDialog.m_hWnd, IDC_RA_CBO_SEARCHSYSTEMRAM), TRUE);
         }
         else
@@ -1557,15 +1581,10 @@ void Dlg_Memory::OnLoad_NewRom()
             EnableWindow(GetDlgItem(g_MemoryDialog.m_hWnd, IDC_RA_CBO_SEARCHSYSTEMRAM), FALSE);
         }
 
-        if (GetGameMemoryRange(start, end))
+        if (m_nGameRamEnd != 0U)
         {
-            TCHAR label[64]{};
-            if (g_MemManager.TotalBankSize() > 0x10000)
-                _stprintf_s(label, 64, TEXT("Game Memory (0x%06X-0x%06X)"), start, end);
-            else
-                _stprintf_s(label, 64, TEXT("Game Memory (0x%04X-0x%04X)"), start, end);
-
-            SetDlgItemText(g_MemoryDialog.m_hWnd, IDC_RA_CBO_SEARCHGAMERAM, label);
+            const auto sLabel = ra::StringPrintf("Game Memory (%s-%s)", ra::ByteAddressToString(m_nGameRamStart), ra::ByteAddressToString(m_nGameRamEnd));
+            SetDlgItemText(g_MemoryDialog.m_hWnd, IDC_RA_CBO_SEARCHGAMERAM, NativeStr(sLabel).c_str());
             EnableWindow(GetDlgItem(g_MemoryDialog.m_hWnd, IDC_RA_CBO_SEARCHGAMERAM), TRUE);
         }
         else
@@ -1674,133 +1693,6 @@ void Dlg_Memory::AddBank(size_t nBankID)
     ComboBox_SetCurSel(hMemBanks, 0);
 }
 
-bool Dlg_Memory::GetSystemMemoryRange(ra::ByteAddress& start, ra::ByteAddress& end) noexcept
-{
-    switch (ra::services::ServiceLocator::Get<ra::data::ConsoleContext>().Id())
-    {
-        case ConsoleID::NES:
-            // $0000-$07FF are the 2KB internal RAM for the NES. It's mirrored every 2KB until $1FFF.
-            start = 0x0000;
-            end = 0x07FF;
-            return TRUE;
-
-        case ConsoleID::SNES:
-            // SNES RAM runs from $7E0000-$7FFFFF. $7E0000-$7E1FFF is LowRAM, $7E2000-$7E7FFF is
-            // considered HighRAM, and $7E8000-$7FFFFF is considered Expanded RAM. The Memory Manager
-            // addresses this data from $000000-$1FFFFF. For simplicity, we'll treat LowRAM and HighRAM
-            // as system memory and Expanded RAM as game memory.
-            start = 0x0000;
-            end = 0x7FFF;
-            return TRUE;
-
-        case ConsoleID::GB:
-        case ConsoleID::GBC:
-            // $C000-$CFFF is fixed internal RAM, $D000-$DFFF is banked internal RAM. $C000-$DFFF is
-            // mirrored to $E000-$FDFF.
-            start = 0xC000;
-            end = 0xDFFF;
-            return TRUE;
-
-        case ConsoleID::GBA:
-            // Gameboy Advance memory has three separate memory blocks. $02000000-$0203FFFF is
-            // on-board RAM, $03000000-$03007FF0 is in-chip RAM, and $0E000000-$0E00FFFF is
-            // game pak RAM. The Memory Manager sees the in-chip RAM as $00000-$07FF0, and the
-            // on-board as $8000-$47FFF
-            start = 0x8000;
-            end = 0x47FFF;
-            return TRUE;
-
-        case ConsoleID::MegaDrive:
-            // Genesis RAM runs from $E00000-$FFFFFF. It's really only 64KB, and mirrored for
-            // each $E0-$FF lead byte. Typically, it's only accessed from $FFxxxx. I'm not sure
-            // what memory is represented by $10000-$1FFFF in the Memory Manager.
-            start = 0x0000;
-            end = 0xFFFF;
-            return TRUE;
-
-        case ConsoleID::MasterSystem:
-            // $C000-$DFFF is system RAM. It's mirrored at $E000-$FFFF.
-            start = 0xC000;
-            end = 0xDFFF;
-            return TRUE;
-
-        case ConsoleID::N64:
-            // $00000-$3FFFFF covers the standard 4MB RDRAM.
-            // $00000-$1FFFFF is RDRAM range 0, while $200000-$3FFFFF is RDRAM range 1.
-            start = 0x000000;
-            end = 0x3FFFFF;
-            return TRUE;
-
-        default:
-            start = 0;
-            end = 0;
-            return FALSE;
-    }
-}
-
-bool Dlg_Memory::GetGameMemoryRange(ra::ByteAddress& start, ra::ByteAddress& end) noexcept
-{
-    switch (ra::services::ServiceLocator::Get<ra::data::ConsoleContext>().Id())
-    {
-        case ConsoleID::NES:
-            // $4020-$FFFF is cartridge memory and subranges will vary by mapper. The most common mappers reference
-            // battery-backed RAM or additional work RAM in the $6000-$7FFF range. $8000-$FFFF is usually read-only.
-            start = 0x4020;
-            end = 0xFFFF;
-            return TRUE;
-
-        case ConsoleID::SNES:
-            // SNES RAM runs from $7E0000-$7FFFFF. $7E0000-$7E1FFF is LowRAM, $7E2000-$7E7FFF is
-            // considered HighRAM, and $7E8000-$7FFFFF is considered Expanded RAM. The Memory Manager
-            // addresses this data from $000000-$1FFFFF. For simplicity, we'll treat LowRAM and HighRAM
-            // as system memory and Expanded RAM as game memory.
-            start = 0x008000;
-            end = 0x1FFFFF;
-            return TRUE;
-
-        case ConsoleID::GB:
-        case ConsoleID::GBC:
-            // $A000-$BFFF is 8KB is external RAM (in cartridge)
-            start = 0xA000;
-            end = 0xBFFF;
-            return TRUE;
-
-        case ConsoleID::GBA:
-            // Gameboy Advance memory has three separate memory blocks. $02000000-$0203FFFF is
-            // on-board RAM, $03000000-$03007FF0 is in-chip RAM, and $0E000000-$0E00FFFF is
-            // game pak RAM. The Memory Manager sees the in-chip RAM as $00000-$07FF0, and the
-            // on-board as $8000-$47FFF
-            start = 0x0000;
-            end = 0x7FFF;
-            return TRUE;
-
-        case ConsoleID::MasterSystem:
-            // $0000-$BFFF is cartridge ROM/RAM
-            start = 0x0000;
-            end = 0xBFFF;
-            return TRUE;
-
-        case ConsoleID::N64:
-            // This range contains the extra 4MB provided by the Expansion Pak.
-            // Only avaliable when memory size is greater than 4MB.
-            if (g_MemManager.TotalBankSize() > 0x400000)
-            {
-                start = 0x400000;
-                end = 0x7FFFFF;
-                return TRUE;
-            }
-            else
-            {
-                return FALSE;
-            }
-
-        default:
-            start = 0;
-            end = 0;
-            return FALSE;
-    }
-}
-
 inline static constexpr auto ParseAddress(TCHAR* ptr, ra::ByteAddress& address) noexcept
 {
     if (ptr == nullptr)
@@ -1853,10 +1745,18 @@ bool Dlg_Memory::GetSelectedMemoryRange(ra::ByteAddress& start, ra::ByteAddress&
     }
 
     if (IsDlgButtonChecked(m_hWnd, IDC_RA_CBO_SEARCHSYSTEMRAM) == BST_CHECKED)
-        return GetSystemMemoryRange(start, end);
+    {
+        start = m_nSystemRamStart;
+        end = m_nSystemRamEnd;
+        return (end > start);
+    }
 
     if (IsDlgButtonChecked(m_hWnd, IDC_RA_CBO_SEARCHGAMERAM) == BST_CHECKED)
-        return GetGameMemoryRange(start, end);
+    {
+        start = m_nGameRamStart;
+        end = m_nGameRamEnd;
+        return (end > start);
+    }
 
     if (IsDlgButtonChecked(m_hWnd, IDC_RA_CBO_SEARCHCUSTOM) == BST_CHECKED)
     {

--- a/src/RA_Dlg_Memory.cpp
+++ b/src/RA_Dlg_Memory.cpp
@@ -1569,7 +1569,7 @@ void Dlg_Memory::OnLoad_NewRom()
             }
         }
 
-        if (m_nSystemRamEnd != 0U)
+        if (m_nSystemRamEnd != 0U && (m_nSystemRamEnd - m_nSystemRamStart) != g_MemManager.TotalBankSize())
         {
             const auto sLabel = ra::StringPrintf("System Memory (%s-%s)", ra::ByteAddressToString(m_nSystemRamStart), ra::ByteAddressToString(m_nSystemRamEnd));
             SetDlgItemText(g_MemoryDialog.m_hWnd, IDC_RA_CBO_SEARCHSYSTEMRAM, NativeStr(sLabel).c_str());

--- a/src/RA_Dlg_Memory.cpp
+++ b/src/RA_Dlg_Memory.cpp
@@ -7,6 +7,7 @@
 #include "RA_User.h"
 #include "RA_httpthread.h"
 
+#include "data\ConsoleContext.hh"
 #include "data\EmulatorContext.hh"
 #include "data\GameContext.hh"
 
@@ -1675,7 +1676,7 @@ void Dlg_Memory::AddBank(size_t nBankID)
 
 bool Dlg_Memory::GetSystemMemoryRange(ra::ByteAddress& start, ra::ByteAddress& end) noexcept
 {
-    switch (g_ConsoleID)
+    switch (ra::services::ServiceLocator::Get<ra::data::ConsoleContext>().Id())
     {
         case ConsoleID::NES:
             // $0000-$07FF are the 2KB internal RAM for the NES. It's mirrored every 2KB until $1FFF.
@@ -1739,7 +1740,7 @@ bool Dlg_Memory::GetSystemMemoryRange(ra::ByteAddress& start, ra::ByteAddress& e
 
 bool Dlg_Memory::GetGameMemoryRange(ra::ByteAddress& start, ra::ByteAddress& end) noexcept
 {
-    switch (g_ConsoleID)
+    switch (ra::services::ServiceLocator::Get<ra::data::ConsoleContext>().Id())
     {
         case ConsoleID::NES:
             // $4020-$FFFF is cartridge memory and subranges will vary by mapper. The most common mappers reference

--- a/src/RA_Dlg_Memory.h
+++ b/src/RA_Dlg_Memory.h
@@ -101,10 +101,8 @@ public:
     void GenerateResizes(HWND hDlg);
 
 private:
-    bool GetSystemMemoryRange(ra::ByteAddress& start, ra::ByteAddress& end) noexcept;
-    bool GetGameMemoryRange(ra::ByteAddress& start, ra::ByteAddress& end) noexcept;
-
     bool GetSelectedMemoryRange(ra::ByteAddress& start, ra::ByteAddress& end);
+    ra::ByteAddress m_nSystemRamStart{}, m_nSystemRamEnd{}, m_nGameRamStart{}, m_nGameRamEnd{};
 
     void UpdateSearchResult(const ra::services::SearchResults::Result& result, _Out_ unsigned int& nMemVal, TCHAR(&buffer)[1024]);
     bool CompareSearchResult(unsigned int nCurVal, unsigned int nPrevVal);

--- a/src/RA_Dlg_Memory.h
+++ b/src/RA_Dlg_Memory.h
@@ -90,13 +90,15 @@ public:
     void RepopulateMemNotesFromFile();
     void Invalidate();
 
+    void UpdateMemoryRegions();
+
     void SetWatchingAddress(unsigned int nAddr);
     void UpdateBits() const;
     BOOL IsActive() const noexcept;
 
     const CodeNotes& Notes() const noexcept { return m_CodeNotes; }
 
-    void ClearBanks() noexcept;
+    void ClearBanks();
     void AddBank(size_t nBankID);
     void GenerateResizes(HWND hDlg);
 

--- a/src/RA_Integration.vcxproj
+++ b/src/RA_Integration.vcxproj
@@ -39,6 +39,7 @@
     <ClCompile Include="api\impl\ConnectedServer.cpp" />
     <ClCompile Include="api\impl\DisconnectedServer.cpp" />
     <ClCompile Include="api\impl\OfflineServer.cpp" />
+    <ClCompile Include="data\ConsoleContext.cpp" />
     <ClCompile Include="data\EmulatorContext.cpp" />
     <ClCompile Include="data\SessionTracker.cpp" />
     <ClCompile Include="data\UserContext.cpp" />
@@ -125,6 +126,7 @@
     <ClInclude Include="api\Ping.hh" />
     <ClInclude Include="api\ResolveHash.hh" />
     <ClInclude Include="api\StartSession.hh" />
+    <ClInclude Include="data\ConsoleContext.hh" />
     <ClInclude Include="data\EmulatorContext.hh" />
     <ClInclude Include="data\GameContext.hh" />
     <ClInclude Include="data\SessionTracker.hh" />

--- a/src/RA_Integration.vcxproj.filters
+++ b/src/RA_Integration.vcxproj.filters
@@ -240,6 +240,9 @@
     <ClCompile Include="data\UserContext.cpp">
       <Filter>Data</Filter>
     </ClCompile>
+    <ClCompile Include="data\ConsoleContext.cpp">
+      <Filter>Data</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="RA_Achievement.h">
@@ -592,6 +595,9 @@
     </ClInclude>
     <ClInclude Include="api\AwardAchievement.hh">
       <Filter>API</Filter>
+    </ClInclude>
+    <ClInclude Include="data\ConsoleContext.hh">
+      <Filter>Data</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/data/ConsoleContext.cpp
+++ b/src/data/ConsoleContext.cpp
@@ -6,6 +6,155 @@
 namespace ra {
 namespace data {
 
+const std::vector<ConsoleContext::MemoryRegion> ConsoleContext::m_vEmptyRegions;
+
+// ===== GameBoy | GameBoy Color =====
+
+class GameBoyConsoleContext : public ConsoleContext
+{
+public:
+    GameBoyConsoleContext(ConsoleID nId, const std::wstring&& sName) noexcept : ConsoleContext(nId, std::move(sName)) {}
+
+    const std::vector<MemoryRegion>& MemoryRegions() const noexcept override { return m_vMemoryRegions; }
+
+private:
+    static const std::vector<MemoryRegion> m_vMemoryRegions;
+};
+
+// GameBoy memory is directly exposed to the toolkit
+const std::vector<ConsoleContext::MemoryRegion> GameBoyConsoleContext::m_vMemoryRegions =
+{
+    { 0x0000U, 0x00FFU, ConsoleContext::AddressType::HardwareController, "Interrupt vector" },
+    { 0x0100U, 0x014FU, ConsoleContext::AddressType::VirtualRAM, "Cartridge header" },
+    { 0x0150U, 0x3FFFU, ConsoleContext::AddressType::VirtualRAM, "Cartridge ROM (fixed)" }, // bank 0
+    { 0x4000U, 0x7FFFU, ConsoleContext::AddressType::VirtualRAM, "Cartridge ROM (paged)" }, // bank 1-XX (switchable)
+    { 0x8000U, 0x97FFU, ConsoleContext::AddressType::VideoRAM, "Tile RAM" },
+    { 0x9800U, 0x9BFFU, ConsoleContext::AddressType::VideoRAM, "BG1 map data" },
+    { 0x9C00U, 0x9FFFU, ConsoleContext::AddressType::VideoRAM, "BG2 map data" },
+    { 0xA000U, 0xBFFFU, ConsoleContext::AddressType::SaveRAM, "Cartridge RAM"},
+    { 0xC000U, 0xCFFFU, ConsoleContext::AddressType::SystemRAM, "System RAM (fixed)" },
+    { 0xD000U, 0xDFFFU, ConsoleContext::AddressType::SystemRAM, "System RAM (paged)" },
+    { 0xE000U, 0xFDFFU, ConsoleContext::AddressType::VirtualRAM, "Echo RAM" },
+    { 0xFE00U, 0xFE9FU, ConsoleContext::AddressType::VideoRAM, "Sprite RAM"},
+    { 0xFEA0U, 0xFEFFU, ConsoleContext::AddressType::VirtualRAM, "Unusable"},
+    { 0xFF00U, 0xFF7FU, ConsoleContext::AddressType::HardwareController, "Hardware I/O"},
+    { 0xFF80U, 0xFFFEU, ConsoleContext::AddressType::SystemRAM, "Quick RAM"},
+    { 0xFFFFU, 0xFFFFU, ConsoleContext::AddressType::HardwareController, "Interrupt enable"},
+};
+
+// ===== GameBoy Advance =====
+
+class GameBoyAdvanceConsoleContext : public ConsoleContext
+{
+public:
+    GameBoyAdvanceConsoleContext() noexcept : ConsoleContext(ConsoleID::GBA, L"GameBoy Advance") {}
+
+    const std::vector<MemoryRegion>& MemoryRegions() const noexcept override { return m_vMemoryRegions; }
+
+private:
+    static const std::vector<MemoryRegion> m_vMemoryRegions;
+};
+
+// GameBoy Advance memory is exposed as two chunks
+const std::vector<ConsoleContext::MemoryRegion> GameBoyAdvanceConsoleContext::m_vMemoryRegions =
+{
+    { 0x000000U, 0x007FFFU, ConsoleContext::AddressType::SaveRAM, "Cartridge RAM" }, // internal RAM (normally $03000000-$03007FFF)
+    { 0x008000U, 0x047FFFU, ConsoleContext::AddressType::SystemRAM, "System RAM" }, // work RAM (normally $02000000-$0203FFFF)
+};
+
+// ===== MegaDrive / Genesis | Sega 32X | Sega CD =====
+
+class MegaDriveConsoleContext : public ConsoleContext
+{
+public:
+    MegaDriveConsoleContext(ConsoleID nId, const std::wstring&& sName) noexcept : ConsoleContext(nId, std::move(sName)) {}
+
+    const std::vector<MemoryRegion>& MemoryRegions() const noexcept override { return m_vMemoryRegions; }
+
+private:
+    static const std::vector<MemoryRegion> m_vMemoryRegions;
+};
+
+// MegaDrive memory is exposed as two chunks
+const std::vector<ConsoleContext::MemoryRegion> MegaDriveConsoleContext::m_vMemoryRegions =
+{
+    { 0x000000U, 0x00FFFFU, ConsoleContext::AddressType::SystemRAM, "System RAM" }, // 68000 RAM (normally $FF0000-$FFFFFF)
+    { 0x010000U, 0x01FFFFU, ConsoleContext::AddressType::SaveRAM, "Cartridge RAM" }, // work RAM (normally $000000-$00FFFF)
+};
+
+// ===== Nintendo 64 =====
+
+class Nintendo64ConsoleContext : public ConsoleContext
+{
+public:
+    Nintendo64ConsoleContext() noexcept : ConsoleContext(ConsoleID::N64, L"Nintendo 64") {}
+
+    const std::vector<MemoryRegion>& MemoryRegions() const noexcept override { return m_vMemoryRegions; }
+
+private:
+    static const std::vector<MemoryRegion> m_vMemoryRegions;
+};
+
+// Nintendo 64 memory is exposed as one chunk, that's actually two or three chunks
+// https://raw.githubusercontent.com/mikeryan/n64dev/master/docs/n64ops/n64ops%23h.txt
+const std::vector<ConsoleContext::MemoryRegion> Nintendo64ConsoleContext::m_vMemoryRegions =
+{
+    { 0x000000U, 0x1FFFFFU, ConsoleContext::AddressType::SystemRAM, "System RAM" }, // RDRAM range 0 (2MB)
+    { 0x200000U, 0x3FFFFFU, ConsoleContext::AddressType::SystemRAM, "System RAM" }, // RDRAM range 1 (2MB)
+    { 0x400000U, 0x7FFFFFU, ConsoleContext::AddressType::SystemRAM, "System RAM" }, // Expansion PAK memory (4MB)
+};
+
+// ===== NES =====
+
+class NintendoEntertainmentSystemConsoleContext : public ConsoleContext
+{
+public:
+    NintendoEntertainmentSystemConsoleContext() noexcept : ConsoleContext(ConsoleID::NES, L"Nintendo Entertainment System") {}
+
+    const std::vector<MemoryRegion>& MemoryRegions() const noexcept override { return m_vMemoryRegions; }
+
+private:
+    static const std::vector<MemoryRegion> m_vMemoryRegions;
+};
+
+// NES memory is directly exposed to the toolkit
+const std::vector<ConsoleContext::MemoryRegion> NintendoEntertainmentSystemConsoleContext::m_vMemoryRegions =
+{
+    { 0x0000U, 0x07FFU, ConsoleContext::AddressType::SystemRAM, "System RAM" },
+    { 0x0800U, 0x0FFFU, ConsoleContext::AddressType::VirtualRAM, "Mirror RAM" }, // duplicates memory from $0000-$07FF
+    { 0x1000U, 0x17FFU, ConsoleContext::AddressType::VirtualRAM, "Mirror RAM" }, // duplicates memory from $0000-$07FF
+    { 0x1800U, 0x1FFFU, ConsoleContext::AddressType::VirtualRAM, "Mirror RAM" }, // duplicates memory from $0000-$07FF
+    { 0x2000U, 0x2007U, ConsoleContext::AddressType::HardwareController, "PPU Register" },
+    { 0x2008U, 0x3FFFU, ConsoleContext::AddressType::VirtualRAM, "Mirrored PPU Register" }, // repeats every 8 bytes
+    { 0x4000U, 0x4017U, ConsoleContext::AddressType::HardwareController, "APU and I/O register" },
+    { 0x4018U, 0x401FU, ConsoleContext::AddressType::HardwareController, "APU and I/O test register" },
+    { 0x4020U, 0x5FFFU, ConsoleContext::AddressType::Unknown, "Cartridge data"}, // varies by mapper
+    { 0x6000U, 0x7FFFU, ConsoleContext::AddressType::SaveRAM, "Cartridge RAM"},
+    { 0x8000U, 0xFFFFU, ConsoleContext::AddressType::VirtualRAM, "Cartridge ROM"},
+};
+
+// ===== SNES =====
+
+class SuperNESConsoleContext : public ConsoleContext
+{
+public:
+    SuperNESConsoleContext() noexcept : ConsoleContext(ConsoleID::SNES, L"Super NES") {}
+
+    const std::vector<MemoryRegion>& MemoryRegions() const noexcept override { return m_vMemoryRegions; }
+
+private:
+    static const std::vector<MemoryRegion> m_vMemoryRegions;
+};
+
+// SNES memory is exposed as two chunks
+const std::vector<ConsoleContext::MemoryRegion> SuperNESConsoleContext::m_vMemoryRegions =
+{
+    { 0x000000U, 0x01FFFFU, ConsoleContext::AddressType::SystemRAM, "System RAM" }, // work RAM (normally $7E0000-$7FFFFF)
+    { 0x020000U, 0x03FFFFU, ConsoleContext::AddressType::SaveRAM, "Cartridge RAM" }, // cartridge RAM (normally $FE0000-$FF0000; up to 1MB, typically 32KB or less)
+};
+
+// ===== ConsoleContext =====
+
 std::unique_ptr<ConsoleContext> ConsoleContext::GetContext(ConsoleID nId)
 {
     switch (nId)
@@ -59,13 +208,13 @@ std::unique_ptr<ConsoleContext> ConsoleContext::GetContext(ConsoleID nId)
             return std::make_unique<ConsoleContext>(nId, L"GameGear");
 
         case ConsoleID::GB:
-            return std::make_unique<ConsoleContext>(nId, L"GameBoy");
+            return std::make_unique<GameBoyConsoleContext>(ConsoleID::GB, L"GameBoy");
 
         case ConsoleID::GBA:
-            return std::make_unique<ConsoleContext>(nId, L"GameBoy Advance");
+            return std::make_unique<GameBoyAdvanceConsoleContext>();
 
         case ConsoleID::GBC:
-            return std::make_unique<ConsoleContext>(nId, L"GameBoy Color");
+            return std::make_unique<GameBoyConsoleContext>(ConsoleID::GBC, L"GameBoy Color");
 
         case ConsoleID::Intellivision:
             return std::make_unique<ConsoleContext>(nId, L"Intellivision");
@@ -77,10 +226,10 @@ std::unique_ptr<ConsoleContext> ConsoleContext::GetContext(ConsoleID nId)
             return std::make_unique<ConsoleContext>(nId, L"Lynx");
 
         case ConsoleID::MasterSystem:
-            return std::make_unique<ConsoleContext>(nId, L"Master System");
+            return std::make_unique<MegaDriveConsoleContext>(ConsoleID::MasterSystem, L"Master System");
 
         case ConsoleID::MegaDrive:
-            return std::make_unique<ConsoleContext>(nId, L"MegaDrive / Genesis");
+            return std::make_unique<MegaDriveConsoleContext>(ConsoleID::MegaDrive, L"MegaDrive / Genesis");
 
         case ConsoleID::MSDOS:
             return std::make_unique<ConsoleContext>(nId, L"MS-DOS");
@@ -89,13 +238,13 @@ std::unique_ptr<ConsoleContext> ConsoleContext::GetContext(ConsoleID nId)
             return std::make_unique<ConsoleContext>(nId, L"MSX");
 
         case ConsoleID::N64:
-            return std::make_unique<ConsoleContext>(nId, L"Nintendo 64");
+            return std::make_unique<Nintendo64ConsoleContext>();
 
         case ConsoleID::NeoGeoPocket:
             return std::make_unique<ConsoleContext>(nId, L"NeoGeo Pocket");
 
         case ConsoleID::NES:
-            return std::make_unique<ConsoleContext>(nId, L"Nintendo Entertainment System");
+            return std::make_unique<NintendoEntertainmentSystemConsoleContext>();
 
         case ConsoleID::PC8800:
             return std::make_unique<ConsoleContext>(nId, L"PC-8800");
@@ -117,6 +266,54 @@ std::unique_ptr<ConsoleContext> ConsoleContext::GetContext(ConsoleID nId)
 
         case ConsoleID::PSP:
             return std::make_unique<ConsoleContext>(nId, L"PlayStation Portable");
+
+        case ConsoleID::Saturn:
+            return std::make_unique<ConsoleContext>(nId, L"Saturn");
+
+        case ConsoleID::Sega32X:
+            return std::make_unique<MegaDriveConsoleContext>(ConsoleID::Sega32X, L"SEGA 32X");
+
+        case ConsoleID::SegaCD:
+            return std::make_unique<ConsoleContext>(nId, L"SEGA CD");
+
+        case ConsoleID::SG1000:
+            return std::make_unique<ConsoleContext>(nId, L"SG-1000");
+
+        case ConsoleID::SNES:
+            return std::make_unique<SuperNESConsoleContext>();
+
+        case ConsoleID::ThreeDO:
+            return std::make_unique<ConsoleContext>(nId, L"3D0");
+
+        case ConsoleID::Vectrex:
+            return std::make_unique<ConsoleContext>(nId, L"Vectrex");
+
+        case ConsoleID::VIC20:
+            return std::make_unique<ConsoleContext>(nId, L"VIC-20");
+
+        case ConsoleID::VirtualBoy:
+            return std::make_unique<ConsoleContext>(nId, L"Virtual Boy");
+
+        case ConsoleID::WII:
+            return std::make_unique<ConsoleContext>(nId, L"Wii");
+
+        case ConsoleID::WIIU:
+            return std::make_unique<ConsoleContext>(nId, L"Wii-U");
+
+        case ConsoleID::WonderSwan:
+            return std::make_unique<ConsoleContext>(nId, L"WonderSwan");
+
+        case ConsoleID::X68K:
+            return std::make_unique<ConsoleContext>(nId, L"X68K");
+
+        case ConsoleID::Xbox:
+            return std::make_unique<ConsoleContext>(nId, L"XBOX");
+
+        case ConsoleID::XboxOne:
+            return std::make_unique<ConsoleContext>(nId, L"Xbox One");
+
+        case ConsoleID::ZX81:
+            return std::make_unique<ConsoleContext>(nId, L"ZX-81");
 
         default:
             return std::make_unique<ConsoleContext>(ConsoleID::UnknownConsoleID, L"Unknown");

--- a/src/data/ConsoleContext.cpp
+++ b/src/data/ConsoleContext.cpp
@@ -8,6 +8,50 @@ namespace data {
 
 const std::vector<ConsoleContext::MemoryRegion> ConsoleContext::m_vEmptyRegions;
 
+// ===== Atari 2600 =====
+
+class Atari2600ConsoleContext : public ConsoleContext
+{
+public:
+    GSL_SUPPRESS_F6 Atari2600ConsoleContext() noexcept : ConsoleContext(ConsoleID::Atari2600, L"Atari2600") {}
+
+    const std::vector<MemoryRegion>& MemoryRegions() const noexcept override { return m_vMemoryRegions; }
+
+private:
+    static const std::vector<MemoryRegion> m_vMemoryRegions;
+};
+
+const std::vector<ConsoleContext::MemoryRegion> Atari2600ConsoleContext::m_vMemoryRegions =
+{
+    { 0x000000U, 0x00007FU, ConsoleContext::AddressType::SystemRAM, "System RAM" }, // normally $80-$FF
+};
+
+// ===== Atari 7800 =====
+
+class Atari7800ConsoleContext : public ConsoleContext
+{
+public:
+    GSL_SUPPRESS_F6 Atari7800ConsoleContext() noexcept : ConsoleContext(ConsoleID::Atari7800, L"Atari7800") {}
+
+    const std::vector<MemoryRegion>& MemoryRegions() const noexcept override { return m_vMemoryRegions; }
+
+private:
+    static const std::vector<MemoryRegion> m_vMemoryRegions;
+};
+
+// http://www.atarihq.com/danb/files/78map.txt
+// http://pdf.textfiles.com/technical/7800_devkit.pdf
+const std::vector<ConsoleContext::MemoryRegion> Atari7800ConsoleContext::m_vMemoryRegions =
+{
+    { 0x000000U, 0x0017FFU, ConsoleContext::AddressType::HardwareController, "Hardware Interface" },
+    { 0x001800U, 0x0027FFU, ConsoleContext::AddressType::SystemRAM, "System RAM" },
+    { 0x002800U, 0x002FFFU, ConsoleContext::AddressType::VirtualRAM, "Mirrored RAM" },
+    { 0x003000U, 0x0037FFU, ConsoleContext::AddressType::VirtualRAM, "Mirrored RAM" },
+    { 0x003800U, 0x003FFFU, ConsoleContext::AddressType::VirtualRAM, "Mirrored RAM" },
+    { 0x004000U, 0x007FFFU, ConsoleContext::AddressType::SaveRAM, "Cartridge RAM" },
+    { 0x008000U, 0x00FFFFU, ConsoleContext::AddressType::VirtualRAM, "Cartridge ROM" },
+};
+
 // ===== ColecoVision =====
 
 class ColecoVisionConsoleContext : public ConsoleContext
@@ -102,6 +146,31 @@ const std::vector<ConsoleContext::MemoryRegion> GameGearConsoleContext::m_vMemor
     // TODO: should cartridge memory be exposed ($0000-$BFFF)? it's usually just ROM data, but may contain on-cartridge RAM
 };
 
+// ===== Lynx =====
+
+class LynxConsoleContext : public ConsoleContext
+{
+public:
+    GSL_SUPPRESS_F6 LynxConsoleContext() noexcept : ConsoleContext(ConsoleID::Lynx, L"Lynx") {}
+
+    const std::vector<MemoryRegion>& MemoryRegions() const noexcept override { return m_vMemoryRegions; }
+
+private:
+    static const std::vector<MemoryRegion> m_vMemoryRegions;
+};
+
+// http://www.retroisle.com/atari/lynx/Technical/Programming/lynxprgdumm.php
+const std::vector<ConsoleContext::MemoryRegion> LynxConsoleContext::m_vMemoryRegions =
+{
+    { 0x000000U, 0x0000FFU, ConsoleContext::AddressType::VirtualRAM, "Zero Page" },
+    { 0x000100U, 0x0001FFU, ConsoleContext::AddressType::SystemRAM, "Stack" },
+    { 0x000200U, 0x00FBFFU, ConsoleContext::AddressType::SystemRAM, "System RAM" },
+    { 0x00FC00U, 0x00FCFFU, ConsoleContext::AddressType::HardwareController, "SUZY hardware access" },
+    { 0x00FD00U, 0x00FDFFU, ConsoleContext::AddressType::HardwareController, "MIKEY hardware access" },
+    { 0x00FE00U, 0x00FFF7U, ConsoleContext::AddressType::HardwareController, "Boot ROM" },
+    { 0x00FFF8U, 0x00FFFFU, ConsoleContext::AddressType::HardwareController, "Hardware vectors" },
+};
+
 // ===== Master System =====
 
 class MasterSystemConsoleContext : public ConsoleContext
@@ -165,6 +234,26 @@ const std::vector<ConsoleContext::MemoryRegion> Nintendo64ConsoleContext::m_vMem
     { 0x400000U, 0x7FFFFFU, ConsoleContext::AddressType::SystemRAM, "System RAM" }, // Expansion PAK memory (4MB)
 };
 
+// ===== NeoGeo Pocket =====
+
+class NeoGeoPocketConsoleContext : public ConsoleContext
+{
+public:
+    GSL_SUPPRESS_F6 NeoGeoPocketConsoleContext() noexcept : ConsoleContext(ConsoleID::NeoGeoPocket, L"NeoGeo Pocket") {}
+
+    const std::vector<MemoryRegion>& MemoryRegions() const noexcept override { return m_vMemoryRegions; }
+
+private:
+    static const std::vector<MemoryRegion> m_vMemoryRegions;
+};
+
+// MednafenNGP only exposes 16KB of memory. This document suggest there should be 32KB:
+// http://neopocott.emuunlim.com/docs/tech-11.txt
+const std::vector<ConsoleContext::MemoryRegion> NeoGeoPocketConsoleContext::m_vMemoryRegions =
+{
+    { 0x000000U, 0x003FFFU, ConsoleContext::AddressType::SystemRAM, "System RAM" },
+};
+
 // ===== NES =====
 
 class NintendoEntertainmentSystemConsoleContext : public ConsoleContext
@@ -192,6 +281,25 @@ const std::vector<ConsoleContext::MemoryRegion> NintendoEntertainmentSystemConso
     { 0x4020U, 0x5FFFU, ConsoleContext::AddressType::Unknown, "Cartridge data"}, // varies by mapper
     { 0x6000U, 0x7FFFU, ConsoleContext::AddressType::SaveRAM, "Cartridge RAM"},
     { 0x8000U, 0xFFFFU, ConsoleContext::AddressType::VirtualRAM, "Cartridge ROM"},
+};
+
+// ===== PCEngine =====
+
+class PCEngineConsoleContext : public ConsoleContext
+{
+public:
+    GSL_SUPPRESS_F6 PCEngineConsoleContext() noexcept : ConsoleContext(ConsoleID::PCEngine, L"PCEngine / TurboGrafx 16") {}
+
+    const std::vector<MemoryRegion>& MemoryRegions() const noexcept override { return m_vMemoryRegions; }
+
+private:
+    static const std::vector<MemoryRegion> m_vMemoryRegions;
+};
+
+// https://cc65.github.io/doc/pce.html
+const std::vector<ConsoleContext::MemoryRegion> PCEngineConsoleContext::m_vMemoryRegions =
+{
+    { 0x000000U, 0x001FFFU, ConsoleContext::AddressType::SystemRAM, "System RAM" }, // normally $2000-$3FFF
 };
 
 // ===== SG-1000 =====
@@ -237,6 +345,26 @@ const std::vector<ConsoleContext::MemoryRegion> SuperNESConsoleContext::m_vMemor
     { 0x020000U, 0x03FFFFU, ConsoleContext::AddressType::SaveRAM, "Cartridge RAM" }, // cartridge RAM (normally $FE0000-$FF0000; up to 1MB, typically 32KB or less)
 };
 
+// ===== VirtualBoy =====
+
+class VirtualBoyConsoleContext : public ConsoleContext
+{
+public:
+    GSL_SUPPRESS_F6 VirtualBoyConsoleContext() noexcept : ConsoleContext(ConsoleID::VirtualBoy, L"VirtualBoy") {}
+
+    const std::vector<MemoryRegion>& MemoryRegions() const noexcept override { return m_vMemoryRegions; }
+
+private:
+    static const std::vector<MemoryRegion> m_vMemoryRegions;
+};
+
+// VirtualBoy memory is exposed as two chunks
+const std::vector<ConsoleContext::MemoryRegion> VirtualBoyConsoleContext::m_vMemoryRegions =
+{
+    { 0x000000U, 0x00FFFFU, ConsoleContext::AddressType::SystemRAM, "System RAM" }, // work RAM (normally $05000000-$0500FFFF)
+    { 0x010000U, 0x01FFFFU, ConsoleContext::AddressType::SaveRAM, "Cartridge RAM" }, // cartridge RAM (normally $06000000-$06FFFFFF); up to 16MB, typically 64KB
+};
+
 // ===== ConsoleContext =====
 
 std::unique_ptr<ConsoleContext> ConsoleContext::GetContext(ConsoleID nId)
@@ -259,13 +387,13 @@ std::unique_ptr<ConsoleContext> ConsoleContext::GetContext(ConsoleID nId)
             return std::make_unique<ConsoleContext>(nId, L"Arcade");
 
         case ConsoleID::Atari2600:
-            return std::make_unique<ConsoleContext>(nId, L"Atari 2600");
+            return std::make_unique<Atari2600ConsoleContext>();
 
         case ConsoleID::Atari5200:
             return std::make_unique<ConsoleContext>(nId, L"Atari 5200");
 
         case ConsoleID::Atari7800:
-            return std::make_unique<ConsoleContext>(nId, L"Atari 7800");
+            return std::make_unique<Atari7800ConsoleContext>();
 
         case ConsoleID::C64:
             return std::make_unique<ConsoleContext>(nId, L"Commodore 64");
@@ -307,7 +435,7 @@ std::unique_ptr<ConsoleContext> ConsoleContext::GetContext(ConsoleID nId)
             return std::make_unique<ConsoleContext>(nId, L"Jaguar");
 
         case ConsoleID::Lynx:
-            return std::make_unique<ConsoleContext>(nId, L"Lynx");
+            return std::make_unique<LynxConsoleContext>();
 
         case ConsoleID::MasterSystem:
             return std::make_unique<MasterSystemConsoleContext>();
@@ -376,7 +504,7 @@ std::unique_ptr<ConsoleContext> ConsoleContext::GetContext(ConsoleID nId)
             return std::make_unique<ConsoleContext>(nId, L"VIC-20");
 
         case ConsoleID::VirtualBoy:
-            return std::make_unique<ConsoleContext>(nId, L"Virtual Boy");
+            return std::make_unique<VirtualBoyConsoleContext>();
 
         case ConsoleID::WII:
             return std::make_unique<ConsoleContext>(nId, L"Wii");

--- a/src/data/ConsoleContext.cpp
+++ b/src/data/ConsoleContext.cpp
@@ -47,7 +47,7 @@ const std::vector<ConsoleContext::MemoryRegion> GameBoyConsoleContext::m_vMemory
 class GameBoyAdvanceConsoleContext : public ConsoleContext
 {
 public:
-    GameBoyAdvanceConsoleContext() noexcept : ConsoleContext(ConsoleID::GBA, L"GameBoy Advance") {}
+    GSL_SUPPRESS_F6 GameBoyAdvanceConsoleContext() noexcept : ConsoleContext(ConsoleID::GBA, L"GameBoy Advance") {}
 
     const std::vector<MemoryRegion>& MemoryRegions() const noexcept override { return m_vMemoryRegions; }
 
@@ -87,7 +87,7 @@ const std::vector<ConsoleContext::MemoryRegion> MegaDriveConsoleContext::m_vMemo
 class Nintendo64ConsoleContext : public ConsoleContext
 {
 public:
-    Nintendo64ConsoleContext() noexcept : ConsoleContext(ConsoleID::N64, L"Nintendo 64") {}
+    GSL_SUPPRESS_F6 Nintendo64ConsoleContext() noexcept : ConsoleContext(ConsoleID::N64, L"Nintendo 64") {}
 
     const std::vector<MemoryRegion>& MemoryRegions() const noexcept override { return m_vMemoryRegions; }
 
@@ -109,7 +109,7 @@ const std::vector<ConsoleContext::MemoryRegion> Nintendo64ConsoleContext::m_vMem
 class NintendoEntertainmentSystemConsoleContext : public ConsoleContext
 {
 public:
-    NintendoEntertainmentSystemConsoleContext() noexcept : ConsoleContext(ConsoleID::NES, L"Nintendo Entertainment System") {}
+    GSL_SUPPRESS_F6 NintendoEntertainmentSystemConsoleContext() noexcept : ConsoleContext(ConsoleID::NES, L"Nintendo Entertainment System") {}
 
     const std::vector<MemoryRegion>& MemoryRegions() const noexcept override { return m_vMemoryRegions; }
 
@@ -138,7 +138,7 @@ const std::vector<ConsoleContext::MemoryRegion> NintendoEntertainmentSystemConso
 class SuperNESConsoleContext : public ConsoleContext
 {
 public:
-    SuperNESConsoleContext() noexcept : ConsoleContext(ConsoleID::SNES, L"Super NES") {}
+    GSL_SUPPRESS_F6 SuperNESConsoleContext() noexcept : ConsoleContext(ConsoleID::SNES, L"Super NES") {}
 
     const std::vector<MemoryRegion>& MemoryRegions() const noexcept override { return m_vMemoryRegions; }
 

--- a/src/data/ConsoleContext.cpp
+++ b/src/data/ConsoleContext.cpp
@@ -49,7 +49,7 @@ const std::vector<ConsoleContext::MemoryRegion> Atari7800ConsoleContext::m_vMemo
     { 0x003000U, 0x0037FFU, ConsoleContext::AddressType::VirtualRAM, "Mirrored RAM" },
     { 0x003800U, 0x003FFFU, ConsoleContext::AddressType::VirtualRAM, "Mirrored RAM" },
     { 0x004000U, 0x007FFFU, ConsoleContext::AddressType::SaveRAM, "Cartridge RAM" },
-    { 0x008000U, 0x00FFFFU, ConsoleContext::AddressType::VirtualRAM, "Cartridge ROM" },
+    { 0x008000U, 0x00FFFFU, ConsoleContext::AddressType::ReadOnlyMemory, "Cartridge ROM" },
 };
 
 // ===== ColecoVision =====
@@ -88,9 +88,9 @@ private:
 const std::vector<ConsoleContext::MemoryRegion> GameBoyConsoleContext::m_vMemoryRegions =
 {
     { 0x0000U, 0x00FFU, ConsoleContext::AddressType::HardwareController, "Interrupt vector" },
-    { 0x0100U, 0x014FU, ConsoleContext::AddressType::VirtualRAM, "Cartridge header" },
-    { 0x0150U, 0x3FFFU, ConsoleContext::AddressType::VirtualRAM, "Cartridge ROM (fixed)" }, // bank 0
-    { 0x4000U, 0x7FFFU, ConsoleContext::AddressType::VirtualRAM, "Cartridge ROM (paged)" }, // bank 1-XX (switchable)
+    { 0x0100U, 0x014FU, ConsoleContext::AddressType::ReadOnlyMemory, "Cartridge header" },
+    { 0x0150U, 0x3FFFU, ConsoleContext::AddressType::ReadOnlyMemory, "Cartridge ROM (fixed)" }, // bank 0
+    { 0x4000U, 0x7FFFU, ConsoleContext::AddressType::ReadOnlyMemory, "Cartridge ROM (paged)" }, // bank 1-XX (switchable)
     { 0x8000U, 0x97FFU, ConsoleContext::AddressType::VideoRAM, "Tile RAM" },
     { 0x9800U, 0x9BFFU, ConsoleContext::AddressType::VideoRAM, "BG1 map data" },
     { 0x9C00U, 0x9FFFU, ConsoleContext::AddressType::VideoRAM, "BG2 map data" },
@@ -99,7 +99,7 @@ const std::vector<ConsoleContext::MemoryRegion> GameBoyConsoleContext::m_vMemory
     { 0xD000U, 0xDFFFU, ConsoleContext::AddressType::SystemRAM, "System RAM (paged)" },
     { 0xE000U, 0xFDFFU, ConsoleContext::AddressType::VirtualRAM, "Echo RAM" },
     { 0xFE00U, 0xFE9FU, ConsoleContext::AddressType::VideoRAM, "Sprite RAM"},
-    { 0xFEA0U, 0xFEFFU, ConsoleContext::AddressType::VirtualRAM, "Unusable"},
+    { 0xFEA0U, 0xFEFFU, ConsoleContext::AddressType::ReadOnlyMemory, "Unusable"},
     { 0xFF00U, 0xFF7FU, ConsoleContext::AddressType::HardwareController, "Hardware I/O"},
     { 0xFF80U, 0xFFFEU, ConsoleContext::AddressType::SystemRAM, "Quick RAM"},
     { 0xFFFFU, 0xFFFFU, ConsoleContext::AddressType::HardwareController, "Interrupt enable"},
@@ -162,7 +162,7 @@ private:
 // http://www.retroisle.com/atari/lynx/Technical/Programming/lynxprgdumm.php
 const std::vector<ConsoleContext::MemoryRegion> LynxConsoleContext::m_vMemoryRegions =
 {
-    { 0x000000U, 0x0000FFU, ConsoleContext::AddressType::VirtualRAM, "Zero Page" },
+    { 0x000000U, 0x0000FFU, ConsoleContext::AddressType::SystemRAM, "Zero Page" },
     { 0x000100U, 0x0001FFU, ConsoleContext::AddressType::SystemRAM, "Stack" },
     { 0x000200U, 0x00FBFFU, ConsoleContext::AddressType::SystemRAM, "System RAM" },
     { 0x00FC00U, 0x00FCFFU, ConsoleContext::AddressType::HardwareController, "SUZY hardware access" },
@@ -268,6 +268,7 @@ private:
 };
 
 // NES memory is directly exposed to the toolkit
+// https://wiki.nesdev.com/w/index.php/CPU_memory_map
 const std::vector<ConsoleContext::MemoryRegion> NintendoEntertainmentSystemConsoleContext::m_vMemoryRegions =
 {
     { 0x0000U, 0x07FFU, ConsoleContext::AddressType::SystemRAM, "System RAM" },
@@ -278,9 +279,9 @@ const std::vector<ConsoleContext::MemoryRegion> NintendoEntertainmentSystemConso
     { 0x2008U, 0x3FFFU, ConsoleContext::AddressType::VirtualRAM, "Mirrored PPU Register" }, // repeats every 8 bytes
     { 0x4000U, 0x4017U, ConsoleContext::AddressType::HardwareController, "APU and I/O register" },
     { 0x4018U, 0x401FU, ConsoleContext::AddressType::HardwareController, "APU and I/O test register" },
-    { 0x4020U, 0x5FFFU, ConsoleContext::AddressType::Unknown, "Cartridge data"}, // varies by mapper
+    { 0x4020U, 0x5FFFU, ConsoleContext::AddressType::ReadOnlyMemory, "Cartridge data"}, // varies by mapper
     { 0x6000U, 0x7FFFU, ConsoleContext::AddressType::SaveRAM, "Cartridge RAM"},
-    { 0x8000U, 0xFFFFU, ConsoleContext::AddressType::VirtualRAM, "Cartridge ROM"},
+    { 0x8000U, 0xFFFFU, ConsoleContext::AddressType::ReadOnlyMemory, "Cartridge ROM"},
 };
 
 // ===== PCEngine =====

--- a/src/data/ConsoleContext.cpp
+++ b/src/data/ConsoleContext.cpp
@@ -8,6 +8,25 @@ namespace data {
 
 const std::vector<ConsoleContext::MemoryRegion> ConsoleContext::m_vEmptyRegions;
 
+// ===== ColecoVision =====
+
+class ColecoVisionConsoleContext : public ConsoleContext
+{
+public:
+    GSL_SUPPRESS_F6 ColecoVisionConsoleContext() noexcept : ConsoleContext(ConsoleID::Colecovision, L"ColecoVision") {}
+
+    const std::vector<MemoryRegion>& MemoryRegions() const noexcept override { return m_vMemoryRegions; }
+
+private:
+    static const std::vector<MemoryRegion> m_vMemoryRegions;
+};
+
+// ColecoVision memory is exposed as a single chunk
+const std::vector<ConsoleContext::MemoryRegion> ColecoVisionConsoleContext::m_vMemoryRegions =
+{
+    { 0x000000U, 0x0003FFU, ConsoleContext::AddressType::SystemRAM, "System RAM" }, // RAM (normally $6000-$63FF)
+};
+
 // ===== GameBoy | GameBoy Color =====
 
 class GameBoyConsoleContext : public ConsoleContext
@@ -60,6 +79,48 @@ const std::vector<ConsoleContext::MemoryRegion> GameBoyAdvanceConsoleContext::m_
 {
     { 0x000000U, 0x007FFFU, ConsoleContext::AddressType::SaveRAM, "Cartridge RAM" }, // internal RAM (normally $03000000-$03007FFF)
     { 0x008000U, 0x047FFFU, ConsoleContext::AddressType::SystemRAM, "System RAM" }, // work RAM (normally $02000000-$0203FFFF)
+};
+
+// ===== Game Gear =====
+
+class GameGearConsoleContext : public ConsoleContext
+{
+public:
+    GSL_SUPPRESS_F6 GameGearConsoleContext() noexcept : ConsoleContext(ConsoleID::GameGear, L"Game Gear") {}
+
+    const std::vector<MemoryRegion>& MemoryRegions() const noexcept override { return m_vMemoryRegions; }
+
+private:
+    static const std::vector<MemoryRegion> m_vMemoryRegions;
+};
+
+// Game Gear memory is exposed as a single chunk
+// http://www.smspower.org/Development/MemoryMap
+const std::vector<ConsoleContext::MemoryRegion> GameGearConsoleContext::m_vMemoryRegions =
+{
+    { 0x000000U, 0x001FFFU, ConsoleContext::AddressType::SystemRAM, "System RAM" }, // RAM (normally $C000-$DFFF)
+    // TODO: should cartridge memory be exposed ($0000-$BFFF)? it's usually just ROM data, but may contain on-cartridge RAM
+};
+
+// ===== Master System =====
+
+class MasterSystemConsoleContext : public ConsoleContext
+{
+public:
+    GSL_SUPPRESS_F6 MasterSystemConsoleContext() noexcept : ConsoleContext(ConsoleID::MasterSystem, L"Master System") {}
+
+    const std::vector<MemoryRegion>& MemoryRegions() const noexcept override { return m_vMemoryRegions; }
+
+private:
+    static const std::vector<MemoryRegion> m_vMemoryRegions;
+};
+
+// Master System memory is exposed as a single chunk
+// http://www.smspower.org/Development/MemoryMap
+const std::vector<ConsoleContext::MemoryRegion> MasterSystemConsoleContext::m_vMemoryRegions =
+{
+    { 0x000000U, 0x001FFFU, ConsoleContext::AddressType::SystemRAM, "System RAM" }, // RAM (normally $C000-$DFFF)
+    // TODO: should cartridge memory be exposed ($0000-$BFFF)? it's usually just ROM data, but may contain on-cartridge RAM
 };
 
 // ===== MegaDrive / Genesis | Sega 32X | Sega CD =====
@@ -133,6 +194,29 @@ const std::vector<ConsoleContext::MemoryRegion> NintendoEntertainmentSystemConso
     { 0x8000U, 0xFFFFU, ConsoleContext::AddressType::VirtualRAM, "Cartridge ROM"},
 };
 
+// ===== SG-1000 =====
+
+class SG1000ConsoleContext : public ConsoleContext
+{
+public:
+    GSL_SUPPRESS_F6 SG1000ConsoleContext() noexcept : ConsoleContext(ConsoleID::MasterSystem, L"SG-1000") {}
+
+    const std::vector<MemoryRegion>& MemoryRegions() const noexcept override { return m_vMemoryRegions; }
+
+private:
+    static const std::vector<MemoryRegion> m_vMemoryRegions;
+};
+
+// SG-1000 memory is exposed as a single chunk
+// http://www.smspower.org/Development/MemoryMap
+const std::vector<ConsoleContext::MemoryRegion> SG1000ConsoleContext::m_vMemoryRegions =
+{
+    { 0x000000U, 0x0003FFU, ConsoleContext::AddressType::SystemRAM, "System RAM" }, // RAM (normally $C000-$C3FF)
+    // TODO: should cartridge memory be exposed ($0000-$BFFF)? it's usually just ROM data, but may contain on-cartridge RAM
+    // This not is also concerning: http://www.smspower.org/Development/MemoryMap
+    //   Cartridges may disable the system RAM and thus take over the full 64KB address space.
+};
+
 // ===== SNES =====
 
 class SuperNESConsoleContext : public ConsoleContext
@@ -190,7 +274,7 @@ std::unique_ptr<ConsoleContext> ConsoleContext::GetContext(ConsoleID nId)
             return std::make_unique<ConsoleContext>(nId, L"CD-I");
 
         case ConsoleID::Colecovision:
-            return std::make_unique<ConsoleContext>(nId, L"Colecovision");
+            return std::make_unique<ColecoVisionConsoleContext>();
 
         case ConsoleID::Dreamcast:
             return std::make_unique<ConsoleContext>(nId, L"Dreamcast");
@@ -205,7 +289,7 @@ std::unique_ptr<ConsoleContext> ConsoleContext::GetContext(ConsoleID nId)
             return std::make_unique<ConsoleContext>(nId, L"GameCube");
 
         case ConsoleID::GameGear:
-            return std::make_unique<ConsoleContext>(nId, L"GameGear");
+            return std::make_unique<GameGearConsoleContext>();
 
         case ConsoleID::GB:
             return std::make_unique<GameBoyConsoleContext>(ConsoleID::GB, L"GameBoy");
@@ -226,7 +310,7 @@ std::unique_ptr<ConsoleContext> ConsoleContext::GetContext(ConsoleID nId)
             return std::make_unique<ConsoleContext>(nId, L"Lynx");
 
         case ConsoleID::MasterSystem:
-            return std::make_unique<MegaDriveConsoleContext>(ConsoleID::MasterSystem, L"Master System");
+            return std::make_unique<MasterSystemConsoleContext>();
 
         case ConsoleID::MegaDrive:
             return std::make_unique<MegaDriveConsoleContext>(ConsoleID::MegaDrive, L"MegaDrive / Genesis");
@@ -277,7 +361,7 @@ std::unique_ptr<ConsoleContext> ConsoleContext::GetContext(ConsoleID nId)
             return std::make_unique<ConsoleContext>(nId, L"SEGA CD");
 
         case ConsoleID::SG1000:
-            return std::make_unique<ConsoleContext>(nId, L"SG-1000");
+            return std::make_unique<SG1000ConsoleContext>();
 
         case ConsoleID::SNES:
             return std::make_unique<SuperNESConsoleContext>();

--- a/src/data/ConsoleContext.cpp
+++ b/src/data/ConsoleContext.cpp
@@ -1,0 +1,127 @@
+#include "ConsoleContext.hh"
+
+#include "RA_Log.h"
+#include "RA_StringUtils.h"
+
+namespace ra {
+namespace data {
+
+std::unique_ptr<ConsoleContext> ConsoleContext::GetContext(ConsoleID nId)
+{
+    switch (nId)
+    {
+        case ConsoleID::Amiga:
+            return std::make_unique<ConsoleContext>(nId, L"Amiga");
+
+        case ConsoleID::AmigaST:
+            return std::make_unique<ConsoleContext>(nId, L"Amiga ST");
+
+        case ConsoleID::AmstradCPC:
+            return std::make_unique<ConsoleContext>(nId, L"Amstrad CPC");
+
+        case ConsoleID::AppleII:
+            return std::make_unique<ConsoleContext>(nId, L"Apple II");
+
+        case ConsoleID::Arcade:
+            return std::make_unique<ConsoleContext>(nId, L"Arcade");
+
+        case ConsoleID::Atari2600:
+            return std::make_unique<ConsoleContext>(nId, L"Atari 2600");
+
+        case ConsoleID::Atari5200:
+            return std::make_unique<ConsoleContext>(nId, L"Atari 5200");
+
+        case ConsoleID::Atari7800:
+            return std::make_unique<ConsoleContext>(nId, L"Atari 7800");
+
+        case ConsoleID::C64:
+            return std::make_unique<ConsoleContext>(nId, L"Commodore 64");
+
+        case ConsoleID::CDi:
+            return std::make_unique<ConsoleContext>(nId, L"CD-I");
+
+        case ConsoleID::Colecovision:
+            return std::make_unique<ConsoleContext>(nId, L"Colecovision");
+
+        case ConsoleID::Dreamcast:
+            return std::make_unique<ConsoleContext>(nId, L"Dreamcast");
+
+        case ConsoleID::DS:
+            return std::make_unique<ConsoleContext>(nId, L"Nintendo DS");
+
+        case ConsoleID::Events:
+            return std::make_unique<ConsoleContext>(nId, L"Events");
+
+        case ConsoleID::GameCube:
+            return std::make_unique<ConsoleContext>(nId, L"GameCube");
+
+        case ConsoleID::GameGear:
+            return std::make_unique<ConsoleContext>(nId, L"GameGear");
+
+        case ConsoleID::GB:
+            return std::make_unique<ConsoleContext>(nId, L"GameBoy");
+
+        case ConsoleID::GBA:
+            return std::make_unique<ConsoleContext>(nId, L"GameBoy Advance");
+
+        case ConsoleID::GBC:
+            return std::make_unique<ConsoleContext>(nId, L"GameBoy Color");
+
+        case ConsoleID::Intellivision:
+            return std::make_unique<ConsoleContext>(nId, L"Intellivision");
+
+        case ConsoleID::Jaguar:
+            return std::make_unique<ConsoleContext>(nId, L"Jaguar");
+
+        case ConsoleID::Lynx:
+            return std::make_unique<ConsoleContext>(nId, L"Lynx");
+
+        case ConsoleID::MasterSystem:
+            return std::make_unique<ConsoleContext>(nId, L"Master System");
+
+        case ConsoleID::MegaDrive:
+            return std::make_unique<ConsoleContext>(nId, L"MegaDrive / Genesis");
+
+        case ConsoleID::MSDOS:
+            return std::make_unique<ConsoleContext>(nId, L"MS-DOS");
+
+        case ConsoleID::MSX:
+            return std::make_unique<ConsoleContext>(nId, L"MSX");
+
+        case ConsoleID::N64:
+            return std::make_unique<ConsoleContext>(nId, L"Nintendo 64");
+
+        case ConsoleID::NeoGeoPocket:
+            return std::make_unique<ConsoleContext>(nId, L"NeoGeo Pocket");
+
+        case ConsoleID::NES:
+            return std::make_unique<ConsoleContext>(nId, L"Nintendo Entertainment System");
+
+        case ConsoleID::PC8800:
+            return std::make_unique<ConsoleContext>(nId, L"PC-8800");
+
+        case ConsoleID::PC9800:
+            return std::make_unique<ConsoleContext>(nId, L"PC-9800");
+
+        case ConsoleID::PCEngine:
+            return std::make_unique<ConsoleContext>(nId, L"PCEngine / TurboGrafx 16");
+
+        case ConsoleID::PCFX:
+            return std::make_unique<ConsoleContext>(nId, L"PCFX");
+
+        case ConsoleID::PlayStation:
+            return std::make_unique<ConsoleContext>(nId, L"PlayStation");
+
+        case ConsoleID::PlayStation2:
+            return std::make_unique<ConsoleContext>(nId, L"PlayStation 2");
+
+        case ConsoleID::PSP:
+            return std::make_unique<ConsoleContext>(nId, L"PlayStation Portable");
+
+        default:
+            return std::make_unique<ConsoleContext>(ConsoleID::UnknownConsoleID, L"Unknown");
+    }
+}
+
+} // namespace data
+} // namespace ra

--- a/src/data/ConsoleContext.cpp
+++ b/src/data/ConsoleContext.cpp
@@ -284,6 +284,25 @@ const std::vector<ConsoleContext::MemoryRegion> NintendoEntertainmentSystemConso
     { 0x8000U, 0xFFFFU, ConsoleContext::AddressType::ReadOnlyMemory, "Cartridge ROM"},
 };
 
+// ===== PC-8800 =====
+
+class PC8800ConsoleContext : public ConsoleContext
+{
+public:
+    GSL_SUPPRESS_F6 PC8800ConsoleContext() noexcept : ConsoleContext(ConsoleID::PC8800, L"PC-8000/8800") {}
+
+    const std::vector<MemoryRegion>& MemoryRegions() const noexcept override { return m_vMemoryRegions; }
+
+private:
+    static const std::vector<MemoryRegion> m_vMemoryRegions;
+};
+
+const std::vector<ConsoleContext::MemoryRegion> PC8800ConsoleContext::m_vMemoryRegions =
+{
+    { 0x000000U, 0x00FFFFU, ConsoleContext::AddressType::SystemRAM, "Main RAM" },
+    { 0x010000U, 0x010FFFU, ConsoleContext::AddressType::VideoRAM, "Text VRAM" }, // technically VRAM, but often used as system RAM
+};
+
 // ===== PCEngine =====
 
 class PCEngineConsoleContext : public ConsoleContext
@@ -460,7 +479,7 @@ std::unique_ptr<ConsoleContext> ConsoleContext::GetContext(ConsoleID nId)
             return std::make_unique<NintendoEntertainmentSystemConsoleContext>();
 
         case ConsoleID::PC8800:
-            return std::make_unique<ConsoleContext>(nId, L"PC-8800");
+            return std::make_unique<PC8800ConsoleContext>();
 
         case ConsoleID::PC9800:
             return std::make_unique<ConsoleContext>(nId, L"PC-9800");

--- a/src/data/ConsoleContext.hh
+++ b/src/data/ConsoleContext.hh
@@ -61,6 +61,11 @@ public:
         /// Address reserved for interacting with system components.
         /// </summary>
         HardwareController,
+
+        /// <summary>
+        /// Address space that maps to some segment of read only memory (typically ROM chips on the loaded cartridge)
+        /// </summary>
+        ReadOnlyMemory,
     };
 
     struct MemoryRegion

--- a/src/data/ConsoleContext.hh
+++ b/src/data/ConsoleContext.hh
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "RA_Interface.h"
+#include "ra_fwd.h"
 
 #include <string>
 
@@ -29,6 +30,52 @@ public:
     /// </summary>
     const std::wstring& Name() const noexcept { return m_sName; }
 
+    enum class AddressType
+    {        
+        /// <summary>
+        /// Address use is unknown.
+        /// </summary>
+        Unknown,
+
+        /// <summary>
+        /// RAM that persists between sessions. Typically found on a cratridge backed up by a battery.
+        /// </summary>
+        SaveRAM,
+
+        /// <summary>
+        /// Generic RAM available for temporary storage.
+        /// </summary>
+        SystemRAM,
+
+        /// <summary>
+        /// Secondary address space that maps to real memory in SystemRAM. Also known as Echo RAM or Mirror RAM.
+        /// </summary>
+        VirtualRAM,
+
+        /// <summary>
+        /// RAM reserved for graphical processing.
+        /// </summary>
+        VideoRAM,
+
+        /// <summary>
+        /// Address reserved for interacting with system components.
+        /// </summary>
+        HardwareController,
+    };
+
+    struct MemoryRegion
+    {
+        ra::ByteAddress StartAddress;
+        ra::ByteAddress EndAddress;
+        AddressType Type;
+        std::string Description;
+    };
+
+    /// <summary>
+    /// Gets the list of memory regions mapped for the system.
+    /// </summary>
+    virtual const std::vector<MemoryRegion>& MemoryRegions() const noexcept { return m_vEmptyRegions; }
+
     /// <summary>
     /// Gets a context object for the specified console.
     /// </summary>
@@ -37,6 +84,8 @@ public:
 protected:
     ConsoleID m_nId{};
     std::wstring m_sName;
+
+    static const std::vector<MemoryRegion> m_vEmptyRegions;
 };
 
 } // namespace data

--- a/src/data/ConsoleContext.hh
+++ b/src/data/ConsoleContext.hh
@@ -1,0 +1,45 @@
+#ifndef RA_DATA_CONSOLECONTEXT_HH
+#define RA_DATA_CONSOLECONTEXT_HH
+#pragma once
+
+#include "RA_Interface.h"
+
+#include <string>
+
+namespace ra {
+namespace data {
+
+class ConsoleContext
+{
+public:
+    ConsoleContext(ConsoleID nId, const std::wstring&& sName) noexcept : m_nId(nId), m_sName(std::move(sName)) {}
+    virtual ~ConsoleContext() noexcept = default;
+    ConsoleContext(const ConsoleContext&) noexcept = delete;
+    ConsoleContext& operator=(const ConsoleContext&) noexcept = delete;
+    ConsoleContext(ConsoleContext&&) noexcept = delete;
+    ConsoleContext& operator=(ConsoleContext&&) noexcept = delete;
+    
+    /// <summary>
+    /// Gets the unique identifier of the console.
+    /// </summary>
+    ConsoleID Id() const noexcept { return m_nId; }
+
+    /// <summary>
+    /// Gets a descriptive name for the console.
+    /// </summary>
+    const std::wstring& Name() const noexcept { return m_sName; }
+
+    /// <summary>
+    /// Gets a context object for the specified console.
+    /// </summary>
+    static std::unique_ptr<ConsoleContext> GetContext(ConsoleID nId);
+
+protected:
+    ConsoleID m_nId{};
+    std::wstring m_sName;
+};
+
+} // namespace data
+} // namespace ra
+
+#endif // !RA_DATA_CONSOLECONTEXT_HH

--- a/src/data/ConsoleContext.hh
+++ b/src/data/ConsoleContext.hh
@@ -13,7 +13,7 @@ namespace data {
 class ConsoleContext
 {
 public:
-    ConsoleContext(ConsoleID nId, const std::wstring&& sName) noexcept : m_nId(nId), m_sName(std::move(sName)) {}
+    GSL_SUPPRESS_F6 ConsoleContext(ConsoleID nId, const std::wstring&& sName) noexcept : m_nId(nId), m_sName(std::move(sName)) {}
     virtual ~ConsoleContext() noexcept = default;
     ConsoleContext(const ConsoleContext&) noexcept = delete;
     ConsoleContext& operator=(const ConsoleContext&) noexcept = delete;

--- a/src/data/EmulatorContext.cpp
+++ b/src/data/EmulatorContext.cpp
@@ -16,12 +16,6 @@
 
 #include "ui\viewmodels\MessageBoxViewModel.hh"
 
-#ifdef RA_UTEST
-API void CCONV _RA_SetConsoleID(unsigned int)
-{
-}
-#endif
-
 namespace ra {
 namespace data {
 

--- a/src/services/Initialization.cpp
+++ b/src/services/Initialization.cpp
@@ -2,6 +2,7 @@
 
 #include "api\impl\DisconnectedServer.hh"
 
+#include "data\ConsoleContext.hh"
 #include "data\EmulatorContext.hh"
 #include "data\GameContext.hh"
 #include "data\SessionTracker.hh"
@@ -81,6 +82,13 @@ void Initialization::RegisterServices(EmulatorID nEmulatorId)
     pEmulatorContext->Initialize(nEmulatorId);
     auto& sClientName = pEmulatorContext->GetClientName();
     ra::services::ServiceLocator::Provide<ra::data::EmulatorContext>(std::move(pEmulatorContext));
+
+    // if EmulatorContext->Initialize doesn't specify the ConsoleContext, initialize a default ConsoleContext
+    if (!ra::services::ServiceLocator::Exists<ra::data::ConsoleContext>())
+    {
+        auto pConsoleContext = ra::data::ConsoleContext::GetContext(ConsoleID::UnknownConsoleID);
+        ra::services::ServiceLocator::Provide<ra::data::ConsoleContext>(std::move(pConsoleContext));
+    }
 
     auto* pConfiguration = dynamic_cast<ra::services::impl::JsonFileConfiguration*>(
         &ra::services::ServiceLocator::GetMutable<ra::services::IConfiguration>());

--- a/tests/RA_Integration.Tests.vcxproj
+++ b/tests/RA_Integration.Tests.vcxproj
@@ -185,6 +185,7 @@
     <ClCompile Include="..\src\api\impl\ConnectedServer.cpp" />
     <ClCompile Include="..\src\api\impl\DisconnectedServer.cpp" />
     <ClCompile Include="..\src\api\impl\OfflineServer.cpp" />
+    <ClCompile Include="..\src\data\ConsoleContext.cpp" />
     <ClCompile Include="..\src\data\EmulatorContext.cpp" />
     <ClCompile Include="..\src\data\SessionTracker.cpp" />
     <ClCompile Include="..\src\data\GameContext.cpp" />

--- a/tests/RA_Integration.Tests.vcxproj.filters
+++ b/tests/RA_Integration.Tests.vcxproj.filters
@@ -262,6 +262,9 @@
     <ClInclude Include="mocks\MockConfiguration.hh">
       <Filter>Tests\Mocks</Filter>
     </ClInclude>
+    <ClCompile Include="..\src\data\ConsoleContext.cpp">
+      <Filter>Code</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="base.props" />


### PR DESCRIPTION
Starting with memory regions.

Also eliminates `g_ConsoleID`