### PR TITLE
Render overlay in transparent window

### DIFF
--- a/src/Exports.cpp
+++ b/src/Exports.cpp
@@ -186,7 +186,7 @@ API void CCONV _RA_UpdateAppTitle(const char* sMessage)
 
 API bool _RA_IsOverlayFullyVisible()
 {
-    return ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().IsOverlayFullyVisible();
+    return ra::services::ServiceLocator::Get<ra::ui::viewmodels::OverlayManager>().IsOverlayFullyVisible();
 }
 
 _Use_decl_annotations_

--- a/src/Exports.cpp
+++ b/src/Exports.cpp
@@ -184,14 +184,25 @@ API void CCONV _RA_UpdateAppTitle(const char* sMessage)
     vmEmulator.SetWindowTitle(sTitle);
 }
 
+API bool _RA_IsOverlayFullyVisible()
+{
+    return ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().IsOverlayFullyVisible();
+}
+
 _Use_decl_annotations_
-API int _RA_UpdateOverlay(const ControllerInput* pInput, float, bool, bool)
+API void _RA_NavigateOverlay(const ControllerInput* pInput)
 {
     static const ControllerInput pNoInput{};
     if (pInput == nullptr)
         pInput = &pNoInput;
 
     ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().Update(*pInput);
+}
+
+_Use_decl_annotations_
+API int _RA_UpdateOverlay(const ControllerInput* pInput, float, bool, bool)
+{
+    _RA_NavigateOverlay(pInput);
     return true; // was return state = closing - does anything check this?
 }
 
@@ -209,12 +220,8 @@ API void _RA_RenderOverlay(HDC hDC, const RECT* rcSize)
 }
 #endif
 
-API void CCONV _RA_DoAchievementsFrame()
+static void ProcessAchievements()
 {
-#ifndef RA_UTEST
-    g_MemoryDialog.Invalidate();
-#endif
-
     auto& pRuntime = ra::services::ServiceLocator::GetMutable<ra::services::AchievementRuntime>();
     if (pRuntime.IsPaused())
         return;
@@ -359,3 +366,12 @@ API void CCONV _RA_DoAchievementsFrame()
     }
 }
 
+API void CCONV _RA_DoAchievementsFrame()
+{
+    ProcessAchievements();
+
+#ifndef RA_UTEST
+    // make sure we process the achievements _before_ the frozen bookmarks modify the memory
+    g_MemoryDialog.Invalidate();
+#endif
+}

--- a/src/Exports.cpp
+++ b/src/Exports.cpp
@@ -202,7 +202,6 @@ API void _RA_RenderOverlay(HDC hDC, const RECT* rcSize)
     switch (ra::services::ServiceLocator::Get<ra::data::EmulatorContext>().GetEmulatorId())
     {
         case EmulatorID::RA_Gens:
-        case EmulatorID::RA_Meka:
             ra::ui::drawing::gdi::GDISurface pSurface(hDC, *rcSize);
             ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().Render(pSurface, true);
             break;

--- a/src/Exports.cpp
+++ b/src/Exports.cpp
@@ -185,24 +185,15 @@ API void CCONV _RA_UpdateAppTitle(const char* sMessage)
 }
 
 _Use_decl_annotations_
-API int _RA_UpdateOverlay(const ControllerInput* pInput, float fElapsedSeconds, bool, bool)
+API int _RA_UpdateOverlay(const ControllerInput* pInput, float, bool, bool)
 {
     static const ControllerInput pNoInput{};
     if (pInput == nullptr)
         pInput = &pNoInput;
 
-    ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().Update(*pInput, fElapsedSeconds);
+    ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().Update(*pInput);
     return true; // was return state = closing - does anything check this?
 }
-
-#ifndef RA_UTEST
-_Use_decl_annotations_
-API void _RA_RenderOverlay(HDC hDC, const RECT* rcSize)
-{
-    ra::ui::drawing::gdi::GDISurface pSurface(hDC, *rcSize);
-    ra::services::ServiceLocator::Get<ra::ui::viewmodels::OverlayManager>().Render(pSurface);
-}
-#endif
 
 API void CCONV _RA_DoAchievementsFrame()
 {

--- a/src/Exports.cpp
+++ b/src/Exports.cpp
@@ -195,6 +195,21 @@ API int _RA_UpdateOverlay(const ControllerInput* pInput, float, bool, bool)
     return true; // was return state = closing - does anything check this?
 }
 
+#ifndef RA_UTEST
+_Use_decl_annotations_
+API void _RA_RenderOverlay(HDC hDC, const RECT* rcSize)
+{
+    switch (ra::services::ServiceLocator::Get<ra::data::EmulatorContext>().GetEmulatorId())
+    {
+        case EmulatorID::RA_Gens:
+        case EmulatorID::RA_Meka:
+            ra::ui::drawing::gdi::GDISurface pSurface(hDC, *rcSize);
+            ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().Render(pSurface, true);
+            break;
+    }
+}
+#endif
+
 API void CCONV _RA_DoAchievementsFrame()
 {
 #ifndef RA_UTEST

--- a/src/Exports.hh
+++ b/src/Exports.hh
@@ -93,6 +93,7 @@ extern "C" {
     API void CCONV _RA_InstallSharedFunctionsExt(bool(*)(void), void(*fpCauseUnpause)(void), void(*fpCausePause)(void), void(*fpRebuildMenu)(void), void(*fpEstimateTitle)(char*), void(*fpResetEmulation)(void), void(*fpLoadROM)(const char*));
 
     struct ControllerInput;
+    API void CCONV _RA_NavigateOverlay(_In_ const ControllerInput* pInput);
     API int CCONV _RA_UpdateOverlay(_In_ const ControllerInput* pInput, _In_ float /*fDTime*/,
         _In_ bool /*Full_Screen*/, _In_ bool /*Paused*/);
     API void CCONV _RA_RenderOverlay(_In_ HDC hDC, _In_ const RECT* rcSize);

--- a/src/Exports.hh
+++ b/src/Exports.hh
@@ -95,6 +95,7 @@ extern "C" {
     struct ControllerInput;
     API int CCONV _RA_UpdateOverlay(_In_ const ControllerInput* pInput, _In_ float /*fDTime*/,
         _In_ bool /*Full_Screen*/, _In_ bool /*Paused*/);
+    API void CCONV _RA_RenderOverlay(_In_ HDC hDC, _In_ const RECT* rcSize);
     API bool CCONV _RA_IsOverlayFullyVisible();
 
 #ifdef __cplusplus

--- a/src/Exports.hh
+++ b/src/Exports.hh
@@ -93,9 +93,8 @@ extern "C" {
     API void CCONV _RA_InstallSharedFunctionsExt(bool(*)(void), void(*fpCauseUnpause)(void), void(*fpCausePause)(void), void(*fpRebuildMenu)(void), void(*fpEstimateTitle)(char*), void(*fpResetEmulation)(void), void(*fpLoadROM)(const char*));
 
     struct ControllerInput;
-    API int CCONV _RA_UpdateOverlay(_In_ const ControllerInput* pInput, _In_ float fDTime,
+    API int CCONV _RA_UpdateOverlay(_In_ const ControllerInput* pInput, _In_ float /*fDTime*/,
         _In_ bool /*Full_Screen*/, _In_ bool /*Paused*/);
-    API void CCONV _RA_RenderOverlay(_In_ HDC hDC, _In_ const RECT* rcSize);
     API bool CCONV _RA_IsOverlayFullyVisible();
 
 #ifdef __cplusplus

--- a/src/RA_Core.cpp
+++ b/src/RA_Core.cpp
@@ -34,6 +34,7 @@
 #include "ui\viewmodels\OverlayManager.hh"
 #include "ui\viewmodels\WindowManager.hh"
 #include "ui\win32\Desktop.hh"
+#include "ui\win32\OverlayWindow.hh"
 
 std::wstring g_sHomeDir;
 std::string g_sROMDirLocation;
@@ -68,6 +69,9 @@ static void InitCommon(HWND hMainHWND, /*enum EmulatorID*/int nEmulatorID)
     auto& pDesktop = dynamic_cast<ra::ui::win32::Desktop&>(ra::services::ServiceLocator::GetMutable<ra::ui::IDesktop>());
     pDesktop.SetMainHWnd(hMainHWND);
     g_RAMainWnd = hMainHWND;
+
+    auto& pOverlayWindow = ra::services::ServiceLocator::GetMutable<ra::ui::win32::OverlayWindow>();
+    pOverlayWindow.CreateOverlayWindow(hMainHWND);
 
     auto& pFileSystem = ra::services::ServiceLocator::Get<ra::services::IFileSystem>();
     g_sHomeDir = pFileSystem.BaseDirectory();

--- a/src/RA_Core.cpp
+++ b/src/RA_Core.cpp
@@ -229,6 +229,11 @@ API bool CCONV _RA_WarnDisableHardcore(const char* sActivity)
 
 API void CCONV _RA_OnReset()
 {
+    // if there's no game loaded, there shouldn't be any active achievements or popups to clear - except maybe the
+    // logging in messages, which we don't want to clear.
+    if (ra::services::ServiceLocator::Get<ra::data::GameContext>().GameId() == 0U)
+        return;
+
     // Temporarily disable achievements while the system is resetting. They will automatically re-enable when
     // DoAchievementsFrame is called if the trigger is not active. Prevents most unexpected triggering caused
     // by resetting the emulator.

--- a/src/RA_Integration.vcxproj
+++ b/src/RA_Integration.vcxproj
@@ -115,6 +115,7 @@
     <ClCompile Include="ui\win32\GameChecksumDialog.cpp" />
     <ClCompile Include="ui\win32\LoginDialog.cpp" />
     <ClCompile Include="ui\win32\MessageBoxDialog.cpp" />
+    <ClCompile Include="ui\win32\OverlayWindow.cpp" />
     <ClCompile Include="ui\win32\RichPresenceDialog.cpp" />
     <ClCompile Include="ui\win32\UnknownGameDialog.cpp" />
     <ClCompile Include="ui\WindowViewModelBase.cpp" />
@@ -249,6 +250,7 @@
     <ClInclude Include="ui\win32\GameChecksumDialog.hh" />
     <ClInclude Include="ui\win32\LoginDialog.hh" />
     <ClInclude Include="ui\win32\MessageBoxDialog.hh" />
+    <ClInclude Include="ui\win32\OverlayWindow.hh" />
     <ClInclude Include="ui\win32\RichPresenceDialog.hh" />
     <ClInclude Include="ui\win32\IDialogPresenter.hh" />
     <ClInclude Include="ui\win32\UnknownGameDialog.hh" />

--- a/src/RA_Integration.vcxproj.filters
+++ b/src/RA_Integration.vcxproj.filters
@@ -270,6 +270,9 @@
     <ClCompile Include="ui\viewmodels\OverlayListPageViewModel.cpp">
       <Filter>UI\ViewModels</Filter>
     </ClCompile>
+    <ClCompile Include="ui\win32\OverlayWindow.cpp">
+      <Filter>UI\Win32</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="RA_Achievement.h">
@@ -673,6 +676,9 @@
     </ClInclude>
     <ClInclude Include="ui\viewmodels\OverlayListPageViewModel.hh">
       <Filter>UI\ViewModels</Filter>
+    </ClInclude>
+    <ClInclude Include="ui\win32\OverlayWindow.hh">
+      <Filter>UI\Win32</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/RA_Interface.cpp
+++ b/src/RA_Interface.cpp
@@ -42,7 +42,9 @@ int     (CCONV *_RA_SetConsoleID)(unsigned int nConsoleID) = nullptr;
 int     (CCONV *_RA_HardcoreModeIsActive)(void) = nullptr;
 bool    (CCONV *_RA_WarnDisableHardcore)(const char* sActivity) = nullptr;
 //  Overlay:
+void    (CCONV *_RA_NavigateOverlay)(ControllerInput* pInput) = nullptr;
 int     (CCONV *_RA_UpdateOverlay)(ControllerInput* pInput, float fDeltaTime, bool Full_Screen, bool Paused) = nullptr;
+void    (CCONV *_RA_RenderOverlay)(HDC hDC, RECT* prcSize) = nullptr;
 bool    (CCONV *_RA_IsOverlayFullyVisible) () = nullptr;
 
 
@@ -55,10 +57,19 @@ void RA_AttemptLogin(bool bBlocking)
         _RA_AttemptLogin(bBlocking);
 }
 
+void RA_NavigateOverlay(ControllerInput* pInput)
+{
+    if (_RA_NavigateOverlay != nullptr)
+        _RA_NavigateOverlay(pInput);
+}
+
 void RA_UpdateRenderOverlay(HDC hDC, ControllerInput* pInput, float fDeltaTime, RECT* prcSize, bool Full_Screen, bool Paused)
 {
     if (_RA_UpdateOverlay != nullptr)
         _RA_UpdateOverlay(pInput, fDeltaTime, Full_Screen, Paused);
+
+    if (_RA_RenderOverlay != nullptr)
+        _RA_RenderOverlay(hDC, prcSize);
 }
 
 bool RA_IsOverlayFullyVisible()
@@ -432,7 +443,9 @@ static const char* CCONV _RA_InstallIntegration()
     _RA_InitOffline = (int(CCONV *)(HWND, int, const char*))                          GetProcAddress(g_hRADLL, "_RA_InitOffline");
     _RA_Shutdown = (int(CCONV *)())                                                   GetProcAddress(g_hRADLL, "_RA_Shutdown");
     _RA_AttemptLogin = (void(CCONV *)(bool))                                          GetProcAddress(g_hRADLL, "_RA_AttemptLogin");
+    _RA_NavigateOverlay = (void(CCONV *)(ControllerInput*))                           GetProcAddress(g_hRADLL, "_RA_NavigateOverlay");
     _RA_UpdateOverlay = (int(CCONV *)(ControllerInput*, float, bool, bool))           GetProcAddress(g_hRADLL, "_RA_UpdateOverlay");
+    _RA_RenderOverlay = (void(CCONV *)(HDC, RECT*))                                   GetProcAddress(g_hRADLL, "_RA_RenderOverlay");
     _RA_IsOverlayFullyVisible = (bool(CCONV *)())                                     GetProcAddress(g_hRADLL, "_RA_IsOverlayFullyVisible");
     _RA_OnLoadNewRom = (int(CCONV *)(const BYTE*, unsigned int))                      GetProcAddress(g_hRADLL, "_RA_OnLoadNewRom");
     _RA_IdentifyRom = (unsigned int(CCONV *)(const BYTE*, unsigned int))              GetProcAddress(g_hRADLL, "_RA_IdentifyRom");
@@ -601,7 +614,9 @@ void RA_Shutdown()
     _RA_IntegrationVersion = nullptr;
     _RA_InitI = nullptr;
     _RA_Shutdown = nullptr;
+    _RA_NavigateOverlay = nullptr;
     _RA_UpdateOverlay = nullptr;
+    _RA_RenderOverlay = nullptr;
     _RA_OnLoadNewRom = nullptr;
     _RA_IdentifyRom = nullptr;
     _RA_ActivateGame = nullptr;

--- a/src/RA_Interface.cpp
+++ b/src/RA_Interface.cpp
@@ -43,7 +43,6 @@ int     (CCONV *_RA_HardcoreModeIsActive)(void) = nullptr;
 bool    (CCONV *_RA_WarnDisableHardcore)(const char* sActivity) = nullptr;
 //  Overlay:
 int     (CCONV *_RA_UpdateOverlay)(ControllerInput* pInput, float fDeltaTime, bool Full_Screen, bool Paused) = nullptr;
-void    (CCONV *_RA_RenderOverlay)(HDC hDC, RECT* prcSize) = nullptr;
 bool    (CCONV *_RA_IsOverlayFullyVisible) () = nullptr;
 
 
@@ -60,9 +59,6 @@ void RA_UpdateRenderOverlay(HDC hDC, ControllerInput* pInput, float fDeltaTime, 
 {
     if (_RA_UpdateOverlay != nullptr)
         _RA_UpdateOverlay(pInput, fDeltaTime, Full_Screen, Paused);
-
-    if (_RA_RenderOverlay != nullptr)
-        _RA_RenderOverlay(hDC, prcSize);
 }
 
 bool RA_IsOverlayFullyVisible()
@@ -437,7 +433,6 @@ static const char* CCONV _RA_InstallIntegration()
     _RA_Shutdown = (int(CCONV *)())                                                   GetProcAddress(g_hRADLL, "_RA_Shutdown");
     _RA_AttemptLogin = (void(CCONV *)(bool))                                          GetProcAddress(g_hRADLL, "_RA_AttemptLogin");
     _RA_UpdateOverlay = (int(CCONV *)(ControllerInput*, float, bool, bool))           GetProcAddress(g_hRADLL, "_RA_UpdateOverlay");
-    _RA_RenderOverlay = (void(CCONV *)(HDC, RECT*))                                   GetProcAddress(g_hRADLL, "_RA_RenderOverlay");
     _RA_IsOverlayFullyVisible = (bool(CCONV *)())                                     GetProcAddress(g_hRADLL, "_RA_IsOverlayFullyVisible");
     _RA_OnLoadNewRom = (int(CCONV *)(const BYTE*, unsigned int))                      GetProcAddress(g_hRADLL, "_RA_OnLoadNewRom");
     _RA_IdentifyRom = (unsigned int(CCONV *)(const BYTE*, unsigned int))              GetProcAddress(g_hRADLL, "_RA_IdentifyRom");
@@ -607,7 +602,6 @@ void RA_Shutdown()
     _RA_InitI = nullptr;
     _RA_Shutdown = nullptr;
     _RA_UpdateOverlay = nullptr;
-    _RA_RenderOverlay = nullptr;
     _RA_OnLoadNewRom = nullptr;
     _RA_IdentifyRom = nullptr;
     _RA_ActivateGame = nullptr;

--- a/src/RA_Interface.h
+++ b/src/RA_Interface.h
@@ -132,6 +132,7 @@ extern void RA_DoAchievementsFrame();
 //	Updates and renders all on-screen overlays.
 extern void RA_UpdateRenderOverlay(HDC hDC, struct ControllerInput* pInput, float fDeltaTime, RECT* prcSize, bool Full_Screen,
                                    bool Paused);
+extern void RA_NavigateOverlay(struct ControllerInput* pInput);
 
 //  Determines if the overlay is completely covering the screen.
 extern bool RA_IsOverlayFullyVisible();

--- a/src/services/Initialization.cpp
+++ b/src/services/Initialization.cpp
@@ -28,6 +28,7 @@
 #include "ui\viewmodels\OverlayManager.hh"
 #include "ui\viewmodels\WindowManager.hh"
 #include "ui\win32\Desktop.hh"
+#include "ui\win32\OverlayWindow.hh"
 
 // this, in combination with the "#define ISOLATION_AWARE_ENABLED 1" in pch.h, allows our
 // UI to use visual styles introduced in ComCtl32 v6, even if the emulator does not enable them.
@@ -148,6 +149,9 @@ void Initialization::RegisterServices(EmulatorID nEmulatorId)
     auto pWindowManager = std::make_unique<ra::ui::viewmodels::WindowManager>();
     ra::services::ServiceLocator::Provide<ra::ui::viewmodels::WindowManager>(std::move(pWindowManager));
 
+    auto pOverlayWindow = std::make_unique<ra::ui::win32::OverlayWindow>();
+    ra::services::ServiceLocator::Provide<ra::ui::win32::OverlayWindow>(std::move(pOverlayWindow));
+
     auto pOverlayManager = std::make_unique<ra::ui::viewmodels::OverlayManager>();
     ra::services::ServiceLocator::Provide<ra::ui::viewmodels::OverlayManager>(std::move(pOverlayManager));
 
@@ -166,6 +170,8 @@ void Initialization::Shutdown()
         return;
 
     ra::services::ServiceLocator::GetMutable<ra::ui::IDesktop>().Shutdown();
+
+    ra::services::ServiceLocator::GetMutable<ra::ui::win32::OverlayWindow>().DestroyOverlayWindow();
 
     ra::services::ServiceLocator::GetMutable<ra::services::IThreadPool>().Shutdown(true);
 

--- a/src/ui/drawing/gdi/GDISurface.cpp
+++ b/src/ui/drawing/gdi/GDISurface.cpp
@@ -17,7 +17,7 @@ GDISurface::GDISurface(HDC hDC, const RECT& rcDEST, ResourceRepository& pResourc
 
 void GDISurface::FillRectangle(int nX, int nY, int nWidth, int nHeight, Color nColor) noexcept
 {
-    assert(nColor.Channel.A == 0xFF);
+    assert(nColor.Channel.A == 0xFF || nColor.Channel.A == 0x00);
     SetDCBrushColor(m_hDC, RGB(nColor.Channel.R, nColor.Channel.G, nColor.Channel.B));
     SetDCPenColor(m_hDC, RGB(nColor.Channel.R, nColor.Channel.G, nColor.Channel.B));
     Rectangle(m_hDC, nX, nY, nX + nWidth, nY + nHeight);

--- a/src/ui/viewmodels/OverlayListPageViewModel.cpp
+++ b/src/ui/viewmodels/OverlayListPageViewModel.cpp
@@ -3,6 +3,7 @@
 #include "ra_math.h"
 
 #include "ui\OverlayTheme.hh"
+#include "ui\viewmodels\OverlayManager.hh"
 
 namespace ra {
 namespace ui {
@@ -222,6 +223,12 @@ bool OverlayListPageViewModel::SetDetail(bool bDetail)
     }
 
     return false;
+}
+
+void OverlayListPageViewModel::ForceRedraw()
+{
+    m_bRedraw = true;
+    ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().RequestRender();
 }
 
 } // namespace viewmodels

--- a/src/ui/viewmodels/OverlayListPageViewModel.hh
+++ b/src/ui/viewmodels/OverlayListPageViewModel.hh
@@ -101,7 +101,7 @@ public:
 
 protected:
     bool SetDetail(bool bDetail);
-    void ForceRedraw() noexcept { m_bRedraw = true; }
+    void ForceRedraw();
     virtual void FetchItemDetail(_UNUSED ItemViewModel& vmItem) noexcept(false) {};
 
     gsl::index m_nScrollOffset = 0;

--- a/src/ui/viewmodels/OverlayManager.cpp
+++ b/src/ui/viewmodels/OverlayManager.cpp
@@ -57,6 +57,9 @@ void OverlayManager::Update(const ControllerInput& pInput)
 
 void OverlayManager::RequestRender()
 {
+    if (!m_fHandleRenderRequest)
+        return;
+
     const bool bNeedsRender = (m_vmOverlay.CurrentState() != OverlayViewModel::State::Hidden ||
         !m_vPopupMessages.empty() || !m_vScoreboards.empty() || !m_vScoreTrackers.empty());
 
@@ -68,16 +71,14 @@ void OverlayManager::RequestRender()
             m_tLastRender = pClock.UpTime();
 
             m_bIsRendering = true;
-
-            if (m_fHandleRenderRequest)
-                m_fHandleRenderRequest();
+            m_fHandleRenderRequest();
         }
         else
         {
             m_bIsRendering = false;
         }
     }
-    else if (m_bIsRendering && m_fHandleRenderRequest)
+    else if (m_bIsRendering)
     {
         auto& pClock = ra::services::ServiceLocator::Get<ra::services::IClock>();
         const auto tNow = pClock.UpTime();

--- a/src/ui/viewmodels/OverlayManager.cpp
+++ b/src/ui/viewmodels/OverlayManager.cpp
@@ -57,7 +57,7 @@ void OverlayManager::Update(const ControllerInput& pInput)
 
 void OverlayManager::RequestRender()
 {
-    bool bNeedsRender = (m_vmOverlay.CurrentState() != OverlayViewModel::State::Hidden ||
+    const bool bNeedsRender = (m_vmOverlay.CurrentState() != OverlayViewModel::State::Hidden ||
         !m_vPopupMessages.empty() || !m_vScoreboards.empty() || !m_vScoreTrackers.empty());
 
     if (m_bIsRendering != bNeedsRender)
@@ -87,7 +87,7 @@ void OverlayManager::RequestRender()
             if (!m_bRenderRequestPending)
             {
                 m_bRenderRequestPending = true;
-                auto nDelay = tPacing - (tNow - m_tLastRender);
+                const auto nDelay = tPacing - (tNow - m_tLastRender);
                 ra::services::ServiceLocator::GetMutable<ra::services::IThreadPool>().ScheduleAsync(
                     std::chrono::duration_cast<std::chrono::milliseconds>(nDelay), [this]()
                 {
@@ -106,9 +106,9 @@ void OverlayManager::RequestRender()
 void OverlayManager::Render(ra::ui::drawing::ISurface& pSurface)
 {
     auto& pClock = ra::services::ServiceLocator::Get<ra::services::IClock>();
-    auto tNow = pClock.UpTime();
-    auto tElapsed = tNow - m_tLastRender;
-    double fElapsed = std::chrono::duration_cast<std::chrono::microseconds>(tElapsed).count() / 1000000.0;
+    const auto tNow = pClock.UpTime();
+    const auto tElapsed = tNow - m_tLastRender;
+    const double fElapsed = std::chrono::duration_cast<std::chrono::microseconds>(tElapsed).count() / 1000000.0;
     m_tLastRender = tNow;
 
     if (m_vmOverlay.CurrentState() == OverlayViewModel::State::Hidden)
@@ -216,7 +216,7 @@ void OverlayManager::UpdatePopup(ra::ui::drawing::ISurface& pSurface, double fEl
         return;
     }
 
-    bool bUpdated = vmPopup.UpdateRenderImage(fElapsed);
+    const bool bUpdated = vmPopup.UpdateRenderImage(fElapsed);
 
     const int nNewX = GetAbsolutePosition(vmPopup.GetRenderLocationX(), vmPopup.GetRenderLocationXRelativePosition(), pSurface.GetWidth());
     const int nNewY = GetAbsolutePosition(vmPopup.GetRenderLocationY(), vmPopup.GetRenderLocationYRelativePosition(), pSurface.GetHeight());

--- a/src/ui/viewmodels/OverlayManager.cpp
+++ b/src/ui/viewmodels/OverlayManager.cpp
@@ -2,31 +2,12 @@
 
 #include "services\IClock.hh"
 #include "services\IConfiguration.hh"
+#include "services\IThreadPool.hh"
 #include "services\ServiceLocator.hh"
 
 namespace ra {
 namespace ui {
 namespace viewmodels {
-
-void OverlayManager::Update(const ControllerInput& pInput, double fElapsed)
-{
-    if (m_vmOverlay.CurrentState() == OverlayViewModel::State::Hidden)
-    {
-        if (!m_vPopupMessages.empty())
-            UpdateActiveMessage(fElapsed);
-
-        if (!m_vScoreboards.empty())
-            UpdateActiveScoreboard(fElapsed);
-
-        for (auto& pScoreTracker : m_vScoreTrackers)
-            pScoreTracker->UpdateRenderImage(fElapsed);
-    }
-    else
-    {
-        m_vmOverlay.ProcessInput(pInput);
-        m_vmOverlay.UpdateRenderImage(fElapsed);
-    }
-}
 
 static int GetAbsolutePosition(int nValue, RelativePosition nRelativePosition, size_t nFarValue) noexcept
 {
@@ -46,64 +27,130 @@ static int GetAbsolutePosition(int nValue, RelativePosition nRelativePosition, s
     }
 }
 
-void OverlayManager::Render(ra::ui::drawing::ISurface& pSurface) const
+static void RenderPopup(ra::ui::drawing::ISurface& pSurface, const PopupViewModelBase& vmPopup)
 {
-    if (m_vmOverlay.CurrentState() != OverlayViewModel::State::Visible)
-        RenderPopups(pSurface);
+    if (!vmPopup.IsAnimationStarted())
+        return;
 
-    if (m_vmOverlay.CurrentState() != OverlayViewModel::State::Hidden)
+    const int nX = GetAbsolutePosition(vmPopup.GetRenderLocationX(), vmPopup.GetRenderLocationXRelativePosition(), pSurface.GetWidth());
+    const int nY = GetAbsolutePosition(vmPopup.GetRenderLocationY(), vmPopup.GetRenderLocationYRelativePosition(), pSurface.GetHeight());
+    pSurface.DrawSurface(nX, nY, vmPopup.GetRenderImage());
+}
+
+static void RenderPopupClippedX(ra::ui::drawing::ISurface& pSurface, const PopupViewModelBase& vmPopup, int nClipX)
+{
+    if (!vmPopup.IsAnimationStarted())
+        return;
+
+    const int nX = GetAbsolutePosition(vmPopup.GetRenderLocationX(), vmPopup.GetRenderLocationXRelativePosition(), pSurface.GetWidth());
+    const int nY = GetAbsolutePosition(vmPopup.GetRenderLocationY(), vmPopup.GetRenderLocationYRelativePosition(), pSurface.GetHeight());
+
+    if (nX + ra::to_signed(vmPopup.GetRenderImage().GetWidth()) > nClipX)
+        pSurface.DrawSurface(nX, nY, vmPopup.GetRenderImage());
+}
+
+void OverlayManager::Update(const ControllerInput& pInput)
+{
+    if (m_vmOverlay.CurrentState() == OverlayViewModel::State::Visible)
+        m_vmOverlay.ProcessInput(pInput);
+}
+
+void OverlayManager::RequestRender()
+{
+    bool bNeedsRender = (m_vmOverlay.CurrentState() != OverlayViewModel::State::Hidden ||
+        !m_vPopupMessages.empty() || !m_vScoreboards.empty() || !m_vScoreTrackers.empty());
+
+    if (m_bIsRendering != bNeedsRender)
     {
-        const int nX = GetAbsolutePosition(m_vmOverlay.GetRenderLocationX(), m_vmOverlay.GetRenderLocationXRelativePosition(), pSurface.GetWidth());
-        const int nY = GetAbsolutePosition(m_vmOverlay.GetRenderLocationY(), m_vmOverlay.GetRenderLocationYRelativePosition(), pSurface.GetHeight());
-        pSurface.DrawSurface(nX, nY, m_vmOverlay.GetRenderImage());
+        if (bNeedsRender)
+        {
+            auto& pClock = ra::services::ServiceLocator::Get<ra::services::IClock>();
+            m_tLastRender = pClock.UpTime();
+
+            m_bIsRendering = true;
+
+            if (m_fHandleRenderRequest)
+                m_fHandleRenderRequest();
+        }
+        else
+        {
+            m_bIsRendering = false;
+        }
+    }
+    else if (m_bIsRendering && m_fHandleRenderRequest)
+    {
+        auto& pClock = ra::services::ServiceLocator::Get<ra::services::IClock>();
+        const auto tNow = pClock.UpTime();
+        const auto tPacing = std::chrono::milliseconds(10);
+        if (tNow - m_tLastRender < tPacing)
+        {
+            if (!m_bRenderRequestPending)
+            {
+                m_bRenderRequestPending = true;
+                auto nDelay = tPacing - (tNow - m_tLastRender);
+                ra::services::ServiceLocator::GetMutable<ra::services::IThreadPool>().ScheduleAsync(
+                    std::chrono::duration_cast<std::chrono::milliseconds>(nDelay), [this]()
+                {
+                    m_bRenderRequestPending = false;
+                    m_fHandleRenderRequest();
+                });
+            }
+        }
+        else if (!m_bRenderRequestPending)
+        {
+            m_fHandleRenderRequest();
+        }
     }
 }
 
-void OverlayManager::RenderPopups(ra::ui::drawing::ISurface& pSurface) const
+void OverlayManager::Render(ra::ui::drawing::ISurface& pSurface)
 {
-    int nScoreboardHeight = 0;
-    if (!m_vScoreboards.empty())
+    auto& pClock = ra::services::ServiceLocator::Get<ra::services::IClock>();
+    auto tNow = pClock.UpTime();
+    auto tElapsed = tNow - m_tLastRender;
+    double fElapsed = std::chrono::duration_cast<std::chrono::microseconds>(tElapsed).count() / 1000000.0;
+    m_tLastRender = tNow;
+
+    if (m_vmOverlay.CurrentState() == OverlayViewModel::State::Hidden)
     {
-        // if the animation hasn't started, it was queued after the last update was called.
-        // ignore it for now as the location won't be correct, and the render image won't be ready.
-        const auto& pActiveScoreboard = m_vScoreboards.front();
-        if (pActiveScoreboard.IsAnimationStarted())
-        {
-            const int nX = GetAbsolutePosition(pActiveScoreboard.GetRenderLocationX(), pActiveScoreboard.GetRenderLocationXRelativePosition(), pSurface.GetWidth());
-            const int nY = GetAbsolutePosition(pActiveScoreboard.GetRenderLocationY(), pActiveScoreboard.GetRenderLocationYRelativePosition(), pSurface.GetHeight());
-            pSurface.DrawSurface(nX, nY, pActiveScoreboard.GetRenderImage());
-            nScoreboardHeight = pActiveScoreboard.GetRenderImage().GetHeight() + 10;
-        }
+        if (!m_vScoreboards.empty())
+            UpdateActiveScoreboard(pSurface, fElapsed);
+
+        if (!m_vScoreTrackers.empty())
+            UpdateScoreTrackers(pSurface, fElapsed);
+
+        if (!m_vPopupMessages.empty())
+            UpdateActiveMessage(pSurface, fElapsed);
+    }
+    else
+    {
+        UpdateOverlay(pSurface, fElapsed);
     }
 
-    if (!m_vScoreTrackers.empty())
-    {
-        auto& pConfiguration = ra::services::ServiceLocator::Get<ra::services::IConfiguration>();
-        if (pConfiguration.IsFeatureEnabled(ra::services::Feature::LeaderboardCounters))
-        {
-            const auto nX = pSurface.GetWidth() - 10;
-            int nY = pSurface.GetHeight() - 10 - nScoreboardHeight;
+    RequestRender();
+}
 
-            for (auto& pTracker : m_vScoreTrackers)
-            {
-                const auto& pRenderImage = pTracker->GetRenderImage();
-                nY -= pRenderImage.GetHeight();
-                pSurface.DrawSurface(nX - pRenderImage.GetWidth(), nY, pRenderImage);
-                nY -= 10;
-            }
-        }
-    }
+ScoreTrackerViewModel& OverlayManager::AddScoreTracker(ra::LeaderboardID nLeaderboardId)
+{
+    auto pScoreTracker = std::make_unique<ScoreTrackerViewModel>();
+    pScoreTracker->SetPopupId(nLeaderboardId);
+    pScoreTracker->UpdateRenderImage(0.0);
+    auto& pReturn = *m_vScoreTrackers.emplace_back(std::move(pScoreTracker));
 
-    if (!m_vPopupMessages.empty())
+    RequestRender();
+
+    return pReturn;
+}
+
+void OverlayManager::RemoveScoreTracker(ra::LeaderboardID nLeaderboardId)
+{
+    for (auto pIter = m_vScoreTrackers.begin(); pIter != m_vScoreTrackers.end(); ++pIter)
     {
-        // if the animation hasn't started, it was queued after the last update was called.
-        // ignore it for now as the location won't be correct, and the render image won't be ready.
-        const auto& pActiveMessage = m_vPopupMessages.front();
-        if (pActiveMessage.IsAnimationStarted())
+        if (ra::to_unsigned((*pIter)->GetPopupId()) == nLeaderboardId)
         {
-            const int nX = GetAbsolutePosition(pActiveMessage.GetRenderLocationX(), pActiveMessage.GetRenderLocationXRelativePosition(), pSurface.GetWidth());
-            const int nY = GetAbsolutePosition(pActiveMessage.GetRenderLocationY(), pActiveMessage.GetRenderLocationYRelativePosition(), pSurface.GetHeight());
-            pSurface.DrawSurface(nX, nY, pActiveMessage.GetRenderImage());
+            (*pIter)->SetDestroyPending();
+            RequestRender();
+            break;
         }
     }
 }
@@ -112,6 +159,8 @@ void OverlayManager::QueueScoreboard(ra::LeaderboardID nLeaderboardId, Scoreboar
 {
     vmScoreboard.SetPopupId(nLeaderboardId);
     m_vScoreboards.push_back(std::move(vmScoreboard));
+
+    RequestRender();
 }
 
 int OverlayManager::QueueMessage(PopupMessageViewModel&& pMessage)
@@ -128,36 +177,84 @@ int OverlayManager::QueueMessage(PopupMessageViewModel&& pMessage)
 
     m_vPopupMessages.emplace_back(std::move(pMessage));
 
+    RequestRender();
+
     return pMessage.GetPopupId();
 }
 
 void OverlayManager::ClearPopups()
 {
-    while (!m_vPopupMessages.empty())
-        m_vPopupMessages.pop_front();
+    for (auto& pPopup : m_vPopupMessages)
+        pPopup.SetDestroyPending();
 
-    while (!m_vScoreboards.empty())
-        m_vScoreboards.pop_front();
+    for (auto& pScoreboard : m_vScoreboards)
+        pScoreboard.SetDestroyPending();
 
-    m_vScoreTrackers.clear();
+    for (auto& pTracker : m_vScoreTrackers)
+        pTracker->SetDestroyPending();
 
     m_vmOverlay.Deactivate();
+
+    RequestRender();
 }
 
-void OverlayManager::UpdateActiveMessage(double fElapsed)
+void OverlayManager::UpdatePopup(ra::ui::drawing::ISurface& pSurface, double fElapsed, ra::ui::viewmodels::PopupViewModelBase& vmPopup)
 {
-    assert(!m_vPopupMessages.empty());
-    auto* pActiveMessage = &m_vPopupMessages.front();
-
-    if (!pActiveMessage->IsAnimationStarted())
+    if (!vmPopup.IsAnimationStarted())
     {
-        pActiveMessage->BeginAnimation();
+        vmPopup.BeginAnimation();
         fElapsed = 0.0;
     }
 
-    pActiveMessage->UpdateRenderImage(fElapsed);
+    const int nOldX = GetAbsolutePosition(vmPopup.GetRenderLocationX(), vmPopup.GetRenderLocationXRelativePosition(), pSurface.GetWidth());
+    const int nOldY = GetAbsolutePosition(vmPopup.GetRenderLocationY(), vmPopup.GetRenderLocationYRelativePosition(), pSurface.GetHeight());
 
-    while (pActiveMessage->IsAnimationComplete())
+    if (vmPopup.IsDestroyPending())
+    {
+        const auto& pImage = vmPopup.GetRenderImage();
+        pSurface.FillRectangle(nOldX, nOldY, pImage.GetWidth(), pImage.GetHeight(), ra::ui::Color::Transparent);
+        return;
+    }
+
+    bool bUpdated = vmPopup.UpdateRenderImage(fElapsed);
+
+    const int nNewX = GetAbsolutePosition(vmPopup.GetRenderLocationX(), vmPopup.GetRenderLocationXRelativePosition(), pSurface.GetWidth());
+    const int nNewY = GetAbsolutePosition(vmPopup.GetRenderLocationY(), vmPopup.GetRenderLocationYRelativePosition(), pSurface.GetHeight());
+
+    if (bUpdated)
+    {
+        const auto& pImage = vmPopup.GetRenderImage();
+
+        // if the image moved, we have to blank out the area it previously covered
+        if (nOldY != nNewY || nOldX != nNewX)
+        {
+            const int nWidth = pImage.GetWidth() + std::abs(nNewX - nOldX);
+            const int nHeight = pImage.GetHeight() + std::abs(nNewY - nOldY);
+
+            if (nNewX > nOldX)
+                pSurface.FillRectangle(nOldX, nOldY, nNewX - nOldX, nHeight, ra::ui::Color::Transparent);
+            else if (nNewX < nOldX)
+                pSurface.FillRectangle(nNewX + pImage.GetWidth() - 1, nOldY, nOldX - nNewX + 1, nHeight, ra::ui::Color::Transparent);
+
+            if (nNewY > nOldY)
+                pSurface.FillRectangle(nOldX, nOldY, nWidth, nNewY - nOldY, ra::ui::Color::Transparent);
+            else if (nNewY < nOldY)
+                pSurface.FillRectangle(nOldX, nNewY + pImage.GetHeight() - 1, nWidth, nOldY - nNewY + 1, ra::ui::Color::Transparent);
+        }
+
+        if (!vmPopup.IsAnimationComplete())
+            pSurface.DrawSurface(nNewX, nNewY, pImage);
+    }
+}
+
+void OverlayManager::UpdateActiveMessage(ra::ui::drawing::ISurface& pSurface, double fElapsed)
+{
+    assert(!m_vPopupMessages.empty());
+
+    auto* pActiveMessage = &m_vPopupMessages.front();
+    UpdatePopup(pSurface, fElapsed, *pActiveMessage);
+
+    while (pActiveMessage->IsAnimationComplete() || pActiveMessage->IsDestroyPending())
     {
         m_vPopupMessages.pop_front();
         if (m_vPopupMessages.empty())
@@ -169,20 +266,14 @@ void OverlayManager::UpdateActiveMessage(double fElapsed)
     }
 }
 
-void OverlayManager::UpdateActiveScoreboard(double fElapsed)
+void OverlayManager::UpdateActiveScoreboard(ra::ui::drawing::ISurface& pSurface, double fElapsed)
 {
     assert(!m_vScoreboards.empty());
+
     auto* pActiveScoreboard = &m_vScoreboards.front();
+    UpdatePopup(pSurface, fElapsed, *pActiveScoreboard);
 
-    if (!pActiveScoreboard->IsAnimationStarted())
-    {
-        pActiveScoreboard->BeginAnimation();
-        fElapsed = 0.0;
-    }
-
-    pActiveScoreboard->UpdateRenderImage(fElapsed);
-
-    while (pActiveScoreboard->IsAnimationComplete())
+    while (pActiveScoreboard->IsAnimationComplete() || pActiveScoreboard->IsDestroyPending())
     {
         m_vScoreboards.pop_front();
         if (m_vScoreboards.empty())
@@ -191,6 +282,103 @@ void OverlayManager::UpdateActiveScoreboard(double fElapsed)
         pActiveScoreboard = &m_vScoreboards.front();
         pActiveScoreboard->BeginAnimation();
         pActiveScoreboard->UpdateRenderImage(0.0);
+    }
+}
+
+void OverlayManager::UpdateScoreTrackers(ra::ui::drawing::ISurface& pSurface, double fElapsed)
+{
+    assert(!m_vScoreTrackers.empty());
+
+    auto& pConfiguration = ra::services::ServiceLocator::Get<ra::services::IConfiguration>();
+    if (!pConfiguration.IsFeatureEnabled(ra::services::Feature::LeaderboardCounters))
+    {
+        auto pIter = m_vScoreTrackers.begin();
+        while (pIter != m_vScoreTrackers.end())
+        {
+            if ((*pIter)->IsDestroyPending())
+                pIter = m_vScoreTrackers.erase(pIter);
+            else
+                ++pIter;
+        }
+
+        return;
+    }
+
+    int nOffset = 10;
+    if (!m_vScoreboards.empty())
+        nOffset += m_vScoreboards.front().GetRenderImage().GetHeight() + 10;
+
+    bool bPopupMoved = false;
+    auto pIter = m_vScoreTrackers.begin();
+    while (pIter != m_vScoreTrackers.end())
+    {
+        auto& vmTracker = **pIter;
+        if (vmTracker.IsDestroyPending())
+        {
+            bPopupMoved = true;
+            UpdatePopup(pSurface, fElapsed, vmTracker);
+            pIter = m_vScoreTrackers.erase(pIter);
+        }
+        else
+        {
+            bPopupMoved |= vmTracker.SetOffset(nOffset);
+            UpdatePopup(pSurface, fElapsed, vmTracker);
+            nOffset += vmTracker.GetRenderImage().GetHeight() + 10;
+            ++pIter;
+        }
+    }
+
+    // if one or more of the popups moved, we will have drawn a transparent square where the popup used to be. redraw all the popups to make sure we didn't erase one
+    if (bPopupMoved)
+    {
+        for (auto& vmTracker : m_vScoreTrackers)
+            RenderPopup(pSurface, *vmTracker);
+
+        if (!m_vScoreboards.empty())
+            RenderPopup(pSurface, m_vScoreboards.front());
+    }
+}
+
+void OverlayManager::UpdateOverlay(ra::ui::drawing::ISurface& pSurface, double fElapsed)
+{
+    if (pSurface.GetWidth() != m_vmOverlay.GetRenderImage().GetWidth() ||
+        pSurface.GetHeight() != m_vmOverlay.GetRenderImage().GetHeight())
+    {
+        m_vmOverlay.Resize(pSurface.GetWidth(), pSurface.GetHeight());
+    }
+
+    if (m_vmOverlay.CurrentState() == OverlayViewModel::State::FadeOut)
+    {
+        // when fading out, have to redraw the popups that were obscured by the overlay
+        const int nOverlayRight = GetAbsolutePosition(m_vmOverlay.GetRenderLocationX(),
+            m_vmOverlay.GetRenderLocationXRelativePosition(), pSurface.GetWidth()) +
+            m_vmOverlay.GetRenderImage().GetWidth();
+
+        for (auto& pTracker : m_vScoreTrackers)
+            RenderPopupClippedX(pSurface, *pTracker, nOverlayRight);
+
+        if (!m_vScoreboards.empty())
+            RenderPopupClippedX(pSurface, m_vScoreboards.front(), nOverlayRight);
+
+        if (!m_vPopupMessages.empty())
+            RenderPopupClippedX(pSurface, m_vPopupMessages.front(), nOverlayRight);
+    }
+
+    UpdatePopup(pSurface, fElapsed, m_vmOverlay);
+
+    if (m_vmOverlay.CurrentState() == OverlayViewModel::State::Hidden)
+    {
+        m_vmOverlay.DestroyRenderImage();
+
+        // fade out completed, render everything that was obscured by the overlay
+        for (auto& pTracker : m_vScoreTrackers)
+            RenderPopup(pSurface, *pTracker);
+
+        if (!m_vScoreboards.empty())
+            RenderPopup(pSurface, m_vScoreboards.front());
+
+        if (!m_vPopupMessages.empty())
+            RenderPopup(pSurface, m_vPopupMessages.front());
     }
 }
 

--- a/src/ui/viewmodels/OverlayManager.cpp
+++ b/src/ui/viewmodels/OverlayManager.cpp
@@ -221,6 +221,7 @@ void OverlayManager::UpdatePopup(ra::ui::drawing::ISurface& pSurface, double fEl
     if (!vmPopup.IsAnimationStarted())
     {
         vmPopup.BeginAnimation();
+        vmPopup.UpdateRenderImage(0.0);
         fElapsed = 0.0;
     }
 
@@ -239,12 +240,7 @@ void OverlayManager::UpdatePopup(ra::ui::drawing::ISurface& pSurface, double fEl
     const int nNewX = GetAbsolutePosition(vmPopup.GetRenderLocationX(), vmPopup.GetRenderLocationXRelativePosition(), pSurface.GetWidth());
     const int nNewY = GetAbsolutePosition(vmPopup.GetRenderLocationY(), vmPopup.GetRenderLocationYRelativePosition(), pSurface.GetHeight());
 
-    if (m_bRedrawAll)
-    {
-        if (!vmPopup.IsAnimationComplete())
-            pSurface.DrawSurface(nNewX, nNewY, vmPopup.GetRenderImage());
-    }
-    else if (bUpdated)
+    if (bUpdated)
     {
         const auto& pImage = vmPopup.GetRenderImage();
 
@@ -267,6 +263,11 @@ void OverlayManager::UpdatePopup(ra::ui::drawing::ISurface& pSurface, double fEl
 
         if (!vmPopup.IsAnimationComplete())
             pSurface.DrawSurface(nNewX, nNewY, pImage);
+    }
+    else if (m_bRedrawAll)
+    {
+        if (!vmPopup.IsAnimationComplete())
+            pSurface.DrawSurface(nNewX, nNewY, vmPopup.GetRenderImage());
     }
 }
 

--- a/src/ui/viewmodels/OverlayManager.hh
+++ b/src/ui/viewmodels/OverlayManager.hh
@@ -32,6 +32,7 @@ public:
     void ShowOverlay()
     {
         m_vmOverlay.Activate();
+        RequestRender();
     }
 
     /// <summary>
@@ -170,7 +171,7 @@ public:
     /// <summary>
     /// Clears all popups.
     /// </summary>
-    void ClearPopups();
+    virtual void ClearPopups();
 
     /// <summary>
     /// Sets the function to call when there's something to be rendered.
@@ -179,6 +180,12 @@ public:
     {
         m_fHandleRenderRequest = std::move(fHandleRenderRequest);
     }
+
+protected:
+    ra::ui::viewmodels::OverlayViewModel m_vmOverlay;
+    std::deque<PopupMessageViewModel> m_vPopupMessages;
+    std::vector<std::unique_ptr<ScoreTrackerViewModel>> m_vScoreTrackers;
+    std::deque<ScoreboardViewModel> m_vScoreboards;
 
 private:
     void UpdateActiveMessage(ra::ui::drawing::ISurface& pSurface, double fElapsed);
@@ -190,15 +197,11 @@ private:
 
     void RequestRender();
 
-    ra::ui::viewmodels::OverlayViewModel m_vmOverlay;
     bool m_bIsRendering = false;
     bool m_bRenderRequestPending = false;
     std::chrono::steady_clock::time_point m_tLastRender{};
     std::function<void()> m_fHandleRenderRequest;
 
-    std::deque<PopupMessageViewModel> m_vPopupMessages;
-    std::vector<std::unique_ptr<ScoreTrackerViewModel>> m_vScoreTrackers;
-    std::deque<ScoreboardViewModel> m_vScoreboards;
     std::atomic<int> m_nPopupId{ 0 };
 };
 

--- a/src/ui/viewmodels/OverlayManager.hh
+++ b/src/ui/viewmodels/OverlayManager.hh
@@ -14,6 +14,13 @@ namespace viewmodels {
 
 class OverlayManager {
 public:    
+    GSL_SUPPRESS_F6 OverlayManager() = default;
+    virtual ~OverlayManager() noexcept = default;
+    OverlayManager(const OverlayManager&) noexcept = delete;
+    OverlayManager& operator=(const OverlayManager&) noexcept = delete;
+    OverlayManager(OverlayManager&&) noexcept = delete;
+    OverlayManager& operator=(OverlayManager&&) noexcept = delete;
+
     /// <summary>
     /// Updates the overlay.
     /// </summary>

--- a/src/ui/viewmodels/OverlayManager.hh
+++ b/src/ui/viewmodels/OverlayManager.hh
@@ -27,12 +27,16 @@ public:
     void Render(ra::ui::drawing::ISurface& pSurface);
 
     /// <summary>
+    /// Requests the overlay be redrawn.
+    /// </summary>
+    void RequestRender();
+
+    /// <summary>
     /// Starts the animation to show the overlay.
     /// </summary>
     void ShowOverlay()
     {
         m_vmOverlay.Activate();
-        RequestRender();
     }
 
     /// <summary>
@@ -187,6 +191,8 @@ protected:
     std::vector<std::unique_ptr<ScoreTrackerViewModel>> m_vScoreTrackers;
     std::deque<ScoreboardViewModel> m_vScoreboards;
 
+    bool m_bRenderRequestPending = false;
+
 private:
     void UpdateActiveMessage(ra::ui::drawing::ISurface& pSurface, double fElapsed);
     void UpdateActiveScoreboard(ra::ui::drawing::ISurface& pSurface, double fElapsed);
@@ -195,10 +201,7 @@ private:
 
     void UpdateOverlay(ra::ui::drawing::ISurface& pSurface, double fElapsed);
 
-    void RequestRender();
-
     bool m_bIsRendering = false;
-    bool m_bRenderRequestPending = false;
     std::chrono::steady_clock::time_point m_tLastRender{};
     std::function<void()> m_fHandleRenderRequest;
 

--- a/src/ui/viewmodels/OverlayManager.hh
+++ b/src/ui/viewmodels/OverlayManager.hh
@@ -24,7 +24,8 @@ public:
     /// Renders the overlay.
     /// </summary>
     /// <param name="pSurface">The surface to render to.</param>
-    void Render(ra::ui::drawing::ISurface& pSurface);
+    /// <param name="bRedrawAll">True to redraw everything even if it hasn't changed or moved.</param>
+    void Render(ra::ui::drawing::ISurface& pSurface, bool bRedrawAll);
 
     /// <summary>
     /// Requests the overlay be redrawn.
@@ -201,6 +202,7 @@ private:
 
     void UpdateOverlay(ra::ui::drawing::ISurface& pSurface, double fElapsed);
 
+    bool m_bRedrawAll = false;
     bool m_bIsRendering = false;
     std::chrono::steady_clock::time_point m_tLastRender{};
     std::function<void()> m_fHandleRenderRequest;

--- a/src/ui/viewmodels/OverlayViewModel.cpp
+++ b/src/ui/viewmodels/OverlayViewModel.cpp
@@ -27,11 +27,16 @@ void OverlayViewModel::BeginAnimation()
     const auto& vmEmulator = ra::services::ServiceLocator::Get<ra::ui::viewmodels::WindowManager>().Emulator;
     const auto szEmulator = ra::services::ServiceLocator::Get<ra::ui::IDesktop>().GetClientSize(vmEmulator);
 
-    m_pSurface = ra::services::ServiceLocator::GetMutable<ra::ui::drawing::ISurfaceFactory>().CreateSurface(szEmulator.Width, szEmulator.Height);
-    m_bSurfaceStale = true;
+    Resize(szEmulator.Width, szEmulator.Height);
 
     SetRenderLocationX(-szEmulator.Width);
     SetRenderLocationY(0);
+}
+
+void OverlayViewModel::Resize(int nWidth, int nHeight)
+{
+    m_pSurface = ra::services::ServiceLocator::GetMutable<ra::ui::drawing::ISurfaceFactory>().CreateSurface(nWidth, nHeight);
+    m_bSurfaceStale = true;
 }
 
 bool OverlayViewModel::UpdateRenderImage(double fElapsed)
@@ -66,10 +71,7 @@ bool OverlayViewModel::UpdateRenderImage(double fElapsed)
                 bUpdated = true;
 
                 if (nNewX == 0)
-                {
                     m_nState = State::Visible;
-                    m_fAnimationProgress = -1.0;
-                }
             }
         }
         else if (m_nState == State::FadeOut)
@@ -91,8 +93,6 @@ bool OverlayViewModel::UpdateRenderImage(double fElapsed)
                 {
                     m_nState = State::Hidden;
                     m_fAnimationProgress = -1.0;
-                    m_bSurfaceStale = false;
-                    m_pSurface.reset();
                     return true;
                 }
             }
@@ -285,6 +285,7 @@ void OverlayViewModel::Deactivate()
         case State::FadeIn:
             m_nState = State::FadeOut;
             m_fAnimationProgress = INOUT_TIME - m_fAnimationProgress;
+            SetRenderLocationX(GetRenderImage().GetWidth() - GetRenderLocationX());
             ra::services::ServiceLocator::Get<ra::data::EmulatorContext>().Unpause();
             break;
     }

--- a/src/ui/viewmodels/OverlayViewModel.hh
+++ b/src/ui/viewmodels/OverlayViewModel.hh
@@ -109,6 +109,8 @@ private:
     void PopulatePages();
     void CreateRenderImage();
 
+    void RefreshOverlay();
+
     State m_nState = State::Hidden;
     bool m_bSurfaceStale = false;
 

--- a/src/ui/viewmodels/OverlayViewModel.hh
+++ b/src/ui/viewmodels/OverlayViewModel.hh
@@ -39,7 +39,7 @@ public:
     /// <summary>
     /// Releases the memory used to cache the render image.
     /// </summary>
-    void DestroyRenderImage()
+    void DestroyRenderImage() noexcept
     {
         m_bSurfaceStale = false;
         m_pSurface.reset();

--- a/src/ui/viewmodels/OverlayViewModel.hh
+++ b/src/ui/viewmodels/OverlayViewModel.hh
@@ -11,6 +11,16 @@ namespace viewmodels {
 
 class OverlayViewModel : public PopupViewModelBase {
 public:
+    enum class State
+    {
+        Hidden,
+        FadeIn,
+        Visible,
+        FadeOut,
+    };
+
+    State CurrentState() const noexcept { return m_nState; }
+
     /// <summary>
     /// Begins the animation cycle.
     /// </summary>
@@ -27,6 +37,15 @@ public:
     void RebuildRenderImage() noexcept { m_bSurfaceStale = true; }
 
     /// <summary>
+    /// Releases the memory used to cache the render image.
+    /// </summary>
+    void DestroyRenderImage()
+    {
+        m_bSurfaceStale = false;
+        m_pSurface.reset();
+    }
+
+    /// <summary>
     /// Determines whether the animation cycle has started.
     /// </summary>
     bool IsAnimationStarted() const noexcept override
@@ -39,20 +58,12 @@ public:
     /// </summary>
     bool IsAnimationComplete() const noexcept override
     {
-        return (m_fAnimationProgress >= INOUT_TIME);
+        return (m_nState == State::Hidden);
     }
 
-    enum class State
-    {
-        Hidden,
-        FadeIn,
-        Visible,
-        FadeOut,
-    };
-
-    State CurrentState() const noexcept { return m_nState; }
-
     void ProcessInput(const ControllerInput& pInput);
+
+    void Resize(int nWidth, int nHeight);
 
     void Activate();
     void Deactivate();

--- a/src/ui/viewmodels/PopupMessageViewModel.cpp
+++ b/src/ui/viewmodels/PopupMessageViewModel.cpp
@@ -7,9 +7,9 @@ namespace ui {
 namespace viewmodels {
 
 static _CONSTANT_VAR FONT_TO_USE = "Tahoma";
-static _CONSTANT_VAR FONT_SIZE_TITLE = 24;
-static _CONSTANT_VAR FONT_SIZE_SUBTITLE = 20;
-static _CONSTANT_VAR FONT_SIZE_DETAIL = 18;
+static _CONSTANT_VAR FONT_SIZE_TITLE = 26;
+static _CONSTANT_VAR FONT_SIZE_SUBTITLE = 18;
+static _CONSTANT_VAR FONT_SIZE_DETAIL = 16;
 
 const StringModelProperty PopupMessageViewModel::TitleProperty("PopupMessageViewModel", "Title", L"");
 const StringModelProperty PopupMessageViewModel::DescriptionProperty("PopupMessageViewModel", "Description", L"");
@@ -23,9 +23,9 @@ void PopupMessageViewModel::BeginAnimation()
     // left margin 10px
     SetRenderLocationX(10);
 
-    // animate to bottom margin 10px. assume height = 64+2
+    // animate to bottom margin 10px. assume height = 64+6
     m_nInitialY = 0;
-    m_nTargetY = 10 + 64 + 2;
+    m_nTargetY = 10 + 64 + 6;
     SetRenderLocationY(m_nInitialY);
     SetRenderLocationYRelativePosition(RelativePosition::Far);
 }
@@ -96,7 +96,7 @@ void PopupMessageViewModel::CreateRenderImage()
         std::max(szTitle.Width, std::max(szSubTitle.Width, szDetail.Width) + nSubTitleIndent) + 6 + 4 + nShadowOffset;
     const int nHeight = 4 + nImageSize + 4 + nShadowOffset;
 
-    pSurface = pSurfaceFactory.CreateTransparentSurface(nWidth, nHeight);
+    pSurface = pSurfaceFactory.CreateSurface(nWidth, nHeight);
     m_pSurface = std::move(pSurface);
 
     int nX = 4;
@@ -121,7 +121,7 @@ void PopupMessageViewModel::CreateRenderImage()
 
     // title
     nY -= 1;
-    m_pSurface->WriteText(nX + 1, nY + 1, nFontTitle, pOverlayTheme.ColorTextShadow(), sTitle);
+    m_pSurface->WriteText(nX + 2, nY + 2, nFontTitle, pOverlayTheme.ColorTextShadow(), sTitle);
     m_pSurface->WriteText(nX, nY, nFontTitle, pOverlayTheme.ColorTitle(), sTitle);
     nX += nSubTitleIndent;
 
@@ -129,7 +129,7 @@ void PopupMessageViewModel::CreateRenderImage()
     nY += FONT_SIZE_TITLE - 1;
     if (!sSubTitle.empty())
     {
-        m_pSurface->WriteText(nX + 1, nY + 1, nFontSubtitle, pOverlayTheme.ColorTextShadow(), sSubTitle);
+        m_pSurface->WriteText(nX + 2, nY + 2, nFontSubtitle, pOverlayTheme.ColorTextShadow(), sSubTitle);
         m_pSurface->WriteText(nX, nY, nFontSubtitle, pOverlayTheme.ColorDescription(), sSubTitle);
     }
 
@@ -137,11 +137,9 @@ void PopupMessageViewModel::CreateRenderImage()
     nY += FONT_SIZE_SUBTITLE;
     if (!sDetail.empty())
     {
-        m_pSurface->WriteText(nX + 1, nY + 1, nFontDetail, pOverlayTheme.ColorTextShadow(), sDetail);
+        m_pSurface->WriteText(nX + 2, nY + 2, nFontDetail, pOverlayTheme.ColorTextShadow(), sDetail);
         m_pSurface->WriteText(nX, nY, nFontDetail, IsDetailError() ? pOverlayTheme.ColorError() : pOverlayTheme.ColorDetail(), sDetail);
     }
-
-    m_pSurface->SetOpacity(0.85);
 }
 
 } // namespace viewmodels

--- a/src/ui/viewmodels/PopupViewModelBase.hh
+++ b/src/ui/viewmodels/PopupViewModelBase.hh
@@ -125,11 +125,22 @@ public:
     /// </summary>
     void SetPopupId(int nPopupId) noexcept { m_nPopupId = nPopupId; }
 
+    /// <summary>
+    /// Gets whether this instance has been marked for destruction.
+    /// </summary>
+    bool IsDestroyPending() const noexcept { return m_bDestroyPending; }
+
+    /// <summary>
+    /// Marks this instance to be destroyed.
+    /// </summary>
+    void SetDestroyPending() noexcept { m_bDestroyPending = true; }
+
 protected:
     static int GetFadeOffset(double fAnimationProgress, double fTotalAnimationTime, double fInOutTime, int nInitialOffset, int nTargetOffset);
 
     std::unique_ptr<ra::ui::drawing::ISurface> m_pSurface;
-    int m_nPopupId{ 0 };
+    int m_nPopupId = 0;
+    bool m_bDestroyPending = false;
 };
 
 } // namespace viewmodels

--- a/src/ui/viewmodels/ScoreTrackerViewModel.cpp
+++ b/src/ui/viewmodels/ScoreTrackerViewModel.cpp
@@ -21,7 +21,10 @@ bool ScoreTrackerViewModel::UpdateRenderImage(_UNUSED double fElapsed)
     {
         const auto nOffset = GetRenderLocationY() + ra::to_signed(GetRenderImage().GetHeight());
         if (m_nOffset != nOffset)
+        {
             SetRenderLocationY(m_nOffset + GetRenderImage().GetHeight());
+            return true;
+        }
 
         return false;
     }

--- a/src/ui/viewmodels/ScoreTrackerViewModel.cpp
+++ b/src/ui/viewmodels/ScoreTrackerViewModel.cpp
@@ -54,13 +54,14 @@ bool ScoreTrackerViewModel::UpdateRenderImage(_UNUSED double fElapsed)
 
     // text
     m_pSurface->WriteText(4, 0, nFontText, pTheme.ColorLeaderboardEntry(), sScoreSoFar);
-#endif
 
+    // set location
     SetRenderLocationX(10 + m_pSurface->GetWidth());
     SetRenderLocationXRelativePosition(RelativePosition::Far);
 
     SetRenderLocationY(m_nOffset + m_pSurface->GetHeight());
     SetRenderLocationYRelativePosition(RelativePosition::Far);
+#endif
 
     m_bSurfaceStale = false;
     return true;

--- a/src/ui/viewmodels/ScoreTrackerViewModel.cpp
+++ b/src/ui/viewmodels/ScoreTrackerViewModel.cpp
@@ -3,6 +3,7 @@
 #include "ra_math.h"
 
 #include "ui\OverlayTheme.hh"
+#include "ui\viewmodels\OverlayManager.hh"
 
 namespace ra {
 namespace ui {
@@ -12,9 +13,18 @@ static _CONSTANT_VAR FONT_TO_USE = "Tahoma";
 static _CONSTANT_VAR FONT_SIZE_TEXT = 22;
 
 const StringModelProperty ScoreTrackerViewModel::DisplayTextProperty("ScoreTrackerViewModel", "DisplayText", L"0");
-#ifdef RA_UTEST
-GSL_SUPPRESS_F6
-#endif
+
+void ScoreTrackerViewModel::SetDisplayText(const std::wstring& sValue)
+{
+    if (sValue != GetDisplayText())
+    {
+        SetValue(DisplayTextProperty, sValue);
+
+        m_bSurfaceStale = true;
+        ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().RequestRender();
+    }
+}
+
 bool ScoreTrackerViewModel::UpdateRenderImage(_UNUSED double fElapsed)
 {
     if (m_pSurface && !m_bSurfaceStale)
@@ -29,7 +39,6 @@ bool ScoreTrackerViewModel::UpdateRenderImage(_UNUSED double fElapsed)
         return false;
     }
 
-#ifndef RA_UTEST
     // create a temporary surface so we can determine the size required for the actual surface
     const auto& pSurfaceFactory = ra::services::ServiceLocator::Get<ra::ui::drawing::ISurfaceFactory>();
     auto pTempSurface = pSurfaceFactory.CreateSurface(1, 1);
@@ -61,7 +70,6 @@ bool ScoreTrackerViewModel::UpdateRenderImage(_UNUSED double fElapsed)
 
     SetRenderLocationY(m_nOffset + m_pSurface->GetHeight());
     SetRenderLocationYRelativePosition(RelativePosition::Far);
-#endif
 
     m_bSurfaceStale = false;
     return true;

--- a/src/ui/viewmodels/ScoreTrackerViewModel.cpp
+++ b/src/ui/viewmodels/ScoreTrackerViewModel.cpp
@@ -12,14 +12,19 @@ static _CONSTANT_VAR FONT_TO_USE = "Tahoma";
 static _CONSTANT_VAR FONT_SIZE_TEXT = 22;
 
 const StringModelProperty ScoreTrackerViewModel::DisplayTextProperty("ScoreTrackerViewModel", "DisplayText", L"0");
-
 #ifdef RA_UTEST
 GSL_SUPPRESS_F6
 #endif
 bool ScoreTrackerViewModel::UpdateRenderImage(_UNUSED double fElapsed)
 {
     if (m_pSurface && !m_bSurfaceStale)
+    {
+        const auto nOffset = GetRenderLocationY() + ra::to_signed(GetRenderImage().GetHeight());
+        if (m_nOffset != nOffset)
+            SetRenderLocationY(m_nOffset + GetRenderImage().GetHeight());
+
         return false;
+    }
 
 #ifndef RA_UTEST
     // create a temporary surface so we can determine the size required for the actual surface
@@ -31,7 +36,7 @@ bool ScoreTrackerViewModel::UpdateRenderImage(_UNUSED double fElapsed)
     const auto sScoreSoFar = GetDisplayText();
     const auto szScoreSoFar = pTempSurface->MeasureText(nFontText, sScoreSoFar);
 
-    m_pSurface = pSurfaceFactory.CreateTransparentSurface(szScoreSoFar.Width + 8 + 2, szScoreSoFar.Height + 2);
+    m_pSurface = pSurfaceFactory.CreateSurface(szScoreSoFar.Width + 8 + 2, szScoreSoFar.Height + 2);
 
     // background
     const auto& pTheme = ra::services::ServiceLocator::Get<ra::ui::OverlayTheme>();
@@ -46,9 +51,13 @@ bool ScoreTrackerViewModel::UpdateRenderImage(_UNUSED double fElapsed)
 
     // text
     m_pSurface->WriteText(4, 0, nFontText, pTheme.ColorLeaderboardEntry(), sScoreSoFar);
-
-    m_pSurface->SetOpacity(0.85);
 #endif
+
+    SetRenderLocationX(10 + m_pSurface->GetWidth());
+    SetRenderLocationXRelativePosition(RelativePosition::Far);
+
+    SetRenderLocationY(m_nOffset + m_pSurface->GetHeight());
+    SetRenderLocationYRelativePosition(RelativePosition::Far);
 
     m_bSurfaceStale = false;
     return true;

--- a/src/ui/viewmodels/ScoreTrackerViewModel.hh
+++ b/src/ui/viewmodels/ScoreTrackerViewModel.hh
@@ -42,8 +42,19 @@ public:
     bool IsAnimationStarted() const noexcept override { return true; }
     bool IsAnimationComplete() const noexcept override { return false; }
 
+    bool SetOffset(int nValue) noexcept
+    {
+        if (m_nOffset == nValue)
+            return false;
+
+        m_nOffset = nValue;
+        return true;
+    }
+
 private:
     bool m_bSurfaceStale = false;
+
+    int m_nOffset = 10;
 };
 
 } // namespace viewmodels

--- a/src/ui/viewmodels/ScoreTrackerViewModel.hh
+++ b/src/ui/viewmodels/ScoreTrackerViewModel.hh
@@ -24,14 +24,7 @@ public:
     /// <summary>
     /// Sets the title message to display, empty string for no title message.
     /// </summary>
-    void SetDisplayText(const std::wstring& sValue)
-    {
-        if (sValue != GetDisplayText())
-        {
-            SetValue(DisplayTextProperty, sValue);
-            m_bSurfaceStale = true;
-        }
-    }
+    void SetDisplayText(const std::wstring& sValue);
 
     /// <summary>
     /// Updates the image to render.

--- a/src/ui/viewmodels/ScoreboardViewModel.cpp
+++ b/src/ui/viewmodels/ScoreboardViewModel.cpp
@@ -56,7 +56,7 @@ bool ScoreboardViewModel::UpdateRenderImage(double fElapsed)
         const auto nShadowOffset = pTheme.ShadowOffset();
 
         const auto& pSurfaceFactory = ra::services::ServiceLocator::Get<ra::ui::drawing::ISurfaceFactory>();
-        m_pSurface = pSurfaceFactory.CreateTransparentSurface(SCOREBOARD_WIDTH, SCOREBOARD_HEIGHT);
+        m_pSurface = pSurfaceFactory.CreateSurface(SCOREBOARD_WIDTH, SCOREBOARD_HEIGHT);
         auto nFontTitle = m_pSurface->LoadFont(FONT_TO_USE, FONT_SIZE_TITLE, ra::ui::FontStyles::Normal);
         auto nFontText = m_pSurface->LoadFont(FONT_TO_USE, FONT_SIZE_TEXT, ra::ui::FontStyles::Normal);
 
@@ -97,8 +97,6 @@ bool ScoreboardViewModel::UpdateRenderImage(double fElapsed)
 
             nY += FONT_SIZE_TEXT + 2;
         }
-
-        m_pSurface->SetOpacity(0.85);
 
         bUpdated = true;
     }

--- a/src/ui/win32/OverlayWindow.cpp
+++ b/src/ui/win32/OverlayWindow.cpp
@@ -55,7 +55,7 @@ void OverlayWindow::CreateOverlayWindow(HWND hWnd)
     wndEx.lpszClassName = "RA_WND_CLASS";
     wndEx.lpfnWndProc = OverlayWndProc;
     wndEx.hbrBackground = CreateSolidBrush(nTransparentColor);
-    wndEx.hInstance = (HINSTANCE)GetWindowLongPtr(m_hWnd, GWLP_HINSTANCE);
+    GSL_SUPPRESS_TYPE1 wndEx.hInstance = reinterpret_cast<HINSTANCE>(GetWindowLongPtr(m_hWnd, GWLP_HINSTANCE));
     RegisterClass(&wndEx);
 
     m_hOverlayWnd = CreateWindowEx(
@@ -64,7 +64,7 @@ void OverlayWindow::CreateOverlayWindow(HWND hWnd)
         "TransparentOverlayWindow",
         (WS_POPUP),
         CW_USEDEFAULT, CW_USEDEFAULT, rcMainWindowClientArea.right, rcMainWindowClientArea.bottom,
-        m_hWnd, NULL, wndEx.hInstance, NULL);
+        m_hWnd, nullptr, wndEx.hInstance, nullptr);
 
     SetLayeredWindowAttributes(m_hOverlayWnd, nTransparentColor, nAlpha, LWA_ALPHA | LWA_COLORKEY);
 
@@ -73,16 +73,16 @@ void OverlayWindow::CreateOverlayWindow(HWND hWnd)
     ShowWindow(m_hOverlayWnd, SW_SHOWNOACTIVATE);
 
     // watch for location/size changes in the parent window
-    m_hEventHook = SetWinEventHook(EVENT_OBJECT_LOCATIONCHANGE, EVENT_OBJECT_LOCATIONCHANGE, NULL, HandleWinEvent, GetCurrentProcessId(), 0, WINEVENT_OUTOFCONTEXT);
+    m_hEventHook = SetWinEventHook(EVENT_OBJECT_LOCATIONCHANGE, EVENT_OBJECT_LOCATIONCHANGE, nullptr, HandleWinEvent, GetCurrentProcessId(), 0, WINEVENT_OUTOFCONTEXT);
     UpdateOverlayPosition();
 
     auto& pOverlayManager = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>();
-    pOverlayManager.SetRenderRequestHandler([this]() {
-        InvalidateRect(m_hOverlayWnd, NULL, FALSE);
+    pOverlayManager.SetRenderRequestHandler([this]() noexcept {
+        InvalidateRect(m_hOverlayWnd, nullptr, FALSE);
     });
 }
 
-void OverlayWindow::DestroyOverlayWindow()
+void OverlayWindow::DestroyOverlayWindow() noexcept
 {
     if (m_hEventHook)
     {
@@ -99,7 +99,7 @@ void OverlayWindow::DestroyOverlayWindow()
     m_hWnd = nullptr;
 }
 
-void OverlayWindow::UpdateOverlayPosition()
+void OverlayWindow::UpdateOverlayPosition() noexcept
 {
     RECT rcWindowClientArea, rcOverlay;
     GetClientRect(m_hOverlayWnd, &rcOverlay);
@@ -109,7 +109,7 @@ void OverlayWindow::UpdateOverlayPosition()
     const int nHeight = rcWindowClientArea.bottom - rcWindowClientArea.top;
 
     // get the screen position of the client rect
-    ClientToScreen(m_hWnd, reinterpret_cast<POINT*>(&rcWindowClientArea.left));
+    GSL_SUPPRESS_TYPE1 ClientToScreen(m_hWnd, reinterpret_cast<POINT*>(&rcWindowClientArea.left));
     rcWindowClientArea.right = rcWindowClientArea.left + nWidth;
     rcWindowClientArea.bottom = rcWindowClientArea.top + nHeight;
 

--- a/src/ui/win32/OverlayWindow.cpp
+++ b/src/ui/win32/OverlayWindow.cpp
@@ -1,5 +1,7 @@
 #include "OverlayWindow.hh"
 
+#include "data\EmulatorContext.hh"
+
 #include "services\IClock.hh"
 
 #include "ui\drawing\gdi\GDISurface.hh"
@@ -39,6 +41,13 @@ void OverlayWindow::CreateOverlayWindow(HWND hWnd)
 {
     if (m_hOverlayWnd)
         return;
+
+    switch (ra::services::ServiceLocator::Get<ra::data::EmulatorContext>().GetEmulatorId())
+    {
+        case EmulatorID::RA_Gens:
+        case EmulatorID::RA_Meka:
+            return;
+    }
 
     m_hWnd = hWnd;
 

--- a/src/ui/win32/OverlayWindow.cpp
+++ b/src/ui/win32/OverlayWindow.cpp
@@ -186,6 +186,7 @@ void OverlayWindow::UpdateOverlayPosition() noexcept
     // move the layered window over the client window
     MoveWindow(m_hOverlayWnd, rcWindowClientArea.left, rcWindowClientArea.top, nWidth, nHeight, FALSE);
 
+    // if the size changed, we want to redraw everything on the next repaint
     if (rcOverlay.right - rcOverlay.left != nWidth || rcOverlay.bottom - rcOverlay.top != nHeight)
     {
         m_bErase = true;
@@ -206,6 +207,7 @@ void OverlayWindow::Render()
 
     if (m_bErase)
     {
+        // redraw everything
         m_bErase = false;
 
         pSurface.FillRectangle(ps.rcPaint.left, ps.rcPaint.top,
@@ -214,6 +216,7 @@ void OverlayWindow::Render()
     }
     else
     {
+        // only redraw the stuff that changes
         pOverlayManager.Render(pSurface, false);
     }
 

--- a/src/ui/win32/OverlayWindow.cpp
+++ b/src/ui/win32/OverlayWindow.cpp
@@ -1,0 +1,151 @@
+#include "OverlayWindow.hh"
+
+#include "services\IClock.hh"
+
+#include "ui\drawing\gdi\GDISurface.hh"
+
+#include "ui\viewmodels\OverlayManager.hh"
+
+namespace ra {
+namespace ui {
+namespace win32 {
+
+static LRESULT CALLBACK OverlayWndProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam)
+{
+    switch (Msg)
+    {
+        case WM_PAINT:
+            ra::services::ServiceLocator::GetMutable<OverlayWindow>().Render();
+            return 0;
+
+        case WM_SIZE:
+            return SIZE_RESTORED;
+
+        case WM_NCHITTEST:
+            return HTNOWHERE;
+
+        default:
+            return DefWindowProc(hWnd, Msg, wParam, lParam);
+    }
+}
+
+static void CALLBACK HandleWinEvent(HWINEVENTHOOK, DWORD nEvent, HWND, LONG nObjectId, LONG, DWORD, DWORD)
+{
+    if (nEvent == EVENT_OBJECT_LOCATIONCHANGE && nObjectId == CHILDID_SELF)
+        ra::services::ServiceLocator::GetMutable<OverlayWindow>().UpdateOverlayPosition();
+}
+
+void OverlayWindow::CreateOverlayWindow(HWND hWnd)
+{
+    if (m_hOverlayWnd)
+        return;
+
+    m_hWnd = hWnd;
+
+    RECT rcMainWindowClientArea;
+    GetClientRect(m_hWnd, &rcMainWindowClientArea);
+
+    const COLORREF nTransparentColor = RGB(ra::ui::Color::Transparent.Channel.R, ra::ui::Color::Transparent.Channel.G, ra::ui::Color::Transparent.Channel.B);
+    constexpr int nAlpha = (255 * 90 / 100); // 90% transparency
+
+    // Create the overlay window
+    WNDCLASSA wndEx;
+    memset(&wndEx, 0, sizeof(wndEx));
+    wndEx.cbWndExtra = sizeof(wndEx);
+    wndEx.lpszClassName = "RA_WND_CLASS";
+    wndEx.lpfnWndProc = OverlayWndProc;
+    wndEx.hbrBackground = CreateSolidBrush(nTransparentColor);
+    wndEx.hInstance = (HINSTANCE)GetWindowLongPtr(m_hWnd, GWLP_HINSTANCE);
+    RegisterClass(&wndEx);
+
+    m_hOverlayWnd = CreateWindowEx(
+        (WS_EX_NOACTIVATE | WS_EX_TRANSPARENT | WS_EX_LAYERED),
+        wndEx.lpszClassName,
+        "TransparentOverlayWindow",
+        (WS_POPUP),
+        CW_USEDEFAULT, CW_USEDEFAULT, rcMainWindowClientArea.right, rcMainWindowClientArea.bottom,
+        m_hWnd, NULL, wndEx.hInstance, NULL);
+
+    SetLayeredWindowAttributes(m_hOverlayWnd, nTransparentColor, nAlpha, LWA_ALPHA | LWA_COLORKEY);
+
+    SetParent(m_hWnd, m_hOverlayWnd);
+
+    ShowWindow(m_hOverlayWnd, SW_SHOWNOACTIVATE);
+
+    // watch for location/size changes in the parent window
+    m_hEventHook = SetWinEventHook(EVENT_OBJECT_LOCATIONCHANGE, EVENT_OBJECT_LOCATIONCHANGE, NULL, HandleWinEvent, GetCurrentProcessId(), 0, WINEVENT_OUTOFCONTEXT);
+    UpdateOverlayPosition();
+
+    auto& pOverlayManager = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>();
+    pOverlayManager.SetRenderRequestHandler([this]() {
+        InvalidateRect(m_hOverlayWnd, NULL, FALSE);
+    });
+}
+
+void OverlayWindow::DestroyOverlayWindow()
+{
+    if (m_hEventHook)
+    {
+        UnhookWinEvent(m_hEventHook);
+        m_hEventHook = nullptr;
+    }
+
+    if (m_hOverlayWnd)
+    {
+        DestroyWindow(m_hOverlayWnd);
+        m_hOverlayWnd = nullptr;
+    }
+
+    m_hWnd = nullptr;
+}
+
+void OverlayWindow::UpdateOverlayPosition()
+{
+    RECT rcWindowClientArea, rcOverlay;
+    GetClientRect(m_hOverlayWnd, &rcOverlay);
+
+    GetClientRect(m_hWnd, &rcWindowClientArea);
+    const int nWidth = rcWindowClientArea.right - rcWindowClientArea.left;
+    const int nHeight = rcWindowClientArea.bottom - rcWindowClientArea.top;
+
+    // get the screen position of the client rect
+    ClientToScreen(m_hWnd, reinterpret_cast<POINT*>(&rcWindowClientArea.left));
+    rcWindowClientArea.right = rcWindowClientArea.left + nWidth;
+    rcWindowClientArea.bottom = rcWindowClientArea.top + nHeight;
+
+    // move the layered window over the client window
+    MoveWindow(m_hOverlayWnd, rcWindowClientArea.left, rcWindowClientArea.top, nWidth, nHeight, FALSE);
+
+    if (rcOverlay.right - rcOverlay.left != nWidth || rcOverlay.bottom - rcOverlay.top != nHeight)
+    {
+        m_bErase = true;
+        InvalidateRect(m_hOverlayWnd, nullptr, false);
+    }
+}
+
+void OverlayWindow::Render()
+{
+    RECT rcClientArea;
+    ::GetClientRect(m_hWnd, &rcClientArea);
+
+    PAINTSTRUCT ps;
+    HDC hDC = BeginPaint(m_hOverlayWnd, &ps);
+    ra::ui::drawing::gdi::GDISurface pSurface(hDC, rcClientArea);
+
+    if (m_bErase)
+    {
+        m_bErase = false;
+
+        pSurface.FillRectangle(ps.rcPaint.left, ps.rcPaint.top,
+            ps.rcPaint.right - ps.rcPaint.left, ps.rcPaint.bottom - ps.rcPaint.top, ra::ui::Color::Transparent);
+    }
+
+    auto& pOverlayManager = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>();
+    pOverlayManager.Render(pSurface);
+
+    EndPaint(m_hOverlayWnd, &ps);
+}
+
+} // namespace win32
+} // namespace ui
+} // namespace ra

--- a/src/ui/win32/OverlayWindow.cpp
+++ b/src/ui/win32/OverlayWindow.cpp
@@ -132,16 +132,20 @@ void OverlayWindow::Render()
     HDC hDC = BeginPaint(m_hOverlayWnd, &ps);
     ra::ui::drawing::gdi::GDISurface pSurface(hDC, rcClientArea);
 
+    auto& pOverlayManager = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>();
+
     if (m_bErase)
     {
         m_bErase = false;
 
         pSurface.FillRectangle(ps.rcPaint.left, ps.rcPaint.top,
             ps.rcPaint.right - ps.rcPaint.left, ps.rcPaint.bottom - ps.rcPaint.top, ra::ui::Color::Transparent);
+        pOverlayManager.Render(pSurface, true);
     }
-
-    auto& pOverlayManager = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>();
-    pOverlayManager.Render(pSurface);
+    else
+    {
+        pOverlayManager.Render(pSurface, false);
+    }
 
     EndPaint(m_hOverlayWnd, &ps);
 }

--- a/src/ui/win32/OverlayWindow.cpp
+++ b/src/ui/win32/OverlayWindow.cpp
@@ -55,8 +55,8 @@ void OverlayWindow::CreateOverlayWindow(HWND hWnd)
 
     m_hWnd = hWnd;
 
-    auto hParentThread = GetWindowThreadProcessId(m_hWnd, nullptr);
-    auto hCurrentThread = GetCurrentThreadId();
+    const auto hParentThread = GetWindowThreadProcessId(m_hWnd, nullptr);
+    const auto hCurrentThread = GetCurrentThreadId();
     if (hParentThread == hCurrentThread)
     {
         // we're on the thread that owns the parent window, it's message pump will serve us
@@ -75,7 +75,7 @@ DWORD OverlayWindow::OverlayWindowThread()
     CreateOverlayWindow();
 
     MSG msg;
-    while (GetMessageA(&msg, NULL, 0, 0))
+    while (GetMessageA(&msg, nullptr, 0, 0))
     {
         TranslateMessage(&msg);
         DispatchMessageA(&msg);

--- a/src/ui/win32/OverlayWindow.hh
+++ b/src/ui/win32/OverlayWindow.hh
@@ -1,0 +1,34 @@
+#ifndef RA_UI_WIN32_OVERLAYWINDOW_H
+#define RA_UI_WIN32_OVERLAYWINDOW_H
+#pragma once
+
+#include "ui\viewmodels\OverlayViewModel.hh"
+#include "ui\win32\IDialogPresenter.hh"
+
+namespace ra {
+namespace ui {
+namespace win32 {
+
+class OverlayWindow
+{
+public:
+    void CreateOverlayWindow(HWND hWnd);
+    void DestroyOverlayWindow();
+
+    void UpdateOverlayPosition();
+
+    void Render();
+
+private:
+    bool m_bErase = false;
+
+    HWND m_hWnd{};
+    HWND m_hOverlayWnd{};
+    HWINEVENTHOOK m_hEventHook{};
+};
+
+} // namespace win32
+} // namespace ui
+} // namespace ra
+
+#endif // !RA_UI_WIN32_OVERLAYWINDOW_H

--- a/src/ui/win32/OverlayWindow.hh
+++ b/src/ui/win32/OverlayWindow.hh
@@ -19,7 +19,10 @@ public:
 
     void Render();
 
+    DWORD OverlayWindowThread();
 private:
+    void CreateOverlayWindow();
+
     bool m_bErase = false;
 
     HWND m_hWnd{};

--- a/src/ui/win32/OverlayWindow.hh
+++ b/src/ui/win32/OverlayWindow.hh
@@ -13,9 +13,9 @@ class OverlayWindow
 {
 public:
     void CreateOverlayWindow(HWND hWnd);
-    void DestroyOverlayWindow();
+    void DestroyOverlayWindow() noexcept;
 
-    void UpdateOverlayPosition();
+    void UpdateOverlayPosition() noexcept;
 
     void Render();
 

--- a/src/ui/win32/OverlayWindow.hh
+++ b/src/ui/win32/OverlayWindow.hh
@@ -28,6 +28,7 @@ private:
     HWND m_hWnd{};
     HWND m_hOverlayWnd{};
     HWINEVENTHOOK m_hEventHook{};
+    HANDLE m_hOverlayWndThread{};
 };
 
 } // namespace win32

--- a/tests/Exports_Tests.cpp
+++ b/tests/Exports_Tests.cpp
@@ -10,10 +10,13 @@
 #include "tests\mocks\MockEmulatorContext.hh"
 #include "tests\mocks\MockGameContext.hh"
 #include "tests\mocks\MockOverlayManager.hh"
+#include "tests\mocks\MockOverlayTheme.hh"
 #include "tests\mocks\MockServer.hh"
 #include "tests\mocks\MockSessionTracker.hh"
+#include "tests\mocks\MockSurface.hh"
 #include "tests\mocks\MockThreadPool.hh"
 #include "tests\mocks\MockUserContext.hh"
+#include "tests\mocks\MockWindowManager.hh"
 #include "tests\RA_UnitTestHelpers.h"
 
 #include "services\AchievementRuntime.hh"
@@ -33,8 +36,11 @@ using ra::services::mocks::MockAudioSystem;
 using ra::services::mocks::MockConfiguration;
 using ra::services::mocks::MockThreadPool;
 using ra::ui::mocks::MockDesktop;
+using ra::ui::mocks::MockOverlayTheme;
+using ra::ui::drawing::mocks::MockSurfaceFactory;
 using ra::ui::viewmodels::MessageBoxViewModel;
 using ra::ui::viewmodels::mocks::MockOverlayManager;
+using ra::ui::viewmodels::mocks::MockWindowManager;
 
 namespace ra {
 namespace tests {
@@ -73,8 +79,6 @@ private:
     class AttemptLoginHarness
     {
     public:
-        AttemptLoginHarness() noexcept : m_WindowManagerService(&windowManager) {}
-
         MockUserContext mockUserContext;
         MockSessionTracker mockSessionTracker;
         MockConfiguration mockConfiguration;
@@ -84,11 +88,7 @@ private:
         MockEmulatorContext mockEmulatorContext;
         MockDesktop mockDesktop;
         MockThreadPool mockThreadPool;
-
-        ra::ui::viewmodels::WindowManager windowManager;
-
-    private:
-        ra::services::ServiceLocator::ServiceOverride<ra::ui::viewmodels::WindowManager> m_WindowManagerService;
+        MockWindowManager mockWindowManager;
     };
 
 public:
@@ -173,7 +173,7 @@ public:
         Assert::IsTrue(bWasMenuRebuilt);
 
         // titlebar
-        Assert::AreEqual(std::wstring(L"RATests - 0.1 - User []"), harness.windowManager.Emulator.GetWindowTitle());
+        Assert::AreEqual(std::wstring(L"RATests - 0.1 - User []"), harness.mockWindowManager.Emulator.GetWindowTitle());
     }
 
     TEST_METHOD(TestAttemptLoginSuccessWithMessages)
@@ -357,6 +357,8 @@ private:
         MockAudioSystem mockAudioSystem;
         MockConfiguration mockConfiguration;
         MockEmulatorContext mockEmulatorContext;
+        MockSurfaceFactory mockSurfaceFactory;
+        MockOverlayTheme mockTheme;
 
         DoAchievementsFrameHarness() noexcept
         {

--- a/tests/RA_Integration.Tests.vcxproj
+++ b/tests/RA_Integration.Tests.vcxproj
@@ -261,6 +261,7 @@
     <ClCompile Include="ui\viewmodels\OverlayAchievementsPageViewModel_Tests.cpp" />
     <ClCompile Include="ui\viewmodels\OverlayLeaderboardsPageViewModel_Tests.cpp" />
     <ClCompile Include="ui\viewmodels\OverlayListPageViewModel_Tests.cpp" />
+    <ClCompile Include="ui\viewmodels\OverlayManager_Tests.cpp" />
     <ClCompile Include="ui\viewmodels\RichPresenceMonitorViewModel_Tests.cpp" />
     <ClCompile Include="ui\viewmodels\UnknownGameViewModel_Tests.cpp" />
     <ClCompile Include="ui\WindowViewModelBase_Tests.cpp" />
@@ -278,10 +279,13 @@
     <ClInclude Include="mocks\MockImageRepository.hh" />
     <ClInclude Include="mocks\MockLocalStorage.hh" />
     <ClInclude Include="mocks\MockOverlayManager.hh" />
+    <ClInclude Include="mocks\MockOverlayTheme.hh" />
     <ClInclude Include="mocks\MockServer.hh" />
     <ClInclude Include="mocks\MockSessionTracker.hh" />
+    <ClInclude Include="mocks\MockSurface.hh" />
     <ClInclude Include="mocks\MockThreadPool.hh" />
     <ClInclude Include="mocks\MockUserContext.hh" />
+    <ClInclude Include="mocks\MockWindowManager.hh" />
     <ClInclude Include="RA_UnitTestHelpers.h" />
     <ClCompile Include="RA_Condition_Tests.cpp" />
     <ClCompile Include="RA_Leaderboard_Tests.cpp" />

--- a/tests/RA_Integration.Tests.vcxproj.filters
+++ b/tests/RA_Integration.Tests.vcxproj.filters
@@ -285,6 +285,9 @@
     <ClCompile Include="ui\viewmodels\OverlayLeaderboardsPageViewModel_Tests.cpp">
       <Filter>Tests\UI\ViewModels</Filter>
     </ClCompile>
+    <ClCompile Include="ui\viewmodels\OverlayManager_Tests.cpp">
+      <Filter>Tests\UI\ViewModels</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="base.props" />
@@ -342,6 +345,15 @@
       <Filter>Code</Filter>
     </ClInclude>
     <ClInclude Include="mocks\MockImageRepository.hh">
+      <Filter>Mocks</Filter>
+    </ClInclude>
+    <ClInclude Include="mocks\MockSurface.hh">
+      <Filter>Mocks</Filter>
+    </ClInclude>
+    <ClInclude Include="mocks\MockOverlayTheme.hh">
+      <Filter>Mocks</Filter>
+    </ClInclude>
+    <ClInclude Include="mocks\MockWindowManager.hh">
       <Filter>Mocks</Filter>
     </ClInclude>
   </ItemGroup>

--- a/tests/mocks/MockOverlayManager.hh
+++ b/tests/mocks/MockOverlayManager.hh
@@ -18,6 +18,19 @@ public:
     {
     }
 
+    void ClearPopups() override
+    {
+        while (!m_vPopupMessages.empty())
+            m_vPopupMessages.pop_front();
+
+        while (!m_vScoreboards.empty())
+            m_vScoreboards.pop_front();
+
+        m_vScoreTrackers.clear();
+
+        m_vmOverlay.Deactivate();
+    }
+
 private:
     ra::services::ServiceLocator::ServiceOverride<ra::ui::viewmodels::OverlayManager> m_Override;
 };

--- a/tests/mocks/MockOverlayTheme.hh
+++ b/tests/mocks/MockOverlayTheme.hh
@@ -1,0 +1,28 @@
+#ifndef RA_SERVICES_MOCK_OVERLAY_THEME_HH
+#define RA_SERVICES_MOCK_OVERLAY_THEME_HH
+#pragma once
+
+#include "ui\OverlayTheme.hh"
+#include "services\ServiceLocator.hh"
+
+namespace ra {
+namespace ui {
+namespace mocks {
+
+class MockOverlayTheme : public OverlayTheme
+{
+public:
+    MockOverlayTheme() noexcept
+        : m_Override(this)
+    {
+    }
+
+private:
+    ra::services::ServiceLocator::ServiceOverride<ra::ui::OverlayTheme> m_Override;
+};
+
+} // namespace mocks
+} // namespace ui
+} // namespace ra
+
+#endif // !RA_SERVICES_MOCK_OVERLAY_THEME_HH

--- a/tests/mocks/MockSurface.hh
+++ b/tests/mocks/MockSurface.hh
@@ -1,0 +1,68 @@
+#ifndef RA_SERVICES_MOCK_SURFACE_HH
+#define RA_SERVICES_MOCK_SURFACE_HH
+#pragma once
+
+#include "ra_fwd.h"
+
+#include "ui\drawing\ISurface.hh"
+
+namespace ra {
+namespace ui {
+namespace drawing {
+namespace mocks {
+
+class MockSurface : public ISurface
+{
+public:
+    MockSurface(size_t nWidth, size_t nHeight)
+        : m_nWidth(nWidth), m_nHeight(nHeight)
+    {
+    }
+
+    size_t GetWidth() const override { return m_nWidth; }
+    size_t GetHeight() const override { return m_nHeight; }
+
+    void FillRectangle(int, int, int, int, Color) override {}
+    int LoadFont(const std::string&, int, FontStyles) override { return 1; }
+
+    ra::ui::Size MeasureText(int, const std::wstring& sText) const override
+    {
+        return { ra::to_signed(sText.length()), 1 };
+    }
+
+    void WriteText(int, int, int, Color, const std::wstring&) override {}
+    void DrawImage(int, int, int, int, const ImageReference&) override {}
+    void DrawImageStretched(int, int, int, int, const ImageReference&) override {}
+    void DrawSurface(int, int, const ISurface&) override {}
+    void SetOpacity(double) override {}
+
+private:
+    size_t m_nWidth;
+    size_t m_nHeight;
+};
+
+class MockSurfaceFactory : public ISurfaceFactory
+{
+public:
+    MockSurfaceFactory() noexcept : m_Override(this) {}
+
+    std::unique_ptr<ISurface> CreateSurface(int nWidth, int nHeight) const override
+    {
+        return std::make_unique<MockSurface>(nWidth, nHeight);
+    }
+
+    std::unique_ptr<ISurface> CreateTransparentSurface(int nWidth, int nHeight) const override
+    {
+        return std::make_unique<MockSurface>(nWidth, nHeight);
+    }
+
+private:
+    ra::services::ServiceLocator::ServiceOverride<ISurfaceFactory> m_Override;
+};
+
+} // namespace mocks
+} // namespace drawing
+} // namespace ui
+} // namespace ra
+
+#endif // !RA_SERVICES_MOCK_SURFACE_HH

--- a/tests/mocks/MockWindowManager.hh
+++ b/tests/mocks/MockWindowManager.hh
@@ -1,0 +1,30 @@
+#ifndef RA_SERVICES_MOCK_WINDOW_MANAGER_HH
+#define RA_SERVICES_MOCK_WINDOW_MANAGER_HH
+#pragma once
+
+#include "ui\viewmodels\WindowManager.hh"
+#include "services\ServiceLocator.hh"
+
+namespace ra {
+namespace ui {
+namespace viewmodels {
+namespace mocks {
+
+class MockWindowManager : public WindowManager
+{
+public:
+    MockWindowManager() noexcept
+        : m_Override(this)
+    {
+    }
+
+private:
+    ra::services::ServiceLocator::ServiceOverride<WindowManager> m_Override;
+};
+
+} // namespace mocks
+} // namespace viewmodels
+} // namespace ui
+} // namespace ra
+
+#endif // !RA_SERVICES_MOCK_WINDOW_MANAGER_HH

--- a/tests/ui/viewmodels/OverlayAchievementsPageViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/OverlayAchievementsPageViewModel_Tests.cpp
@@ -4,6 +4,7 @@
 
 #include "tests\mocks\MockGameContext.hh"
 #include "tests\mocks\MockImageRepository.hh"
+#include "tests\mocks\MockOverlayManager.hh"
 #include "tests\mocks\MockServer.hh"
 #include "tests\mocks\MockSessionTracker.hh"
 #include "tests\mocks\MockThreadPool.hh"
@@ -29,6 +30,7 @@ private:
         ra::data::mocks::MockUserContext mockUserContext;
         ra::services::mocks::MockThreadPool mockThreadPool;
         ra::ui::mocks::MockImageRepository mockImageRepository;
+        ra::ui::viewmodels::mocks::MockOverlayManager mockOverlayManager;
 
         ItemViewModel* GetItem(gsl::index nIndex) { return m_vItems.GetItemAt(nIndex); }
 

--- a/tests/ui/viewmodels/OverlayLeaderboardsPageViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/OverlayLeaderboardsPageViewModel_Tests.cpp
@@ -4,6 +4,7 @@
 
 #include "tests\mocks\MockGameContext.hh"
 #include "tests\mocks\MockImageRepository.hh"
+#include "tests\mocks\MockOverlayManager.hh"
 #include "tests\mocks\MockServer.hh"
 #include "tests\mocks\MockThreadPool.hh"
 #include "tests\mocks\MockUserContext.hh"
@@ -27,6 +28,7 @@ private:
         ra::data::mocks::MockUserContext mockUserContext;
         ra::services::mocks::MockThreadPool mockThreadPool;
         ra::ui::mocks::MockImageRepository mockImageRepository;
+        ra::ui::viewmodels::mocks::MockOverlayManager mockOverlayManager;
 
         ItemViewModel* GetItem(gsl::index nIndex) { return m_vItems.GetItemAt(nIndex); }
 

--- a/tests/ui/viewmodels/OverlayListPageViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/OverlayListPageViewModel_Tests.cpp
@@ -3,6 +3,7 @@
 #include "ui\viewmodels\OverlayListPageViewModel.hh"
 
 #include "tests\mocks\MockImageRepository.hh"
+#include "tests\mocks\MockOverlayManager.hh"
 #include "tests\RA_UnitTestHelpers.h"
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
@@ -19,6 +20,7 @@ private:
     {
     public:
         ra::ui::mocks::MockImageRepository mockImageRepository;
+        ra::ui::viewmodels::mocks::MockOverlayManager mockOverlayManager;
 
         void Refresh() override
         {

--- a/tests/ui/viewmodels/OverlayManager_Tests.cpp
+++ b/tests/ui/viewmodels/OverlayManager_Tests.cpp
@@ -139,7 +139,7 @@ public:
 
         ra::ui::drawing::mocks::MockSurface mockSurface(800, 600);
         overlay.ResetRenderRequested();
-        overlay.Render(mockSurface);
+        overlay.Render(mockSurface, false);
         Assert::AreEqual(pPopup->GetRenderLocationY(), 0);
         // no time has elapsed since the popup was queued, we're still waiting for the first render
         Assert::IsFalse(overlay.WasRenderRequested());
@@ -147,7 +147,7 @@ public:
         // 0.8 seconds to fully visualize, expect it to be partially onscreen after 0.5 seconds
         overlay.mockClock.AdvanceTime(std::chrono::milliseconds(500));
         overlay.ResetRenderRequested();
-        overlay.Render(mockSurface);
+        overlay.Render(mockSurface, false);
         Assert::IsTrue(pPopup->GetRenderLocationY() > 0);
         Assert::IsTrue(pPopup->GetRenderLocationY() < 80);
         Assert::IsTrue(overlay.WasRenderRequested());
@@ -155,35 +155,35 @@ public:
         // after 1 second, it should be fully on screen
         overlay.mockClock.AdvanceTime(std::chrono::milliseconds(500));
         overlay.ResetRenderRequested();
-        overlay.Render(mockSurface);
+        overlay.Render(mockSurface, false);
         Assert::AreEqual(pPopup->GetRenderLocationY(), 80);
         Assert::IsTrue(overlay.WasRenderRequested());
 
         // after 2 seconds, it should be fully on screen
         overlay.mockClock.AdvanceTime(std::chrono::seconds(1));
         overlay.ResetRenderRequested();
-        overlay.Render(mockSurface);
+        overlay.Render(mockSurface, false);
         Assert::AreEqual(pPopup->GetRenderLocationY(), 80);
         Assert::IsTrue(overlay.WasRenderRequested());
 
         // after 3 seconds, it should be fully on screen
         overlay.mockClock.AdvanceTime(std::chrono::seconds(1));
         overlay.ResetRenderRequested();
-        overlay.Render(mockSurface);
+        overlay.Render(mockSurface, false);
         Assert::AreEqual(pPopup->GetRenderLocationY(), 80);
         Assert::IsTrue(overlay.WasRenderRequested());
 
         // after 4 seconds, it should be fully on screen
         overlay.mockClock.AdvanceTime(std::chrono::seconds(1));
         overlay.ResetRenderRequested();
-        overlay.Render(mockSurface);
+        overlay.Render(mockSurface, false);
         Assert::AreEqual(pPopup->GetRenderLocationY(), 80);
         Assert::IsTrue(overlay.WasRenderRequested());
 
         // after 4.5 seconds, it should be starting to scroll offscreen
         overlay.mockClock.AdvanceTime(std::chrono::milliseconds(500));
         overlay.ResetRenderRequested();
-        overlay.Render(mockSurface);
+        overlay.Render(mockSurface, false);
         Assert::IsTrue(pPopup->GetRenderLocationY() > 0);
         Assert::IsTrue(pPopup->GetRenderLocationY() < 80);
         Assert::IsTrue(overlay.WasRenderRequested());
@@ -193,7 +193,7 @@ public:
         // since it's removed from the queue, we can't read RenderLocationY.
         overlay.mockClock.AdvanceTime(std::chrono::milliseconds(500));
         overlay.ResetRenderRequested();
-        overlay.Render(mockSurface);
+        overlay.Render(mockSurface, false);
         Assert::IsFalse(overlay.WasRenderRequested());
         Assert::IsNull(overlay.GetMessage(nId));
     }
@@ -213,7 +213,7 @@ public:
         Assert::IsTrue(&vmScoreTracker == overlay.GetScoreTracker(3));
 
         ra::ui::drawing::mocks::MockSurface mockSurface(800, 600);
-        overlay.Render(mockSurface);
+        overlay.Render(mockSurface, false);
         Assert::AreEqual(13, vmScoreTracker.GetRenderLocationY());
 
         overlay.ResetRenderRequested();
@@ -222,7 +222,7 @@ public:
         Assert::IsTrue(overlay.WasRenderRequested());
         Assert::IsNotNull(overlay.GetScoreTracker(3));
 
-        overlay.Render(mockSurface);
+        overlay.Render(mockSurface, false);
         Assert::IsNull(overlay.GetScoreTracker(3)); // render should erase and destroy
     }
 
@@ -241,7 +241,7 @@ public:
         Assert::IsTrue(&vmScoreTracker == overlay.GetScoreTracker(3));
 
         ra::ui::drawing::mocks::MockSurface mockSurface(800, 600);
-        overlay.Render(mockSurface);
+        overlay.Render(mockSurface, false);
         Assert::AreEqual(13, vmScoreTracker.GetRenderLocationY());
 
         overlay.ResetRenderRequested();
@@ -250,7 +250,7 @@ public:
         Assert::IsTrue(overlay.WasRenderRequested());
         Assert::IsNotNull(overlay.GetScoreTracker(3));
 
-        overlay.Render(mockSurface);
+        overlay.Render(mockSurface, false);
         Assert::IsNull(overlay.GetScoreTracker(3)); // render should erase and destroy
     }
 
@@ -283,7 +283,7 @@ public:
 
         ra::ui::drawing::mocks::MockSurface mockSurface(800, 600);
         overlay.ResetRenderRequested();
-        overlay.Render(mockSurface);
+        overlay.Render(mockSurface, false);
         Assert::AreEqual(pScoreboard->GetRenderLocationX(), 0);
         // no time has elapsed since the popup was queued, we're still waiting for the first render
         Assert::IsFalse(overlay.WasRenderRequested());
@@ -291,7 +291,7 @@ public:
         // 0.8 seconds to fully visualize, expect it to be partially onscreen after 0.5 seconds
         overlay.mockClock.AdvanceTime(std::chrono::milliseconds(500));
         overlay.ResetRenderRequested();
-        overlay.Render(mockSurface);
+        overlay.Render(mockSurface, false);
         Assert::IsTrue(pScoreboard->GetRenderLocationX() > 0);
         Assert::IsTrue(pScoreboard->GetRenderLocationX() < 310);
         Assert::IsTrue(overlay.WasRenderRequested());
@@ -299,49 +299,49 @@ public:
         // after 1 second, it should be fully on screen
         overlay.mockClock.AdvanceTime(std::chrono::milliseconds(500));
         overlay.ResetRenderRequested();
-        overlay.Render(mockSurface);
+        overlay.Render(mockSurface, false);
         Assert::AreEqual(pScoreboard->GetRenderLocationX(), 310);
         Assert::IsTrue(overlay.WasRenderRequested());
 
         // after 2 seconds, it should be fully on screen
         overlay.mockClock.AdvanceTime(std::chrono::seconds(1));
         overlay.ResetRenderRequested();
-        overlay.Render(mockSurface);
+        overlay.Render(mockSurface, false);
         Assert::AreEqual(pScoreboard->GetRenderLocationX(), 310);
         Assert::IsTrue(overlay.WasRenderRequested());
 
         // after 3 seconds, it should be fully on screen
         overlay.mockClock.AdvanceTime(std::chrono::seconds(1));
         overlay.ResetRenderRequested();
-        overlay.Render(mockSurface);
+        overlay.Render(mockSurface, false);
         Assert::AreEqual(pScoreboard->GetRenderLocationX(), 310);
         Assert::IsTrue(overlay.WasRenderRequested());
 
         // after 4 seconds, it should be fully on screen
         overlay.mockClock.AdvanceTime(std::chrono::seconds(1));
         overlay.ResetRenderRequested();
-        overlay.Render(mockSurface);
+        overlay.Render(mockSurface, false);
         Assert::AreEqual(pScoreboard->GetRenderLocationX(), 310);
         Assert::IsTrue(overlay.WasRenderRequested());
 
         // after 5 seconds, it should be fully on screen
         overlay.mockClock.AdvanceTime(std::chrono::seconds(1));
         overlay.ResetRenderRequested();
-        overlay.Render(mockSurface);
+        overlay.Render(mockSurface, false);
         Assert::AreEqual(pScoreboard->GetRenderLocationX(), 310);
         Assert::IsTrue(overlay.WasRenderRequested());
 
         // after 6 seconds, it should be fully on screen
         overlay.mockClock.AdvanceTime(std::chrono::seconds(1));
         overlay.ResetRenderRequested();
-        overlay.Render(mockSurface);
+        overlay.Render(mockSurface, false);
         Assert::AreEqual(pScoreboard->GetRenderLocationX(), 310);
         Assert::IsTrue(overlay.WasRenderRequested());
 
         // after 6.5 seconds, it should be starting to scroll offscreen
         overlay.mockClock.AdvanceTime(std::chrono::milliseconds(500));
         overlay.ResetRenderRequested();
-        overlay.Render(mockSurface);
+        overlay.Render(mockSurface, false);
         Assert::IsTrue(pScoreboard->GetRenderLocationX() > 0);
         Assert::IsTrue(pScoreboard->GetRenderLocationX() < 310);
         Assert::IsTrue(overlay.WasRenderRequested());
@@ -351,7 +351,7 @@ public:
         // since it's removed from the queue, we can't read RenderLocationY.
         overlay.mockClock.AdvanceTime(std::chrono::milliseconds(500));
         overlay.ResetRenderRequested();
-        overlay.Render(mockSurface);
+        overlay.Render(mockSurface, false);
         Assert::IsFalse(overlay.WasRenderRequested());
         Assert::IsNull(overlay.GetScoreboard(3));
     }
@@ -368,7 +368,7 @@ public:
         // 0.8 seconds to fully visualize, expect it to be partially onscreen after 0.5 seconds
         overlay.mockClock.AdvanceTime(std::chrono::milliseconds(500));
         overlay.ResetRenderRequested();
-        overlay.Render(mockSurface);
+        overlay.Render(mockSurface, false);
         Assert::IsTrue(overlay.GetOverlayRenderX() < 0);
         Assert::IsTrue(overlay.GetOverlayRenderX() > -800);
         Assert::IsTrue(overlay.WasRenderRequested());
@@ -376,7 +376,7 @@ public:
         // after 1 second, it should be fully on screen
         overlay.mockClock.AdvanceTime(std::chrono::milliseconds(500));
         overlay.ResetRenderRequested();
-        overlay.Render(mockSurface);
+        overlay.Render(mockSurface, false);
         Assert::AreEqual(0, overlay.GetOverlayRenderX());
         Assert::IsFalse(overlay.WasRenderRequested());
 
@@ -388,7 +388,7 @@ public:
         // 0.8 seconds to fully collapse, expect it to be partially onscreen after 0.5 seconds
         overlay.mockClock.AdvanceTime(std::chrono::milliseconds(500));
         overlay.ResetRenderRequested();
-        overlay.Render(mockSurface);
+        overlay.Render(mockSurface, false);
         Assert::IsTrue(overlay.GetOverlayRenderX() < 0);
         Assert::IsTrue(overlay.GetOverlayRenderX() > -800);
         Assert::IsTrue(overlay.WasRenderRequested());
@@ -396,7 +396,7 @@ public:
         // after 1 second, it should be fully on screen
         overlay.mockClock.AdvanceTime(std::chrono::milliseconds(500));
         overlay.ResetRenderRequested();
-        overlay.Render(mockSurface);
+        overlay.Render(mockSurface, false);
         Assert::AreEqual(-800, overlay.GetOverlayRenderX());
         Assert::IsFalse(overlay.WasRenderRequested());
 

--- a/tests/ui/viewmodels/OverlayManager_Tests.cpp
+++ b/tests/ui/viewmodels/OverlayManager_Tests.cpp
@@ -1,0 +1,410 @@
+#include "CppUnitTest.h"
+
+#include "ui\viewmodels\OverlayManager.hh"
+
+#include "ui\OverlayTheme.hh"
+
+#include "tests\mocks\MockClock.hh"
+#include "tests\mocks\MockConfiguration.hh"
+#include "tests\mocks\MockDesktop.hh"
+#include "tests\mocks\MockEmulatorContext.hh"
+#include "tests\mocks\MockGameContext.hh"
+#include "tests\mocks\MockImageRepository.hh"
+#include "tests\mocks\MockOverlayTheme.hh"
+#include "tests\mocks\MockSurface.hh"
+#include "tests\mocks\MockThreadPool.hh"
+#include "tests\mocks\MockUserContext.hh"
+#include "tests\mocks\MockWindowManager.hh"
+
+#include "tests\RA_UnitTestHelpers.h"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace ra {
+namespace ui {
+namespace viewmodels {
+namespace tests {
+
+TEST_CLASS(OverlayManager_Tests)
+{
+private:
+    class OverlayManagerHarness : public OverlayManager
+    {
+    public:
+        ra::data::mocks::MockEmulatorContext mockEmulatorContext;
+        ra::data::mocks::MockGameContext mockGameContext;
+        ra::data::mocks::MockUserContext mockUserContext;
+        ra::services::mocks::MockClock mockClock;
+        ra::services::mocks::MockConfiguration mockConfiguration;
+        ra::services::mocks::MockThreadPool mockThreadPool;
+        ra::ui::mocks::MockDesktop mockDesktop;
+        ra::ui::mocks::MockImageRepository mockImageRepository;
+        ra::ui::mocks::MockOverlayTheme mockTheme;
+        ra::ui::drawing::mocks::MockSurfaceFactory mockSurfaceFactory;
+        ra::ui::viewmodels::mocks::MockWindowManager mockWindowManager;
+
+        OverlayManagerHarness() noexcept
+            : m_Override(this)
+        {
+            SetRenderRequestHandler([this]()
+            {
+                m_bRenderRequested = true;
+            });
+        }
+
+        bool WasRenderRequested() const noexcept { return m_bRenderRequested; }
+
+        void ResetRenderRequested() noexcept
+        {
+            m_bRenderRequestPending = false;
+            m_bRenderRequested = false;
+        }
+
+        int GetOverlayRenderX() const noexcept { return m_vmOverlay.GetRenderLocationX(); }
+
+    private:
+        bool m_bRenderRequested = false;
+        ra::services::ServiceLocator::ServiceOverride<OverlayManager> m_Override;
+    };
+
+public:
+    TEST_METHOD(TestQueueMessageTitleDesc)
+    {
+        OverlayManagerHarness overlay;
+        const auto nId = overlay.QueueMessage(L"Title", L"Description");
+
+        const auto* pPopup = overlay.GetMessage(nId);
+        Expects(pPopup != nullptr);
+        Assert::AreEqual(std::wstring(L"Title"), pPopup->GetTitle());
+        Assert::AreEqual(std::wstring(L"Description"), pPopup->GetDescription());
+        Assert::AreEqual(std::wstring(L""), pPopup->GetDetail());
+        Assert::AreEqual(ra::ui::ImageType::None, pPopup->GetImage().Type());
+
+        Assert::IsTrue(overlay.WasRenderRequested());
+    }
+
+    TEST_METHOD(TestQueueMessageTitleDescDetail)
+    {
+        OverlayManagerHarness overlay;
+        const auto nId = overlay.QueueMessage(L"Title", L"Description", L"Detail");
+
+        const auto* pPopup = overlay.GetMessage(nId);
+        Expects(pPopup != nullptr);
+        Assert::AreEqual(std::wstring(L"Title"), pPopup->GetTitle());
+        Assert::AreEqual(std::wstring(L"Description"), pPopup->GetDescription());
+        Assert::AreEqual(std::wstring(L"Detail"), pPopup->GetDetail());
+        Assert::AreEqual(ra::ui::ImageType::None, pPopup->GetImage().Type());
+
+        Assert::IsTrue(overlay.WasRenderRequested());
+    }
+
+    TEST_METHOD(TestQueueMessageTitleDescImage)
+    {
+        OverlayManagerHarness overlay;
+        const auto nId = overlay.QueueMessage(L"Title", L"Description", ra::ui::ImageType::Badge, "BadgeURI");
+
+        const auto* pPopup = overlay.GetMessage(nId);
+        Expects(pPopup != nullptr);
+        Assert::AreEqual(std::wstring(L"Title"), pPopup->GetTitle());
+        Assert::AreEqual(std::wstring(L"Description"), pPopup->GetDescription());
+        Assert::AreEqual(std::wstring(L""), pPopup->GetDetail());
+        Assert::AreEqual(ra::ui::ImageType::Badge, pPopup->GetImage().Type());
+        Assert::AreEqual(std::string("BadgeURI"), pPopup->GetImage().Name());
+
+        Assert::IsTrue(overlay.WasRenderRequested());
+    }
+
+    TEST_METHOD(TestQueueMessageTitleDescDetailImage)
+    {
+        OverlayManagerHarness overlay;
+        const auto nId = overlay.QueueMessage(L"Title", L"Description", L"Detail", ra::ui::ImageType::Badge, "BadgeURI");
+
+        const auto* pPopup = overlay.GetMessage(nId);
+        Expects(pPopup != nullptr);
+        Assert::AreEqual(std::wstring(L"Title"), pPopup->GetTitle());
+        Assert::AreEqual(std::wstring(L"Description"), pPopup->GetDescription());
+        Assert::AreEqual(std::wstring(L"Detail"), pPopup->GetDetail());
+        Assert::AreEqual(ra::ui::ImageType::Badge, pPopup->GetImage().Type());
+        Assert::AreEqual(std::string("BadgeURI"), pPopup->GetImage().Name());
+
+        Assert::IsTrue(overlay.WasRenderRequested());
+    }
+
+    TEST_METHOD(TestRenderPopup)
+    {
+        OverlayManagerHarness overlay;
+        const auto nId = overlay.QueueMessage(L"Title", L"Description");
+        const auto* pPopup = overlay.GetMessage(nId);
+        Expects(pPopup != nullptr);
+
+        ra::ui::drawing::mocks::MockSurface mockSurface(800, 600);
+        overlay.ResetRenderRequested();
+        overlay.Render(mockSurface);
+        Assert::AreEqual(pPopup->GetRenderLocationY(), 0);
+        // no time has elapsed since the popup was queued, we're still waiting for the first render
+        Assert::IsFalse(overlay.WasRenderRequested());
+
+        // 0.8 seconds to fully visualize, expect it to be partially onscreen after 0.5 seconds
+        overlay.mockClock.AdvanceTime(std::chrono::milliseconds(500));
+        overlay.ResetRenderRequested();
+        overlay.Render(mockSurface);
+        Assert::IsTrue(pPopup->GetRenderLocationY() > 0);
+        Assert::IsTrue(pPopup->GetRenderLocationY() < 80);
+        Assert::IsTrue(overlay.WasRenderRequested());
+
+        // after 1 second, it should be fully on screen
+        overlay.mockClock.AdvanceTime(std::chrono::milliseconds(500));
+        overlay.ResetRenderRequested();
+        overlay.Render(mockSurface);
+        Assert::AreEqual(pPopup->GetRenderLocationY(), 80);
+        Assert::IsTrue(overlay.WasRenderRequested());
+
+        // after 2 seconds, it should be fully on screen
+        overlay.mockClock.AdvanceTime(std::chrono::seconds(1));
+        overlay.ResetRenderRequested();
+        overlay.Render(mockSurface);
+        Assert::AreEqual(pPopup->GetRenderLocationY(), 80);
+        Assert::IsTrue(overlay.WasRenderRequested());
+
+        // after 3 seconds, it should be fully on screen
+        overlay.mockClock.AdvanceTime(std::chrono::seconds(1));
+        overlay.ResetRenderRequested();
+        overlay.Render(mockSurface);
+        Assert::AreEqual(pPopup->GetRenderLocationY(), 80);
+        Assert::IsTrue(overlay.WasRenderRequested());
+
+        // after 4 seconds, it should be fully on screen
+        overlay.mockClock.AdvanceTime(std::chrono::seconds(1));
+        overlay.ResetRenderRequested();
+        overlay.Render(mockSurface);
+        Assert::AreEqual(pPopup->GetRenderLocationY(), 80);
+        Assert::IsTrue(overlay.WasRenderRequested());
+
+        // after 4.5 seconds, it should be starting to scroll offscreen
+        overlay.mockClock.AdvanceTime(std::chrono::milliseconds(500));
+        overlay.ResetRenderRequested();
+        overlay.Render(mockSurface);
+        Assert::IsTrue(pPopup->GetRenderLocationY() > 0);
+        Assert::IsTrue(pPopup->GetRenderLocationY() < 80);
+        Assert::IsTrue(overlay.WasRenderRequested());
+        Assert::IsNotNull(overlay.GetMessage(nId));
+
+        // after 5 seconds, it should be fully offscreen and removed from the queue
+        // since it's removed from the queue, we can't read RenderLocationY.
+        overlay.mockClock.AdvanceTime(std::chrono::milliseconds(500));
+        overlay.ResetRenderRequested();
+        overlay.Render(mockSurface);
+        Assert::IsFalse(overlay.WasRenderRequested());
+        Assert::IsNull(overlay.GetMessage(nId));
+    }
+
+    TEST_METHOD(TestAddRemoveScoreTrackerLeaderboardEnabled)
+    {
+        OverlayManagerHarness overlay;
+        overlay.mockConfiguration.SetFeatureEnabled(ra::services::Feature::LeaderboardCounters, true);
+
+        const auto& vmScoreTracker = overlay.AddScoreTracker(3);
+        Assert::AreEqual(3, vmScoreTracker.GetPopupId());
+        Assert::AreEqual(std::wstring(L"0"), vmScoreTracker.GetDisplayText());
+        Assert::IsTrue(overlay.WasRenderRequested());
+        Assert::IsFalse(vmScoreTracker.IsDestroyPending());
+        Assert::AreEqual(13, vmScoreTracker.GetRenderLocationY());
+
+        Assert::IsTrue(&vmScoreTracker == overlay.GetScoreTracker(3));
+
+        ra::ui::drawing::mocks::MockSurface mockSurface(800, 600);
+        overlay.Render(mockSurface);
+        Assert::AreEqual(13, vmScoreTracker.GetRenderLocationY());
+
+        overlay.ResetRenderRequested();
+        overlay.RemoveScoreTracker(3);
+        Assert::IsTrue(vmScoreTracker.IsDestroyPending()); // has to erase itself in render
+        Assert::IsTrue(overlay.WasRenderRequested());
+        Assert::IsNotNull(overlay.GetScoreTracker(3));
+
+        overlay.Render(mockSurface);
+        Assert::IsNull(overlay.GetScoreTracker(3)); // render should erase and destroy
+    }
+
+    TEST_METHOD(TestAddRemoveScoreTrackerLeaderboardDisabled)
+    {
+        OverlayManagerHarness overlay;
+        overlay.mockConfiguration.SetFeatureEnabled(ra::services::Feature::LeaderboardCounters, false);
+
+        const auto& vmScoreTracker = overlay.AddScoreTracker(3);
+        Assert::AreEqual(3, vmScoreTracker.GetPopupId());
+        Assert::AreEqual(std::wstring(L"0"), vmScoreTracker.GetDisplayText());
+        Assert::IsTrue(overlay.WasRenderRequested());
+        Assert::IsFalse(vmScoreTracker.IsDestroyPending());
+        Assert::AreEqual(13, vmScoreTracker.GetRenderLocationY());
+
+        Assert::IsTrue(&vmScoreTracker == overlay.GetScoreTracker(3));
+
+        ra::ui::drawing::mocks::MockSurface mockSurface(800, 600);
+        overlay.Render(mockSurface);
+        Assert::AreEqual(13, vmScoreTracker.GetRenderLocationY());
+
+        overlay.ResetRenderRequested();
+        overlay.RemoveScoreTracker(3);
+        Assert::IsTrue(vmScoreTracker.IsDestroyPending()); // has to erase itself in render
+        Assert::IsTrue(overlay.WasRenderRequested());
+        Assert::IsNotNull(overlay.GetScoreTracker(3));
+
+        overlay.Render(mockSurface);
+        Assert::IsNull(overlay.GetScoreTracker(3)); // render should erase and destroy
+    }
+
+    TEST_METHOD(TestQueueScoreboard)
+    {
+        OverlayManagerHarness overlay;
+        {
+            ScoreboardViewModel vmScoreboard;
+            vmScoreboard.SetHeaderText(L"HeaderText");
+            overlay.QueueScoreboard(3, std::move(vmScoreboard));
+        }
+
+        const auto* pScoreboard = overlay.GetScoreboard(3);
+        Expects(pScoreboard != nullptr);
+        Assert::AreEqual(std::wstring(L"HeaderText"), pScoreboard->GetHeaderText());
+        Assert::IsTrue(overlay.WasRenderRequested());
+    }
+
+    TEST_METHOD(TestRenderScoreboard)
+    {
+        OverlayManagerHarness overlay;
+        {
+            ScoreboardViewModel vmScoreboard;
+            vmScoreboard.SetHeaderText(L"HeaderText");
+            overlay.QueueScoreboard(3, std::move(vmScoreboard));
+        }
+
+        const auto* pScoreboard = overlay.GetScoreboard(3);
+        Expects(pScoreboard != nullptr);
+
+        ra::ui::drawing::mocks::MockSurface mockSurface(800, 600);
+        overlay.ResetRenderRequested();
+        overlay.Render(mockSurface);
+        Assert::AreEqual(pScoreboard->GetRenderLocationX(), 0);
+        // no time has elapsed since the popup was queued, we're still waiting for the first render
+        Assert::IsFalse(overlay.WasRenderRequested());
+
+        // 0.8 seconds to fully visualize, expect it to be partially onscreen after 0.5 seconds
+        overlay.mockClock.AdvanceTime(std::chrono::milliseconds(500));
+        overlay.ResetRenderRequested();
+        overlay.Render(mockSurface);
+        Assert::IsTrue(pScoreboard->GetRenderLocationX() > 0);
+        Assert::IsTrue(pScoreboard->GetRenderLocationX() < 310);
+        Assert::IsTrue(overlay.WasRenderRequested());
+
+        // after 1 second, it should be fully on screen
+        overlay.mockClock.AdvanceTime(std::chrono::milliseconds(500));
+        overlay.ResetRenderRequested();
+        overlay.Render(mockSurface);
+        Assert::AreEqual(pScoreboard->GetRenderLocationX(), 310);
+        Assert::IsTrue(overlay.WasRenderRequested());
+
+        // after 2 seconds, it should be fully on screen
+        overlay.mockClock.AdvanceTime(std::chrono::seconds(1));
+        overlay.ResetRenderRequested();
+        overlay.Render(mockSurface);
+        Assert::AreEqual(pScoreboard->GetRenderLocationX(), 310);
+        Assert::IsTrue(overlay.WasRenderRequested());
+
+        // after 3 seconds, it should be fully on screen
+        overlay.mockClock.AdvanceTime(std::chrono::seconds(1));
+        overlay.ResetRenderRequested();
+        overlay.Render(mockSurface);
+        Assert::AreEqual(pScoreboard->GetRenderLocationX(), 310);
+        Assert::IsTrue(overlay.WasRenderRequested());
+
+        // after 4 seconds, it should be fully on screen
+        overlay.mockClock.AdvanceTime(std::chrono::seconds(1));
+        overlay.ResetRenderRequested();
+        overlay.Render(mockSurface);
+        Assert::AreEqual(pScoreboard->GetRenderLocationX(), 310);
+        Assert::IsTrue(overlay.WasRenderRequested());
+
+        // after 5 seconds, it should be fully on screen
+        overlay.mockClock.AdvanceTime(std::chrono::seconds(1));
+        overlay.ResetRenderRequested();
+        overlay.Render(mockSurface);
+        Assert::AreEqual(pScoreboard->GetRenderLocationX(), 310);
+        Assert::IsTrue(overlay.WasRenderRequested());
+
+        // after 6 seconds, it should be fully on screen
+        overlay.mockClock.AdvanceTime(std::chrono::seconds(1));
+        overlay.ResetRenderRequested();
+        overlay.Render(mockSurface);
+        Assert::AreEqual(pScoreboard->GetRenderLocationX(), 310);
+        Assert::IsTrue(overlay.WasRenderRequested());
+
+        // after 6.5 seconds, it should be starting to scroll offscreen
+        overlay.mockClock.AdvanceTime(std::chrono::milliseconds(500));
+        overlay.ResetRenderRequested();
+        overlay.Render(mockSurface);
+        Assert::IsTrue(pScoreboard->GetRenderLocationX() > 0);
+        Assert::IsTrue(pScoreboard->GetRenderLocationX() < 310);
+        Assert::IsTrue(overlay.WasRenderRequested());
+        Assert::IsNotNull(overlay.GetScoreboard(3));
+
+        // after 7 seconds, it should be fully offscreen and removed from the queue
+        // since it's removed from the queue, we can't read RenderLocationY.
+        overlay.mockClock.AdvanceTime(std::chrono::milliseconds(500));
+        overlay.ResetRenderRequested();
+        overlay.Render(mockSurface);
+        Assert::IsFalse(overlay.WasRenderRequested());
+        Assert::IsNull(overlay.GetScoreboard(3));
+    }
+
+    TEST_METHOD(TestShowHideOverlay)
+    {
+        OverlayManagerHarness overlay;
+        ra::ui::drawing::mocks::MockSurface mockSurface(800, 600);
+        Assert::IsFalse(overlay.IsOverlayFullyVisible());
+
+        overlay.ShowOverlay();
+        Assert::IsTrue(overlay.WasRenderRequested());
+
+        // 0.8 seconds to fully visualize, expect it to be partially onscreen after 0.5 seconds
+        overlay.mockClock.AdvanceTime(std::chrono::milliseconds(500));
+        overlay.ResetRenderRequested();
+        overlay.Render(mockSurface);
+        Assert::IsTrue(overlay.GetOverlayRenderX() < 0);
+        Assert::IsTrue(overlay.GetOverlayRenderX() > -800);
+        Assert::IsTrue(overlay.WasRenderRequested());
+
+        // after 1 second, it should be fully on screen
+        overlay.mockClock.AdvanceTime(std::chrono::milliseconds(500));
+        overlay.ResetRenderRequested();
+        overlay.Render(mockSurface);
+        Assert::AreEqual(0, overlay.GetOverlayRenderX());
+        Assert::IsFalse(overlay.WasRenderRequested());
+
+        Assert::IsTrue(overlay.IsOverlayFullyVisible());
+
+        overlay.HideOverlay();
+        Assert::IsTrue(overlay.WasRenderRequested());
+
+        // 0.8 seconds to fully collapse, expect it to be partially onscreen after 0.5 seconds
+        overlay.mockClock.AdvanceTime(std::chrono::milliseconds(500));
+        overlay.ResetRenderRequested();
+        overlay.Render(mockSurface);
+        Assert::IsTrue(overlay.GetOverlayRenderX() < 0);
+        Assert::IsTrue(overlay.GetOverlayRenderX() > -800);
+        Assert::IsTrue(overlay.WasRenderRequested());
+
+        // after 1 second, it should be fully on screen
+        overlay.mockClock.AdvanceTime(std::chrono::milliseconds(500));
+        overlay.ResetRenderRequested();
+        overlay.Render(mockSurface);
+        Assert::AreEqual(-800, overlay.GetOverlayRenderX());
+        Assert::IsFalse(overlay.WasRenderRequested());
+
+        Assert::IsFalse(overlay.IsOverlayFullyVisible());
+    }
+};
+
+} // namespace tests
+} // namespace viewmodels
+} // namespace ui
+} // namespace ra


### PR DESCRIPTION
Overlay elements are now rendered in a transparent window floating above the emulator window. This ensures that the overlay elements can be rendered independently from the emulator's rendering implementation.

* Fixes https://github.com/RetroAchievements/RALibretro/issues/3 - overlay rendering is still done in GDI, but on a separate layer so we don't get intermediate flickering from the SDL rendering completing before doing the GDI rendering.
* Fixes https://github.com/RetroAchievements/RAEmus/issues/18 - overlay elements are rendered actual size instead of being rendered into the emulator buffer and stretched to fit the window
* Partially fixes https://github.com/RetroAchievements/RAEmus/issues/20 - overlay elements are now supported in Direct3D and OpenGL modes, but a code change will be required to allow navigation within the overlay in those modes.

This also changes the interaction between the emulator and the toolkit - the emulator now only needs to provide inputs when the overlay flyout is open. Psuedo-code:
```
if (RA_IsOverlayFullyVisible()) {
    ControllerInput input;
    // populate input structure
    RA_NavigateOverlay(&input);
}
```
The emulator no longer needs to calculate the time between rendering frames or erase/repaint portions of the screen previously covered by the overlays (implements #219).

After releasing this change, each emulator can be updated to expect this behavior, possibly eliminating extra steps being taken to get an HDC to pass to the DLL or repaint the screen between frames.

**NOTE**: RAGens is still using the legacy rendering logic because it flickered even worse than RALibRetro when using the layered window. I couldn't figure out why and assume it's related to https://github.com/RetroAchievements/RAEmus/issues/12 . For the highest level of compatibility, this is handled internally to the DLL. `RA_RenderOverlay` is a no-op for anything other than RAGens and `RA_UpdateOverlay` calls `RA_NavigateOverlay` for all emulators. `RA_RenderOverlay` in RAGens calls the modified code the update the overlay and draws the overlays onto the provided HDC, just like before. If we fix RAGens in the future, we will have to remove the one-off code for RAGens and release a new DLL.

