### PR TITLE
Remove /w45045 from test project configuration

### DIFF
--- a/tests/RA_Integration.Tests.vcxproj
+++ b/tests/RA_Integration.Tests.vcxproj
@@ -153,7 +153,6 @@
       <UseFullPaths>true</UseFullPaths>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <DisableSpecificWarnings>4201</DisableSpecificWarnings>
-      <AdditionalOptions>/w45045 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
I can see value in displaying warnings for code where Spectre mitigations can be inserted in the distributed integration code, but for tests it is irrelevant. This avoids displaying the C5045 informational warning by default for that project only.