### PR TITLE
don't clear mem viewer when game unloaded (fixes #302)

### DIFF
--- a/src/RA_Dlg_MemBookmark.h
+++ b/src/RA_Dlg_MemBookmark.h
@@ -170,6 +170,7 @@ public:
 private:
     int m_nNumOccupiedRows{};
     HWND m_hMemBookmarkDialog{};
+    unsigned int m_nGameId{};
     std::vector<MemBookmark> m_vBookmarks;
 };
 


### PR DESCRIPTION
I've changed the behavior of the memory viewer when a game is unloaded. Instead of clearing out the memory (resetting to the initial state when the emulator is started), it now just disables the Notes section. All of the notes/bookmarks/search results from the last loaded game will remain until a new game is loaded. They will also remain if the same game is reloaded.

However, reading/writing the memory is dependent on the emulator, and some of the emulators free the memory associated to the game when the game is unloaded. Attempting to read or write this memory while a game is not loaded _will crash the emulator_. Use at your own risk!

