### PR TITLE
Show memory region watermark in search results if no code note exists

### DIFF
--- a/src/RA_Dlg_Memory.h
+++ b/src/RA_Dlg_Memory.h
@@ -107,7 +107,7 @@ private:
     bool GetSelectedMemoryRange(ra::ByteAddress& start, ra::ByteAddress& end);
     ra::ByteAddress m_nSystemRamStart{}, m_nSystemRamEnd{}, m_nGameRamStart{}, m_nGameRamEnd{};
 
-    void UpdateSearchResult(const ra::services::SearchResults::Result& result, _Out_ unsigned int& nMemVal, TCHAR(&buffer)[1024]);
+    static void UpdateSearchResult(const ra::services::SearchResults::Result& result, _Out_ unsigned int& nMemVal, std::wstring& sBuffer);
     bool CompareSearchResult(unsigned int nCurVal, unsigned int nPrevVal);
 
     static CodeNotes m_CodeNotes;

--- a/src/data/ConsoleContext.cpp
+++ b/src/data/ConsoleContext.cpp
@@ -387,6 +387,27 @@ const std::vector<ConsoleContext::MemoryRegion> VirtualBoyConsoleContext::m_vMem
 
 // ===== ConsoleContext =====
 
+const ConsoleContext::MemoryRegion* ConsoleContext::GetMemoryRegion(ra::ByteAddress nAddress) const
+{
+    const auto& vRegions = MemoryRegions();
+    gsl::index nStart = 0;
+    gsl::index nEnd = vRegions.size() - 1;
+    while (nStart <= nEnd)
+    {
+        const gsl::index nMid = (nStart + nEnd) / 2;
+        const auto& pRegion = vRegions.at(nMid);
+        if (pRegion.StartAddress > nAddress)
+            nEnd = nMid - 1;
+        else if (pRegion.EndAddress < nAddress)
+            nStart = nMid + 1;
+        else
+            return &pRegion;
+    }
+
+    return nullptr;
+}
+
+
 std::unique_ptr<ConsoleContext> ConsoleContext::GetContext(ConsoleID nId)
 {
     switch (nId)

--- a/src/data/ConsoleContext.hh
+++ b/src/data/ConsoleContext.hh
@@ -82,6 +82,12 @@ public:
     virtual const std::vector<MemoryRegion>& MemoryRegions() const noexcept { return m_vEmptyRegions; }
 
     /// <summary>
+    /// Gets the memory region containing the specified address.
+    /// </summary>
+    /// <returns>Matching <see cref="MemoryRegion"/>, <c>nullptr</c> if not found.
+    const MemoryRegion* GetMemoryRegion(ra::ByteAddress nAddress) const;
+
+    /// <summary>
     /// Gets a context object for the specified console.
     /// </summary>
     static std::unique_ptr<ConsoleContext> GetContext(ConsoleID nId);


### PR DESCRIPTION
[Old implementation](http://docs.retroachievements.org/Memory-Inspector-Overview/#4-results-window):
![image](https://user-images.githubusercontent.com/8508804/38765608-c43a724c-3f9b-11e8-8ae4-676cc273fb92.png)
* Notes were wrapped in parenthesis
* Entries without notes were just left blank
----------
New implementation (in RANes):
![image](https://user-images.githubusercontent.com/32680403/53702593-dd2bd600-3dc5-11e9-98c8-10ded6ecf5f8.png)
* Entries without notes have watermarks identifying how the address is used ([if defined in toolkit](https://github.com/RetroAchievements/RAIntegration/blob/master/src/data/ConsoleContext.cpp#L272)).
* If highest known address is less than 0x010000, only four digits are displayed in the address field.

Another example, showing highlights for existing notes (blue) and bookmarked items (green):
![image](https://user-images.githubusercontent.com/32680403/53702602-f16fd300-3dc5-11e9-899a-88749fa77498.png)
* Notes are no longer wrapped in parenthesis

Example from RASnes9x showing data that no longer matches the filter (red):
![image](https://user-images.githubusercontent.com/32680403/53702612-09475700-3dc6-11e9-9f6f-0e65abd7c17c.png)
