### PR TITLE
Copy memory reference size when comparing two memory references

### DIFF
--- a/src/RA_Dlg_AchEditor.cpp
+++ b/src/RA_Dlg_AchEditor.cpp
@@ -1647,6 +1647,8 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
                         }
                         case CondSubItems::Type_Src:
                         {
+                            bool bWasValue = rCond.CompSource().GetType() == CompVariable::Type::ValueComparison;
+
                             if (sData == "Mem")
                                 rCond.CompSource().SetType(CompVariable::Type::Address);
                             else if (sData == "Delta")
@@ -1654,16 +1656,32 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
                             else
                                 rCond.CompSource().SetType(CompVariable::Type::ValueComparison);
 
+                            if (bWasValue &&
+                                rCond.CompSource().GetType() != CompVariable::Type::ValueComparison &&
+                                rCond.CompTarget().GetType() != CompVariable::Type::ValueComparison)
+                            {
+                                rCond.CompSource().SetSize(rCond.CompTarget().GetSize());
+                            }
+
                             break;
                         }
                         case CondSubItems::Type_Tgt:
                         {
+                            bool bWasValue = rCond.CompTarget().GetType() == CompVariable::Type::ValueComparison;
+
                             if (sData == "Mem")
                                 rCond.CompTarget().SetType(CompVariable::Type::Address);
                             else if (sData == "Delta")
                                 rCond.CompTarget().SetType(CompVariable::Type::DeltaMem);
                             else
                                 rCond.CompTarget().SetType(CompVariable::Type::ValueComparison);
+
+                            if (bWasValue &&
+                                rCond.CompTarget().GetType() != CompVariable::Type::ValueComparison &&
+                                rCond.CompSource().GetType() != CompVariable::Type::ValueComparison)
+                            {
+                                rCond.CompTarget().SetSize(rCond.CompSource().GetSize());
+                            }
 
                             break;
                         }

--- a/src/RA_Dlg_AchEditor.cpp
+++ b/src/RA_Dlg_AchEditor.cpp
@@ -1647,7 +1647,7 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
                         }
                         case CondSubItems::Type_Src:
                         {
-                            bool bWasValue = rCond.CompSource().GetType() == CompVariable::Type::ValueComparison;
+                            const bool bWasValue = rCond.CompSource().GetType() == CompVariable::Type::ValueComparison;
 
                             if (sData == "Mem")
                                 rCond.CompSource().SetType(CompVariable::Type::Address);
@@ -1667,7 +1667,7 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
                         }
                         case CondSubItems::Type_Tgt:
                         {
-                            bool bWasValue = rCond.CompTarget().GetType() == CompVariable::Type::ValueComparison;
+                            const bool bWasValue = rCond.CompTarget().GetType() == CompVariable::Type::ValueComparison;
 
                             if (sData == "Mem")
                                 rCond.CompTarget().SetType(CompVariable::Type::Address);


### PR DESCRIPTION
Request from Thoreau:
> after the update, when you add a new requirement and you're going to change the right side of the comparison from Value to Mem, the "Size" field that is coming as default is the "32-bit" one, but before it was the "8-bit" one which is much better because it's what we mostly use and so we didn't have to change that field most of the time.

This is a result of the `rcheevos` integration. A "Value" is implicitly 32-bit, so when it's converted to a "Mem" or "Delta", the size appears as 32-bit.

I've modified the logic to dynamically update the size when changing from "Value" to "Mem" or "Delta" if the other side is already "Mem" or "Delta". For example, if the condition were `"8-Bit Mem 0x1234 = Value 6"`, and you changed "Value" to "Mem" it would become `"8-Bit Mem 0x1234 = 8-Bit Mem 0x0006"`. Similarly, if it were `"16-Bit Mem 0x1234 = Value 6"` , it would become `"16-Bit Mem 0x1234 = 16-Bit Mem 0x0006"`.