### PR TITLE
don't force noexcept policy for API calls

### DIFF
--- a/src/api/ApiCall.cpp
+++ b/src/api/ApiCall.cpp
@@ -9,25 +9,24 @@
 namespace ra {
 namespace api {
 
-static ra::api::IServer& Server() noexcept
+static ra::api::IServer& Server()
 {
-    GSL_SUPPRESS_F6
     return ra::services::ServiceLocator::GetMutable<ra::api::IServer>();
 }
 
-Login::Response Login::Request::Call() const noexcept { return Server().Login(*this); }
-Logout::Response Logout::Request::Call() const noexcept { return Server().Logout(*this); }
-StartSession::Response StartSession::Request::Call() const noexcept { return Server().StartSession(*this); }
-Ping::Response Ping::Request::Call() const noexcept { return Server().Ping(*this); }
-FetchUserUnlocks::Response FetchUserUnlocks::Request::Call() const noexcept { return Server().FetchUserUnlocks(*this); }
-AwardAchievement::Response AwardAchievement::Request::Call() const noexcept { return Server().AwardAchievement(*this); }
-SubmitLeaderboardEntry::Response SubmitLeaderboardEntry::Request::Call() const noexcept { return Server().SubmitLeaderboardEntry(*this); }
-ResolveHash::Response ResolveHash::Request::Call() const noexcept { return Server().ResolveHash(*this); }
-FetchGameData::Response FetchGameData::Request::Call() const noexcept { return Server().FetchGameData(*this); }
-FetchLeaderboardInfo::Response FetchLeaderboardInfo::Request::Call() const noexcept { return Server().FetchLeaderboardInfo(*this); }
-LatestClient::Response LatestClient::Request::Call() const noexcept { return Server().LatestClient(*this); }
-FetchGamesList::Response FetchGamesList::Request::Call() const noexcept { return Server().FetchGamesList(*this); }
-SubmitNewTitle::Response SubmitNewTitle::Request::Call() const noexcept { return Server().SubmitNewTitle(*this); }
+Login::Response Login::Request::Call() const { return Server().Login(*this); }
+Logout::Response Logout::Request::Call() const { return Server().Logout(*this); }
+StartSession::Response StartSession::Request::Call() const { return Server().StartSession(*this); }
+Ping::Response Ping::Request::Call() const { return Server().Ping(*this); }
+FetchUserUnlocks::Response FetchUserUnlocks::Request::Call() const { return Server().FetchUserUnlocks(*this); }
+AwardAchievement::Response AwardAchievement::Request::Call() const { return Server().AwardAchievement(*this); }
+SubmitLeaderboardEntry::Response SubmitLeaderboardEntry::Request::Call() const { return Server().SubmitLeaderboardEntry(*this); }
+ResolveHash::Response ResolveHash::Request::Call() const { return Server().ResolveHash(*this); }
+FetchGameData::Response FetchGameData::Request::Call() const { return Server().FetchGameData(*this); }
+FetchLeaderboardInfo::Response FetchLeaderboardInfo::Request::Call() const { return Server().FetchLeaderboardInfo(*this); }
+LatestClient::Response LatestClient::Request::Call() const { return Server().LatestClient(*this); }
+FetchGamesList::Response FetchGamesList::Request::Call() const { return Server().FetchGamesList(*this); }
+SubmitNewTitle::Response SubmitNewTitle::Request::Call() const { return Server().SubmitNewTitle(*this); }
 
 } // namespace api
 } // namespace ra

--- a/src/api/AwardAchievement.hh
+++ b/src/api/AwardAchievement.hh
@@ -25,7 +25,7 @@ public:
 
         using Callback = std::function<void(const Response& response)>;
 
-        Response Call() const noexcept;
+        Response Call() const;
 
         void CallAsync(Callback&& callback) const
         {

--- a/src/api/FetchGameData.hh
+++ b/src/api/FetchGameData.hh
@@ -53,7 +53,7 @@ public:
 
         using Callback = std::function<void(const Response& response)>;
 
-        Response Call() const noexcept;
+        Response Call() const;
 
         void CallAsync(Callback&& callback) const
         {

--- a/src/api/FetchGamesList.hh
+++ b/src/api/FetchGamesList.hh
@@ -31,7 +31,7 @@ public:
 
         using Callback = std::function<void(const Response& response)>;
 
-        Response Call() const noexcept;
+        Response Call() const;
 
         void CallAsync(Callback&& callback) const
         {

--- a/src/api/FetchLeaderboardInfo.hh
+++ b/src/api/FetchLeaderboardInfo.hh
@@ -37,7 +37,7 @@ public:
 
         using Callback = std::function<void(const Response& response)>;
 
-        Response Call() const noexcept;
+        Response Call() const;
 
         void CallAsync(Callback&& callback) const
         {

--- a/src/api/FetchUserUnlocks.hh
+++ b/src/api/FetchUserUnlocks.hh
@@ -24,7 +24,7 @@ public:
 
         using Callback = std::function<void(const Response& response)>;
 
-        Response Call() const noexcept;
+        Response Call() const;
 
         void CallAsync(Callback&& callback) const
         {

--- a/src/api/IServer.hh
+++ b/src/api/IServer.hh
@@ -25,23 +25,23 @@ public:
     virtual const char* Name() const noexcept = 0;
 
     // === user functions ===
-    virtual Login::Response Login(const Login::Request& request) noexcept = 0;
-    virtual Logout::Response Logout(const Logout::Request& request) noexcept = 0;
-    virtual StartSession::Response StartSession(const StartSession::Request& request) noexcept = 0;
-    virtual Ping::Response Ping(const Ping::Request& request) noexcept = 0;
-    virtual FetchUserUnlocks::Response FetchUserUnlocks(const FetchUserUnlocks::Request& request) noexcept = 0;
-    virtual AwardAchievement::Response AwardAchievement(const AwardAchievement::Request& request) noexcept = 0;
-    virtual SubmitLeaderboardEntry::Response SubmitLeaderboardEntry(const SubmitLeaderboardEntry::Request& request) noexcept = 0;
+    virtual Login::Response Login(const Login::Request& request) = 0;
+    virtual Logout::Response Logout(const Logout::Request& request) = 0;
+    virtual StartSession::Response StartSession(const StartSession::Request& request) = 0;
+    virtual Ping::Response Ping(const Ping::Request& request) = 0;
+    virtual FetchUserUnlocks::Response FetchUserUnlocks(const FetchUserUnlocks::Request& request) = 0;
+    virtual AwardAchievement::Response AwardAchievement(const AwardAchievement::Request& request) = 0;
+    virtual SubmitLeaderboardEntry::Response SubmitLeaderboardEntry(const SubmitLeaderboardEntry::Request& request) = 0;
 
     // === game functions ===
-    virtual ResolveHash::Response ResolveHash(const ResolveHash::Request& request) noexcept = 0;
-    virtual FetchGameData::Response FetchGameData(const FetchGameData::Request& request) noexcept = 0;
-    virtual FetchLeaderboardInfo::Response FetchLeaderboardInfo(const FetchLeaderboardInfo::Request& request) noexcept = 0;
+    virtual ResolveHash::Response ResolveHash(const ResolveHash::Request& request) = 0;
+    virtual FetchGameData::Response FetchGameData(const FetchGameData::Request& request) = 0;
+    virtual FetchLeaderboardInfo::Response FetchLeaderboardInfo(const FetchLeaderboardInfo::Request& request) = 0;
 
     // === other functions ===
-    virtual LatestClient::Response LatestClient(const LatestClient::Request& request) noexcept = 0;
-    virtual FetchGamesList::Response FetchGamesList(const FetchGamesList::Request& request) noexcept = 0;
-    virtual SubmitNewTitle::Response SubmitNewTitle(const SubmitNewTitle::Request& request) noexcept = 0;
+    virtual LatestClient::Response LatestClient(const LatestClient::Request& request) = 0;
+    virtual FetchGamesList::Response FetchGamesList(const FetchGamesList::Request& request) = 0;
+    virtual SubmitNewTitle::Response SubmitNewTitle(const SubmitNewTitle::Request& request) = 0;
 
 protected:
     IServer() noexcept = default;

--- a/src/api/LatestClient.hh
+++ b/src/api/LatestClient.hh
@@ -23,7 +23,7 @@ public:
 
         using Callback = std::function<void(const Response& response)>;
 
-        Response Call() const noexcept;
+        Response Call() const;
 
         void CallAsync(Callback&& callback) const
         {

--- a/src/api/Login.hh
+++ b/src/api/Login.hh
@@ -28,7 +28,7 @@ public:
 
         using Callback = std::function<void(const Response& response)>;
 
-        Response Call() const noexcept;
+        Response Call() const;
 
         void CallAsync(Callback&& callback) const
         {

--- a/src/api/Logout.hh
+++ b/src/api/Logout.hh
@@ -20,7 +20,7 @@ public:
     {
         using Callback = std::function<void(const Response& response)>;
 
-        Response Call() const noexcept;
+        Response Call() const;
 
         void CallAsync(Callback&& callback) const
         {

--- a/src/api/Ping.hh
+++ b/src/api/Ping.hh
@@ -23,7 +23,7 @@ public:
 
         using Callback = std::function<void(const Response& response)>;
 
-        Response Call() const noexcept;
+        Response Call() const;
 
         void CallAsync(Callback&& callback) const
         {

--- a/src/api/ResolveHash.hh
+++ b/src/api/ResolveHash.hh
@@ -23,7 +23,7 @@ public:
 
         using Callback = std::function<void(const Response& response)>;
 
-        Response Call() const noexcept;
+        Response Call() const;
 
         void CallAsync(Callback&& callback) const
         {

--- a/src/api/StartSession.hh
+++ b/src/api/StartSession.hh
@@ -22,7 +22,7 @@ public:
 
         using Callback = std::function<void(const Response& response)>;
 
-        Response Call() const noexcept;
+        Response Call() const;
 
         void CallAsync(Callback&& callback) const
         {

--- a/src/api/SubmitLeaderboardEntry.hh
+++ b/src/api/SubmitLeaderboardEntry.hh
@@ -37,7 +37,7 @@ public:
 
         using Callback = std::function<void(const Response& response)>;
 
-        Response Call() const noexcept;
+        Response Call() const;
 
         void CallAsync(Callback&& callback) const
         {

--- a/src/api/SubmitNewTitle.hh
+++ b/src/api/SubmitNewTitle.hh
@@ -25,7 +25,7 @@ public:
 
         using Callback = std::function<void(const Response& response)>;
 
-        Response Call() const noexcept;
+        Response Call() const;
 
         void CallAsync(Callback&& callback) const
         {

--- a/src/api/impl/ConnectedServer.cpp
+++ b/src/api/impl/ConnectedServer.cpp
@@ -221,7 +221,7 @@ static void AppendUrlParam(_Inout_ std::string& sParams, _In_ const char* const 
 
 // === APIs ===
 
-Login::Response ConnectedServer::Login(const Login::Request& request) noexcept
+Login::Response ConnectedServer::Login(const Login::Request& request)
 {
     ra::services::Http::Request httpRequest(ra::StringPrintf("%s/login_app.php", m_sHost));
 
@@ -256,7 +256,7 @@ Login::Response ConnectedServer::Login(const Login::Request& request) noexcept
     return std::move(response);
 }
 
-Logout::Response ConnectedServer::Logout(_UNUSED const Logout::Request& /*request*/) noexcept
+Logout::Response ConnectedServer::Logout(const Logout::Request&)
 {
     // update the global API pointer to a disconnected API
     ra::services::ServiceLocator::Provide<ra::api::IServer>(std::make_unique<DisconnectedServer>(m_sHost));
@@ -289,7 +289,7 @@ static bool DoRequest(const std::string& sHost, const char* restrict sApiName, c
     return GetJson(sApiName, httpResponse, pResponse, document);
 }
 
-StartSession::Response ConnectedServer::StartSession(const StartSession::Request& request) noexcept
+StartSession::Response ConnectedServer::StartSession(const StartSession::Request& request)
 {
     StartSession::Response response;
     rapidjson::Document document;
@@ -311,7 +311,7 @@ StartSession::Response ConnectedServer::StartSession(const StartSession::Request
     return std::move(response);
 }
 
-Ping::Response ConnectedServer::Ping(const Ping::Request& request) noexcept
+Ping::Response ConnectedServer::Ping(const Ping::Request& request)
 {
     Ping::Response response;
     rapidjson::Document document;
@@ -327,7 +327,7 @@ Ping::Response ConnectedServer::Ping(const Ping::Request& request) noexcept
     return std::move(response);
 }
 
-FetchUserUnlocks::Response ConnectedServer::FetchUserUnlocks(const FetchUserUnlocks::Request& request) noexcept
+FetchUserUnlocks::Response ConnectedServer::FetchUserUnlocks(const FetchUserUnlocks::Request& request)
 {
     FetchUserUnlocks::Response response;
     rapidjson::Document document;
@@ -356,7 +356,7 @@ FetchUserUnlocks::Response ConnectedServer::FetchUserUnlocks(const FetchUserUnlo
     return std::move(response);
 }
 
-AwardAchievement::Response ConnectedServer::AwardAchievement(const AwardAchievement::Request& request) noexcept
+AwardAchievement::Response ConnectedServer::AwardAchievement(const AwardAchievement::Request& request)
 {
     AwardAchievement::Response response;
     rapidjson::Document document;
@@ -376,7 +376,7 @@ AwardAchievement::Response ConnectedServer::AwardAchievement(const AwardAchievem
     return std::move(response);
 }
 
-SubmitLeaderboardEntry::Response ConnectedServer::SubmitLeaderboardEntry(const SubmitLeaderboardEntry::Request& request) noexcept
+SubmitLeaderboardEntry::Response ConnectedServer::SubmitLeaderboardEntry(const SubmitLeaderboardEntry::Request& request)
 {
     SubmitLeaderboardEntry::Response response;
     rapidjson::Document document;
@@ -440,7 +440,7 @@ SubmitLeaderboardEntry::Response ConnectedServer::SubmitLeaderboardEntry(const S
     return std::move(response);
 }
 
-ResolveHash::Response ConnectedServer::ResolveHash(const ResolveHash::Request& request) noexcept
+ResolveHash::Response ConnectedServer::ResolveHash(const ResolveHash::Request& request)
 {
     ResolveHash::Response response;
     rapidjson::Document document;
@@ -457,7 +457,7 @@ ResolveHash::Response ConnectedServer::ResolveHash(const ResolveHash::Request& r
     return std::move(response);
 }
 
-FetchGameData::Response ConnectedServer::FetchGameData(const FetchGameData::Request& request) noexcept
+FetchGameData::Response ConnectedServer::FetchGameData(const FetchGameData::Request& request)
 {
     FetchGameData::Response response;
     rapidjson::Document document;
@@ -496,7 +496,7 @@ FetchGameData::Response ConnectedServer::FetchGameData(const FetchGameData::Requ
     return std::move(response);
 }
 
-FetchLeaderboardInfo::Response ConnectedServer::FetchLeaderboardInfo(const FetchLeaderboardInfo::Request& request) noexcept
+FetchLeaderboardInfo::Response ConnectedServer::FetchLeaderboardInfo(const FetchLeaderboardInfo::Request& request)
 {
     FetchLeaderboardInfo::Response response;
     rapidjson::Document document;
@@ -613,7 +613,7 @@ void ConnectedServer::ProcessGamePatchData(ra::api::FetchGameData::Response &res
     }
 }
 
-LatestClient::Response ConnectedServer::LatestClient(const LatestClient::Request& request) noexcept
+LatestClient::Response ConnectedServer::LatestClient(const LatestClient::Request& request)
 {
     LatestClient::Response response;
     rapidjson::Document document;
@@ -637,7 +637,7 @@ LatestClient::Response ConnectedServer::LatestClient(const LatestClient::Request
     return response;
 }
 
-FetchGamesList::Response ConnectedServer::FetchGamesList(const FetchGamesList::Request& request) noexcept
+FetchGamesList::Response ConnectedServer::FetchGamesList(const FetchGamesList::Request& request)
 {
     FetchGamesList::Response response;
     rapidjson::Document document;
@@ -697,7 +697,7 @@ FetchGamesList::Response ConnectedServer::FetchGamesList(const FetchGamesList::R
     return response;
 }
 
-SubmitNewTitle::Response ConnectedServer::SubmitNewTitle(const SubmitNewTitle::Request& request) noexcept
+SubmitNewTitle::Response ConnectedServer::SubmitNewTitle(const SubmitNewTitle::Request& request)
 {
     SubmitNewTitle::Response response;
     rapidjson::Document document;

--- a/src/api/impl/ConnectedServer.hh
+++ b/src/api/impl/ConnectedServer.hh
@@ -13,19 +13,19 @@ public:
 
     const char* Name() const noexcept override { return m_sHost.c_str(); }
 
-    GSL_SUPPRESS_F6 Login::Response Login(const Login::Request& request) noexcept override;
-    GSL_SUPPRESS_F6 Logout::Response Logout(_UNUSED const Logout::Request& /*request*/) noexcept override;
-    GSL_SUPPRESS_F6 StartSession::Response StartSession(const StartSession::Request& request) noexcept override;
-    GSL_SUPPRESS_F6 Ping::Response Ping(const Ping::Request& request) noexcept override;
-    GSL_SUPPRESS_F6 FetchUserUnlocks::Response FetchUserUnlocks(const FetchUserUnlocks::Request& request) noexcept override;
-    GSL_SUPPRESS_F6 AwardAchievement::Response AwardAchievement(const AwardAchievement::Request& request) noexcept override;
-    GSL_SUPPRESS_F6 SubmitLeaderboardEntry::Response SubmitLeaderboardEntry(const SubmitLeaderboardEntry::Request& request) noexcept override;
-    GSL_SUPPRESS_F6 ResolveHash::Response ResolveHash(const ResolveHash::Request& request) noexcept override;
-    GSL_SUPPRESS_F6 FetchGameData::Response FetchGameData(const FetchGameData::Request& request) noexcept override;
-    GSL_SUPPRESS_F6 FetchLeaderboardInfo::Response FetchLeaderboardInfo(const FetchLeaderboardInfo::Request& request) noexcept override;
-    GSL_SUPPRESS_F6 LatestClient::Response LatestClient(const LatestClient::Request& request) noexcept override;
-    GSL_SUPPRESS_F6 FetchGamesList::Response FetchGamesList(const FetchGamesList::Request& request) noexcept override;
-    GSL_SUPPRESS_F6 SubmitNewTitle::Response SubmitNewTitle(const SubmitNewTitle::Request& request) noexcept override;
+    Login::Response Login(const Login::Request& request) override;
+    Logout::Response Logout(const Logout::Request&) override;
+    StartSession::Response StartSession(const StartSession::Request& request) override;
+    Ping::Response Ping(const Ping::Request& request) override;
+    FetchUserUnlocks::Response FetchUserUnlocks(const FetchUserUnlocks::Request& request) override;
+    AwardAchievement::Response AwardAchievement(const AwardAchievement::Request& request) override;
+    SubmitLeaderboardEntry::Response SubmitLeaderboardEntry(const SubmitLeaderboardEntry::Request& request) override;
+    ResolveHash::Response ResolveHash(const ResolveHash::Request& request) override;
+    FetchGameData::Response FetchGameData(const FetchGameData::Request& request) override;
+    FetchLeaderboardInfo::Response FetchLeaderboardInfo(const FetchLeaderboardInfo::Request& request) override;
+    LatestClient::Response LatestClient(const LatestClient::Request& request) override;
+    FetchGamesList::Response FetchGamesList(const FetchGamesList::Request& request) override;
+    SubmitNewTitle::Response SubmitNewTitle(const SubmitNewTitle::Request& request) override;
 
     static void ProcessGamePatchData(FetchGameData::Response &response, const rapidjson::Value& PatchData);
 

--- a/src/api/impl/DisconnectedServer.cpp
+++ b/src/api/impl/DisconnectedServer.cpp
@@ -8,7 +8,7 @@ namespace ra {
 namespace api {
 namespace impl {
 
-Login::Response DisconnectedServer::Login(const Login::Request& request) noexcept
+Login::Response DisconnectedServer::Login(const Login::Request& request)
 {
     // use the normal ServerApi to attempt to connect
     auto serverApi = std::make_unique<ConnectedServer>(m_sHost);
@@ -22,7 +22,7 @@ Login::Response DisconnectedServer::Login(const Login::Request& request) noexcep
     return response;
 }
 
-LatestClient::Response DisconnectedServer::LatestClient(const LatestClient::Request& request) noexcept
+LatestClient::Response DisconnectedServer::LatestClient(const LatestClient::Request& request)
 {
     // LatestClient call doesn't require being logged in. Dispatch to the ConnectedServer::LatestClient method.
     ConnectedServer serverApi(m_sHost);

--- a/src/api/impl/DisconnectedServer.hh
+++ b/src/api/impl/DisconnectedServer.hh
@@ -13,10 +13,10 @@ public:
 
     const char* Name() const noexcept override { return "disconnected client"; }
 
-    GSL_SUPPRESS_F6 Login::Response Login(const Login::Request& request) noexcept override;
+    Login::Response Login(const Login::Request& request) override;
     const std::string& Host() const noexcept { return m_sHost; }
 
-    GSL_SUPPRESS_F6 LatestClient::Response LatestClient(const LatestClient::Request& request) noexcept override;
+    LatestClient::Response LatestClient(const LatestClient::Request& request) override;
 
 private:
     const std::string m_sHost;

--- a/src/api/impl/OfflineServer.cpp
+++ b/src/api/impl/OfflineServer.cpp
@@ -11,9 +11,8 @@ namespace ra {
 namespace api {
 namespace impl {
 
-Login::Response OfflineServer::Login(const Login::Request& request) noexcept
+Login::Response OfflineServer::Login(const Login::Request& request)
 {
-    
     Login::Response response;
     response.Result = ApiResult::Success;
     response.Username = request.Username;
@@ -21,14 +20,14 @@ Login::Response OfflineServer::Login(const Login::Request& request) noexcept
     return std::move(response);
 }
 
-Logout::Response OfflineServer::Logout(_UNUSED const Logout::Request& /*request*/) noexcept
+Logout::Response OfflineServer::Logout(const Logout::Request&)
 {
     Logout::Response response;
     response.Result = ApiResult::Success;
     return std::move(response);
 }
 
-FetchGameData::Response OfflineServer::FetchGameData(const FetchGameData::Request& request) noexcept
+FetchGameData::Response OfflineServer::FetchGameData(const FetchGameData::Request& request)
 {
     FetchGameData::Response response;
     rapidjson::Document document;

--- a/src/api/impl/OfflineServer.hh
+++ b/src/api/impl/OfflineServer.hh
@@ -11,10 +11,10 @@ class OfflineServer : public ServerBase
 public:
     const char* Name() const noexcept override { return "offline client"; }
 
-    GSL_SUPPRESS_F6 Login::Response Login(const Login::Request& request) noexcept override;
-    Logout::Response Logout(_UNUSED const Logout::Request& /*request*/) noexcept override;
+    Login::Response Login(const Login::Request& request) override;
+    Logout::Response Logout(const Logout::Request&) override;
 
-    GSL_SUPPRESS_F6 FetchGameData::Response FetchGameData(const FetchGameData::Request& request) noexcept override;
+    FetchGameData::Response FetchGameData(const FetchGameData::Request& request) override;
 };
 
 } // namespace impl

--- a/src/api/impl/ServerBase.hh
+++ b/src/api/impl/ServerBase.hh
@@ -17,97 +17,83 @@ class ServerBase : public IServer
 {
 public:
     // === user functions ===
-    Login::Response Login(_UNUSED const Login::Request& /*request*/) noexcept override
+    Login::Response Login(const Login::Request&) override
     {
-        GSL_SUPPRESS_F6
         return UnsupportedApi<Login::Response>(Login::Name());
     }
 
-    Logout::Response Logout(_UNUSED const Logout::Request& /*request*/) noexcept override
+    Logout::Response Logout(const Logout::Request&) override
     {
-        GSL_SUPPRESS_F6
         return UnsupportedApi<Logout::Response>(Logout::Name());
     }
 
-    StartSession::Response StartSession(_UNUSED const StartSession::Request& /*request*/) noexcept override
+    StartSession::Response StartSession(const StartSession::Request&) override
     {
-        GSL_SUPPRESS_F6
         return UnsupportedApi<StartSession::Response>(StartSession::Name());
     }
 
-    Ping::Response Ping(_UNUSED const Ping::Request& /*request*/) noexcept override
+    Ping::Response Ping(const Ping::Request&) override
     {
-        GSL_SUPPRESS_F6
         return UnsupportedApi<Ping::Response>(Ping::Name());
     }
 
-    FetchUserUnlocks::Response FetchUserUnlocks(_UNUSED const FetchUserUnlocks::Request& /*request*/) noexcept override
+    FetchUserUnlocks::Response FetchUserUnlocks(const FetchUserUnlocks::Request&) override
     {
-        GSL_SUPPRESS_F6
         return UnsupportedApi<FetchUserUnlocks::Response>(FetchUserUnlocks::Name());
     }
 
-    AwardAchievement::Response AwardAchievement(_UNUSED const AwardAchievement::Request& /*request*/) noexcept override
+    AwardAchievement::Response AwardAchievement(const AwardAchievement::Request&) override
     {
-        GSL_SUPPRESS_F6
         return UnsupportedApi<AwardAchievement::Response>(AwardAchievement::Name());
     }
 
-    SubmitLeaderboardEntry::Response SubmitLeaderboardEntry(_UNUSED const SubmitLeaderboardEntry::Request& /*request*/) noexcept override
+    SubmitLeaderboardEntry::Response SubmitLeaderboardEntry(const SubmitLeaderboardEntry::Request&) override
     {
-        GSL_SUPPRESS_F6
         return UnsupportedApi<SubmitLeaderboardEntry::Response>(SubmitLeaderboardEntry::Name());
     }
 
     // === game functions ===
 
-    ResolveHash::Response ResolveHash(_UNUSED const ResolveHash::Request& /*request*/) noexcept override
+    ResolveHash::Response ResolveHash(const ResolveHash::Request&) override
     {
-        GSL_SUPPRESS_F6
         return UnsupportedApi<ResolveHash::Response>(ResolveHash::Name());
     }
 
-    FetchGameData::Response FetchGameData(_UNUSED const FetchGameData::Request& /*request*/) noexcept override
+    FetchGameData::Response FetchGameData(const FetchGameData::Request&) override
     {
-        GSL_SUPPRESS_F6
         return UnsupportedApi<FetchGameData::Response>(FetchGameData::Name());
     }
 
-    FetchLeaderboardInfo::Response FetchLeaderboardInfo(_UNUSED const FetchLeaderboardInfo::Request& /*request*/) noexcept override
+    FetchLeaderboardInfo::Response FetchLeaderboardInfo(const FetchLeaderboardInfo::Request&) override
     {
-        GSL_SUPPRESS_F6
         return UnsupportedApi<FetchLeaderboardInfo::Response>(FetchLeaderboardInfo::Name());
     }
 
     // === other functions ===
 
-    LatestClient::Response LatestClient(_UNUSED const LatestClient::Request& /*request*/) noexcept override
+    LatestClient::Response LatestClient(const LatestClient::Request&) override
     {
-        GSL_SUPPRESS_F6
         return UnsupportedApi<LatestClient::Response>(LatestClient::Name());
     }
 
-    FetchGamesList::Response FetchGamesList(_UNUSED const FetchGamesList::Request& /*request*/) noexcept override
+    FetchGamesList::Response FetchGamesList(const FetchGamesList::Request&) override
     {
-        GSL_SUPPRESS_F6
         return UnsupportedApi<FetchGamesList::Response>(FetchGamesList::Name());
     }
 
-    SubmitNewTitle::Response SubmitNewTitle(_UNUSED const SubmitNewTitle::Request& /*request*/) noexcept override
+    SubmitNewTitle::Response SubmitNewTitle(const SubmitNewTitle::Request&) override
     {
-        GSL_SUPPRESS_F6
         return UnsupportedApi<SubmitNewTitle::Response>(SubmitNewTitle::Name());
     }
 
 protected:
     template<typename TResponse>
-    inline typename TResponse UnsupportedApi(const char* const restrict apiName) const noexcept
+    inline typename TResponse UnsupportedApi(const char* const restrict apiName) const
     {
         static_assert(std::is_base_of<ApiResponseBase, TResponse>::value, "TResponse must derive from ApiResponseBase");
 
         TResponse response;
         response.Result = ApiResult::Unsupported;
-        GSL_SUPPRESS_F6
         response.ErrorMessage = ra::StringPrintf("%s is not supported by %s.", apiName, Name());
         return response;
     }

--- a/tests/mocks/MockServer.hh
+++ b/tests/mocks/MockServer.hh
@@ -56,79 +56,78 @@ public:
 
     // === user functions ===
 
-    Login::Response Login(const Login::Request& request) noexcept override
+    Login::Response Login(const Login::Request& request) override
     {
         return HandleRequest<ra::api::Login>(request);
     }
 
-    Logout::Response Logout(const Logout::Request& request) noexcept override
+    Logout::Response Logout(const Logout::Request& request) override
     {
         return HandleRequest<ra::api::Logout>(request);
     }
 
-    StartSession::Response StartSession(const StartSession::Request& request) noexcept override
+    StartSession::Response StartSession(const StartSession::Request& request) override
     {
         return HandleRequest<ra::api::StartSession>(request);
     }
 
-    Ping::Response Ping(const Ping::Request& request) noexcept override
+    Ping::Response Ping(const Ping::Request& request) override
     {
         return HandleRequest<ra::api::Ping>(request);
     }
 
-    FetchUserUnlocks::Response FetchUserUnlocks(const FetchUserUnlocks::Request& request) noexcept override
+    FetchUserUnlocks::Response FetchUserUnlocks(const FetchUserUnlocks::Request& request) override
     {
         return HandleRequest<ra::api::FetchUserUnlocks>(request);
     }
 
-    AwardAchievement::Response AwardAchievement(const AwardAchievement::Request& request) noexcept override
+    AwardAchievement::Response AwardAchievement(const AwardAchievement::Request& request) override
     {
         return HandleRequest<ra::api::AwardAchievement>(request);
     }
 
-    SubmitLeaderboardEntry::Response SubmitLeaderboardEntry(const SubmitLeaderboardEntry::Request& request) noexcept override
+    SubmitLeaderboardEntry::Response SubmitLeaderboardEntry(const SubmitLeaderboardEntry::Request& request) override
     {
         return HandleRequest<ra::api::SubmitLeaderboardEntry>(request);
     }
 
     // === game functions ===
 
-    ResolveHash::Response ResolveHash(const ResolveHash::Request& request) noexcept override
+    ResolveHash::Response ResolveHash(const ResolveHash::Request& request) override
     {
         return HandleRequest<ra::api::ResolveHash>(request);
     }
 
-    FetchGameData::Response FetchGameData(const FetchGameData::Request& request) noexcept override
+    FetchGameData::Response FetchGameData(const FetchGameData::Request& request) override
     {
         return HandleRequest<ra::api::FetchGameData>(request);
     }
 
-    FetchLeaderboardInfo::Response FetchLeaderboardInfo(const FetchLeaderboardInfo::Request& request) noexcept override
+    FetchLeaderboardInfo::Response FetchLeaderboardInfo(const FetchLeaderboardInfo::Request& request) override
     {
         return HandleRequest<ra::api::FetchLeaderboardInfo>(request);
     }
 
     // === other functions ===
 
-    LatestClient::Response LatestClient(const LatestClient::Request& request) noexcept override
+    LatestClient::Response LatestClient(const LatestClient::Request& request) override
     {
         return HandleRequest<ra::api::LatestClient>(request);
     }
 
-    FetchGamesList::Response FetchGamesList(const FetchGamesList::Request& request) noexcept override
+    FetchGamesList::Response FetchGamesList(const FetchGamesList::Request& request) override
     {
         return HandleRequest<ra::api::FetchGamesList>(request);
     }
 
-    SubmitNewTitle::Response SubmitNewTitle(const SubmitNewTitle::Request& request) noexcept override
+    SubmitNewTitle::Response SubmitNewTitle(const SubmitNewTitle::Request& request) override
     {
         return HandleRequest<ra::api::SubmitNewTitle>(request);
     }
 
 protected:
     template<typename TApi>
-    GSL_SUPPRESS_F6
-    inline auto HandleRequest(const ApiRequestBase& pRequest) const noexcept
+    inline auto HandleRequest(const ApiRequestBase& pRequest) const
     {
         typename TApi::Response response;
         std::string sApiName(TApi::Name());


### PR DESCRIPTION
Eliminates the need to suppress analysis rules for virtual method override implementations that may call functions that may throw exceptions. Even if we don't want these methods to throw exceptions, telling the compiler that they never will is misleading.