### PR TITLE
initialize session on manual login

### DIFF
--- a/src/Exports.cpp
+++ b/src/Exports.cpp
@@ -79,7 +79,7 @@ static void HandleLoginResponse(const ra::api::Login::Response& response)
         pUserContext.Initialize(response.Username, response.ApiToken);
         pUserContext.SetScore(response.Score);
 
-        // start a new session
+        // load the session information
         auto& pSessionTracker = ra::services::ServiceLocator::GetMutable<ra::data::SessionTracker>();
         pSessionTracker.Initialize(response.Username);
 

--- a/src/ui/viewmodels/LoginViewModel.cpp
+++ b/src/ui/viewmodels/LoginViewModel.cpp
@@ -7,6 +7,7 @@
 #include "api\Login.hh"
 
 #include "data\EmulatorContext.hh"
+#include "data\SessionTracker.hh"
 #include "data\UserContext.hh"
 
 #include "services\IConfiguration.hh"
@@ -65,8 +66,14 @@ bool LoginViewModel::Login() const
     pConfiguration.SetApiToken(bRememberLogin ? response.ApiToken : "");
     pConfiguration.Save();
 
+    // initialize the user context
     auto& pUserContext = ra::services::ServiceLocator::GetMutable<ra::data::UserContext>();
     pUserContext.Initialize(response.Username, response.ApiToken);
+    pUserContext.SetScore(response.Score);
+
+    // load the session information
+    auto& pSessionTracker = ra::services::ServiceLocator::GetMutable<ra::data::SessionTracker>();
+    pSessionTracker.Initialize(response.Username);
 
     ra::ui::viewmodels::MessageBoxViewModel::ShowInfoMessage(
         std::wstring(L"Successfully logged in as ") + ra::Widen(response.Username));

--- a/tests/ui/viewmodels/LoginViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/LoginViewModel_Tests.cpp
@@ -7,11 +7,13 @@
 #include "tests\mocks\MockDesktop.hh"
 #include "tests\mocks\MockEmulatorContext.hh"
 #include "tests\mocks\MockServer.hh"
+#include "tests\mocks\MockSessionTracker.hh"
 #include "tests\mocks\MockUserContext.hh"
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 using ra::api::mocks::MockServer;
 using ra::data::mocks::MockEmulatorContext;
+using ra::data::mocks::MockSessionTracker;
 using ra::data::mocks::MockUserContext;
 using ra::services::mocks::MockConfiguration;
 using ra::ui::mocks::MockDesktop;
@@ -34,6 +36,7 @@ private:
         MockServer mockServer;
         MockUserContext mockUserContext;
         MockEmulatorContext mockEmulatorContext;
+        MockSessionTracker mockSessionTracker;
     };
 
 public:
@@ -120,9 +123,13 @@ public:
         // API token should not be set unless "remember me" is checked
         Assert::AreEqual(std::string(""), vmLogin.mockConfiguration.GetApiToken());
 
-        // values should also be updated in UserContext, including API token
+        // values should also be updated in UserContext, including API token and score
         Assert::AreEqual(std::string("User"), vmLogin.mockUserContext.GetUsername());
         Assert::AreEqual(std::string("ApiToken"), vmLogin.mockUserContext.GetApiToken());
+        Assert::AreEqual(12345U, vmLogin.mockUserContext.GetScore());
+
+        // session tracker should know user name
+        Assert::AreEqual(std::wstring(L"User"), vmLogin.mockSessionTracker.GetUsername());
 
         // emulator should have been notified to rebuild the RetroAchievements menu
         Assert::IsTrue(bWasMenuRebuilt);


### PR DESCRIPTION
Fixes issue where session information is stored in "-history.txt" instead of "User-history.txt" when using the manual login feature. 