### PR TITLE
ensure minor version is still displayed for x.0 versions

### DIFF
--- a/src/data/EmulatorContext.cpp
+++ b/src/data/EmulatorContext.cpp
@@ -187,10 +187,14 @@ bool EmulatorContext::ValidateClientVersion()
     std::string sClientVersion = m_sVersion;
     while (ra::StringEndsWith(sClientVersion, ".0"))
         sClientVersion.resize(sClientVersion.length() - 2);
+    if (sClientVersion.find('.') == std::string::npos)
+        sClientVersion.append(".0");
 
     std::string sNewVersion = m_sLatestVersion;
     while (ra::StringEndsWith(sNewVersion, ".0"))
         sNewVersion.resize(sNewVersion.length() - 2);
+    if (sNewVersion.find('.') == std::string::npos)
+        sNewVersion.append(".0");
 
     bool bUpdate = false;
     bool bResult = true;

--- a/tests/data/EmulatorContext_Tests.cpp
+++ b/tests/data/EmulatorContext_Tests.cpp
@@ -300,6 +300,44 @@ public:
         Assert::IsTrue(emulator.mockConfiguration.IsFeatureEnabled(ra::services::Feature::Hardcore));
     }
 
+    TEST_METHOD(TestValidateClientVersionTo1_0)
+    {
+        // ensures "1.0" doesn't get trimmed to "1"
+        EmulatorContextHarness emulator;
+        emulator.Initialize(EmulatorID::RA_Snes9x);
+        emulator.mockConfiguration.SetHostName("host");
+        emulator.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, true);
+        emulator.MockVersions("0.57.0.0", "1.0.0.0");
+        emulator.mockDesktop.ExpectWindow<ra::ui::viewmodels::MessageBoxViewModel>([](ra::ui::viewmodels::MessageBoxViewModel& vmMessageBox)
+        {
+            Assert::AreEqual(std::wstring(L"The latest client is required for hardcore mode."), vmMessageBox.GetHeader());
+            Assert::AreEqual(std::wstring(L"A new version of RASnes9X is available to download at host.\n\n- Current version: 0.57\n- New version: 1.0\n\nPress OK to logout and download the new version, or Cancel to disable hardcore mode and proceed."), vmMessageBox.GetMessage());
+            return ra::ui::DialogResult::Cancel;
+        });
+
+        Assert::IsTrue(emulator.ValidateClientVersion());
+        Assert::IsTrue(emulator.mockDesktop.WasDialogShown());
+    }
+
+    TEST_METHOD(TestValidateClientVersionFrom1_0)
+    {
+        // ensures "1.0" doesn't get trimmed to "1"
+        EmulatorContextHarness emulator;
+        emulator.Initialize(EmulatorID::RA_Snes9x);
+        emulator.mockConfiguration.SetHostName("host");
+        emulator.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, true);
+        emulator.MockVersions("1.0.0.0", "1.0.1.0");
+        emulator.mockDesktop.ExpectWindow<ra::ui::viewmodels::MessageBoxViewModel>([](ra::ui::viewmodels::MessageBoxViewModel& vmMessageBox)
+        {
+            Assert::AreEqual(std::wstring(L"The latest client is required for hardcore mode."), vmMessageBox.GetHeader());
+            Assert::AreEqual(std::wstring(L"A new version of RASnes9X is available to download at host.\n\n- Current version: 1.0\n- New version: 1.0.1\n\nPress OK to logout and download the new version, or Cancel to disable hardcore mode and proceed."), vmMessageBox.GetMessage());
+            return ra::ui::DialogResult::Cancel;
+        });
+
+        Assert::IsTrue(emulator.ValidateClientVersion());
+        Assert::IsTrue(emulator.mockDesktop.WasDialogShown());
+    }
+
     TEST_METHOD(TestValidateClientVersionUnknownClient)
     {
         EmulatorContextHarness emulator;


### PR DESCRIPTION
Fixes display for "1.0" release:

![image](https://user-images.githubusercontent.com/32680403/52914622-03129000-3288-11e9-9de2-83e03afc5c67.png)

to:

![image](https://user-images.githubusercontent.com/32680403/52914649-4240e100-3288-11e9-9d86-c6f162d3e4b9.png)
