### PR TITLE
move emulator callbacks into EmulatorContext

### DIFF
--- a/src/Exports.cpp
+++ b/src/Exports.cpp
@@ -27,6 +27,7 @@
 #ifndef RA_UTEST
 #include "RA_Dlg_Achievement.h"
 #include "RA_Dlg_AchEditor.h"
+#include "RA_Dlg_GameLibrary.h"
 #include "RA_Dlg_Memory.h"
 #endif
 
@@ -42,6 +43,28 @@ API int CCONV _RA_HardcoreModeIsActive()
 {
     const auto& pConfiguration = ra::services::ServiceLocator::Get<ra::services::IConfiguration>();
     return pConfiguration.IsFeatureEnabled(ra::services::Feature::Hardcore);
+}
+
+
+API void CCONV _RA_InstallSharedFunctions(bool(*)(void), void(*fpCauseUnpause)(void), void(*fpRebuildMenu)(void),
+                                          void(*fpEstimateTitle)(char*), void(*fpResetEmulation)(void), void(*fpLoadROM)(const char*))
+{
+    _RA_InstallSharedFunctionsExt(nullptr, fpCauseUnpause, nullptr, fpRebuildMenu, fpEstimateTitle, fpResetEmulation, fpLoadROM);
+}
+
+API void CCONV _RA_InstallSharedFunctionsExt(bool(*)(void), void(*fpCauseUnpause)(void), void(*fpCausePause)(void), void(*fpRebuildMenu)(void),
+                                             void(*fpEstimateTitle)(char*), void(*fpResetEmulation)(void), [[maybe_unused]] void(*fpLoadROM)(const char*))
+{
+    auto& pEmulatorContext = ra::services::ServiceLocator::GetMutable<ra::data::EmulatorContext>();
+    pEmulatorContext.SetResetFunction(fpResetEmulation);
+    pEmulatorContext.SetPauseFunction(fpCausePause);
+    pEmulatorContext.SetUnpauseFunction(fpCauseUnpause);
+    pEmulatorContext.SetGetGameTitleFunction(fpEstimateTitle);
+    pEmulatorContext.SetRebuildMenuFunction(fpRebuildMenu);
+
+#ifndef RA_UTEST
+    g_GameLibrary.m_fpLoadROM = fpLoadROM;
+#endif
 }
 
 static void HandleLoginResponse(const ra::api::Login::Response& response)
@@ -72,11 +95,11 @@ static void HandleLoginResponse(const ra::api::Login::Response& response)
         message.SetImage(ra::ui::ImageType::UserPic, response.Username);
         ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().QueueMessage(std::move(message));
 
-#ifndef RA_UTEST
         // notify the client to update the RetroAchievements menu
-        RA_RebuildMenu();
+        ra::services::ServiceLocator::Get<ra::data::EmulatorContext>().RebuildMenu();
 
         // update the client title-bar to include the user name
+#ifndef RA_UTEST
         _RA_UpdateAppTitle();
 
         // notify the overlay of the new user image
@@ -204,9 +227,7 @@ API void CCONV _RA_DoAchievementsFrame()
             case ra::services::AchievementRuntime::ChangeType::AchievementReset:
             {
                 // we only watch for AchievementReset if PauseOnReset is set, so handle that now.
-#ifndef RA_UTEST
-                RA_CausePause();
-#endif
+                ra::services::ServiceLocator::Get<ra::data::EmulatorContext>().Pause();
                 const auto* pAchievement = pGameContext.FindAchievement(pChange.nId);
                 if (pAchievement)
                 {
@@ -247,9 +268,7 @@ API void CCONV _RA_DoAchievementsFrame()
 
                 if (pAchievement->GetPauseOnTrigger())
                 {
-#ifndef RA_UTEST
-                    RA_CausePause();
-#endif
+                    ra::services::ServiceLocator::Get<ra::data::EmulatorContext>().Pause();
                     std::wstring sMessage = ra::StringPrintf(L"Pause on Trigger: %s", pAchievement->Title());
                     ra::ui::viewmodels::MessageBoxViewModel::ShowMessage(sMessage);
                 }

--- a/src/Exports.hh
+++ b/src/Exports.hh
@@ -89,8 +89,8 @@ extern "C" {
     API bool CCONV _RA_WarnDisableHardcore(const char* sActivity);
 
     // Install user-side functions that can be called from the DLL
-    API void CCONV _RA_InstallSharedFunctions(bool(*fpIsActive)(void), void(*fpCauseUnpause)(void), void(*fpRebuildMenu)(void), void(*fpEstimateTitle)(char*), void(*fpResetEmulation)(void), void(*fpLoadROM)(const char*));
-    API void CCONV _RA_InstallSharedFunctionsExt(bool(*fpIsActive)(void), void(*fpCauseUnpause)(void), void(*fpCausePause)(void), void(*fpRebuildMenu)(void), void(*fpEstimateTitle)(char*), void(*fpResetEmulation)(void), void(*fpLoadROM)(const char*));
+    API void CCONV _RA_InstallSharedFunctions(bool(*)(void), void(*fpCauseUnpause)(void), void(*fpRebuildMenu)(void), void(*fpEstimateTitle)(char*), void(*fpResetEmulation)(void), void(*fpLoadROM)(const char*));
+    API void CCONV _RA_InstallSharedFunctionsExt(bool(*)(void), void(*fpCauseUnpause)(void), void(*fpCausePause)(void), void(*fpRebuildMenu)(void), void(*fpEstimateTitle)(char*), void(*fpResetEmulation)(void), void(*fpLoadROM)(const char*));
 
     struct ControllerInput;
     API int CCONV _RA_UpdatePopups(_In_ ControllerInput* pInput, _In_ float fElapsedSeconds, _In_ bool bFullScreen, _In_ bool bPaused);

--- a/src/RA_AchievementOverlay.cpp
+++ b/src/RA_AchievementOverlay.cpp
@@ -99,7 +99,7 @@ void AchievementOverlay::Deactivate() noexcept
         m_nTransitionState = TransitionState::Out;
         m_fTransitionTimer = 0.0F;
 
-        RA_CauseUnpause();
+        ra::services::ServiceLocator::Get<ra::data::EmulatorContext>().Unpause();
     }
 }
 

--- a/src/RA_Dlg_AchEditor.cpp
+++ b/src/RA_Dlg_AchEditor.cpp
@@ -10,6 +10,8 @@
 #include "RA_User.h"
 #include "RA_httpthread.h"
 
+#include "data\EmulatorContext.hh"
+
 #include "services\IConfiguration.hh"
 #include "services\ServiceLocator.hh"
 
@@ -790,7 +792,7 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
                 LoadAchievement(pAchievement, false);
             }
 
-            if (!CanCausePause())
+            if (!ra::services::ServiceLocator::Get<ra::data::EmulatorContext>().CanPause())
             {
                 ShowWindow(GetDlgItem(m_hAchievementEditorDlg, IDC_RA_CHK_ACH_PAUSE_ON_TRIGGER), SW_HIDE);
                 ShowWindow(GetDlgItem(m_hAchievementEditorDlg, IDC_RA_CHK_ACH_PAUSE_ON_RESET), SW_HIDE);

--- a/src/RA_Dlg_Achievement.cpp
+++ b/src/RA_Dlg_Achievement.cpp
@@ -400,7 +400,7 @@ INT_PTR Dlg_Achievements::AchievementsProc(HWND hDlg, UINT nMsg, WPARAM wParam, 
 
                 case IDC_RA_PROMOTE_ACH:
                     //  Replace with background upload?
-                    if (!RA_GameIsActive())
+                    if (ra::services::ServiceLocator::Get<ra::data::GameContext>().GameId() == 0U)
                     {
                         MessageBox(hDlg, TEXT("ROM not loaded: please load a ROM first!"), TEXT("Error!"), MB_OK);
                     }
@@ -484,7 +484,7 @@ INT_PTR Dlg_Achievements::AchievementsProc(HWND hDlg, UINT nMsg, WPARAM wParam, 
                     break;
                 case IDC_RA_DOWNLOAD_ACH:
                 {
-                    if (!RA_GameIsActive())
+                    if (ra::services::ServiceLocator::Get<ra::data::GameContext>().GameId() == 0U)
                         break;
 
                     if (g_nActiveAchievementSet == AchievementSet::Type::Local)
@@ -538,7 +538,7 @@ INT_PTR Dlg_Achievements::AchievementsProc(HWND hDlg, UINT nMsg, WPARAM wParam, 
 
                 case IDC_RA_ADD_ACH:
                 {
-                    if (!RA_GameIsActive())
+                    if (ra::services::ServiceLocator::Get<ra::data::GameContext>().GameId() == 0U)
                     {
                         MessageBox(hDlg, TEXT("ROM not loaded: please load a ROM first!"), TEXT("Error!"), MB_OK);
                         break;
@@ -577,7 +577,7 @@ INT_PTR Dlg_Achievements::AchievementsProc(HWND hDlg, UINT nMsg, WPARAM wParam, 
 
                 case IDC_RA_CLONE_ACH:
                 {
-                    if (!RA_GameIsActive())
+                    if (ra::services::ServiceLocator::Get<ra::data::GameContext>().GameId() == 0U)
                     {
                         MessageBox(hDlg, TEXT("ROM not loaded: please load a ROM first!"), TEXT("Error!"), MB_OK);
                         break;
@@ -660,7 +660,7 @@ INT_PTR Dlg_Achievements::AchievementsProc(HWND hDlg, UINT nMsg, WPARAM wParam, 
 
                 case IDC_RA_COMMIT_ACH:
                 {
-                    if (!RA_GameIsActive())
+                    if (ra::services::ServiceLocator::Get<ra::data::GameContext>().GameId() == 0U)
                         break;
 
                     const auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::GameContext>();
@@ -691,7 +691,7 @@ INT_PTR Dlg_Achievements::AchievementsProc(HWND hDlg, UINT nMsg, WPARAM wParam, 
 
                 case IDC_RA_REVERTSELECTED:
                 {
-                    if (!RA_GameIsActive())
+                    if (ra::services::ServiceLocator::Get<ra::data::GameContext>().GameId() == 0U)
                         break;
 
                     //  Attempt to remove from list, but if it has an Id > 0,
@@ -742,7 +742,7 @@ INT_PTR Dlg_Achievements::AchievementsProc(HWND hDlg, UINT nMsg, WPARAM wParam, 
 
                 case IDC_RA_RESET_ACH:
                 {
-                    if (!RA_GameIsActive())
+                    if (ra::services::ServiceLocator::Get<ra::data::GameContext>().GameId() == 0U)
                         break;
 
                     // this could fuck up in so, so many ways. But fuck it, just reset achieved status.
@@ -801,7 +801,7 @@ INT_PTR Dlg_Achievements::AchievementsProc(HWND hDlg, UINT nMsg, WPARAM wParam, 
 
                 case IDC_RA_ACTIVATE_ALL_ACH:
                 {
-                    if (!RA_GameIsActive() || g_pActiveAchievements->NumAchievements() == 0)
+                    if (ra::services::ServiceLocator::Get<ra::data::GameContext>().GameId() == 0U || g_pActiveAchievements->NumAchievements() == 0)
                         break;
 
                     if (MessageBox(hDlg, TEXT("Activate all achievements?"), TEXT("Activate Achievements"), MB_YESNO) ==

--- a/src/RA_Dlg_GameLibrary.cpp
+++ b/src/RA_Dlg_GameLibrary.cpp
@@ -446,7 +446,7 @@ BOOL Dlg_GameLibrary::LaunchSelected()
         SetWindowText(GetDlgItem(m_hDialogBox, IDC_RA_GLIB_NAME), buffer);
 
         ListView_GetItemText(hList, nSel, 3, buffer, 1024);
-        _RA_LoadROM(ra::Narrow(buffer).c_str());
+        m_fpLoadROM(ra::Narrow(buffer).c_str());
 
         return TRUE;
     }

--- a/src/RA_Dlg_GameLibrary.h
+++ b/src/RA_Dlg_GameLibrary.h
@@ -28,6 +28,8 @@ public:
     static INT_PTR CALLBACK s_GameLibraryProc(HWND, UINT, WPARAM, LPARAM);
     INT_PTR CALLBACK GameLibraryProc(HWND, UINT, WPARAM, LPARAM);
 
+    void(*m_fpLoadROM)(const char*);
+
 public:
     void InstallHWND(HWND hWnd) noexcept { m_hDialogBox = hWnd; }
     HWND GetHWND() const noexcept { return m_hDialogBox; }

--- a/src/RA_Dlg_Memory.cpp
+++ b/src/RA_Dlg_Memory.cpp
@@ -298,7 +298,7 @@ bool MemoryViewerControl::OnEditInput(UINT c)
     if (g_MemManager.NumMemoryBanks() == 0)
         return false;
 
-    if (c > 255 || !RA_GameIsActive())
+    if (c > 255 || ra::services::ServiceLocator::Get<ra::data::GameContext>().GameId() == 0U)
     {
         MessageBeep(ra::to_unsigned(-1));
         return false;

--- a/src/RA_Interface.cpp
+++ b/src/RA_Interface.cpp
@@ -1,59 +1,5 @@
 #include "RA_Interface.h"
 
-// Exposed, shared
-// App-level:
-bool (CCONV *_RA_GameIsActive) (void) = nullptr;
-void (CCONV *_RA_CauseUnpause) (void) = nullptr;
-void (CCONV *_RA_CausePause) (void) = nullptr;
-void (CCONV *_RA_RebuildMenu) (void) = nullptr;
-void (CCONV *_RA_ResetEmulation) (void) = nullptr;
-void (CCONV *_RA_GetEstimatedGameTitle) (char* sNameOut) = nullptr;
-void (CCONV *_RA_LoadROM) (const char* sNameOut) = nullptr;
-
-bool RA_GameIsActive()
-{
-    if (_RA_GameIsActive != nullptr)
-        return _RA_GameIsActive();
-    return false;
-}
-
-void RA_CauseUnpause()
-{
-    if (_RA_CauseUnpause != nullptr)
-        _RA_CauseUnpause();
-}
-
-void RA_CausePause()
-{
-    if (_RA_CausePause != nullptr)
-        _RA_CausePause();
-}
-
-void RA_RebuildMenu()
-{
-    if (_RA_RebuildMenu != nullptr)
-        _RA_RebuildMenu();
-}
-
-void RA_ResetEmulation()
-{
-    if (_RA_ResetEmulation != nullptr)
-        _RA_ResetEmulation();
-}
-
-void RA_LoadROM(const char* sFullPath)
-{
-    if (_RA_LoadROM != nullptr)
-        _RA_LoadROM(sFullPath);
-}
-
-void RA_GetEstimatedGameTitle(char* sNameOut)
-{
-    if (_RA_GetEstimatedGameTitle != nullptr)
-        _RA_GetEstimatedGameTitle(sNameOut);
-}
-
-
 #ifndef RA_EXPORTS
 
 #include <winhttp.h>
@@ -648,19 +594,10 @@ void RA_Init(HWND hMainHWND, int nConsoleID, const char* sClientVersion)
     }
 }
 
-void RA_InstallSharedFunctions(bool(*fpIsActive)(void), void(*fpCauseUnpause)(void), void(*fpCausePause)(void), void(*fpRebuildMenu)(void), void(*fpEstimateTitle)(char*), void(*fpResetEmulation)(void), void(*fpLoadROM)(const char*))
+void RA_InstallSharedFunctions(bool(*)(void), void(*fpCauseUnpause)(void), void(*fpCausePause)(void), void(*fpRebuildMenu)(void), void(*fpEstimateTitle)(char*), void(*fpResetEmulation)(void), void(*fpLoadROM)(const char*))
 {
-    _RA_GameIsActive = fpIsActive;
-    _RA_CauseUnpause = fpCauseUnpause;
-    _RA_CausePause = fpCausePause;
-    _RA_RebuildMenu = fpRebuildMenu;
-    _RA_GetEstimatedGameTitle = fpEstimateTitle;
-    _RA_ResetEmulation = fpResetEmulation;
-    _RA_LoadROM = fpLoadROM;
-
-    //	Also install *within* DLL! FFS
     if (_RA_InstallSharedFunctions != nullptr)
-        _RA_InstallSharedFunctions(fpIsActive, fpCauseUnpause, fpCausePause, fpRebuildMenu, fpEstimateTitle, fpResetEmulation, fpLoadROM);
+        _RA_InstallSharedFunctions(nullptr, fpCauseUnpause, fpCausePause, fpRebuildMenu, fpEstimateTitle, fpResetEmulation, fpLoadROM);
 }
 
 void RA_Shutdown()

--- a/src/RA_Interface.h
+++ b/src/RA_Interface.h
@@ -99,29 +99,6 @@ enum ConsoleID
     NumConsoleIDs
 };
 
-extern bool (*_RA_GameIsActive)();
-extern void (*_RA_CauseUnpause)();
-extern void (*_RA_CausePause)();
-extern void (*_RA_RebuildMenu)();
-extern void (*_RA_GetEstimatedGameTitle)(char* sNameOut);
-extern void (*_RA_ResetEmulation)();
-extern void (*_RA_LoadROM)(const char* sFullPath);
-
-// Shared funcs, should be implemented by emulator.
-#ifdef __cplusplus
-extern "C" {
-#endif // __cplusplus
-extern bool RA_GameIsActive();
-extern void RA_CauseUnpause();
-extern void RA_CausePause();
-extern void RA_RebuildMenu();
-extern void RA_GetEstimatedGameTitle(char* sNameOut);
-extern void RA_ResetEmulation();
-extern void RA_LoadROM(const char* sFullPath);
-#ifdef __cplusplus
-}
-#endif // __cplusplus
-
 #ifndef RA_EXPORTS
 
 #include <wtypes.h>
@@ -141,7 +118,7 @@ extern void RA_LoadROM(const char* sFullPath);
 extern void RA_Init(HWND hMainHWND, /*enum ConsoleType*/ int console, const char* sClientVersion);
 
 //	Call with shared function pointers from app.
-extern void RA_InstallSharedFunctions(bool (*fpIsActive)(void), void (*fpCauseUnpause)(void),
+extern void RA_InstallSharedFunctions(bool (*fpUnusedIsActive)(void), void (*fpCauseUnpause)(void),
                                       void (*fpCausePause)(void), void (*fpRebuildMenu)(void),
                                       void (*fpEstimateTitle)(char*), void (*fpResetEmulator)(void),
                                       void (*fpLoadROM)(const char*));

--- a/src/data/EmulatorContext.cpp
+++ b/src/data/EmulatorContext.cpp
@@ -251,9 +251,9 @@ void EmulatorContext::DisableHardcoreMode()
     {
         pConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, false);
 
-#ifndef RA_UTEST
-        _RA_RebuildMenu();
+        RebuildMenu();
 
+#ifndef RA_UTEST
         auto& pLeaderboardManager = ra::services::ServiceLocator::GetMutable<ra::services::ILeaderboardManager>();
         pLeaderboardManager.DeactivateLeaderboards();
 #endif
@@ -307,12 +307,13 @@ bool EmulatorContext::EnableHardcoreMode()
         }
     }
 
-#ifndef RA_UTEST
-    // TODO: move these into EmulatorContext
-    _RA_RebuildMenu();
+    RebuildMenu();
 
     // when enabling hardcore mode, force a system reset
-    _RA_ResetEmulation();
+    if (m_fResetEmulator)
+        m_fResetEmulator();
+
+#ifndef RA_UTEST
     _RA_OnReset();
 #endif
 
@@ -360,6 +361,16 @@ std::string EmulatorContext::GetAppTitle(const std::string& sMessage) const
     }
 
     return builder.ToString();
+}
+
+std::string EmulatorContext::GetGameTitle() const
+{
+    if (!m_fGetGameTitle)
+        return std::string();
+
+    std::array<char, 256> buffer{};
+    m_fGetGameTitle(buffer.data());
+    return std::string(buffer.data());
 }
 
 } // namespace data

--- a/src/data/EmulatorContext.hh
+++ b/src/data/EmulatorContext.hh
@@ -74,6 +74,68 @@ public:
     /// </summary>
     /// <param name="sMessage">A custom message provided by the emulator to also display in the title bar.</param>
     std::string GetAppTitle(const std::string& sMessage) const;
+    
+    /// <summary>
+    /// Gets the game title from the emulator.
+    /// </summary>
+    std::string GetGameTitle() const;
+    
+    /// <summary>
+    /// Notifies the emulator that the RetroAchievements menu has changed.
+    /// </summary>
+    void RebuildMenu() const
+    {
+        if (m_fRebuildMenu)
+            m_fRebuildMenu();
+    }
+
+    /// <summary>
+    /// Gets whether or not the emulator can be paused.
+    /// </summary>
+    bool CanPause() const { return m_fPauseEmulator != nullptr; }
+
+    /// <summary>
+    /// Pauses the emulator.
+    /// </summary>
+    void Pause() const
+    {
+        if (m_fPauseEmulator)
+            m_fPauseEmulator();
+    }
+
+    /// <summary>
+    /// Unpauses the emulator.
+    /// </summary>
+    void Unpause() const
+    {
+        if (m_fUnpauseEmulator)
+            m_fUnpauseEmulator();
+    }
+
+    /// <summary>
+    /// Sets a function to call to reset the emulator.
+    /// </summary>
+    void SetResetFunction(std::function<void()>&& fResetEmulator) { m_fResetEmulator = fResetEmulator; }
+
+    /// <summary>
+    /// Sets a function to call to pause the emulator.
+    /// </summary>
+    void SetPauseFunction(std::function<void()>&& fPauseEmulator) { m_fPauseEmulator = fPauseEmulator; }
+
+    /// <summary>
+    /// Sets a function to call to unpause the emulator.
+    /// </summary>
+    void SetUnpauseFunction(std::function<void()>&& fUnpauseEmulator) { m_fUnpauseEmulator = fUnpauseEmulator; }
+
+    /// <summary>
+    /// Sets a function to call to get the game title from the emulator.
+    /// </summary>
+    void SetGetGameTitleFunction(std::function<void(char*)> fGetGameTitle) { m_fGetGameTitle = fGetGameTitle; }
+
+    /// <summary>
+    /// Sets a function to call to notify the emulator that the RetroAchievements menu has changed.
+    /// </summary>
+    void SetRebuildMenuFunction(std::function<void()>&& fRebuildMenu) { m_fRebuildMenu = fRebuildMenu; }
 
 protected:
     EmulatorID m_nEmulatorId = EmulatorID::UnknownEmulator;
@@ -81,6 +143,12 @@ protected:
     std::string m_sLatestVersion;
     std::string m_sLatestVersionError;
     std::string m_sClientName;
+
+    std::function<void()> m_fResetEmulator;
+    std::function<void()> m_fPauseEmulator;
+    std::function<void()> m_fUnpauseEmulator;
+    std::function<void(char*)> m_fGetGameTitle;
+    std::function<void()> m_fRebuildMenu;
 };
 
 } // namespace data

--- a/src/data/UserContext.cpp
+++ b/src/data/UserContext.cpp
@@ -4,6 +4,8 @@
 
 #include "api\Logout.hh"
 
+#include "data\EmulatorContext.hh"
+
 #include "services\IConfiguration.hh"
 
 #include "ui\viewmodels\MessageBoxViewModel.hh"
@@ -29,8 +31,8 @@ void UserContext::Logout()
         ra::services::ServiceLocator::Get<ra::services::IConfiguration>().Save();
 #ifndef RA_UTEST
         _RA_UpdateAppTitle();
-        RA_RebuildMenu();
 #endif
+        ra::services::ServiceLocator::Get<ra::data::EmulatorContext>().RebuildMenu();
 
         ra::ui::viewmodels::MessageBoxViewModel::ShowInfoMessage(L"You are now logged out.");
     }

--- a/src/ui/viewmodels/LoginViewModel.cpp
+++ b/src/ui/viewmodels/LoginViewModel.cpp
@@ -6,6 +6,7 @@
 
 #include "api\Login.hh"
 
+#include "data\EmulatorContext.hh"
 #include "data\UserContext.hh"
 
 #include "services\IConfiguration.hh"
@@ -70,8 +71,8 @@ bool LoginViewModel::Login() const
     ra::ui::viewmodels::MessageBoxViewModel::ShowInfoMessage(
         std::wstring(L"Successfully logged in as ") + ra::Widen(response.Username));
 
+    ra::services::ServiceLocator::Get<ra::data::EmulatorContext>().RebuildMenu();
 #ifndef RA_UTEST
-    RA_RebuildMenu();
     _RA_UpdateAppTitle();
 #endif
 

--- a/tests/RA_Integration.Tests.vcxproj
+++ b/tests/RA_Integration.Tests.vcxproj
@@ -250,6 +250,7 @@
     <ClInclude Include="mocks\MockClock.hh" />
     <ClInclude Include="mocks\MockConfiguration.hh" />
     <ClInclude Include="mocks\MockDesktop.hh" />
+    <ClInclude Include="mocks\MockEmulatorContext.hh" />
     <ClInclude Include="mocks\MockFileSystem.hh" />
     <ClInclude Include="mocks\MockGameContext.hh" />
     <ClInclude Include="mocks\MockHttpRequester.hh" />

--- a/tests/RA_Integration.Tests.vcxproj.filters
+++ b/tests/RA_Integration.Tests.vcxproj.filters
@@ -269,4 +269,9 @@
   <ItemGroup>
     <None Include="base.props" />
   </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="mocks\MockEmulatorContext.hh">
+      <Filter>Tests\Mocks</Filter>
+    </ClInclude>
+  </ItemGroup>
 </Project>

--- a/tests/mocks/MockEmulatorContext.hh
+++ b/tests/mocks/MockEmulatorContext.hh
@@ -1,0 +1,29 @@
+#ifndef RA_DATA_MOCK_EMULATORCONTEXT_HH
+#define RA_DATA_MOCK_EMULATORCONTEXT_HH
+#pragma once
+
+#include "data\EmulatorContext.hh"
+
+#include "services\ServiceLocator.hh"
+
+namespace ra {
+namespace data {
+namespace mocks {
+
+class MockEmulatorContext : public EmulatorContext
+{
+public:
+    MockEmulatorContext() noexcept
+        : m_Override(this)
+    {
+    }
+
+private:
+    ra::services::ServiceLocator::ServiceOverride<ra::data::EmulatorContext> m_Override;
+};
+
+} // namespace mocks
+} // namespace data
+} // namespace ra
+
+#endif // !RA_DATA_MOCK_EMULATORCONTEXT_HH

--- a/tests/ui/viewmodels/LoginViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/LoginViewModel_Tests.cpp
@@ -5,11 +5,13 @@
 #include "tests\RA_UnitTestHelpers.h"
 #include "tests\mocks\MockConfiguration.hh"
 #include "tests\mocks\MockDesktop.hh"
+#include "tests\mocks\MockEmulatorContext.hh"
 #include "tests\mocks\MockServer.hh"
 #include "tests\mocks\MockUserContext.hh"
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 using ra::api::mocks::MockServer;
+using ra::data::mocks::MockEmulatorContext;
 using ra::data::mocks::MockUserContext;
 using ra::services::mocks::MockConfiguration;
 using ra::ui::mocks::MockDesktop;
@@ -31,6 +33,7 @@ private:
         MockDesktop mockDesktop;
         MockServer mockServer;
         MockUserContext mockUserContext;
+        MockEmulatorContext mockEmulatorContext;
     };
 
 public:
@@ -103,6 +106,8 @@ public:
             Assert::AreEqual(MessageBoxViewModel::Icon::Info, vmMessageBox.GetIcon());
             return DialogResult::OK;
         });
+        bool bWasMenuRebuilt = false;
+        vmLogin.mockEmulatorContext.SetRebuildMenuFunction([&bWasMenuRebuilt] { bWasMenuRebuilt = true; });
 
         vmLogin.SetUsername(L"user");
         vmLogin.SetPassword(L"Pa$$w0rd");
@@ -118,6 +123,9 @@ public:
         // values should also be updated in UserContext, including API token
         Assert::AreEqual(std::string("User"), vmLogin.mockUserContext.GetUsername());
         Assert::AreEqual(std::string("ApiToken"), vmLogin.mockUserContext.GetApiToken());
+
+        // emulator should have been notified to rebuild the RetroAchievements menu
+        Assert::IsTrue(bWasMenuRebuilt);
     }
 
     TEST_METHOD(TestLoginInvalidPassword)


### PR DESCRIPTION
* deprecates `fpIsActive` callback. All previous calls to `fpIsActive` now check `GameId != 0`
* `fpLoadROM` is associated to the game library dialog, which is currently disabled, but not removed.
* other "shared" functions are loaded into and called through the `EmulatorContext` class.