### PR TITLE
Update Unknown Game dialog

### DIFF
--- a/src/RA_Core.cpp
+++ b/src/RA_Core.cpp
@@ -267,8 +267,10 @@ static unsigned int IdentifyRom(const BYTE* pROM, unsigned int nROMSize, std::st
 
                     ra::ui::viewmodels::UnknownGameViewModel vmUnknownGame;
                     vmUnknownGame.InitializeGameTitles();
+                    vmUnknownGame.SetSystemName(ra::services::ServiceLocator::Get<ra::data::ConsoleContext>().Name());
                     vmUnknownGame.SetChecksum(ra::Widen(sCurrentROMMD5));
-                    vmUnknownGame.SetNewGameName(ra::Widen(sEstimatedGameTitle));
+                    vmUnknownGame.SetEstimatedGameName(ra::Widen(sEstimatedGameTitle));
+                    vmUnknownGame.SetNewGameName(vmUnknownGame.GetEstimatedGameName());
 
                     if (vmUnknownGame.ShowModal() == ra::ui::DialogResult::OK)
                         nGameId = vmUnknownGame.GetSelectedGameId();

--- a/src/RA_Core.cpp
+++ b/src/RA_Core.cpp
@@ -237,6 +237,12 @@ API bool CCONV _RA_WarnDisableHardcore(const char* sActivity)
 
 static unsigned int IdentifyRom(const BYTE* pROM, unsigned int nROMSize, std::string& sCurrentROMMD5)
 {
+    if (ra::services::ServiceLocator::Get<ra::data::ConsoleContext>().Id() == 0U)
+    {
+        ra::ui::viewmodels::MessageBoxViewModel::ShowErrorMessage(L"Cannot identify game for unknown console.");
+        return 0U;
+    }
+
     unsigned int nGameId = 0U;
 
     if (pROM == nullptr || nROMSize == 0)

--- a/src/RA_Resource.h
+++ b/src/RA_Resource.h
@@ -9,15 +9,18 @@
 #define IDC_RA_ADD_BOOKMARK             1024
 #define IDC_RA_DEL_BOOKMARK             1025
 #define IDC_RA_CLEAR_CHANGE             1026
-#define IDC_RA_RESULTS_BACK             1026
 #define IDC_RA_FREEZE                   1027
-#define IDC_RA_RESULTS_FORWARD          1027
 #define IDC_RA_BREAKPOINT               1028
-#define IDC_RA_RESULTS_REMOVE           1028
-#define IDC_RA_RESULTS_HIGHLIGHT        1029
 #define IDC_RA_DECIMALBOOKMARK          1029
 #define IDC_RA_SAVEBOOKMARK             1030
 #define IDC_RA_LOADBOOKMARK             1031
+#define IDC_RA_RESULTS_BACK             1032
+#define IDC_RA_RESULTS_FORWARD          1033
+#define IDC_RA_RESULTS_REMOVE           1034
+#define IDC_RA_RESULTS_HIGHLIGHT        1035
+#define IDC_RA_SYSTEMNAME               1036
+#define IDC_RA_LINK                     1037
+#define IDC_RA_GAMENAME                 1038
 #define IDD_RA_MEMORY                   1501
 #define IDD_RA_ACHIEVEMENTS             1502
 #define IDD_RA_ACHIEVEMENTEDITOR        1503
@@ -154,9 +157,9 @@
 // 
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
-#define _APS_NEXT_RESOURCE_VALUE        119
+#define _APS_NEXT_RESOURCE_VALUE        120
 #define _APS_NEXT_COMMAND_VALUE         40001
-#define _APS_NEXT_CONTROL_VALUE         1030
+#define _APS_NEXT_CONTROL_VALUE         1039
 #define _APS_NEXT_SYMED_VALUE           101
 #endif
 #endif

--- a/src/RA_Shared.rc
+++ b/src/RA_Shared.rc
@@ -154,23 +154,28 @@ BEGIN
     PUSHBUTTON      "Close",IDCLOSE,374,168,50,15
 END
 
-IDD_RA_GAMETITLESEL DIALOGEX 0, 0, 248, 138
+IDD_RA_GAMETITLESEL DIALOGEX 0, 0, 249, 136
 STYLE DS_SETFONT | DS_MODALFRAME | DS_FIXEDSYS | WS_POPUP | WS_CAPTION | WS_SYSMENU
 EXSTYLE WS_EX_TOOLWINDOW
 CAPTION "Unknown Title"
 FONT 8, "MS Shell Dlg", 400, 0, 0x1
 BEGIN
-    GROUPBOX        "Unrecognised Title",IDC_STATIC,7,7,234,105
-    LTEXT           "To load existing achievements, please try to locate the game in the following list:",IDC_STATIC,14,18,219,20
-    LTEXT           "New Title:",IDC_STATIC,21,91,49,11
-    LTEXT           "Checksum:",IDC_STATIC,14,121,36,8
-    LTEXT           "Otherwise, please confirm that the following title is suitable for this new game.",IDC_STATIC,14,67,219,18
-    LTEXT           "Existing Title:",IDC_STATIC,21,45,47,11
-    LTEXT           "",IDC_RA_CHECKSUM,58,120,77,9,SS_SUNKEN
-    EDITTEXT        IDC_RA_GAMETITLE,70,88,163,14,ES_AUTOHSCROLL | ES_WANTRETURN
-    COMBOBOX        IDC_RA_KNOWNGAMES,70,44,163,137,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
-    DEFPUSHBUTTON   "Submit",IDOK,191,117,50,14
-    PUSHBUTTON      "Cancel",IDCANCEL,139,117,50,14
+    LTEXT           "The provided game could not be identified.",IDC_STATIC,4,4,138,8
+    LTEXT           "Name:",IDC_STATIC,8,16,22,8
+    LTEXT           "My Game (U)",IDC_RA_GAMENAME,48,16,197,8
+    LTEXT           "System:",IDC_STATIC,8,24,27,8
+    LTEXT           "Some System",IDC_RA_SYSTEMNAME,48,24,131,8
+    LTEXT           "Checksum:",IDC_STATIC,8,32,36,8
+    LTEXT           "ABCDEF0123456789",IDC_RA_CHECKSUM,48,32,131,8
+    LTEXT           "Select an existing title for the game from the following list of known titles:",IDC_STATIC,4,44,241,10
+    COMBOBOX        IDC_RA_KNOWNGAMES,4,54,241,137,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
+    LTEXT           "Or provide an appropriate name to create a new entry:",IDC_STATIC,4,70,219,10
+    EDITTEXT        IDC_RA_GAMETITLE,4,80,241,14,ES_AUTOHSCROLL | ES_WANTRETURN
+    LTEXT           "Then press 'Link' to associate the checksum to the game, or 'Test' to load the game without registering the checksum.",IDC_STATIC,4,98,241,18
+    PUSHBUTTON      "Link",IDC_RA_LINK,4,118,66,14
+    DEFPUSHBUTTON   "Test",IDOK,113,118,66,14
+    PUSHBUTTON      "Cancel",IDCANCEL,179,118,66,14
+    PUSHBUTTON      "Copy Checksum",IDC_RA_COPYCHECKSUMCLIPBOARD,179,26,66,14
 END
 
 IDD_RA_ACHIEVEMENTPROGRESS DIALOGEX 0, 0, 261, 105
@@ -389,17 +394,19 @@ BEGIN
 
     IDD_RA_GAMETITLESEL, DIALOG
     BEGIN
-        LEFTMARGIN, 7
-        RIGHTMARGIN, 241
-        VERTGUIDE, 14
-        VERTGUIDE, 21
-        VERTGUIDE, 70
-        VERTGUIDE, 233
-        TOPMARGIN, 7
-        BOTTOMMARGIN, 131
-        HORZGUIDE, 56
-        HORZGUIDE, 102
-        HORZGUIDE, 129
+        LEFTMARGIN, 4
+        RIGHTMARGIN, 245
+        VERTGUIDE, 8
+        VERTGUIDE, 48
+        VERTGUIDE, 179
+        TOPMARGIN, 4
+        BOTTOMMARGIN, 132
+        HORZGUIDE, 24
+        HORZGUIDE, 32
+        HORZGUIDE, 40
+        HORZGUIDE, 54
+        HORZGUIDE, 80
+        HORZGUIDE, 98
     END
 
     IDD_RA_ACHIEVEMENTPROGRESS, DIALOG
@@ -538,6 +545,11 @@ BEGIN
 END
 
 IDD_RA_LOGIN AFX_DIALOG_LAYOUT
+BEGIN
+    0
+END
+
+IDD_RA_GAMETITLESEL AFX_DIALOG_LAYOUT
 BEGIN
     0
 END

--- a/src/RA_StringUtils.cpp
+++ b/src/RA_StringUtils.cpp
@@ -79,7 +79,7 @@ std::string Narrow(const std::string& str)
 }
 
 _Use_decl_annotations_
-std::string& TrimLineEnding(std::string& str) noexcept
+std::string& TrimLineEnding(std::string& str)
 {
     if (!str.empty())
     {
@@ -88,6 +88,22 @@ std::string& TrimLineEnding(std::string& str) noexcept
         if (str.back() == '\r')
             str.pop_back();
     }
+
+    return str;
+}
+
+_Use_decl_annotations_
+std::wstring& Trim(std::wstring& str)
+{
+    while (!str.empty() && iswspace(str.back()))
+        str.pop_back();
+
+    size_t nIndex = 0;
+    while (nIndex < str.length() && iswspace(str.at(nIndex)))
+        ++nIndex;
+
+    if (nIndex > 0)
+        str.erase(0, nIndex);
 
     return str;
 }

--- a/src/RA_StringUtils.h
+++ b/src/RA_StringUtils.h
@@ -24,7 +24,13 @@ _NODISCARD std::string Narrow(_In_ const std::string& wstr);
 /// Removes one "\r", "\n", or "\r\n" from the end of a string.
 /// </summary>
 /// <returns>Reference to <paramref name="str" /> for chaining.</returns>
-GSL_SUPPRESS_F6 std::string& TrimLineEnding(_Inout_ std::string& str) noexcept;
+std::string& TrimLineEnding(_Inout_ std::string& str);
+
+/// <summary>
+/// Removes all whitespace characters from the front and back of a string.
+/// </summary>
+/// <returns>Reference to <paramref name="str" /> for chaining.</returns>
+std::wstring& Trim(_Inout_ std::wstring& str);
 
 // ----- ToString -----
 

--- a/src/api/SubmitNewTitle.hh
+++ b/src/api/SubmitNewTitle.hh
@@ -22,6 +22,8 @@ public:
         unsigned int ConsoleId{0U};
         std::string Hash;
         std::wstring GameName;
+        unsigned int GameId{0U};
+        std::wstring Description;
 
         using Callback = std::function<void(const Response& response)>;
 

--- a/src/api/impl/ConnectedServer.cpp
+++ b/src/api/impl/ConnectedServer.cpp
@@ -642,6 +642,12 @@ SubmitNewTitle::Response ConnectedServer::SubmitNewTitle(const SubmitNewTitle::R
     AppendUrlParam(sPostData, "m", request.Hash);
     AppendUrlParam(sPostData, "i", ra::Narrow(request.GameName));
 
+    if (request.GameId)
+        AppendUrlParam(sPostData, "g", std::to_string(request.GameId));
+
+    if (!request.Description.empty())
+        AppendUrlParam(sPostData, "d", ra::Narrow(request.Description));
+
     if (DoRequest(m_sHost, SubmitNewTitle::Name(), "submitgametitle", sPostData, response, document))
     {
         if (!document.HasMember("Response"))

--- a/src/ui/WindowViewModelBase.cpp
+++ b/src/ui/WindowViewModelBase.cpp
@@ -14,6 +14,11 @@ DialogResult WindowViewModelBase::ShowModal()
     return ra::services::ServiceLocator::Get<ra::ui::IDesktop>().ShowModal(*this);
 }
 
+DialogResult WindowViewModelBase::ShowModal(const ra::ui::WindowViewModelBase& vmParentWindow)
+{
+    return ra::services::ServiceLocator::Get<ra::ui::IDesktop>().ShowModal(*this, vmParentWindow);
+}
+
 void WindowViewModelBase::Show()
 {
     return ra::services::ServiceLocator::Get<ra::ui::IDesktop>().ShowWindow(*this);

--- a/src/ui/WindowViewModelBase.hh
+++ b/src/ui/WindowViewModelBase.hh
@@ -72,6 +72,11 @@ public:
     /// </summary>
     DialogResult ShowModal();
 
+    /// <summary>
+    /// Shows a modal window for this view model. Method will not return until the window is closed.
+    /// </summary>
+    DialogResult ShowModal(const ra::ui::WindowViewModelBase& vmParentWindow);
+
 protected:
     WindowViewModelBase() noexcept(std::is_nothrow_default_constructible_v<ViewModelBase>) = default;
 };

--- a/src/ui/viewmodels/MessageBoxViewModel.hh
+++ b/src/ui/viewmodels/MessageBoxViewModel.hh
@@ -190,6 +190,27 @@ public:
         viewModel.SetIcon(Icon::Error);
         viewModel.ShowModal();
     }
+
+    /// <summary>
+    /// Shows an error message.
+    /// </summary>
+    static void ShowErrorMessage(const ra::ui::WindowViewModelBase& vmParentWindow, const std::wstring& sMessage)
+    {
+        MessageBoxViewModel viewModel(sMessage);
+        viewModel.SetIcon(Icon::Error);
+        viewModel.ShowModal(vmParentWindow);
+    }
+
+    /// <summary>
+    /// Shows an error message with a header message.
+    /// </summary>
+    static void ShowErrorMessage(const ra::ui::WindowViewModelBase& vmParentWindow, const std::wstring& sHeader, const std::wstring& sMessage)
+    {
+        MessageBoxViewModel viewModel(sMessage);
+        viewModel.SetHeader(sHeader);
+        viewModel.SetIcon(Icon::Error);
+        viewModel.ShowModal(vmParentWindow);
+    }
 };
 
 } // namespace viewmodels

--- a/src/ui/viewmodels/UnknownGameViewModel.cpp
+++ b/src/ui/viewmodels/UnknownGameViewModel.cpp
@@ -79,6 +79,7 @@ bool UnknownGameViewModel::Associate()
     }
     else
     {
+        request.GameId = nGameId;
         request.GameName = m_vGameTitles.GetLabelForId(nGameId);
 
         ra::ui::viewmodels::MessageBoxViewModel vmMessageBox;
@@ -92,6 +93,7 @@ bool UnknownGameViewModel::Associate()
     const auto& pConsoleContext = ra::services::ServiceLocator::Get<ra::data::ConsoleContext>();
     request.ConsoleId = pConsoleContext.Id();
     request.Hash = ra::Narrow(GetChecksum());
+    request.Description = GetEstimatedGameName();
 
     auto response = request.Call();
     if (response.Succeeded())

--- a/src/ui/viewmodels/UnknownGameViewModel.cpp
+++ b/src/ui/viewmodels/UnknownGameViewModel.cpp
@@ -7,6 +7,8 @@
 
 #include "data\ConsoleContext.hh"
 
+#include "services\IClipboard.hh"
+
 #include "ui\viewmodels\MessageBoxViewModel.hh"
 
 namespace ra {
@@ -16,6 +18,8 @@ namespace viewmodels {
 const IntModelProperty UnknownGameViewModel::SelectedGameIdProperty("UnknownGameViewModel", "SelectedGameId", 0);
 const StringModelProperty UnknownGameViewModel::NewGameNameProperty("UnknownGameViewModel", "NewGameName", L"");
 const StringModelProperty UnknownGameViewModel::ChecksumProperty("UnknownGameViewModel", "Checksum", L"");
+const StringModelProperty UnknownGameViewModel::EstimatedGameNameProperty("UnknownGameViewModel", "EstimatedGameName", L"");
+const StringModelProperty UnknownGameViewModel::SystemNameProperty("UnknownGameViewModel", "SystemName", L"");
 
 UnknownGameViewModel::UnknownGameViewModel() noexcept
 {
@@ -37,7 +41,7 @@ void UnknownGameViewModel::InitializeGameTitles()
     {
         if (response.Failed())
         {
-            ra::ui::viewmodels::MessageBoxViewModel::ShowErrorMessage(L"Could not retrieve list of existing games",
+            ra::ui::viewmodels::MessageBoxViewModel::ShowErrorMessage(*this, L"Could not retrieve list of existing games",
                                                                       ra::Widen(response.ErrorMessage));
         }
         else
@@ -52,17 +56,42 @@ void UnknownGameViewModel::InitializeGameTitles()
 
 bool UnknownGameViewModel::Associate()
 {
-    const auto& pConsoleContext = ra::services::ServiceLocator::Get<ra::data::ConsoleContext>();
-
     ra::api::SubmitNewTitle::Request request;
-    request.ConsoleId = pConsoleContext.Id();
-    request.Hash = ra::Narrow(GetChecksum());
 
     const auto nGameId = GetSelectedGameId();
     if (nGameId == 0)
+    {
         request.GameName = GetNewGameName();
+        ra::Trim(request.GameName);
+
+        if (request.GameName.length() < 3)
+        {
+            ra::ui::viewmodels::MessageBoxViewModel::ShowErrorMessage(*this, L"New game name must be at least three characters long.");
+            return false;
+        }
+
+        ra::ui::viewmodels::MessageBoxViewModel vmMessageBox;
+        vmMessageBox.SetHeader(ra::StringPrintf(L"Are you sure you want to create a new entry for '%s'?", request.GameName));
+        vmMessageBox.SetMessage(L"If you were unable to find an existing title, please check to make sure that it's not listed under \"~unlicensed~\", \"~hack~\", \"~prototype~\", or had a leading article removed.");
+        vmMessageBox.SetButtons(ra::ui::viewmodels::MessageBoxViewModel::Buttons::YesNo);
+        if (vmMessageBox.ShowModal(*this) == DialogResult::No)
+            return false;
+    }
     else
+    {
         request.GameName = m_vGameTitles.GetLabelForId(nGameId);
+
+        ra::ui::viewmodels::MessageBoxViewModel vmMessageBox;
+        vmMessageBox.SetHeader(ra::StringPrintf(L"Are you sure you want to add a new checksum to '%s'?", request.GameName));
+        vmMessageBox.SetMessage(L"You should not do this unless you are certain that the new title is compatible. You can use 'Test' mode to check compatibility.");
+        vmMessageBox.SetButtons(ra::ui::viewmodels::MessageBoxViewModel::Buttons::YesNo);
+        if (vmMessageBox.ShowModal(*this) == DialogResult::No)
+            return false;
+    }
+
+    const auto& pConsoleContext = ra::services::ServiceLocator::Get<ra::data::ConsoleContext>();
+    request.ConsoleId = pConsoleContext.Id();
+    request.Hash = ra::Narrow(GetChecksum());
 
     auto response = request.Call();
     if (response.Succeeded())
@@ -71,8 +100,14 @@ bool UnknownGameViewModel::Associate()
         return true;
     }
 
-    ra::ui::viewmodels::MessageBoxViewModel::ShowErrorMessage(L"Could not add new title",
+    ra::ui::viewmodels::MessageBoxViewModel::ShowErrorMessage(*this, L"Could not add new title",
                                                               ra::Widen(response.ErrorMessage));
+    return false;
+}
+
+bool UnknownGameViewModel::BeginTest()
+{
+    ra::ui::viewmodels::MessageBoxViewModel::ShowErrorMessage(*this, L"This feature is not yet supported.");
     return false;
 }
 
@@ -95,6 +130,12 @@ void UnknownGameViewModel::OnViewModelIntValueChanged(const IntModelProperty::Ch
         SetNewGameName(m_vGameTitles.GetLabelForId(args.tNewValue));
         AddNotifyTarget(*this);
     }
+}
+
+void UnknownGameViewModel::CopyChecksumToClipboard() const
+{
+    const auto& pClipboard = ra::services::ServiceLocator::Get<ra::services::IClipboard>();
+    pClipboard.SetText(GetChecksum());
 }
 
 } // namespace viewmodels

--- a/src/ui/viewmodels/UnknownGameViewModel.hh
+++ b/src/ui/viewmodels/UnknownGameViewModel.hh
@@ -79,7 +79,7 @@ public:
     void CopyChecksumToClipboard() const;
 
     /// <summary>
-    /// The <see cref="ModelProperty" /> for the new game name.
+    /// The <see cref="ModelProperty" /> for the game name provided by the emulator.
     /// </summary>
     static const StringModelProperty EstimatedGameNameProperty;
 
@@ -94,7 +94,7 @@ public:
     void SetEstimatedGameName(const std::wstring& sValue) { SetValue(EstimatedGameNameProperty, sValue); }
 
     /// <summary>
-    /// The <see cref="ModelProperty" /> for the new game name.
+    /// The <see cref="ModelProperty" /> for the system name.
     /// </summary>
     static const StringModelProperty SystemNameProperty;
 

--- a/src/ui/viewmodels/UnknownGameViewModel.hh
+++ b/src/ui/viewmodels/UnknownGameViewModel.hh
@@ -74,6 +74,41 @@ public:
     void SetChecksum(const std::wstring& sValue) { SetValue(ChecksumProperty, sValue); }
 
     /// <summary>
+    /// Copies the checksum to the clipboard.
+    /// </summary>
+    void CopyChecksumToClipboard() const;
+
+    /// <summary>
+    /// The <see cref="ModelProperty" /> for the new game name.
+    /// </summary>
+    static const StringModelProperty EstimatedGameNameProperty;
+
+    /// <summary>
+    /// Gets the game name provided by the emulator.
+    /// </summary>
+    const std::wstring& GetEstimatedGameName() const { return GetValue(EstimatedGameNameProperty); }
+
+    /// <summary>
+    /// Sets the game name provided by the emulator.
+    /// </summary>
+    void SetEstimatedGameName(const std::wstring& sValue) { SetValue(EstimatedGameNameProperty, sValue); }
+
+    /// <summary>
+    /// The <see cref="ModelProperty" /> for the new game name.
+    /// </summary>
+    static const StringModelProperty SystemNameProperty;
+
+    /// <summary>
+    /// Gets the system name.
+    /// </summary>
+    const std::wstring& GetSystemName() const { return GetValue(SystemNameProperty); }
+
+    /// <summary>
+    /// Sets the system name.
+    /// </summary>
+    void SetSystemName(const std::wstring& sValue) { SetValue(SystemNameProperty, sValue); }
+
+    /// <summary>
     /// Command handler for Associate button.
     /// </summary>    
     /// <returns>
@@ -81,6 +116,12 @@ public:
     /// <c>false</c> if not.
     /// </returns>
     bool Associate();
+
+    /// <summary>
+    /// Command handler for Test button.
+    /// </summary>
+    /// <returns><c>true</c> if the dialog should be closed, <c>false</c> if not.</returns>
+    bool BeginTest();
 
 protected:
     void OnViewModelStringValueChanged(const StringModelProperty::ChangeArgs& args) override;

--- a/src/ui/win32/DialogBase.cpp
+++ b/src/ui/win32/DialogBase.cpp
@@ -217,7 +217,7 @@ void DialogBase::SetDialogResult(DialogResult nResult)
     m_vmWindow.SetDialogResult(nResult);
 
     if (m_bModal)
-        EndDialog(m_hWnd, IDOK);
+        EndDialog(m_hWnd, 0); // DialogBox call in CreateModalWindow() ignores return value
     else
         DestroyWindow(m_hWnd);
 }

--- a/src/ui/win32/DialogBase.cpp
+++ b/src/ui/win32/DialogBase.cpp
@@ -199,29 +199,27 @@ BOOL DialogBase::OnCommand(WORD nCommand)
     switch (nCommand)
     {
         case IDOK:
-            m_vmWindow.SetDialogResult(DialogResult::OK);
-
-            if (m_bModal)
-                EndDialog(m_hWnd, IDOK);
-            else
-                DestroyWindow(m_hWnd);
-
+            SetDialogResult(DialogResult::OK);
             return TRUE;
 
         case IDCLOSE:
         case IDCANCEL:
-            m_vmWindow.SetDialogResult(DialogResult::Cancel);
-
-            if (m_bModal)
-                EndDialog(m_hWnd, nCommand);
-            else
-                DestroyWindow(m_hWnd);
-
+            SetDialogResult(DialogResult::Cancel);
             return TRUE;
 
         default:
             return FALSE;
     }
+}
+
+void DialogBase::SetDialogResult(DialogResult nResult)
+{
+    m_vmWindow.SetDialogResult(nResult);
+
+    if (m_bModal)
+        EndDialog(m_hWnd, IDOK);
+    else
+        DestroyWindow(m_hWnd);
 }
 
 _Use_decl_annotations_

--- a/src/ui/win32/DialogBase.hh
+++ b/src/ui/win32/DialogBase.hh
@@ -106,6 +106,11 @@ protected:
     /// <param name="oNewPosition">The new size of the client area.</param>
     virtual void OnSize(_In_ const ra::ui::Size& oNewSize);
 
+    /// <summary>
+    /// Sets the specified <see cref="DialogResult"/> for the view model and closes the window.
+    /// </summary>
+    void SetDialogResult(DialogResult nResult);
+
     ra::ui::win32::bindings::WindowBinding m_bindWindow;
 
     ra::ui::WindowViewModelBase& m_vmWindow;

--- a/src/ui/win32/DialogBase.hh
+++ b/src/ui/win32/DialogBase.hh
@@ -71,8 +71,10 @@ protected:
     /// <summary>
     /// Called when the window is created, but before it is shown.
     /// </summary>
-    /// <returns>Return <c>TRUE</c> if passing the keyboard focus to a default control, otherwise return
-    /// <c>FALSE</c>.</returns>
+    /// <returns>
+    /// <c>TRUE</c> to focus the first control in tab order,
+    /// <c>FALSE</c> if the method explicitly focused a control.
+    /// </returns>
     GSL_SUPPRESS_F6 virtual BOOL OnInitDialog() { return TRUE; }
 
     /// <summary>
@@ -89,6 +91,7 @@ protected:
     /// Called when a button is clicked.
     /// </summary>
     /// <param name="nCommand">The unique identifier of the button.</param>
+    /// <return></c>TRUE</c> if the command was handled, <c>FALSE</c> if not.
     virtual BOOL OnCommand(_In_ WORD nCommand);
 
     /// <summary>

--- a/src/ui/win32/UnknownGameDialog.cpp
+++ b/src/ui/win32/UnknownGameDialog.cpp
@@ -38,6 +38,8 @@ UnknownGameDialog::UnknownGameDialog(ra::ui::viewmodels::UnknownGameViewModel& v
     m_bindNewTitle.BindText(ra::ui::viewmodels::UnknownGameViewModel::NewGameNameProperty,
         ra::ui::win32::bindings::TextBoxBinding::UpdateMode::KeyPress);
 
+    m_bindWindow.BindLabel(IDC_RA_GAMENAME, ra::ui::viewmodels::UnknownGameViewModel::EstimatedGameNameProperty);
+    m_bindWindow.BindLabel(IDC_RA_SYSTEMNAME, ra::ui::viewmodels::UnknownGameViewModel::SystemNameProperty);
     m_bindWindow.BindLabel(IDC_RA_CHECKSUM, ra::ui::viewmodels::UnknownGameViewModel::ChecksumProperty);
 }
 
@@ -51,11 +53,30 @@ BOOL UnknownGameDialog::OnInitDialog()
 
 BOOL UnknownGameDialog::OnCommand(WORD nCommand)
 {
-    if (nCommand == IDOK)
+    switch (nCommand)
     {
-        auto& vmUnknownGame = reinterpret_cast<ra::ui::viewmodels::UnknownGameViewModel&>(m_vmWindow);
-        if (!vmUnknownGame.Associate())
+        case IDOK:
+        {
+            auto& vmUnknownGame = reinterpret_cast<ra::ui::viewmodels::UnknownGameViewModel&>(m_vmWindow);
+            if (vmUnknownGame.BeginTest())
+                SetDialogResult(ra::ui::DialogResult::OK);
             return TRUE;
+        }
+
+        case IDC_RA_LINK:
+        {
+            auto& vmUnknownGame = reinterpret_cast<ra::ui::viewmodels::UnknownGameViewModel&>(m_vmWindow);
+            if (vmUnknownGame.Associate())
+                SetDialogResult(ra::ui::DialogResult::OK);
+            return TRUE;
+        }
+
+        case IDC_RA_COPYCHECKSUMCLIPBOARD:
+        {
+            const auto& vmUnknownGame = reinterpret_cast<ra::ui::viewmodels::UnknownGameViewModel&>(m_vmWindow);
+            vmUnknownGame.CopyChecksumToClipboard();
+            return TRUE;
+        }
     }
 
     return DialogBase::OnCommand(nCommand);

--- a/tests/RA_Integration.Tests.vcxproj
+++ b/tests/RA_Integration.Tests.vcxproj
@@ -253,6 +253,7 @@
     <ClCompile Include="ui\WindowViewModelBase_Tests.cpp" />
     <ClInclude Include="..\src\pch.h" />
     <ClInclude Include="mocks\MockAudioSystem.hh" />
+    <ClInclude Include="mocks\MockClipboard.hh" />
     <ClInclude Include="mocks\MockClock.hh" />
     <ClInclude Include="mocks\MockConfiguration.hh" />
     <ClInclude Include="mocks\MockConsoleContext.hh" />

--- a/tests/RA_Integration.Tests.vcxproj.filters
+++ b/tests/RA_Integration.Tests.vcxproj.filters
@@ -293,4 +293,9 @@
   <ItemGroup>
     <None Include="base.props" />
   </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="mocks\MockClipboard.hh">
+      <Filter>Tests\Mocks</Filter>
+    </ClInclude>
+  </ItemGroup>
 </Project>

--- a/tests/RA_StringUtils_Tests.cpp
+++ b/tests/RA_StringUtils_Tests.cpp
@@ -4,11 +4,18 @@ using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
 namespace ra {
 
-[[gsl::suppress(f.6), nodiscard]]
+GSL_SUPPRESS_F6 _NODISCARD
 static std::string TrimLineEnding(std::string&& str) noexcept
 {
     auto sRet{ std::move_if_noexcept(str) };
     return TrimLineEnding(sRet);
+}
+
+GSL_SUPPRESS_F6 _NODISCARD
+static std::wstring Trim(std::wstring&& str) noexcept
+{
+    auto sRet{ std::move_if_noexcept(str) };
+    return Trim(sRet);
 }
 
 namespace services {
@@ -49,6 +56,7 @@ public:
         // invalid UTF-8 replaced with placeholder U+FFFD
         Assert::AreEqual(std::wstring(L"T\xFFFDst"), Widen("T\xA9st")); // should be \xC3\xA9
     }
+
     TEST_METHOD(TestTrimLineEnding)
     {
         Assert::AreEqual(std::string("test"), TrimLineEnding(std::string("test")));
@@ -57,6 +65,16 @@ public:
         Assert::AreEqual(std::string("test"), TrimLineEnding(std::string("test\r\n")));
         Assert::AreEqual(std::string("test\n"), TrimLineEnding(std::string("test\n\n")));
         Assert::AreEqual(std::string("test\r\n"), TrimLineEnding(std::string("test\r\n\r\n")));
+    }
+
+    TEST_METHOD(TestTrim)
+    {
+        Assert::AreEqual(std::wstring(L"test"), Trim(std::wstring(L"test")));
+        Assert::AreEqual(std::wstring(L"test"), Trim(std::wstring(L"test \t\r\n")));
+        Assert::AreEqual(std::wstring(L"test"), Trim(std::wstring(L" \t\r\ntest")));
+        Assert::AreEqual(std::wstring(L"test"), Trim(std::wstring(L" \t\r\ntest \t\r\n")));
+        Assert::AreEqual(std::wstring(L"test"), Trim(std::wstring(L"      test     ")));
+        Assert::AreEqual(std::wstring(L"test test\r\ntest"), Trim(std::wstring(L"\ttest test\r\ntest\r\n\r\n")));
     }
 
     TEST_METHOD(TestToString)

--- a/tests/mocks/MockClipboard.hh
+++ b/tests/mocks/MockClipboard.hh
@@ -1,0 +1,32 @@
+#ifndef RA_SERVICES_MOCK_CLIPBOARD_HH
+#define RA_SERVICES_MOCK_CLIPBOARD_HH
+#pragma once
+
+#include "services\IClipboard.hh"
+#include "services\ServiceLocator.hh"
+
+namespace ra {
+namespace services {
+namespace mocks {
+
+class MockClipboard : public ra::services::IClipboard
+{
+public:
+    MockClipboard() noexcept
+        : m_Override(this)
+    {
+    }
+
+    void SetText(const std::wstring& sValue) const override { m_sText = sValue; }
+    const std::wstring& GetText() const noexcept { return m_sText; }
+
+private:
+    ra::services::ServiceLocator::ServiceOverride<ra::services::IClipboard> m_Override;
+    mutable std::wstring m_sText;
+};
+
+} // namespace mocks
+} // namespace services
+} // namespace ra
+
+#endif // !RA_SERVICES_MOCK_CLIPBOARD_HH

--- a/tests/ui/viewmodels/GameChecksumViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/GameChecksumViewModel_Tests.cpp
@@ -2,14 +2,13 @@
 
 #include "ui\viewmodels\GameChecksumViewModel.hh"
 
-#include "services\ServiceLocator.hh"
-#include "services\IClipboard.hh"
-
 #include "tests\RA_UnitTestHelpers.h"
+#include "tests\mocks\MockClipboard.hh"
 #include "tests\mocks\MockGameContext.hh"
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 using ra::data::mocks::MockGameContext;
+using ra::services::mocks::MockClipboard;
 
 namespace ra {
 namespace ui {
@@ -18,23 +17,6 @@ namespace tests {
 
 TEST_CLASS(GameChecksumViewModel_Tests)
 {
-private:
-    class MockClipboard : public ra::services::IClipboard
-    {
-    public:
-        MockClipboard() noexcept
-            : m_Override(this)
-        {
-        }
-
-        void SetText(const std::wstring& sValue) const override { m_sText = sValue; }
-        const std::wstring& GetText() const noexcept { return m_sText; }
-
-    private:
-        ra::services::ServiceLocator::ServiceOverride<ra::services::IClipboard> m_Override;
-        mutable std::wstring m_sText;
-    };
-
 public:
     TEST_METHOD(TestInitialValueFromGameContext)
     {

--- a/tests/ui/viewmodels/UnknownGameViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/UnknownGameViewModel_Tests.cpp
@@ -146,6 +146,7 @@ public:
         vmUnknownGame.MockGameTitles();
         vmUnknownGame.SetSelectedGameId(40);
         vmUnknownGame.SetChecksum(L"CHECKSUM");
+        vmUnknownGame.SetEstimatedGameName(L"GAME40");
 
         vmUnknownGame.mockDesktop.ExpectWindow<ra::ui::viewmodels::MessageBoxViewModel>([](ra::ui::viewmodels::MessageBoxViewModel& vmMessageBox)
         {
@@ -159,6 +160,8 @@ public:
             Assert::AreEqual(41U, request.ConsoleId);
             Assert::AreEqual(std::string("CHECKSUM"), request.Hash);
             Assert::AreEqual(std::wstring(L"Game 40"), request.GameName);
+            Assert::AreEqual(std::wstring(L"GAME40"), request.Description);
+            Assert::AreEqual(40U, request.GameId);
 
             response.Result = ra::api::ApiResult::Success;
             response.GameId = 40U;
@@ -195,6 +198,7 @@ public:
         vmUnknownGame.MockGameTitles();
         vmUnknownGame.SetNewGameName(L"Game 96");
         vmUnknownGame.SetChecksum(L"CHECKSUM");
+        vmUnknownGame.SetEstimatedGameName(L"GAME96");
 
         vmUnknownGame.mockDesktop.ExpectWindow<ra::ui::viewmodels::MessageBoxViewModel>([](ra::ui::viewmodels::MessageBoxViewModel& vmMessageBox)
         {
@@ -208,6 +212,43 @@ public:
             Assert::AreEqual(34U, request.ConsoleId);
             Assert::AreEqual(std::string("CHECKSUM"), request.Hash);
             Assert::AreEqual(std::wstring(L"Game 96"), request.GameName);
+            Assert::AreEqual(std::wstring(L"GAME96"), request.Description);
+            Assert::AreEqual(0U, request.GameId);
+
+            response.Result = ra::api::ApiResult::Success;
+            response.GameId = 102U;
+
+            return true;
+        });
+
+        Assert::IsTrue(vmUnknownGame.Associate());
+        Assert::AreEqual(102, vmUnknownGame.GetSelectedGameId());
+    }
+
+    TEST_METHOD(TestAssociateNewTrimmed)
+    {
+        UnknownGameViewModelHarness vmUnknownGame;
+        vmUnknownGame.mockConsoleContext.SetId(ConsoleID::VIC20);
+        vmUnknownGame.MockGameTitles();
+        vmUnknownGame.SetNewGameName(L"  Game 96  ");
+        vmUnknownGame.SetChecksum(L"CHECKSUM");
+        vmUnknownGame.SetEstimatedGameName(L"GAME96");
+
+        // name should be trimmed in both the dialog and the request
+        vmUnknownGame.mockDesktop.ExpectWindow<ra::ui::viewmodels::MessageBoxViewModel>([](ra::ui::viewmodels::MessageBoxViewModel& vmMessageBox)
+        {
+            Assert::AreEqual(std::wstring(L"Are you sure you want to create a new entry for 'Game 96'?"), vmMessageBox.GetHeader());
+            return ra::ui::DialogResult::Yes;
+        });
+
+        vmUnknownGame.mockServer.HandleRequest<ra::api::SubmitNewTitle>([]
+        (const ra::api::SubmitNewTitle::Request& request, ra::api::SubmitNewTitle::Response& response)
+        {
+            Assert::AreEqual(34U, request.ConsoleId);
+            Assert::AreEqual(std::string("CHECKSUM"), request.Hash);
+            Assert::AreEqual(std::wstring(L"Game 96"), request.GameName);
+            Assert::AreEqual(std::wstring(L"GAME96"), request.Description);
+            Assert::AreEqual(0U, request.GameId);
 
             response.Result = ra::api::ApiResult::Success;
             response.GameId = 102U;


### PR DESCRIPTION
Old dialog: 

![image](https://user-images.githubusercontent.com/32680403/54326526-35d04f80-45cc-11e9-8e20-d567f040ae7b.png)

New dialog:

![image](https://user-images.githubusercontent.com/32680403/54326555-55677800-45cc-11e9-92b4-cce10ee4d9b6.png)

List of changes:
* Emulator provided name for the game is displayed at all times. Previously, it was initially displayed in the text box, but that could be changed by typing or selecting an item from the dropdown.
* Associated system is displayed (addresses #140)
* Checksum is moved up to the game details section, and a button is added to copy the checksum to the clipboard.
* Test button added - non-functional at this point. Plan is to allow loading achievements for an existing game without actually linking the hash to allow for compatibility testing. More details on that functionality will be in the related PR.
* Submit button changed to "Link" and moved to the left side of the dialog. Link button now prompts the user to confirm that they meant to associate the checksum to an existing entry or create a new entry.
![image](https://user-images.githubusercontent.com/32680403/54326779-3f0dec00-45cd-11e9-8448-1655df688043.png)
![image](https://user-images.githubusercontent.com/32680403/54326808-5e0c7e00-45cd-11e9-8010-a012e27af1b7.png)

Additionally, when associating the hash to an existing game, the game ID is now passed to the server as the 'g' parameter. This will allow the server to make the correct association when certain characters are present in the title (see #230) (requires server changes).