### PR TITLE
initialize new condition with value from memory inspector

### DIFF
--- a/src/RA_Dlg_AchEditor.cpp
+++ b/src/RA_Dlg_AchEditor.cpp
@@ -1062,6 +1062,8 @@ INT_PTR Dlg_AchievementEditor::AchievementEditorProc(HWND hDlg, UINT uMsg, WPARA
                         GetDlgItemText(g_MemoryDialog.GetHWND(), IDC_RA_WATCHING, buffer, 256);
                         unsigned int nVal = strtoul(ra::Narrow(buffer).c_str(), nullptr, 16);
                         NewCondition.CompSource().SetValue(nVal);
+
+                        NewCondition.CompTarget().SetValue(g_MemManager.ActiveBankRAMRead(nVal, NewCondition.CompTarget().GetSize()));
                     }
 
                     const size_t nNewID = pActiveAch->AddCondition(GetSelectedConditionGroup(), NewCondition) - 1;


### PR DESCRIPTION
When pressing the "New Condition" button in the achievement editor, the currently selected memory address is automatically copied into the left side of the condition. This change also copies the current value of the selected memory address to the right side of the condition.