### PR TITLE
Remove references to shared functions in RA_Interface.cpp

### DIFF
--- a/src/RA_Interface.cpp
+++ b/src/RA_Interface.cpp
@@ -637,13 +637,6 @@ void RA_Shutdown()
     _RA_DoAchievementsFrame = nullptr;
     _RA_InstallSharedFunctions = nullptr;
 
-    _RA_GameIsActive = nullptr;
-    _RA_CauseUnpause = nullptr;
-    _RA_CausePause = nullptr;
-    _RA_RebuildMenu = nullptr;
-    _RA_GetEstimatedGameTitle = nullptr;
-    _RA_ResetEmulation = nullptr;
-    _RA_LoadROM = nullptr;
     _RA_SetConsoleID = nullptr;
     _RA_HardcoreModeIsActive = nullptr;
     _RA_WarnDisableHardcore = nullptr;


### PR DESCRIPTION
Compiling emulators with just `RA_Interface` (source and header) after #320 fails due to `RA_Shutdown()` referring to undefined identifiers.

I am not sure if this is a good solution, but for now it fixes compilation.