### PR TITLE
Use v6 ComCtrl32.dll for all emulators

### DIFF
--- a/src/RA_Core.cpp
+++ b/src/RA_Core.cpp
@@ -52,11 +52,16 @@ bool g_bRAMTamperedWith = false;
 
 BOOL APIENTRY DllMain(HMODULE hModule, DWORD dwReason, _UNUSED LPVOID)
 {
-    if (dwReason == DLL_PROCESS_ATTACH)
+    switch (dwReason)
     {
-        g_hThisDLLInst = hModule;
+        case DLL_PROCESS_ATTACH:
+            g_hThisDLLInst = hModule;
+            ra::services::Initialization::RegisterCoreServices();
+            break;
 
-        ra::services::Initialization::RegisterCoreServices();
+        case DLL_PROCESS_DETACH:
+            IsolationAwareCleanup();
+            break;
     }
 
     return TRUE;

--- a/src/pch.h
+++ b/src/pch.h
@@ -1,6 +1,8 @@
 #ifndef PCH_H
 #define PCH_H
 
+#define ISOLATION_AWARE_ENABLED 1
+
 /*
     Only put files that never change or are rarely changed in this file.
     An include graph will be provided for some headers that were not explicit

--- a/src/services/Initialization.cpp
+++ b/src/services/Initialization.cpp
@@ -27,6 +27,13 @@
 #include "ui\viewmodels\WindowManager.hh"
 #include "ui\win32\Desktop.hh"
 
+// this, in combination with the "#define ISOLATION_AWARE_ENABLED 1" in pch.h, allows our
+// UI to use visual styles introduced in ComCtl32 v6, even if the emulator does not enable them.
+// see https://docs.microsoft.com/en-us/windows/desktop/controls/cookbook-overview
+#pragma comment(linker,"\"/manifestdependency:type='win32' \
+name='Microsoft.Windows.Common-Controls' version='6.0.0.0' \
+processorArchitecture='*' publicKeyToken='6595b64144ccf1df' language='*'\"")
+
 namespace ra {
 namespace services {
 


### PR DESCRIPTION
Causes tool windows to be consistently rendered in "flat" style within all emulators. See #182 for examples of v6 (RASnes9x) and v5 (RAVBA). It is implemented using Context Isolation, so dialogs created by the emulators will continue to use the old style. Only dialogs created by the DLL are affected.

This change fixes the unicode display issue in RAVBA (#182).
Before:
![image](https://user-images.githubusercontent.com/32680403/54482431-ddd25c80-4808-11e9-98cc-76e6d3ad0dc7.png)

After:
![image](https://user-images.githubusercontent.com/32680403/54482423-cbf0b980-4808-11e9-99ff-50a1e2b56d56.png)

It also seems to fix the drag-select issue reported in #291.