### PR TITLE
Include stdexcept in RA_Interface.cpp

### DIFF
--- a/src/RA_Interface.cpp
+++ b/src/RA_Interface.cpp
@@ -4,6 +4,7 @@
 
 #include <winhttp.h>
 #include <cassert>
+#include <stdexcept>
 #include <string>
 
 //Note: this is ALL public facing! :S tbd tidy up this bit


### PR DESCRIPTION
VS2019 fails to compile the interface into emulators without this include. This fix is backwards compatible with VS2017. Tested with RASCV.

This is due to the reference to `std::runtime_error&`, which returns E0135 (namespace "std" has no member "runtime_error").