### PR TITLE
Unregister custom class handler when Shutdown is called (fixes #314)

### DIFF
--- a/src/RA_Core.cpp
+++ b/src/RA_Core.cpp
@@ -56,9 +56,11 @@ bool g_bRAMTamperedWith = false;
 BOOL APIENTRY DllMain(HMODULE hModule, DWORD dwReason, _UNUSED LPVOID)
 {
     if (dwReason == DLL_PROCESS_ATTACH)
+    {
         g_hThisDLLInst = hModule;
 
-    ra::services::Initialization::RegisterCoreServices();
+        ra::services::Initialization::RegisterCoreServices();
+    }
 
     return TRUE;
 }
@@ -165,6 +167,7 @@ API int CCONV _RA_Shutdown()
         DestroyWindow(g_MemoryDialog.GetHWND());
         g_MemoryDialog.InstallHWND(nullptr);
     }
+    g_MemoryDialog.Shutdown();
 
     if (g_GameLibrary.GetHWND() != nullptr)
     {

--- a/src/RA_Dlg_Memory.cpp
+++ b/src/RA_Dlg_Memory.cpp
@@ -765,6 +765,11 @@ void Dlg_Memory::Init() noexcept
     ASSERT(checkAtom != 0);
 }
 
+void Dlg_Memory::Shutdown() noexcept
+{
+    ::UnregisterClass(TEXT("MemoryViewerControl"), g_hThisDLLInst);
+}
+
 // static
 INT_PTR CALLBACK Dlg_Memory::s_MemoryProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {

--- a/src/RA_Dlg_Memory.h
+++ b/src/RA_Dlg_Memory.h
@@ -74,6 +74,7 @@ class Dlg_Memory
 {
 public:
     void Init() noexcept;
+    void Shutdown() noexcept;
 
     void ClearLogOutput() noexcept;
 


### PR DESCRIPTION
The memory viewer uses a custom `WNDCLASS`, which has a pointer to a `WndProc`. When the DLL is unloaded and reloaded, the attempt to register the `WNDCLASS` fails as the previous one is still registered. Despite associating it with the DLL instance, it only automatically gets unregistered when the application terminates. As a result, the _new_ memory viewer that is created has a `WndProc` pointing at some random place in memory.

Solution: during `RA_Shutdown`, unregister the custom `WNDCLASS`, so it can be correctly re-registered if the DLL is reloaded.