### PR TITLE
better error messages when JSON parsing the response fails

### DIFF
--- a/src/api/impl/ConnectedServer.cpp
+++ b/src/api/impl/ConnectedServer.cpp
@@ -64,8 +64,32 @@ _NODISCARD static bool GetJson([[maybe_unused]] _In_ const char* sApiName,
         RA_LOG_ERR("-- %s: JSON Parse Error encountered!", sApiName);
 
         pResponse.Result = ApiResult::Error;
-        pResponse.ErrorMessage =
-            ra::StringPrintf("%s (%zu)", GetParseError_En(pDocument.GetParseError()), pDocument.GetErrorOffset());
+
+        if (pDocument.GetParseError() == rapidjson::kParseErrorValueInvalid && pDocument.GetErrorOffset() == 0)
+        {
+            // server did not return JSON, check for HTML
+            if (!ra::StringStartsWith(httpResponse.Content(), "<"))
+            {
+                // not HTML, return first line of response as the error message
+                std::string sContent = httpResponse.Content();
+                const auto nIndex = sContent.find('\n');
+                if (nIndex != std::string::npos)
+                {
+                    sContent.resize(nIndex);
+                    ra::TrimLineEnding(sContent);
+                }
+
+                if (!sContent.empty())
+                    pResponse.ErrorMessage = sContent;
+            }
+        }
+
+        if (pResponse.ErrorMessage.empty())
+        {
+            pResponse.ErrorMessage =
+                ra::StringPrintf("JSON Parse Error: %s (at %zu)", GetParseError_En(pDocument.GetParseError()), pDocument.GetErrorOffset());
+        }
+
         return false;
     }
 

--- a/tests/api/ConnectedServer_Tests.cpp
+++ b/tests/api/ConnectedServer_Tests.cpp
@@ -230,7 +230,30 @@ public:
         auto response = server.Login(request);
 
         Assert::AreEqual(ApiResult::Error, response.Result);
-        Assert::AreEqual(std::string("Invalid value. (0)"), response.ErrorMessage);
+        Assert::AreEqual(std::string("You do not have access to that resource"), response.ErrorMessage);
+        Assert::AreEqual(std::string(""), response.Username);
+        Assert::AreEqual(std::string(""), response.ApiToken);
+        Assert::AreEqual(0U, response.Score);
+        Assert::AreEqual(0U, response.NumUnreadMessages);
+    }
+
+    TEST_METHOD(TestLoginHtmlResponse)
+    {
+        MockHttpRequester mockHttp([]([[maybe_unused]] const Http::Request& /*request*/)
+        {
+            return Http::Response(Http::StatusCode::OK, "<b>You do not have access to that resource</b>");
+        });
+
+        ConnectedServer server("host.com");
+
+        Login::Request request;
+        request.Username = "User";
+        request.Password = "pa$$w0rd";
+
+        auto response = server.Login(request);
+
+        Assert::AreEqual(ApiResult::Error, response.Result);
+        Assert::AreEqual(std::string("JSON Parse Error: Invalid value. (at 0)"), response.ErrorMessage);
         Assert::AreEqual(std::string(""), response.Username);
         Assert::AreEqual(std::string(""), response.ApiToken);
         Assert::AreEqual(0U, response.Score);


### PR DESCRIPTION
Instead of blindly reporting "Invalid value. (0)" when the server returns something other than JSON, attempt to determine if the response is HTML or plain text. If plain text, display the first line of the response. If HTML, change the existing error to "JSON Parse Error: Invalid value. (at 0)" to give the error slightly more meaning.

User provided dialog for existing error:
![image](https://user-images.githubusercontent.com/32680403/53460500-996a5280-39fa-11e9-8911-11c0402d9eca.png)

In this case, their firewall was preventing the request and returning an HTML document. Buried in that document were these error messages:
```
...
                textHeader = "This website is blocked!";
                textActions = sProductNameComodo + " has blocked this website by <strong>website filtering policy</strong>.";
                textIgnoreOnce = "Ignore Once";
                textAddToExclusions = "Add to Exclusions";
                textReportFalsePositive = "Report as a False Positive";
...
```
After these changes, the user would still get a generic error, but it would at least say "JSON Parse Error".