### PR TITLE
Add mode to test game compatibility without linking

### DIFF
--- a/src/RA_Dlg_Achievement.cpp
+++ b/src/RA_Dlg_Achievement.cpp
@@ -1039,7 +1039,7 @@ INT_PTR Dlg_Achievements::CommitAchievements(HWND hDlg)
     return TRUE;
 }
 
-void Dlg_Achievements::UpdateSelectedAchievementButtons(const Achievement* restrict Cheevo) noexcept
+void Dlg_Achievements::UpdateSelectedAchievementButtons(const Achievement* restrict Cheevo)
 {
     if (Cheevo == nullptr)
     {
@@ -1054,12 +1054,22 @@ void Dlg_Achievements::UpdateSelectedAchievementButtons(const Achievement* restr
     else
     {
         EnableWindow(GetDlgItem(m_hAchievementsDlg, IDC_RA_REVERTSELECTED), Cheevo->Modified());
-        EnableWindow(GetDlgItem(m_hAchievementsDlg, IDC_RA_COMMIT_ACH),
-                     g_nActiveAchievementSet == AchievementSet::Type::Local ? TRUE : Cheevo->Modified());
         EnableWindow(GetDlgItem(m_hAchievementsDlg, IDC_RA_CLONE_ACH), TRUE);
         EnableWindow(GetDlgItem(m_hAchievementsDlg, IDC_RA_DEL_ACH),
                      g_nActiveAchievementSet == AchievementSet::Type::Local);
-        EnableWindow(GetDlgItem(m_hAchievementsDlg, IDC_RA_PROMOTE_ACH), TRUE);
+
+        if (ra::services::ServiceLocator::Get<ra::data::GameContext>().GetMode() == ra::data::GameContext::Mode::CompatibilityTest)
+        {
+            EnableWindow(GetDlgItem(m_hAchievementsDlg, IDC_RA_COMMIT_ACH),
+                g_nActiveAchievementSet == AchievementSet::Type::Local);
+            EnableWindow(GetDlgItem(m_hAchievementsDlg, IDC_RA_PROMOTE_ACH), FALSE);
+        }
+        else
+        {
+            EnableWindow(GetDlgItem(m_hAchievementsDlg, IDC_RA_COMMIT_ACH),
+                g_nActiveAchievementSet == AchievementSet::Type::Local ? TRUE : Cheevo->Modified());
+            EnableWindow(GetDlgItem(m_hAchievementsDlg, IDC_RA_PROMOTE_ACH), TRUE);
+        }
 
         if (g_nActiveAchievementSet != AchievementSet::Type::Core)
         {

--- a/src/RA_Dlg_Achievement.h
+++ b/src/RA_Dlg_Achievement.h
@@ -59,7 +59,7 @@ private:
 
     INT_PTR CommitAchievements(HWND hDlg);
 
-    void UpdateSelectedAchievementButtons(const Achievement* restrict Cheevo) noexcept;
+    void UpdateSelectedAchievementButtons(const Achievement* restrict Cheevo);
 
 private:
     HWND m_hAchievementsDlg = nullptr;

--- a/src/RA_Dlg_AchievementsReporter.cpp
+++ b/src/RA_Dlg_AchievementsReporter.cpp
@@ -255,6 +255,8 @@ void Dlg_AchievementsReporter::DoModalDialog(HINSTANCE hInst, HWND hParent)
         ra::ui::viewmodels::MessageBoxViewModel::ShowErrorMessage(L"You must load a game before you can report broken achievements.");
     else if (pGameContext.ActiveAchievementType() == AchievementSet::Type::Local)
         ra::ui::viewmodels::MessageBoxViewModel::ShowErrorMessage(L"You cannot report broken local achievements.");
+    else if (pGameContext.GetMode() == ra::data::GameContext::Mode::CompatibilityTest)
+        ra::ui::viewmodels::MessageBoxViewModel::ShowErrorMessage(L"You cannot report broken achievements in compatibility test mode.");
     else if (g_pActiveAchievements->NumAchievements() == 0)
         ra::ui::viewmodels::MessageBoxViewModel::ShowErrorMessage(L"There are no active achievements to report.");
     else

--- a/src/RA_Dlg_Memory.cpp
+++ b/src/RA_Dlg_Memory.cpp
@@ -1606,9 +1606,19 @@ void Dlg_Memory::OnLoad_NewRom()
         SetDlgItemText(g_MemoryDialog.m_hWnd, IDC_RA_WATCHING, TEXT("Loading..."));
         RepopulateMemNotesFromFile();
 
-        EnableWindow(GetDlgItem(g_MemoryDialog.m_hWnd, IDC_RA_ADDNOTE), TRUE);
-        EnableWindow(GetDlgItem(g_MemoryDialog.m_hWnd, IDC_RA_MEMSAVENOTE), TRUE);
-        EnableWindow(GetDlgItem(g_MemoryDialog.m_hWnd, IDC_RA_REMNOTE), TRUE);
+        if (pGameContext.GetMode() == ra::data::GameContext::Mode::CompatibilityTest)
+        {
+            EnableWindow(GetDlgItem(g_MemoryDialog.m_hWnd, IDC_RA_ADDNOTE), FALSE);
+            EnableWindow(GetDlgItem(g_MemoryDialog.m_hWnd, IDC_RA_MEMSAVENOTE), FALSE);
+            EnableWindow(GetDlgItem(g_MemoryDialog.m_hWnd, IDC_RA_REMNOTE), FALSE);
+        }
+        else
+        {
+            EnableWindow(GetDlgItem(g_MemoryDialog.m_hWnd, IDC_RA_ADDNOTE), TRUE);
+            EnableWindow(GetDlgItem(g_MemoryDialog.m_hWnd, IDC_RA_MEMSAVENOTE), TRUE);
+            EnableWindow(GetDlgItem(g_MemoryDialog.m_hWnd, IDC_RA_REMNOTE), TRUE);
+        }
+
         EnableWindow(GetDlgItem(g_MemoryDialog.m_hWnd, IDC_RA_OPENPAGE), TRUE);
     }
 

--- a/src/data/GameContext.hh
+++ b/src/data/GameContext.hh
@@ -21,10 +21,16 @@ public:
     GameContext(GameContext&&) noexcept = delete;
     GameContext& operator=(GameContext&&) noexcept = delete;
 
+    enum class Mode
+    {
+        Normal,
+        CompatibilityTest,
+    };
+
     /// <summary>
     /// Loads the data for the specified game id.
     /// </summary>
-    void LoadGame(unsigned int nGameId);
+    void LoadGame(unsigned int nGameId, Mode nMode = Mode::Normal);
 
     /// <summary>
     /// Gets the unique identifier of the currently loaded game.
@@ -50,6 +56,11 @@ public:
     /// Sets the game hash.
     /// </summary>
     void SetGameHash(const std::string& sGameHash) { m_sGameHash = sGameHash; }
+
+    /// <summary>
+    /// Gets the current game play mode.
+    /// </summary>
+    Mode GetMode() const noexcept { return m_nMode; }
 
     /// <summary>
     /// Gets which achievements are active.
@@ -183,10 +194,12 @@ protected:
     void MergeLocalAchievements();
     bool ReloadAchievement(Achievement& pAchievement);
     void RefreshUnlocks(bool bUnpause);
+    void UpdateUnlocks(const std::set<unsigned int>& vUnlockedAchievements, bool bUnpause);
 
     unsigned int m_nGameId = 0;
     std::wstring m_sGameTitle;
     std::string m_sGameHash;
+    Mode m_nMode{};
 
     unsigned int m_nNextLocalId = 0;
     static const unsigned int FirstLocalId = 111000001;

--- a/src/data/SessionTracker.cpp
+++ b/src/data/SessionTracker.cpp
@@ -249,6 +249,9 @@ std::wstring SessionTracker::GetCurrentActivity() const
         if (!HasCoreAchievements(pGameContext))
             return L"Developing Achievements";
 
+        if (pGameContext.GetMode() == ra::data::GameContext::Mode::CompatibilityTest)
+            return L"Testing Compatibility";
+
         if (_RA_HardcoreModeIsActive())
             return L"Inspecting Memory in Hardcore mode";
 

--- a/src/ui/viewmodels/UnknownGameViewModel.cpp
+++ b/src/ui/viewmodels/UnknownGameViewModel.cpp
@@ -20,6 +20,7 @@ const StringModelProperty UnknownGameViewModel::NewGameNameProperty("UnknownGame
 const StringModelProperty UnknownGameViewModel::ChecksumProperty("UnknownGameViewModel", "Checksum", L"");
 const StringModelProperty UnknownGameViewModel::EstimatedGameNameProperty("UnknownGameViewModel", "EstimatedGameName", L"");
 const StringModelProperty UnknownGameViewModel::SystemNameProperty("UnknownGameViewModel", "SystemName", L"");
+const BoolModelProperty UnknownGameViewModel::TestModeProperty("UnknownGameViewModel", "TestMode", false);
 
 UnknownGameViewModel::UnknownGameViewModel() noexcept
 {
@@ -113,8 +114,22 @@ bool UnknownGameViewModel::Associate()
 
 bool UnknownGameViewModel::BeginTest()
 {
-    ra::ui::viewmodels::MessageBoxViewModel::ShowErrorMessage(*this, L"This feature is not yet supported.");
-    return false;
+    const auto nGameId = GetSelectedGameId();
+    if (nGameId == 0U)
+    {
+        ra::ui::viewmodels::MessageBoxViewModel::ShowErrorMessage(*this, L"You must select an existing game to test compatibility.");
+        return false;
+    }
+
+    ra::ui::viewmodels::MessageBoxViewModel vmMessageBox;
+    vmMessageBox.SetHeader(ra::StringPrintf(L"Play '%s' in compatability test mode?", m_vGameTitles.GetLabelForId(nGameId)));
+    vmMessageBox.SetMessage(L"Achievements and leaderboards for the game will be loaded, but you will not be able to earn or modify them or modify code notes for the game.");
+    vmMessageBox.SetButtons(ra::ui::viewmodels::MessageBoxViewModel::Buttons::YesNo);
+    if (vmMessageBox.ShowModal(*this) == DialogResult::No)
+        return false;
+
+    SetTestMode(true);
+    return true;
 }
 
 void UnknownGameViewModel::OnViewModelStringValueChanged(const StringModelProperty::ChangeArgs& args)

--- a/src/ui/viewmodels/UnknownGameViewModel.hh
+++ b/src/ui/viewmodels/UnknownGameViewModel.hh
@@ -39,7 +39,7 @@ public:
     /// <summary>
     /// Sets the selected game ID.
     /// </summary>
-    void SetSelectedGameId(int sValue) { SetValue(SelectedGameIdProperty, sValue); }
+    void SetSelectedGameId(int nValue) { SetValue(SelectedGameIdProperty, nValue); }
     
     /// <summary>
     /// Gets the list of known game titles and their IDs
@@ -118,6 +118,21 @@ public:
     /// Sets the system name.
     /// </summary>
     void SetSystemName(const std::wstring& sValue) { SetValue(SystemNameProperty, sValue); }
+
+    /// <summary>
+    /// The <see cref="ModelProperty" /> for the whether test mode is selected.
+    /// </summary>
+    static const BoolModelProperty TestModeProperty;
+
+    /// <summary>
+    /// Gets whether test mode is selected.
+    /// </summary>
+    bool GetTestMode() const { return GetValue(TestModeProperty); }
+
+    /// <summary>
+    /// Sets whether test mode is selected.
+    /// </summary>
+    void SetTestMode(bool bValue) { SetValue(TestModeProperty, bValue); }
 
     /// <summary>
     /// Command handler for Associate button.

--- a/tests/data/SessionTracker_Tests.cpp
+++ b/tests/data/SessionTracker_Tests.cpp
@@ -354,6 +354,14 @@ public:
         Assert::AreEqual(std::wstring(L"Level 10"), tracker.GetActivity());
     }
 
+    TEST_METHOD(TestCurrentActivityRichPresenceCompatibilityMode)
+    {
+        SessionTrackerHarness tracker;
+        tracker.mockGameContext.SetMode(ra::data::GameContext::Mode::CompatibilityTest);
+        tracker.mockGameContext.SetRichPresenceDisplayString(L"Level 10");
+        Assert::AreEqual(std::wstring(L"Level 10"), tracker.GetActivity());
+    }
+
     TEST_METHOD(TestCurrentActivityInspectingMemoryNoAchievements)
     {
         SessionTrackerHarness tracker;
@@ -376,6 +384,15 @@ public:
         tracker.mockGameContext.NewAchievement(AchievementSet::Type::Core);
         tracker.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, true);
         Assert::AreEqual(std::wstring(L"Inspecting Memory in Hardcore mode"), tracker.GetActivity());
+    }
+
+    TEST_METHOD(TestCurrentActivityInspectingMemoryCompatibilityMode)
+    {
+        SessionTrackerHarness tracker;
+        tracker.mockGameContext.NewAchievement(AchievementSet::Type::Core);
+        tracker.mockGameContext.SetMode(ra::data::GameContext::Mode::CompatibilityTest);
+        tracker.MockInspectingMemory(true);
+        Assert::AreEqual(std::wstring(L"Testing Compatibility"), tracker.GetActivity());
     }
 
     TEST_METHOD(TestCurrentActivityInspectingMemoryCoreAchievements)

--- a/tests/mocks/MockGameContext.hh
+++ b/tests/mocks/MockGameContext.hh
@@ -23,6 +23,11 @@ public:
     /// </summary>
     void SetGameId(unsigned int nGameId) noexcept { m_nGameId = nGameId; }
 
+    /// <summary>
+    /// Sets the play mode for the currently loaded game.
+    /// </summary>
+    void SetMode(Mode nMode) noexcept { m_nMode = nMode; }
+
     bool HasRichPresence() const noexcept override { return !m_sRichPresenceDisplayString.empty(); }
 
     std::wstring GetRichPresenceDisplayString() const override { return m_sRichPresenceDisplayString; }


### PR DESCRIPTION
When selecting "Test" from the "Unknown Game" dialog, you can load an existing game to test for compatibility without actually linking the hash. 

In this mode, the achievements and leaderboards are downloaded and activated (regardless of which achievements the player may have previously earned). When the player triggers an achievement, the achievement notification is popped up with a "Test" modifier, but the server is not notified. Similarly, if a leaderboard submission would occur, the popup appears with a "Not applicable in test mode" warning and no submission. Additionally, the ability to edit code notes is disabled, and the ability to commit and promote achievements is disabled.