### PR TITLE
Label GBC RAM area as GBC-only explicitly

### DIFF
--- a/src/data/ConsoleContext.cpp
+++ b/src/data/ConsoleContext.cpp
@@ -122,7 +122,7 @@ const std::vector<ConsoleContext::MemoryRegion> GameBoyConsoleContext::m_vMemory
     { 0xFF00U, 0xFF7FU, ConsoleContext::AddressType::HardwareController, "Hardware I/O"},
     { 0xFF80U, 0xFFFEU, ConsoleContext::AddressType::SystemRAM, "Quick RAM"},
     { 0xFFFFU, 0xFFFFU, ConsoleContext::AddressType::HardwareController, "Interrupt enable"},
-    { 0x10000U, 0x16FFFU, ConsoleContext::AddressType::SystemRAM, "System RAM (static pages)" }, // 7 banks, GBC only
+    { 0x10000U, 0x16FFFU, ConsoleContext::AddressType::SystemRAM, "Static RAM banks (GBC only)" }, // 7 banks, GBC only
 };
 
 // ===== GameBoy Advance =====


### PR DESCRIPTION
Since the RAM is not mapped to 0x10000 for GB, clarify that this memory region can only be used for GBC.

The banked RAM area will usually correspond to bank 1 in GBC mode, and while the extended area will be available when running a GB title in GBC mode, it should not be used for single-bank titles that are backwards-compatible, hence the need to make this obvious.