### PR TITLE
Add banked RAM to the GB/C memory map

### DIFF
--- a/src/data/ConsoleContext.cpp
+++ b/src/data/ConsoleContext.cpp
@@ -122,6 +122,7 @@ const std::vector<ConsoleContext::MemoryRegion> GameBoyConsoleContext::m_vMemory
     { 0xFF00U, 0xFF7FU, ConsoleContext::AddressType::HardwareController, "Hardware I/O"},
     { 0xFF80U, 0xFFFEU, ConsoleContext::AddressType::SystemRAM, "Quick RAM"},
     { 0xFFFFU, 0xFFFFU, ConsoleContext::AddressType::HardwareController, "Interrupt enable"},
+    { 0x10000U, 0x16FFFU, ConsoleContext::AddressType::SystemRAM, "System RAM (static pages)" }, // 7 banks, GBC only
 };
 
 // ===== GameBoy Advance =====


### PR DESCRIPTION
Note that the actual size is different depending on the system (GB/GBC). I prefer avoiding to create two distinct memory maps, but if there are issues caused by defining a memory region that can be larger than the emulator's map, I can change it.