### PR TITLE
switch to three-line popups

### DIFF
--- a/src/Exports.cpp
+++ b/src/Exports.cpp
@@ -87,11 +87,12 @@ static void HandleLoginResponse(const ra::api::Login::Response& response)
         ra::services::ServiceLocator::Get<ra::services::IAudioSystem>().PlayAudioFile(L"Overlay\\login.wav");
 
         ra::ui::viewmodels::PopupMessageViewModel message;
-        message.SetTitle(ra::StringPrintf(L"Welcome %s%s (%u)", pSessionTracker.HasSessionData() ? L"back " : L"",
-            response.Username.c_str(), response.Score));
+        message.SetTitle(ra::StringPrintf(L"Welcome %s%s", pSessionTracker.HasSessionData() ? L"back " : L"",
+            response.Username.c_str()));
         message.SetDescription((response.NumUnreadMessages == 1)
             ? L"You have 1 new message"
             : ra::StringPrintf(L"You have %u new messages", response.NumUnreadMessages));
+        message.SetDetail(ra::StringPrintf(L"%u points", response.Score));
         message.SetImage(ra::ui::ImageType::UserPic, response.Username);
         ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().QueueMessage(std::move(message));
 
@@ -285,8 +286,7 @@ API void CCONV _RA_DoAchievementsFrame()
                     {
                         ra::services::ServiceLocator::Get<ra::services::IAudioSystem>().PlayAudioFile(L"Overlay\\lb.wav");
                         ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().QueueMessage(
-                            ra::StringPrintf(L"Challenge Available: %s", pLeaderboard->Title()),
-                            ra::Widen(pLeaderboard->Description()));
+                            L"Challenge Available", ra::Widen(pLeaderboard->Title()), ra::Widen(pLeaderboard->Description()));
                     }
 
                     auto& pOverlayManager = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>();
@@ -325,7 +325,7 @@ API void CCONV _RA_DoAchievementsFrame()
                     {
                         ra::services::ServiceLocator::Get<ra::services::IAudioSystem>().PlayAudioFile(L"Overlay\\lbcancel.wav");
                         ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().QueueMessage(
-                            L"Leaderboard attempt canceled!", ra::Widen(pLeaderboard->Title()));
+                            L"Leaderboard attempt canceled!", ra::Widen(pLeaderboard->Title()), ra::Widen(pLeaderboard->Description()));
                     }
 
                     auto& pOverlayManager = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>();

--- a/src/data/GameContext.cpp
+++ b/src/data/GameContext.cpp
@@ -590,6 +590,7 @@ void GameContext::AwardAchievement(unsigned int nAchievementId) const
 
     ra::ui::viewmodels::PopupMessageViewModel vmPopup;
     vmPopup.SetDescription(ra::StringPrintf(L"%s (%u)", pAchievement->Title(), pAchievement->Points()));
+    vmPopup.SetDetail(ra::Widen(pAchievement->Description()));
     vmPopup.SetImage(ra::ui::ImageType::Badge, pAchievement->BadgeImageURI());
 
     switch (ra::itoe<AchievementSet::Type>(pAchievement->Category()))

--- a/src/data/GameContext.cpp
+++ b/src/data/GameContext.cpp
@@ -154,23 +154,23 @@ void GameContext::LoadGame(unsigned int nGameId, Mode nMode)
     m_nNextLocalId = GameContext::FirstLocalId;
     MergeLocalAchievements();
 
-    // get user unlocks asynchronously
-    RefreshUnlocks(!bWasPaused);
-
     // show "game loaded" popup
     ra::services::ServiceLocator::Get<ra::services::IAudioSystem>().PlayAudioFile(L"Overlay\\info.wav");
-    ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().QueueMessage(
+    const auto nPopup = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().QueueMessage(
         ra::StringPrintf(L"Loaded %s", response.Title),
-        ra::StringPrintf(L"%u achievements, Total Score %u", nNumCoreAchievements, nTotalCoreAchievementPoints),
+        ra::StringPrintf(L"%u achievements, %u points", nNumCoreAchievements, nTotalCoreAchievementPoints),
         ra::ui::ImageType::Icon, response.ImageIcon);
+
+    // get user unlocks asynchronously
+    RefreshUnlocks(!bWasPaused, nPopup);
 }
 
-void GameContext::RefreshUnlocks(bool bUnpause)
+void GameContext::RefreshUnlocks(bool bUnpause, int nPopup)
 {
     if (m_nMode == Mode::CompatibilityTest)
     {
         std::set<unsigned int> vUnlockedAchievements;
-        UpdateUnlocks(vUnlockedAchievements, bUnpause);
+        UpdateUnlocks(vUnlockedAchievements, bUnpause, nPopup);
         return;
     }
 
@@ -179,13 +179,13 @@ void GameContext::RefreshUnlocks(bool bUnpause)
     ra::api::FetchUserUnlocks::Request request;
     request.GameId = m_nGameId;
     request.Hardcore = pConfiguration.IsFeatureEnabled(ra::services::Feature::Hardcore);
-    request.CallAsync([this, bUnpause](const ra::api::FetchUserUnlocks::Response& response)
+    request.CallAsync([this, bUnpause, nPopup](const ra::api::FetchUserUnlocks::Response& response)
     {
-        UpdateUnlocks(response.UnlockedAchievements, bUnpause);
+        UpdateUnlocks(response.UnlockedAchievements, bUnpause, nPopup);
     });
 }
 
-void GameContext::UpdateUnlocks(const std::set<unsigned int>& vUnlockedAchievements, bool bUnpause)
+void GameContext::UpdateUnlocks(const std::set<unsigned int>& vUnlockedAchievements, bool bUnpause, int nPopup)
 {
     std::set<unsigned int> vLockedAchievements;
     for (auto& pAchievement : m_vAchievements)
@@ -236,6 +236,23 @@ void GameContext::UpdateUnlocks(const std::set<unsigned int>& vUnlockedAchieveme
         }
     }
 #endif
+
+    if (nPopup)
+    {
+        auto* pPopup = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().GetMessage(nPopup);
+        if (pPopup != nullptr)
+        {
+            size_t nUnlockedCoreAchievements = 0U;
+            for (auto& pAchievement : m_vAchievements)
+            {
+                if (pAchievement->Category() == ra::etoi(AchievementSet::Type::Core) && !pAchievement->Active())
+                    ++nUnlockedCoreAchievements;
+            }
+
+            pPopup->SetDetail(ra::StringPrintf(L"You have earned %u achievements", nUnlockedCoreAchievements));
+            pPopup->RebuildRenderImage();
+        }
+    }
 }
 
 void GameContext::MergeLocalAchievements()
@@ -570,38 +587,46 @@ void GameContext::AwardAchievement(unsigned int nAchievementId) const
 
     bool bSubmit = false;
     bool bIsError = false;
-    std::wstring sHeader;
-    std::wstring sMessage = ra::StringPrintf(L"%s (%u)", pAchievement->Title(), pAchievement->Points());
+
+    ra::ui::viewmodels::PopupMessageViewModel vmPopup;
+    vmPopup.SetDescription(ra::StringPrintf(L"%s (%u)", pAchievement->Title(), pAchievement->Points()));
+    vmPopup.SetImage(ra::ui::ImageType::Badge, pAchievement->BadgeImageURI());
 
     switch (ra::itoe<AchievementSet::Type>(pAchievement->Category()))
     {
         case AchievementSet::Type::Local:
-            sHeader = L"Local Achievement Unlocked";
+            vmPopup.SetTitle(L"Local Achievement Unlocked");
             bSubmit = false;
             break;
 
         case AchievementSet::Type::Unofficial:
-            sHeader = L"Unofficial Achievement Unlocked";
+            vmPopup.SetTitle(L"Unofficial Achievement Unlocked");
             bSubmit = false;
             break;
 
         default:
-            sHeader = L"Achievement Unlocked";
+            vmPopup.SetTitle(L"Achievement Unlocked");
             bSubmit = true;
             break;
     }
 
     if (m_nMode == Mode::CompatibilityTest)
     {
+        auto sHeader = vmPopup.GetTitle();
         sHeader.insert(0, L"Test ");
+        vmPopup.SetTitle(sHeader);
+
         bSubmit = false;
     }
 
     if (pAchievement->Modified())
     {
+        auto sHeader = vmPopup.GetTitle();
         sHeader.insert(0, L"Modified ");
         if (ActiveAchievementType() != AchievementSet::Type::Local)
             sHeader.insert(sHeader.length() - 8, L"NOT ");
+        vmPopup.SetTitle(sHeader);
+
         bIsError = true;
         bSubmit = false;
     }
@@ -609,7 +634,9 @@ void GameContext::AwardAchievement(unsigned int nAchievementId) const
 #ifndef RA_UTEST
     if (bSubmit && g_bRAMTamperedWith)
     {
-        sHeader = L"RAM Tampered With! Achievement NOT Unlocked";
+        vmPopup.SetTitle(L"Achievement NOT Unlocked");
+        vmPopup.SetErrorDetail(L"Error: RAM tampered with");
+
         bIsError = true;
         bSubmit = false;
     }
@@ -618,8 +645,8 @@ void GameContext::AwardAchievement(unsigned int nAchievementId) const
     ra::services::ServiceLocator::Get<ra::services::IAudioSystem>().PlayAudioFile(
         bIsError ? L"Overlay\\acherror.wav" : L"Overlay\\unlock.wav");
 
-    const auto nPopupId = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().QueueMessage(
-        sHeader, sMessage, ra::ui::ImageType::Badge, pAchievement->BadgeImageURI());
+    const auto nPopupId =
+        ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().QueueMessage(std::move(vmPopup));
 
     pAchievement->SetActive(false);
 
@@ -646,31 +673,36 @@ void GameContext::AwardAchievement(unsigned int nAchievementId) const
         else
         {
             // an error occurred, update the popup to display the error message
-            auto* pPopup = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().GetMessage(nPopupId);
+            auto& pOverlayManager = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>();
+            auto pPopup = pOverlayManager.GetMessage(nPopupId);
             if (pPopup != nullptr)
             {
-                std::wstring sNewTitle = ra::StringPrintf(L"%s (%s)", pPopup->GetTitle(),
-                    response.ErrorMessage.empty() ? "Error" : response.ErrorMessage);
-
-                pPopup->SetTitle(sNewTitle);
+                pPopup->SetTitle(L"Achievement NOT Unlocked");
+                pPopup->SetErrorDetail(response.ErrorMessage.empty() ?
+                    L"Error submitting unlock" : ra::Widen(response.ErrorMessage));
                 pPopup->RebuildRenderImage();
             }
             else
             {
+                ra::ui::viewmodels::PopupMessageViewModel vmPopup;
+                vmPopup.SetTitle(L"Achievement NOT Unlocked");
+                vmPopup.SetErrorDetail(response.ErrorMessage.empty() ?
+                    L"Error submitting unlock" : ra::Widen(response.ErrorMessage));
+
                 const auto& pGameContext = ra::services::ServiceLocator::Get<GameContext>();
                 const auto* pAchievement = pGameContext.FindAchievement(nAchievementId);
                 if (pAchievement != nullptr)
                 {
-                    auto sHeader = ra::BuildWString("Error unlocking ", pAchievement->Title());
-                    ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().QueueMessage(
-                        sHeader, ra::Widen(response.ErrorMessage), ra::ui::ImageType::Badge, pAchievement->BadgeImageURI());
+                    vmPopup.SetDescription(ra::StringPrintf(L"%s (%u)", pAchievement->Title(), pAchievement->Points()));
+                    vmPopup.SetImage(ra::ui::ImageType::Badge, pAchievement->BadgeImageURI());
                 }
                 else
                 {
-                    auto sHeader = ra::BuildWString("Error unlocking achievement ", nAchievementId);
-                    ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().QueueMessage(
-                        sHeader, ra::Widen(response.ErrorMessage));
+                    vmPopup.SetDescription(ra::StringPrintf(L"Achievement %u", nAchievementId));
                 }
+
+                ra::services::ServiceLocator::Get<ra::services::IAudioSystem>().PlayAudioFile(L"Overlay\\acherror.wav");
+                pOverlayManager.QueueMessage(std::move(vmPopup));
             }
         }
     });
@@ -783,9 +815,13 @@ void GameContext::SubmitLeaderboardEntry(ra::LeaderboardID nLeaderboardId, unsig
 #ifndef RA_UTEST
     if (g_bRAMTamperedWith)
     {
+        ra::ui::viewmodels::PopupMessageViewModel vmPopup;
+        vmPopup.SetTitle(L"Leaderboard NOT Submitted");
+        vmPopup.SetDescription(ra::Widen(pLeaderboard->Title()));
+        vmPopup.SetErrorDetail(L"Error: RAM tampered with");
+
         ra::services::ServiceLocator::Get<ra::services::IAudioSystem>().PlayAudioFile(L"Overlay\\info.wav");
-        ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().QueueMessage(
-            L"Not posting to leaderboard: memory tamper detected!", L"Reset game to re-enable posting.");
+        ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().QueueMessage(std::move(vmPopup));
         return;
     }
 #endif
@@ -793,17 +829,25 @@ void GameContext::SubmitLeaderboardEntry(ra::LeaderboardID nLeaderboardId, unsig
     const auto& pConfiguration = ra::services::ServiceLocator::Get<ra::services::IConfiguration>();
     if (!pConfiguration.IsFeatureEnabled(ra::services::Feature::Hardcore))
     {
+        ra::ui::viewmodels::PopupMessageViewModel vmPopup;
+        vmPopup.SetTitle(L"Leaderboard NOT Submitted");
+        vmPopup.SetDescription(ra::Widen(pLeaderboard->Title()));
+        vmPopup.SetErrorDetail(L"Submission requires Hardcore mode");
+
         ra::services::ServiceLocator::Get<ra::services::IAudioSystem>().PlayAudioFile(L"Overlay\\info.wav");
-        ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().QueueMessage(
-            L"Leaderboard submission post canceled.", L"Enable Hardcore Mode to enable posting.");
+        ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().QueueMessage(std::move(vmPopup));
         return;
     }
 
     if (m_nMode == Mode::CompatibilityTest)
     {
+        ra::ui::viewmodels::PopupMessageViewModel vmPopup;
+        vmPopup.SetTitle(L"Leaderboard NOT Submitted");
+        vmPopup.SetDescription(ra::Widen(pLeaderboard->Title()));
+        vmPopup.SetDetail(L"Leaderboards are not submitted in test mode.");
+
         ra::services::ServiceLocator::Get<ra::services::IAudioSystem>().PlayAudioFile(L"Overlay\\info.wav");
-        ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().QueueMessage(
-            L"Leaderboard submission post canceled.", L"Leaderboards are not submitted in test mode.");
+        ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().QueueMessage(std::move(vmPopup));
         return;
     }
 
@@ -817,14 +861,12 @@ void GameContext::SubmitLeaderboardEntry(ra::LeaderboardID nLeaderboardId, unsig
 
         if (!response.Succeeded())
         {
-            std::wstring sHeader;
-            if (pLeaderboard)
-                sHeader = ra::BuildWString("Error submitting entry for ", pLeaderboard->Title());
-            else
-                sHeader = ra::BuildWString("Error submitting entry for leaderboard ", nLeaderboardId);
+            ra::ui::viewmodels::PopupMessageViewModel vmPopup;
+            vmPopup.SetTitle(L"Leaderboard NOT Submitted");
+            vmPopup.SetDescription(pLeaderboard ? ra::Widen(pLeaderboard->Title()) : ra::StringPrintf(L"Leaderboard %u", nLeaderboardId));
+            vmPopup.SetDetail(!response.ErrorMessage.empty() ? ra::StringPrintf(L"Error: %s", response.ErrorMessage) : L"Error submitting entry");
 
-            ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().QueueMessage(
-                sHeader, ra::Widen(response.ErrorMessage));
+            ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().QueueMessage(std::move(vmPopup));
         }
         else if (pLeaderboard)
         {

--- a/src/data/GameContext.hh
+++ b/src/data/GameContext.hh
@@ -156,7 +156,7 @@ public:
     /// <summary>
     /// Updates the set of unlocked achievements from the server.
     /// </summary>
-    void RefreshUnlocks() { RefreshUnlocks(false); }
+    void RefreshUnlocks() { RefreshUnlocks(false, 0); }
 
     /// <summary>
     /// Gets whether or not the loaded game has a rich presence script.
@@ -193,8 +193,8 @@ public:
 protected:
     void MergeLocalAchievements();
     bool ReloadAchievement(Achievement& pAchievement);
-    void RefreshUnlocks(bool bUnpause);
-    void UpdateUnlocks(const std::set<unsigned int>& vUnlockedAchievements, bool bUnpause);
+    void RefreshUnlocks(bool bUnpause, int nPopup);
+    void UpdateUnlocks(const std::set<unsigned int>& vUnlockedAchievements, bool bUnpause, int nPopup);
 
     unsigned int m_nGameId = 0;
     std::wstring m_sGameTitle;

--- a/src/ui/viewmodels/OverlayManager.hh
+++ b/src/ui/viewmodels/OverlayManager.hh
@@ -39,6 +39,18 @@ public:
     }
 
     /// <summary>
+    /// Queues a popup message.
+    /// </summary>
+    int QueueMessage(const std::wstring& sTitle, const std::wstring& sDescription, const std::wstring& sDetail)
+    {
+        PopupMessageViewModel vmMessage;
+        vmMessage.SetTitle(sTitle);
+        vmMessage.SetDescription(sDescription);
+        vmMessage.SetDetail(sDetail);
+        return QueueMessage(std::move(vmMessage));
+    }
+
+    /// <summary>
     /// Queues a popup message with an image.
     /// </summary>
     int QueueMessage(const std::wstring& sTitle, const std::wstring& sDescription, ra::ui::ImageType nImageType, const std::string& sImageName)
@@ -49,7 +61,20 @@ public:
         vmMessage.SetImage(nImageType, sImageName);
         return QueueMessage(std::move(vmMessage));
     }
-    
+
+    /// <summary>
+    /// Queues a popup message with an image.
+    /// </summary>
+    int QueueMessage(const std::wstring& sTitle, const std::wstring& sDescription, const std::wstring& sDetail, ra::ui::ImageType nImageType, const std::string& sImageName)
+    {
+        PopupMessageViewModel vmMessage;
+        vmMessage.SetTitle(sTitle);
+        vmMessage.SetDescription(sDescription);
+        vmMessage.SetDetail(sDetail);
+        vmMessage.SetImage(nImageType, sImageName);
+        return QueueMessage(std::move(vmMessage));
+    }
+
     /// <summary>
     /// Gets the message associated to the specified unique identifier.
     /// </summary>

--- a/src/ui/viewmodels/PopupMessageViewModel.hh
+++ b/src/ui/viewmodels/PopupMessageViewModel.hh
@@ -57,6 +57,25 @@ public:
     void SetDetail(const std::wstring& sValue) { SetValue(DetailProperty, sValue); }
 
     /// <summary>
+    /// Sets the detail message to display as an error.
+    /// </summary>
+    void SetErrorDetail(const std::wstring& sValue)
+    {
+        SetValue(DetailProperty, sValue);
+        SetValue(IsDetailErrorProperty, true);
+    }
+
+    /// <summary>
+    /// The <see cref="ModelProperty" /> for whether or not the detail message is an error.
+    /// </summary>
+    static const BoolModelProperty IsDetailErrorProperty;
+
+    /// <summary>
+    /// Gets whether the detail message is an error.
+    /// </summary>
+    bool IsDetailError() const { return GetValue(IsDetailErrorProperty); }
+
+    /// <summary>
     /// Sets the image to display.
     /// </summary>
     void SetImage(ra::ui::ImageType nImageType, const std::string& sImageName)

--- a/src/ui/viewmodels/ScoreboardViewModel.cpp
+++ b/src/ui/viewmodels/ScoreboardViewModel.cpp
@@ -64,16 +64,22 @@ bool ScoreboardViewModel::UpdateRenderImage(double fElapsed)
         m_pSurface->FillRectangle(0, 0, m_pSurface->GetWidth(), m_pSurface->GetHeight(), Color::Transparent);
         m_pSurface->FillRectangle(nShadowOffset, nShadowOffset, m_pSurface->GetWidth() - nShadowOffset, m_pSurface->GetHeight() - nShadowOffset,
                                   pTheme.ColorShadow());
+
+        // frame
         m_pSurface->FillRectangle(0, 0, m_pSurface->GetWidth() - nShadowOffset, m_pSurface->GetHeight() - nShadowOffset,
                                   pTheme.ColorBackground());
+        m_pSurface->FillRectangle(1, 1, m_pSurface->GetWidth() - nShadowOffset - 2, m_pSurface->GetHeight() - nShadowOffset - 2,
+            pTheme.ColorBorder());
+        m_pSurface->FillRectangle(2, 2, m_pSurface->GetWidth() - nShadowOffset - 4, m_pSurface->GetHeight() - nShadowOffset - 4,
+            pTheme.ColorBackground());
+        m_pSurface->FillRectangle(2, 25, m_pSurface->GetWidth() - nShadowOffset - 4, 1, pTheme.ColorBorder());
 
         // title
         const auto sResultsTitle = GetHeaderText();
-        m_pSurface->FillRectangle(4, 4, m_pSurface->GetWidth() - nShadowOffset - 8, FONT_SIZE_TITLE, pTheme.ColorBorder());
-        m_pSurface->WriteText(8, 3, nFontTitle, pTheme.ColorTitle(), sResultsTitle);
+        m_pSurface->WriteText(8, 1, nFontTitle, pTheme.ColorTitle(), sResultsTitle);
 
         // scoreboard
-        size_t nY = 4 + FONT_SIZE_TITLE + 4;
+        size_t nY = 4 + FONT_SIZE_TITLE + 2;
         size_t i = 0;
         while (i < m_vEntries.Count() && nY + FONT_SIZE_TEXT < m_pSurface->GetHeight())
         {

--- a/tests/Exports_Tests.cpp
+++ b/tests/Exports_Tests.cpp
@@ -163,8 +163,9 @@ public:
         const auto* pPopup = harness.mockOverlayManager.GetMessage(1);
         Assert::IsNotNull(pPopup);
         Ensures(pPopup != nullptr);
-        Assert::AreEqual(std::wstring(L"Welcome User (12345)"), pPopup->GetTitle());
+        Assert::AreEqual(std::wstring(L"Welcome User"), pPopup->GetTitle());
         Assert::AreEqual(std::wstring(L"You have 0 new messages"), pPopup->GetDescription());
+        Assert::AreEqual(std::wstring(L"12345 points"), pPopup->GetDetail());
         Assert::AreEqual(ra::ui::ImageType::UserPic, pPopup->GetImage().Type());
         Assert::AreEqual(std::string("User"), pPopup->GetImage().Name());
 
@@ -197,8 +198,9 @@ public:
         const auto* pPopup = harness.mockOverlayManager.GetMessage(1);
         Assert::IsNotNull(pPopup);
         Ensures(pPopup != nullptr);
-        Assert::AreEqual(std::wstring(L"Welcome User (0)"), pPopup->GetTitle());
+        Assert::AreEqual(std::wstring(L"Welcome User"), pPopup->GetTitle());
         Assert::AreEqual(std::wstring(L"You have 3 new messages"), pPopup->GetDescription());
+        Assert::AreEqual(std::wstring(L"0 points"), pPopup->GetDetail());
         Assert::AreEqual(ra::ui::ImageType::UserPic, pPopup->GetImage().Type());
         Assert::AreEqual(std::string("User"), pPopup->GetImage().Name());
     }
@@ -229,8 +231,9 @@ public:
         const auto* pPopup = harness.mockOverlayManager.GetMessage(1);
         Assert::IsNotNull(pPopup);
         Ensures(pPopup != nullptr);
-        Assert::AreEqual(std::wstring(L"Welcome back User (12345)"), pPopup->GetTitle());
+        Assert::AreEqual(std::wstring(L"Welcome back User"), pPopup->GetTitle());
         Assert::AreEqual(std::wstring(L"You have 0 new messages"), pPopup->GetDescription());
+        Assert::AreEqual(std::wstring(L"12345 points"), pPopup->GetDetail());
         Assert::AreEqual(ra::ui::ImageType::UserPic, pPopup->GetImage().Type());
         Assert::AreEqual(std::string("User"), pPopup->GetImage().Name());
         Assert::IsTrue(bWasMenuRebuilt);
@@ -496,8 +499,9 @@ public:
         Assert::IsNotNull(pPopup);
         Ensures(pPopup != nullptr);
         Assert::IsTrue(harness.mockAudioSystem.WasAudioFilePlayed(L"Overlay\\lb.wav"));
-        Assert::AreEqual(std::wstring(L"Challenge Available: Title"), pPopup->GetTitle());
-        Assert::AreEqual(std::wstring(L"Description"), pPopup->GetDescription());
+        Assert::AreEqual(std::wstring(L"Challenge Available"), pPopup->GetTitle());
+        Assert::AreEqual(std::wstring(L"Title"), pPopup->GetDescription());
+        Assert::AreEqual(std::wstring(L"Description"), pPopup->GetDetail());
 
         const auto* pScore = harness.mockOverlayManager.GetScoreTracker(1U);
         Assert::IsNotNull(pScore);

--- a/tests/data/GameContext_Tests.cpp
+++ b/tests/data/GameContext_Tests.cpp
@@ -148,7 +148,7 @@ public:
         Expects(pPopup != nullptr);
         Assert::IsNotNull(pPopup);
         Assert::AreEqual(std::wstring(L"Loaded GameTitle"), pPopup->GetTitle());
-        Assert::AreEqual(std::wstring(L"1 achievements, Total Score 5"), pPopup->GetDescription());
+        Assert::AreEqual(std::wstring(L"1 achievements, 5 points"), pPopup->GetDescription());
         Assert::AreEqual(std::string("9743"), pPopup->GetImage().Name());
     }
 
@@ -886,8 +886,10 @@ public:
         game.mockThreadPool.ExecuteNextTask();
 
         // error message should be reported
-        Assert::AreEqual(std::wstring(L"Achievement Unlocked (Achievement data cannot be found for 1)"), pPopup->GetTitle());
+        Assert::AreEqual(std::wstring(L"Achievement NOT Unlocked"), pPopup->GetTitle());
         Assert::AreEqual(std::wstring(L"AchievementTitle (5)"), pPopup->GetDescription());
+        Assert::AreEqual(std::wstring(L"Achievement data cannot be found for 1"), pPopup->GetDetail());
+        Assert::IsTrue(pPopup->IsDetailError());
         Assert::AreEqual(std::string("12345"), pPopup->GetImage().Name());
     }
 
@@ -922,8 +924,9 @@ public:
         pPopup = game.mockOverlayManager.GetMessage(2);
         Expects(pPopup != nullptr);
         Assert::IsNotNull(pPopup);
-        Assert::AreEqual(std::wstring(L"Error unlocking AchievementTitle"), pPopup->GetTitle());
-        Assert::AreEqual(std::wstring(L"Achievement data cannot be found for 1"), pPopup->GetDescription());
+        Assert::AreEqual(std::wstring(L"Achievement NOT Unlocked"), pPopup->GetTitle());
+        Assert::AreEqual(std::wstring(L"AchievementTitle (5)"), pPopup->GetDescription());
+        Assert::AreEqual(std::wstring(L"Achievement data cannot be found for 1"), pPopup->GetDetail());
         Assert::AreEqual(std::string("12345"), pPopup->GetImage().Name());
     }
 
@@ -1084,8 +1087,10 @@ public:
         const auto* pPopup = game.mockOverlayManager.GetMessage(1);
         Expects(pPopup != nullptr);
         Assert::IsNotNull(pPopup);
-        Assert::AreEqual(std::wstring(L"Leaderboard submission post canceled."), pPopup->GetTitle());
-        Assert::AreEqual(std::wstring(L"Enable Hardcore Mode to enable posting."), pPopup->GetDescription());
+        Assert::AreEqual(std::wstring(L"Leaderboard NOT Submitted"), pPopup->GetTitle());
+        Assert::AreEqual(std::wstring(L"LeaderboardTitle"), pPopup->GetDescription());
+        Assert::AreEqual(std::wstring(L"Submission requires Hardcore mode"), pPopup->GetDetail());
+        Assert::IsTrue(pPopup->IsDetailError());
     }
 
     TEST_METHOD(TestSubmitLeaderboardEntryCompatibilityMode)
@@ -1109,8 +1114,10 @@ public:
         const auto* pPopup = game.mockOverlayManager.GetMessage(1);
         Expects(pPopup != nullptr);
         Assert::IsNotNull(pPopup);
-        Assert::AreEqual(std::wstring(L"Leaderboard submission post canceled."), pPopup->GetTitle());
-        Assert::AreEqual(std::wstring(L"Leaderboards are not submitted in test mode."), pPopup->GetDescription());
+        Assert::AreEqual(std::wstring(L"Leaderboard NOT Submitted"), pPopup->GetTitle());
+        Assert::AreEqual(std::wstring(L"LeaderboardTitle"), pPopup->GetDescription());
+        Assert::AreEqual(std::wstring(L"Leaderboards are not submitted in test mode."), pPopup->GetDetail());
+        Assert::IsFalse(pPopup->IsDetailError());
     }
 };
 

--- a/tests/data/GameContext_Tests.cpp
+++ b/tests/data/GameContext_Tests.cpp
@@ -661,6 +661,7 @@ public:
         Assert::IsNotNull(pPopup);
         Assert::AreEqual(std::wstring(L"Achievement Unlocked"), pPopup->GetTitle());
         Assert::AreEqual(std::wstring(L"AchievementTitle (5)"), pPopup->GetDescription());
+        Assert::AreEqual(std::wstring(L"AchievementDescription"), pPopup->GetDetail());
         Assert::AreEqual(std::string("12345"), pPopup->GetImage().Name());
 
         game.mockThreadPool.ExecuteNextTask();
@@ -692,6 +693,7 @@ public:
         Assert::IsNotNull(pPopup);
         Assert::AreEqual(std::wstring(L"Achievement Unlocked"), pPopup->GetTitle());
         Assert::AreEqual(std::wstring(L"AchievementTitle (5)"), pPopup->GetDescription());
+        Assert::AreEqual(std::wstring(L"AchievementDescription"), pPopup->GetDetail());
         Assert::AreEqual(std::string("12345"), pPopup->GetImage().Name());
 
         game.mockThreadPool.ExecuteNextTask();
@@ -712,6 +714,7 @@ public:
         Assert::IsNotNull(pPopup);
         Assert::AreEqual(std::wstring(L"Local Achievement Unlocked"), pPopup->GetTitle());
         Assert::AreEqual(std::wstring(L"AchievementTitle (5)"), pPopup->GetDescription());
+        Assert::AreEqual(std::wstring(L"AchievementDescription"), pPopup->GetDetail());
         Assert::AreEqual(std::string("12345"), pPopup->GetImage().Name());
 
         // AwardAchievement API call is async, try to execute it - expect no tasks queued
@@ -732,6 +735,7 @@ public:
         Assert::IsNotNull(pPopup);
         Assert::AreEqual(std::wstring(L"Unofficial Achievement Unlocked"), pPopup->GetTitle());
         Assert::AreEqual(std::wstring(L"AchievementTitle (5)"), pPopup->GetDescription());
+        Assert::AreEqual(std::wstring(L"AchievementDescription"), pPopup->GetDetail());
         Assert::AreEqual(std::string("12345"), pPopup->GetImage().Name());
 
         // AwardAchievement API call is async, try to execute it - expect no tasks queued
@@ -752,6 +756,7 @@ public:
         Assert::IsNotNull(pPopup);
         Assert::AreEqual(std::wstring(L"Modified Achievement NOT Unlocked"), pPopup->GetTitle());
         Assert::AreEqual(std::wstring(L"AchievementTitle (5)"), pPopup->GetDescription());
+        Assert::AreEqual(std::wstring(L"AchievementDescription"), pPopup->GetDetail());
         Assert::AreEqual(std::string("12345"), pPopup->GetImage().Name());
 
         // AwardAchievement API call is async, try to execute it - expect no tasks queued
@@ -774,6 +779,7 @@ public:
         Assert::IsNotNull(pPopup);
         Assert::AreEqual(std::wstring(L"Modified Local Achievement NOT Unlocked"), pPopup->GetTitle());
         Assert::AreEqual(std::wstring(L"AchievementTitle (5)"), pPopup->GetDescription());
+        Assert::AreEqual(std::wstring(L"AchievementDescription"), pPopup->GetDetail());
         Assert::AreEqual(std::string("12345"), pPopup->GetImage().Name());
 
         // AwardAchievement API call is async, try to execute it - expect no tasks queued
@@ -796,6 +802,7 @@ public:
         Assert::IsNotNull(pPopup);
         Assert::AreEqual(std::wstring(L"Modified Unofficial Achievement NOT Unlocked"), pPopup->GetTitle());
         Assert::AreEqual(std::wstring(L"AchievementTitle (5)"), pPopup->GetDescription());
+        Assert::AreEqual(std::wstring(L"AchievementDescription"), pPopup->GetDetail());
         Assert::AreEqual(std::string("12345"), pPopup->GetImage().Name());
 
         // AwardAchievement API call is async, try to execute it - expect no tasks queued
@@ -821,6 +828,7 @@ public:
         Assert::IsNotNull(pPopup);
         Assert::AreEqual(std::wstring(L"Achievement Unlocked"), pPopup->GetTitle());
         Assert::AreEqual(std::wstring(L"AchievementTitle (5)"), pPopup->GetDescription());
+        Assert::AreEqual(std::wstring(L"AchievementDescription"), pPopup->GetDetail());
         Assert::AreEqual(std::string("12345"), pPopup->GetImage().Name());
 
         game.mockThreadPool.ExecuteNextTask();
@@ -851,6 +859,7 @@ public:
         Assert::IsNotNull(pPopup);
         Assert::AreEqual(std::wstring(L"Achievement Unlocked"), pPopup->GetTitle());
         Assert::AreEqual(std::wstring(L"AchievementTitle (5)"), pPopup->GetDescription());
+        Assert::AreEqual(std::wstring(L"AchievementDescription"), pPopup->GetDetail());
         Assert::AreEqual(std::string("12345"), pPopup->GetImage().Name());
 
         game.mockThreadPool.ExecuteNextTask();
@@ -881,6 +890,7 @@ public:
         Assert::IsNotNull(pPopup);
         Assert::AreEqual(std::wstring(L"Achievement Unlocked"), pPopup->GetTitle());
         Assert::AreEqual(std::wstring(L"AchievementTitle (5)"), pPopup->GetDescription());
+        Assert::AreEqual(std::wstring(L"AchievementDescription"), pPopup->GetDetail());
         Assert::AreEqual(std::string("12345"), pPopup->GetImage().Name());
 
         game.mockThreadPool.ExecuteNextTask();
@@ -913,6 +923,7 @@ public:
         Assert::IsNotNull(pPopup);
         Assert::AreEqual(std::wstring(L"Achievement Unlocked"), pPopup->GetTitle());
         Assert::AreEqual(std::wstring(L"AchievementTitle (5)"), pPopup->GetDescription());
+        Assert::AreEqual(std::wstring(L"AchievementDescription"), pPopup->GetDetail());
         Assert::AreEqual(std::string("12345"), pPopup->GetImage().Name());
 
         // if error occurs after original popup is gone, a new one should be created to display the error
@@ -945,6 +956,7 @@ public:
         Assert::IsNotNull(pPopup);
         Assert::AreEqual(std::wstring(L"Test Achievement Unlocked"), pPopup->GetTitle());
         Assert::AreEqual(std::wstring(L"AchievementTitle (5)"), pPopup->GetDescription());
+        Assert::AreEqual(std::wstring(L"AchievementDescription"), pPopup->GetDetail());
         Assert::AreEqual(std::string("12345"), pPopup->GetImage().Name());
 
         // AwardAchievement API call is async, try to execute it - expect no tasks queued


### PR DESCRIPTION
Default is classic orange:
![image](https://user-images.githubusercontent.com/32680403/55675039-daffe000-5879-11e9-90d7-3472ec5ceb4d.png)
![image](https://user-images.githubusercontent.com/32680403/55675133-6c238680-587b-11e9-8711-a72d5d42574a.png)
NOTE: leaderboard description is shown on the third line, this leaderboard doesn't have a description.

Theming allows for custom colors. I propose changing the default to grey:
![image](https://user-images.githubusercontent.com/32680403/55675057-14385000-587a-11e9-92fa-6d18fac0b30f.png)
![image](https://user-images.githubusercontent.com/32680403/55675060-20bca880-587a-11e9-8241-1dc652ffef6b.png)

More Popups (in grey):
![image](https://user-images.githubusercontent.com/32680403/55675157-ba388a00-587b-11e9-8754-a9510cf34487.png)
![image](https://user-images.githubusercontent.com/32680403/55675739-da6c4700-5883-11e9-8d56-8040c53b64c9.png)
![image](https://user-images.githubusercontent.com/32680403/55675813-531fd300-5885-11e9-8537-807afb1febce.png)
