### PR TITLE
support customizing font and font size in overlay elements

### DIFF
--- a/overlay/theme-classic.json
+++ b/overlay/theme-classic.json
@@ -1,25 +1,44 @@
 {
-  "PopupColors": {
-    "Background": "#FB6600",
-    "Border": "#A04020",
-    "TextShadow": "#B45000",
-    "Title": "#000000",
-    "Description": "#000000",
-    "Detail": "#000000",
-    "Error": "#E0B080",
-    "LeaderboardEntry": "#000000",
-    "LeaderboardPlayer": "#E0B080"
+  "Popup": {
+    "Font": "Tahoma",
+    "FontSizes": {
+      "Title": 26,
+      "Subtitle": 18,
+      "Detail": 16,
+      "LeaderboardTitle": 22,
+      "LeaderboardEntry": 18,
+      "LeaderboardTracker": 18
+    },
+    "Colors": {
+      "Background": "#FB6600",
+      "Border": "#A04020",
+      "TextShadow": "#B45000",
+      "Title": "#000000",
+      "Description": "#000000",
+      "Detail": "#000000",
+      "Error": "#E0B080",
+      "LeaderboardEntry": "#000000",
+      "LeaderboardPlayer": "#E0B080"
+    }
   },
-  "OverlayColors": {
-    "Panel": "#202020",
-    "Text": "#1166DD",
-    "DisabledText": "#747A90",
-    "SubText": "#8C8C8C",
-    "DisabledSubText": "#606060",
-    "SelectionBackground": "#16163C",
-    "SelectionText": "#FFFFFF",
-    "SelectionDisabledText": "#C8C8C8",
-    "ScrollBar": "#404040",
-    "ScrollBarGripper": "#C0C0C0"
+  "Overlay": {
+    "Font": "Tahoma",
+    "FontSizes": {
+      "Title": 32,
+      "Header": 26,
+      "Summary": 22
+    },
+    "Colors": {
+      "Panel": "#202020",
+      "Text": "#1166DD",
+      "DisabledText": "#747A90",
+      "SubText": "#8C8C8C",
+      "DisabledSubText": "#606060",
+      "SelectionBackground": "#16163C",
+      "SelectionText": "#FFFFFF",
+      "SelectionDisabledText": "#C8C8C8",
+      "ScrollBar": "#404040",
+      "ScrollBarGripper": "#C0C0C0"
+    }
   }
 }

--- a/overlay/theme-coloredgrey.json
+++ b/overlay/theme-coloredgrey.json
@@ -1,25 +1,44 @@
 {
-  "PopupColors": {
-    "Background": "#404040",
-    "Border": "#202020",
-    "TextShadow": "#202020",
-    "Title": "#FFFFFF",
-    "Description": "#F0E040",
-    "Detail": "#40C0E0",
-    "Error": "#E02020",
-    "LeaderboardEntry": "#B4B4B4",
-    "LeaderboardPlayer": "#F0E080"
+  "Popup": {
+    "Font": "Tahoma",
+    "FontSizes": {
+      "Title": 26,
+      "Subtitle": 18,
+      "Detail": 16,
+      "LeaderboardTitle": 22,
+      "LeaderboardEntry": 18,
+      "LeaderboardTracker": 18
+    },
+    "Colors": {
+      "Background": "#404040",
+      "Border": "#202020",
+      "TextShadow": "#202020",
+      "Title": "#FFFFFF",
+      "Description": "#F0E040",
+      "Detail": "#40C0E0",
+      "Error": "#E02020",
+      "LeaderboardEntry": "#B4B4B4",
+      "LeaderboardPlayer": "#F0E080"
+    }
   },
-  "OverlayColors": {
-    "Panel": "#202020",
-    "Text": "#1166DD",
-    "DisabledText": "#747A90",
-    "SubText": "#8C8C8C",
-    "DisabledSubText": "#606060",
-    "SelectionBackground": "#16163C",
-    "SelectionText": "#FFFFFF",
-    "SelectionDisabledText": "#C8C8C8",
-    "ScrollBar": "#404040",
-    "ScrollBarGripper": "#C0C0C0"
+  "Overlay": {
+    "Font": "Tahoma",
+    "FontSizes": {
+      "Title": 32,
+      "Header": 26,
+      "Summary": 22
+    },
+    "Colors": {
+      "Panel": "#202020",
+      "Text": "#1166DD",
+      "DisabledText": "#747A90",
+      "SubText": "#8C8C8C",
+      "DisabledSubText": "#606060",
+      "SelectionBackground": "#16163C",
+      "SelectionText": "#FFFFFF",
+      "SelectionDisabledText": "#C8C8C8",
+      "ScrollBar": "#404040",
+      "ScrollBarGripper": "#C0C0C0"
+    }
   }
 }

--- a/src/ui/OverlayTheme.cpp
+++ b/src/ui/OverlayTheme.cpp
@@ -1,12 +1,23 @@
 #include "OverlayTheme.hh"
 
 #include "RA_Json.h"
+#include "RA_Log.h"
 
 #include "services\IFileSystem.hh"
 #include "services\ServiceLocator.hh"
 
 namespace ra {
 namespace ui {
+
+static void ReadSize(int& nSize, const rapidjson::Value& pSizes, const char* pJsonField)
+{
+    if (pSizes.HasMember(pJsonField))
+    {
+        const auto& pField = pSizes[pJsonField];
+        if (pField.IsInt())
+            nSize = pField.GetInt();
+    }
+}
 
 static void ReadColor(Color& nColor, const rapidjson::Value& pColors, const char* pJsonField)
 {
@@ -35,44 +46,84 @@ void OverlayTheme::LoadFromFile()
     const auto& pFileSystem = ra::services::ServiceLocator::Get<ra::services::IFileSystem>();
     std::wstring sFullPath = pFileSystem.BaseDirectory() + L"Overlay\\theme.json";
     auto pFile = pFileSystem.OpenTextFile(sFullPath);
-    if (pFile)
+    if (!pFile)
+        return;
+
+    rapidjson::Document document;
+    if (!LoadDocument(document, *pFile))
     {
-        rapidjson::Document document;
-        if (LoadDocument(document, *pFile))
+        RA_LOG_ERR("Unable to read Overlay\\theme.json: %s (%zu)",
+                    GetParseError_En(document.GetParseError()), document.GetErrorOffset());
+        return;
+    }
+
+    if (document.HasMember("Popup"))
+    {
+        const rapidjson::Value& popup = document["Popup"];
+
+        if (popup.HasMember("Font"))
+            m_sFontPopup = popup["Font"].GetString();
+
+        if (popup.HasMember("FontSizes"))
         {
-            if (document.HasMember("PopupColors"))
-            {
-                const rapidjson::Value& colors = document["PopupColors"];
+            const rapidjson::Value& sizes = popup["FontSizes"];
 
-                ReadColor(m_colorBackground, colors, "Background");
-                ReadColor(m_colorBorder, colors, "Border");
-                ReadColor(m_colorTextShadow, colors, "TextShadow");
-                ReadColor(m_colorTitle, colors, "Title");
-                ReadColor(m_colorDescription, colors, "Description");
-                ReadColor(m_colorDetail, colors, "Detail");
-                ReadColor(m_colorError, colors, "Error");
-                ReadColor(m_colorLeaderboardEntry, colors, "LeaderboardEntry");
-                ReadColor(m_colorLeaderboardPlayer, colors, "LeaderboardPlayer");
-            }
+            ReadSize(m_nFontSizePopupTitle, sizes, "Title");
+            ReadSize(m_nFontSizePopupSubtitle, sizes, "Subtitle");
+            ReadSize(m_nFontSizePopupDetail, sizes, "Detail");
+            ReadSize(m_nFontSizePopupLeaderboardTitle, sizes, "LeaderboardTitle");
+            ReadSize(m_nFontSizePopupLeaderboardEntry, sizes, "LeaderboardEntry");
+            ReadSize(m_nFontSizePopupLeaderboardTracker, sizes, "LeaderboardTracker");
+        }
 
-            if (document.HasMember("OverlayColors"))
-            {
-                const rapidjson::Value& colors = document["OverlayColors"];
+        if (popup.HasMember("Colors"))
+        {
+            const rapidjson::Value& colors = popup["Colors"];
 
-                ReadColor(m_colorOverlayPanel, colors, "Panel");
-                ReadColor(m_colorOverlayText, colors, "Text");
-                ReadColor(m_colorOverlayDisabledText, colors, "DisabledText");
-                ReadColor(m_colorOverlaySubText, colors, "SubText");
-                ReadColor(m_colorOverlayDisabledSubText, colors, "DisabledSubText");
-                ReadColor(m_colorOverlaySelectionBackground, colors, "SelectionBackground");
-                ReadColor(m_colorOverlaySelectionText, colors, "SelectionText");
-                ReadColor(m_colorOverlaySelectionDisabledText, colors, "SelectionDisabledText");
-                ReadColor(m_colorOverlayScrollBar, colors, "ScrollBar");
-                ReadColor(m_colorOverlayScrollBarGripper, colors, "ScrollBarGripper");
-            }
+            ReadColor(m_colorBackground, colors, "Background");
+            ReadColor(m_colorBorder, colors, "Border");
+            ReadColor(m_colorTextShadow, colors, "TextShadow");
+            ReadColor(m_colorTitle, colors, "Title");
+            ReadColor(m_colorDescription, colors, "Description");
+            ReadColor(m_colorDetail, colors, "Detail");
+            ReadColor(m_colorError, colors, "Error");
+            ReadColor(m_colorLeaderboardEntry, colors, "LeaderboardEntry");
+            ReadColor(m_colorLeaderboardPlayer, colors, "LeaderboardPlayer");
         }
     }
 
+    if (document.HasMember("Overlay"))
+    {
+        const rapidjson::Value& overlay = document["Overlay"];
+
+        if (overlay.HasMember("Font"))
+            m_sFontOverlay = overlay["Font"].GetString();
+
+        if (overlay.HasMember("FontSizes"))
+        {
+            const rapidjson::Value& sizes = overlay["FontSizes"];
+
+            ReadSize(m_nFontSizeOverlayTitle, sizes, "Title");
+            ReadSize(m_nFontSizeOverlayHeader, sizes, "Header");
+            ReadSize(m_nFontSizeOverlaySummary, sizes, "Summary");
+        }
+
+        if (overlay.HasMember("Colors"))
+        {
+            const rapidjson::Value& colors = overlay["Colors"];
+
+            ReadColor(m_colorOverlayPanel, colors, "Panel");
+            ReadColor(m_colorOverlayText, colors, "Text");
+            ReadColor(m_colorOverlayDisabledText, colors, "DisabledText");
+            ReadColor(m_colorOverlaySubText, colors, "SubText");
+            ReadColor(m_colorOverlayDisabledSubText, colors, "DisabledSubText");
+            ReadColor(m_colorOverlaySelectionBackground, colors, "SelectionBackground");
+            ReadColor(m_colorOverlaySelectionText, colors, "SelectionText");
+            ReadColor(m_colorOverlaySelectionDisabledText, colors, "SelectionDisabledText");
+            ReadColor(m_colorOverlayScrollBar, colors, "ScrollBar");
+            ReadColor(m_colorOverlayScrollBarGripper, colors, "ScrollBarGripper");
+        }
+    }
 }
 
 } // namespace ui

--- a/src/ui/OverlayTheme.hh
+++ b/src/ui/OverlayTheme.hh
@@ -2,6 +2,8 @@
 #define RA_UI_OVERLAY_THEME_H
 #pragma once
 
+#include "ra_fwd.h"
+
 #include "ui/Types.hh"
 
 namespace ra {
@@ -10,7 +12,7 @@ namespace ui {
 class OverlayTheme
 {
 public:
-    OverlayTheme() noexcept = default;
+    GSL_SUPPRESS_F6 OverlayTheme() = default;
     virtual ~OverlayTheme() noexcept = default;
     OverlayTheme(const OverlayTheme&) noexcept = delete;
     OverlayTheme& operator=(const OverlayTheme&) noexcept = delete;
@@ -18,6 +20,14 @@ public:
     OverlayTheme& operator=(OverlayTheme&&) noexcept = delete;
 
     // ===== popup style =====
+
+    const std::string& FontPopup() const noexcept { return m_sFontPopup; }
+    int FontSizePopupTitle() const noexcept { return m_nFontSizePopupTitle; }
+    int FontSizePopupSubtitle() const noexcept { return m_nFontSizePopupSubtitle; }
+    int FontSizePopupDetail() const noexcept { return m_nFontSizePopupDetail; }
+    int FontSizePopupLeaderboardTitle() const noexcept { return m_nFontSizePopupLeaderboardTitle; }
+    int FontSizePopupLeaderboardEntry() const noexcept { return m_nFontSizePopupLeaderboardEntry; }
+    int FontSizePopupLeaderboardTracker() const noexcept { return m_nFontSizePopupLeaderboardTracker; }
 
     Color ColorBackground() const noexcept { return m_colorBackground; }
     Color ColorBorder() const noexcept { return m_colorBorder; }
@@ -35,6 +45,11 @@ public:
 
     // ===== overlay style =====
 
+    const std::string& FontOverlay() const noexcept { return m_sFontOverlay; }
+    int FontSizeOverlayTitle() const noexcept { return m_nFontSizeOverlayTitle; }
+    int FontSizeOverlayHeader() const noexcept { return m_nFontSizeOverlayHeader; }
+    int FontSizeOverlaySummary() const noexcept { return m_nFontSizeOverlaySummary; }
+
     Color ColorOverlayPanel() const noexcept { return m_colorOverlayPanel; }
     Color ColorOverlayText() const noexcept { return m_colorOverlayText; }
     Color ColorOverlayDisabledText() const noexcept { return m_colorOverlayDisabledText; }
@@ -51,6 +66,14 @@ public:
     void LoadFromFile();
 
 private:
+    std::string m_sFontPopup = "Tahoma";
+    int m_nFontSizePopupTitle = 26;
+    int m_nFontSizePopupSubtitle = 18;
+    int m_nFontSizePopupDetail = 16;
+    int m_nFontSizePopupLeaderboardTitle = 22;
+    int m_nFontSizePopupLeaderboardEntry = 18;
+    int m_nFontSizePopupLeaderboardTracker = 18;
+
     Color m_colorBackground{ 255, 251, 102, 0 };
     Color m_colorBorder{ 255, 96, 48, 0 };
     Color m_colorTextShadow{ 255, 180, 80, 0 };
@@ -60,6 +83,11 @@ private:
     Color m_colorError{ 255, 128, 0, 0 };
     Color m_colorLeaderboardEntry{ 255, 0, 0, 0 };
     Color m_colorLeaderboardPlayer{ 255, 96, 40, 0 };
+
+    std::string m_sFontOverlay = "Tahoma";
+    int m_nFontSizeOverlayTitle = 32;
+    int m_nFontSizeOverlayHeader = 26;
+    int m_nFontSizeOverlaySummary = 22;
 
     Color m_colorOverlayPanel{ 255, 32, 32, 32 };
     Color m_colorOverlayText{ 255, 17, 102, 221 };

--- a/src/ui/viewmodels/OverlayAchievementsPageViewModel.cpp
+++ b/src/ui/viewmodels/OverlayAchievementsPageViewModel.cpp
@@ -127,8 +127,8 @@ void OverlayAchievementsPageViewModel::RenderDetail(ra::ui::drawing::ISurface& p
         return;
 
     const auto& pTheme = ra::services::ServiceLocator::Get<ra::ui::OverlayTheme>();
-    const auto nFont = pSurface.LoadFont(OverlayViewModel::FONT_TO_USE, OverlayViewModel::FONT_SIZE_HEADER, ra::ui::FontStyles::Normal);
-    const auto nSubFont = pSurface.LoadFont(OverlayViewModel::FONT_TO_USE, OverlayViewModel::FONT_SIZE_SUMMARY, ra::ui::FontStyles::Normal);
+    const auto nFont = pSurface.LoadFont(pTheme.FontOverlay(), pTheme.FontSizeOverlayHeader(), ra::ui::FontStyles::Normal);
+    const auto nSubFont = pSurface.LoadFont(pTheme.FontOverlay(), pTheme.FontSizeOverlaySummary(), ra::ui::FontStyles::Normal);
     const auto nAchievementSize = 64;
 
     pSurface.DrawImage(nX, nY, nAchievementSize, nAchievementSize, pAchievement->Image);

--- a/src/ui/viewmodels/OverlayLeaderboardsPageViewModel.cpp
+++ b/src/ui/viewmodels/OverlayLeaderboardsPageViewModel.cpp
@@ -60,8 +60,8 @@ void OverlayLeaderboardsPageViewModel::RenderDetail(ra::ui::drawing::ISurface& p
         return;
 
     const auto& pTheme = ra::services::ServiceLocator::Get<ra::ui::OverlayTheme>();
-    const auto nFont = pSurface.LoadFont(OverlayViewModel::FONT_TO_USE, OverlayViewModel::FONT_SIZE_HEADER, ra::ui::FontStyles::Normal);
-    const auto nSubFont = pSurface.LoadFont(OverlayViewModel::FONT_TO_USE, OverlayViewModel::FONT_SIZE_SUMMARY, ra::ui::FontStyles::Normal);
+    const auto nFont = pSurface.LoadFont(pTheme.FontOverlay(), pTheme.FontSizeOverlayHeader(), ra::ui::FontStyles::Normal);
+    const auto nSubFont = pSurface.LoadFont(pTheme.FontOverlay(), pTheme.FontSizeOverlaySummary(), ra::ui::FontStyles::Normal);
 
     pSurface.WriteText(nX, nY + 4, nFont, pTheme.ColorOverlayText(), pLeaderboard->GetLabel());
     pSurface.WriteText(nX, nY + 4 + 26, nSubFont, pTheme.ColorOverlaySubText(), pLeaderboard->GetDetail());

--- a/src/ui/viewmodels/OverlayListPageViewModel.cpp
+++ b/src/ui/viewmodels/OverlayListPageViewModel.cpp
@@ -71,15 +71,15 @@ void OverlayListPageViewModel::RenderList(ra::ui::drawing::ISurface& pSurface, i
     const auto& sGameTitle = GetListTitle();
     if (!sGameTitle.empty())
     {
-        const auto nTitleFont = pSurface.LoadFont(OverlayViewModel::FONT_TO_USE, OverlayViewModel::FONT_SIZE_TITLE, ra::ui::FontStyles::Normal);
+        const auto nTitleFont = pSurface.LoadFont(pTheme.FontOverlay(), pTheme.FontSizeOverlayTitle(), ra::ui::FontStyles::Normal);
         pSurface.WriteText(nX, nY, nTitleFont, pTheme.ColorOverlayText(), sGameTitle);
         nY += 34;
         nHeight -= 34;
     }
 
     // subtitle
-    const auto nFont = pSurface.LoadFont(OverlayViewModel::FONT_TO_USE, OverlayViewModel::FONT_SIZE_HEADER, ra::ui::FontStyles::Normal);
-    const auto nSubFont = pSurface.LoadFont(OverlayViewModel::FONT_TO_USE, OverlayViewModel::FONT_SIZE_SUMMARY, ra::ui::FontStyles::Normal);
+    const auto nFont = pSurface.LoadFont(pTheme.FontOverlay(), pTheme.FontSizeOverlayHeader(), ra::ui::FontStyles::Normal);
+    const auto nSubFont = pSurface.LoadFont(pTheme.FontOverlay(), pTheme.FontSizeOverlaySummary(), ra::ui::FontStyles::Normal);
     const auto& sSummary = GetSummary();
     pSurface.WriteText(nX, nY, nSubFont, pTheme.ColorOverlaySubText(), sSummary);
     nY += 30;
@@ -105,7 +105,7 @@ void OverlayListPageViewModel::RenderList(ra::ui::drawing::ISurface& pSurface, i
     }
 
     // achievements list
-    while (nHeight > nItemSize + nItemSpacing)
+    while (nHeight >= nItemSize)
     {
         const auto* pItem = m_vItems.GetItemAt(nIndex);
         if (!pItem)

--- a/src/ui/viewmodels/OverlayViewModel.cpp
+++ b/src/ui/viewmodels/OverlayViewModel.cpp
@@ -124,7 +124,7 @@ void OverlayViewModel::CreateRenderImage()
     m_pSurface->DrawImageStretched(0, 0, nWidth, nHeight, pOverlayBackground);
 
     // user frame
-    const auto nFont = m_pSurface->LoadFont(FONT_TO_USE, FONT_SIZE_HEADER, ra::ui::FontStyles::Normal);
+    const auto nFont = m_pSurface->LoadFont(pTheme.FontOverlay(), pTheme.FontSizeOverlayHeader(), ra::ui::FontStyles::Normal);
 
     const auto& pUserContext = ra::services::ServiceLocator::Get<ra::data::UserContext>();
     const auto sUserName = ra::Widen(pUserContext.GetUsername());
@@ -156,7 +156,7 @@ void OverlayViewModel::CreateRenderImage()
     // hardcore indicator
     if (ra::services::ServiceLocator::Get<ra::services::IConfiguration>().IsFeatureEnabled(ra::services::Feature::Hardcore))
     {
-        const auto nHardcoreFont = m_pSurface->LoadFont(FONT_TO_USE, FONT_SIZE_SUMMARY, ra::ui::FontStyles::Normal);
+        const auto nHardcoreFont = m_pSurface->LoadFont(pTheme.FontOverlay(), pTheme.FontSizeOverlaySummary(), ra::ui::FontStyles::Normal);
         const std::wstring sHardcore = L"HARDCORE";
         const auto szHardcore = m_pSurface->MeasureText(nHardcoreFont, sHardcore);
         m_pSurface->WriteText(nWidth - nMargin - szHardcore.Width - nPadding, nMargin + nUserFrameHeight,
@@ -165,7 +165,7 @@ void OverlayViewModel::CreateRenderImage()
 
     // page header
     const auto& pCurrentPage = CurrentPage();
-    const auto nPageHeaderFont = m_pSurface->LoadFont(FONT_TO_USE, FONT_SIZE_TITLE, ra::ui::FontStyles::Normal);
+    const auto nPageHeaderFont = m_pSurface->LoadFont(pTheme.FontOverlay(), pTheme.FontSizeOverlayTitle(), ra::ui::FontStyles::Normal);
     m_pSurface->WriteText(nMargin, nMargin, nPageHeaderFont, pTheme.ColorOverlayText(), pCurrentPage.GetTitle());
 
     // page content
@@ -178,7 +178,7 @@ void OverlayViewModel::CreateRenderImage()
     const auto sNext = std::wstring(L"\u2BC8: Next");
     const auto sPrev = std::wstring(L"\u2BC7: Prev");
 
-    const auto nNavFont = m_pSurface->LoadFont(FONT_TO_USE, FONT_SIZE_SUMMARY, ra::ui::FontStyles::Normal);
+    const auto nNavFont = m_pSurface->LoadFont(pTheme.FontOverlay(), pTheme.FontSizeOverlaySummary(), ra::ui::FontStyles::Normal);
     const auto szBack = m_pSurface->MeasureText(nNavFont, sBack);
     const auto szSelect = m_pSurface->MeasureText(nNavFont, sSelect);
 

--- a/src/ui/viewmodels/OverlayViewModel.hh
+++ b/src/ui/viewmodels/OverlayViewModel.hh
@@ -100,11 +100,6 @@ public:
 
     PageViewModel& CurrentPage() const { return *m_vPages.at(m_nSelectedPage); }
     
-    static _CONSTANT_VAR FONT_TO_USE = "Tahoma";
-    static _CONSTANT_VAR FONT_SIZE_TITLE = 32;
-    static _CONSTANT_VAR FONT_SIZE_HEADER = 26;
-    static _CONSTANT_VAR FONT_SIZE_SUMMARY = 22;
-
 private:
     void PopulatePages();
     void CreateRenderImage();

--- a/src/ui/viewmodels/PopupMessageViewModel.cpp
+++ b/src/ui/viewmodels/PopupMessageViewModel.cpp
@@ -6,11 +6,6 @@ namespace ra {
 namespace ui {
 namespace viewmodels {
 
-static _CONSTANT_VAR FONT_TO_USE = "Tahoma";
-static _CONSTANT_VAR FONT_SIZE_TITLE = 26;
-static _CONSTANT_VAR FONT_SIZE_SUBTITLE = 18;
-static _CONSTANT_VAR FONT_SIZE_DETAIL = 16;
-
 const StringModelProperty PopupMessageViewModel::TitleProperty("PopupMessageViewModel", "Title", L"");
 const StringModelProperty PopupMessageViewModel::DescriptionProperty("PopupMessageViewModel", "Description", L"");
 const StringModelProperty PopupMessageViewModel::DetailProperty("PopupMessageViewModel", "Detail", L"");
@@ -70,23 +65,24 @@ bool PopupMessageViewModel::UpdateRenderImage(double fElapsed)
 
 void PopupMessageViewModel::CreateRenderImage()
 {
+    const auto& pOverlayTheme = ra::services::ServiceLocator::Get<ra::ui::OverlayTheme>();
+
     // create a temporary surface so we can determine the size required for the actual surface
     const auto& pSurfaceFactory = ra::services::ServiceLocator::Get<ra::ui::drawing::ISurfaceFactory>();
     auto pSurface = pSurfaceFactory.CreateSurface(1, 1);
 
-    auto nFontTitle = pSurface->LoadFont(FONT_TO_USE, FONT_SIZE_TITLE, ra::ui::FontStyles::Normal);
+    auto nFontTitle = pSurface->LoadFont(pOverlayTheme.FontPopup(), pOverlayTheme.FontSizePopupTitle(), ra::ui::FontStyles::Normal);
     const auto sTitle = GetTitle();
     const auto szTitle = pSurface->MeasureText(nFontTitle, sTitle);
 
-    auto nFontSubtitle = pSurface->LoadFont(FONT_TO_USE, FONT_SIZE_SUBTITLE, ra::ui::FontStyles::Normal);
+    auto nFontSubtitle = pSurface->LoadFont(pOverlayTheme.FontPopup(), pOverlayTheme.FontSizePopupSubtitle(), ra::ui::FontStyles::Normal);
     const auto sSubTitle = GetDescription();
     const auto szSubTitle = pSurface->MeasureText(nFontSubtitle, sSubTitle);
 
-    auto nFontDetail = pSurface->LoadFont(FONT_TO_USE, FONT_SIZE_DETAIL, ra::ui::FontStyles::Normal);
+    auto nFontDetail = pSurface->LoadFont(pOverlayTheme.FontPopup(), pOverlayTheme.FontSizePopupDetail(), ra::ui::FontStyles::Normal);
     const auto sDetail = GetDetail();
     const auto szDetail = pSurface->MeasureText(nFontDetail, sDetail);
 
-    const auto& pOverlayTheme = ra::services::ServiceLocator::Get<ra::ui::OverlayTheme>();
     const auto nShadowOffset = pOverlayTheme.ShadowOffset();
 
     // create the actual surface
@@ -126,7 +122,7 @@ void PopupMessageViewModel::CreateRenderImage()
     nX += nSubTitleIndent;
 
     // subtitle
-    nY += FONT_SIZE_TITLE - 1;
+    nY += pOverlayTheme.FontSizePopupTitle() - 1;
     if (!sSubTitle.empty())
     {
         m_pSurface->WriteText(nX + 2, nY + 2, nFontSubtitle, pOverlayTheme.ColorTextShadow(), sSubTitle);
@@ -134,7 +130,7 @@ void PopupMessageViewModel::CreateRenderImage()
     }
 
     // detail
-    nY += FONT_SIZE_SUBTITLE;
+    nY += pOverlayTheme.FontSizePopupSubtitle();
     if (!sDetail.empty())
     {
         m_pSurface->WriteText(nX + 2, nY + 2, nFontDetail, pOverlayTheme.ColorTextShadow(), sDetail);

--- a/src/ui/viewmodels/PopupMessageViewModel.cpp
+++ b/src/ui/viewmodels/PopupMessageViewModel.cpp
@@ -71,15 +71,15 @@ void PopupMessageViewModel::CreateRenderImage()
     const auto& pSurfaceFactory = ra::services::ServiceLocator::Get<ra::ui::drawing::ISurfaceFactory>();
     auto pSurface = pSurfaceFactory.CreateSurface(1, 1);
 
-    auto nFontTitle = pSurface->LoadFont(pOverlayTheme.FontPopup(), pOverlayTheme.FontSizePopupTitle(), ra::ui::FontStyles::Normal);
+    const auto nFontTitle = pSurface->LoadFont(pOverlayTheme.FontPopup(), pOverlayTheme.FontSizePopupTitle(), ra::ui::FontStyles::Normal);
     const auto sTitle = GetTitle();
     const auto szTitle = pSurface->MeasureText(nFontTitle, sTitle);
 
-    auto nFontSubtitle = pSurface->LoadFont(pOverlayTheme.FontPopup(), pOverlayTheme.FontSizePopupSubtitle(), ra::ui::FontStyles::Normal);
+    const auto nFontSubtitle = pSurface->LoadFont(pOverlayTheme.FontPopup(), pOverlayTheme.FontSizePopupSubtitle(), ra::ui::FontStyles::Normal);
     const auto sSubTitle = GetDescription();
     const auto szSubTitle = pSurface->MeasureText(nFontSubtitle, sSubTitle);
 
-    auto nFontDetail = pSurface->LoadFont(pOverlayTheme.FontPopup(), pOverlayTheme.FontSizePopupDetail(), ra::ui::FontStyles::Normal);
+    const auto nFontDetail = pSurface->LoadFont(pOverlayTheme.FontPopup(), pOverlayTheme.FontSizePopupDetail(), ra::ui::FontStyles::Normal);
     const auto sDetail = GetDetail();
     const auto szDetail = pSurface->MeasureText(nFontDetail, sDetail);
 

--- a/src/ui/viewmodels/ScoreTrackerViewModel.cpp
+++ b/src/ui/viewmodels/ScoreTrackerViewModel.cpp
@@ -9,9 +9,6 @@ namespace ra {
 namespace ui {
 namespace viewmodels {
 
-static _CONSTANT_VAR FONT_TO_USE = "Tahoma";
-static _CONSTANT_VAR FONT_SIZE_TEXT = 22;
-
 const StringModelProperty ScoreTrackerViewModel::DisplayTextProperty("ScoreTrackerViewModel", "DisplayText", L"0");
 
 void ScoreTrackerViewModel::SetDisplayText(const std::wstring& sValue)
@@ -39,22 +36,23 @@ bool ScoreTrackerViewModel::UpdateRenderImage(_UNUSED double fElapsed)
         return false;
     }
 
+    const auto& pTheme = ra::services::ServiceLocator::Get<ra::ui::OverlayTheme>();
+    const auto nShadowOffset = pTheme.ShadowOffset();
+
     // create a temporary surface so we can determine the size required for the actual surface
     const auto& pSurfaceFactory = ra::services::ServiceLocator::Get<ra::ui::drawing::ISurfaceFactory>();
     auto pTempSurface = pSurfaceFactory.CreateSurface(1, 1);
 
-    const auto nFontText = pTempSurface->LoadFont(FONT_TO_USE, FONT_SIZE_TEXT, ra::ui::FontStyles::Normal);
+    const auto nFontText = pTempSurface->LoadFont(pTheme.FontPopup(), pTheme.FontSizePopupLeaderboardTracker(), ra::ui::FontStyles::Normal);
 
     const auto sScoreSoFar = GetDisplayText();
     const auto szScoreSoFar = pTempSurface->MeasureText(nFontText, sScoreSoFar);
 
-    m_pSurface = pSurfaceFactory.CreateSurface(szScoreSoFar.Width + 8 + 2, szScoreSoFar.Height + 2);
+    m_pSurface = pSurfaceFactory.CreateSurface(szScoreSoFar.Width + 8 + nShadowOffset, szScoreSoFar.Height + nShadowOffset);
 
     // background
-    const auto& pTheme = ra::services::ServiceLocator::Get<ra::ui::OverlayTheme>();
-    const auto nShadowOffset = pTheme.ShadowOffset();
-
     m_pSurface->FillRectangle(0, 0, m_pSurface->GetWidth(), m_pSurface->GetHeight(), Color::Transparent);
+    m_pSurface->FillRectangle(nShadowOffset, nShadowOffset, m_pSurface->GetWidth() - nShadowOffset, m_pSurface->GetHeight() - nShadowOffset, pTheme.ColorShadow());
 
     // frame
     m_pSurface->FillRectangle(nShadowOffset, nShadowOffset, szScoreSoFar.Width + 8,

--- a/src/ui/viewmodels/ScoreboardViewModel.cpp
+++ b/src/ui/viewmodels/ScoreboardViewModel.cpp
@@ -14,13 +14,13 @@ const StringModelProperty ScoreboardViewModel::EntryViewModel::UserNameProperty(
 const StringModelProperty ScoreboardViewModel::EntryViewModel::ScoreProperty("ScoreboardViewModel::EntryViewModel", "Score", L"0");
 const BoolModelProperty ScoreboardViewModel::EntryViewModel::IsHighlightedProperty("ScoreboardViewModel::EntryViewModel", "IsHighlighted", false);
 
-static int CalculateScoreboardHeight(const ra::ui::OverlayTheme& pTheme)
+static int CalculateScoreboardHeight(const ra::ui::OverlayTheme& pTheme) noexcept
 {
     return 4 + pTheme.FontSizePopupLeaderboardTitle() + 2 +
         (pTheme.FontSizePopupLeaderboardEntry() + 2) * 7 + 4;
 }
 
-static int CalculateScoreboardWidth(const ra::ui::OverlayTheme& pTheme)
+static int CalculateScoreboardWidth(const ra::ui::OverlayTheme& pTheme) noexcept
 {
     return 4 + std::max(pTheme.FontSizePopupLeaderboardEntry() * 15, pTheme.FontSizePopupLeaderboardTitle() * 10) + 4;
 }
@@ -68,8 +68,8 @@ bool ScoreboardViewModel::UpdateRenderImage(double fElapsed)
 
         const auto& pSurfaceFactory = ra::services::ServiceLocator::Get<ra::ui::drawing::ISurfaceFactory>();
         m_pSurface = pSurfaceFactory.CreateSurface(nWidth, nHeight);
-        auto nFontTitle = m_pSurface->LoadFont(pTheme.FontPopup(), pTheme.FontSizePopupLeaderboardTitle(), ra::ui::FontStyles::Normal);
-        auto nFontText = m_pSurface->LoadFont(pTheme.FontPopup(), pTheme.FontSizePopupLeaderboardEntry(), ra::ui::FontStyles::Normal);
+        const auto nFontTitle = m_pSurface->LoadFont(pTheme.FontPopup(), pTheme.FontSizePopupLeaderboardTitle(), ra::ui::FontStyles::Normal);
+        const auto nFontText = m_pSurface->LoadFont(pTheme.FontPopup(), pTheme.FontSizePopupLeaderboardEntry(), ra::ui::FontStyles::Normal);
 
         // background
         m_pSurface->FillRectangle(0, 0, m_pSurface->GetWidth(), m_pSurface->GetHeight(), Color::Transparent);

--- a/src/ui/viewmodels/ScoreboardViewModel.cpp
+++ b/src/ui/viewmodels/ScoreboardViewModel.cpp
@@ -8,30 +8,38 @@ namespace ra {
 namespace ui {
 namespace viewmodels {
 
-static _CONSTANT_VAR FONT_TO_USE = "Tahoma";
-static _CONSTANT_VAR FONT_SIZE_TITLE = 22;
-static _CONSTANT_VAR FONT_SIZE_TEXT = 22;
-
-static _CONSTANT_VAR SCOREBOARD_WIDTH = 300;
-static _CONSTANT_VAR SCOREBOARD_HEIGHT = 200;
-
 const StringModelProperty ScoreboardViewModel::HeaderTextProperty("ScoreboardViewModel", "HeaderText", L"");
 const IntModelProperty ScoreboardViewModel::EntryViewModel::RankProperty("ScoreboardViewModel::EntryViewModel", "Rank", 1);
 const StringModelProperty ScoreboardViewModel::EntryViewModel::UserNameProperty("ScoreboardViewModel::EntryViewModel", "UserName", L"");
 const StringModelProperty ScoreboardViewModel::EntryViewModel::ScoreProperty("ScoreboardViewModel::EntryViewModel", "Score", L"0");
 const BoolModelProperty ScoreboardViewModel::EntryViewModel::IsHighlightedProperty("ScoreboardViewModel::EntryViewModel", "IsHighlighted", false);
 
+static int CalculateScoreboardHeight(const ra::ui::OverlayTheme& pTheme)
+{
+    return 4 + pTheme.FontSizePopupLeaderboardTitle() + 2 +
+        (pTheme.FontSizePopupLeaderboardEntry() + 2) * 7 + 4;
+}
+
+static int CalculateScoreboardWidth(const ra::ui::OverlayTheme& pTheme)
+{
+    return 4 + std::max(pTheme.FontSizePopupLeaderboardEntry() * 15, pTheme.FontSizePopupLeaderboardTitle() * 10) + 4;
+}
+
 void ScoreboardViewModel::BeginAnimation()
 {
     m_fAnimationProgress = 0.0;
 
+    const auto& pTheme = ra::services::ServiceLocator::Get<ra::ui::OverlayTheme>();
+    const auto nHeight = CalculateScoreboardHeight(pTheme);
+    const auto nWidth = CalculateScoreboardWidth(pTheme);
+
     // bottom margin 10px
-    SetRenderLocationY(10 + SCOREBOARD_HEIGHT);
+    SetRenderLocationY(10 + nHeight);
     SetRenderLocationYRelativePosition(RelativePosition::Far);
 
     // animate to right margin 10px.
     m_nInitialX = 0;
-    m_nTargetX = 10 + SCOREBOARD_WIDTH;
+    m_nTargetX = 10 + nWidth;
     SetRenderLocationX(m_nInitialX);
     SetRenderLocationXRelativePosition(RelativePosition::Far);
 }
@@ -55,10 +63,13 @@ bool ScoreboardViewModel::UpdateRenderImage(double fElapsed)
         const auto& pTheme = ra::services::ServiceLocator::Get<ra::ui::OverlayTheme>();
         const auto nShadowOffset = pTheme.ShadowOffset();
 
+        const auto nHeight = CalculateScoreboardHeight(pTheme) + nShadowOffset;
+        const auto nWidth = CalculateScoreboardWidth(pTheme) + nShadowOffset;
+
         const auto& pSurfaceFactory = ra::services::ServiceLocator::Get<ra::ui::drawing::ISurfaceFactory>();
-        m_pSurface = pSurfaceFactory.CreateSurface(SCOREBOARD_WIDTH, SCOREBOARD_HEIGHT);
-        auto nFontTitle = m_pSurface->LoadFont(FONT_TO_USE, FONT_SIZE_TITLE, ra::ui::FontStyles::Normal);
-        auto nFontText = m_pSurface->LoadFont(FONT_TO_USE, FONT_SIZE_TEXT, ra::ui::FontStyles::Normal);
+        m_pSurface = pSurfaceFactory.CreateSurface(nWidth, nHeight);
+        auto nFontTitle = m_pSurface->LoadFont(pTheme.FontPopup(), pTheme.FontSizePopupLeaderboardTitle(), ra::ui::FontStyles::Normal);
+        auto nFontText = m_pSurface->LoadFont(pTheme.FontPopup(), pTheme.FontSizePopupLeaderboardEntry(), ra::ui::FontStyles::Normal);
 
         // background
         m_pSurface->FillRectangle(0, 0, m_pSurface->GetWidth(), m_pSurface->GetHeight(), Color::Transparent);
@@ -79,9 +90,9 @@ bool ScoreboardViewModel::UpdateRenderImage(double fElapsed)
         m_pSurface->WriteText(8, 1, nFontTitle, pTheme.ColorTitle(), sResultsTitle);
 
         // scoreboard
-        size_t nY = 4 + FONT_SIZE_TITLE + 2;
+        size_t nY = 4 + pTheme.FontSizePopupLeaderboardTitle() + 2;
         size_t i = 0;
-        while (i < m_vEntries.Count() && nY + FONT_SIZE_TEXT < m_pSurface->GetHeight())
+        while (i < m_vEntries.Count() && nY + pTheme.FontSizePopupLeaderboardEntry() < m_pSurface->GetHeight())
         {
             const auto* pEntry = m_vEntries.GetItemAt(i++);
             if (!pEntry)
@@ -95,7 +106,7 @@ bool ScoreboardViewModel::UpdateRenderImage(double fElapsed)
             const auto szScore = m_pSurface->MeasureText(nFontText, sScore);
             m_pSurface->WriteText(m_pSurface->GetWidth() - 4 - szScore.Width - 8, nY, nFontText, nTextColor, sScore);
 
-            nY += FONT_SIZE_TEXT + 2;
+            nY += pTheme.FontSizePopupLeaderboardEntry() + 2;
         }
 
         bUpdated = true;

--- a/tests/mocks/MockSurface.hh
+++ b/tests/mocks/MockSurface.hh
@@ -14,27 +14,27 @@ namespace mocks {
 class MockSurface : public ISurface
 {
 public:
-    MockSurface(size_t nWidth, size_t nHeight)
+    MockSurface(size_t nWidth, size_t nHeight) noexcept
         : m_nWidth(nWidth), m_nHeight(nHeight)
     {
     }
 
-    size_t GetWidth() const override { return m_nWidth; }
-    size_t GetHeight() const override { return m_nHeight; }
+    size_t GetWidth() const noexcept override { return m_nWidth; }
+    size_t GetHeight() const noexcept override { return m_nHeight; }
 
-    void FillRectangle(int, int, int, int, Color) override {}
-    int LoadFont(const std::string&, int, FontStyles) override { return 1; }
+    void FillRectangle(int, int, int, int, Color) noexcept override {}
+    int LoadFont(const std::string&, int, FontStyles) noexcept override { return 1; }
 
-    ra::ui::Size MeasureText(int, const std::wstring& sText) const override
+    ra::ui::Size MeasureText(int, const std::wstring& sText) const noexcept override
     {
         return { ra::to_signed(sText.length()), 1 };
     }
 
-    void WriteText(int, int, int, Color, const std::wstring&) override {}
-    void DrawImage(int, int, int, int, const ImageReference&) override {}
-    void DrawImageStretched(int, int, int, int, const ImageReference&) override {}
-    void DrawSurface(int, int, const ISurface&) override {}
-    void SetOpacity(double) override {}
+    void WriteText(int, int, int, Color, const std::wstring&) noexcept override {}
+    void DrawImage(int, int, int, int, const ImageReference&) noexcept override {}
+    void DrawImageStretched(int, int, int, int, const ImageReference&) noexcept override {}
+    void DrawSurface(int, int, const ISurface&) noexcept override {}
+    void SetOpacity(double) noexcept override {}
 
 private:
     size_t m_nWidth;

--- a/tests/ui/OverlayTheme_Tests.cpp
+++ b/tests/ui/OverlayTheme_Tests.cpp
@@ -41,6 +41,21 @@ TEST_CLASS(OverlayTheme_Tests)
         {"ScrollBarGripper", [](const OverlayTheme& pTheme) noexcept { return pTheme.ColorOverlayScrollBarGripper(); } },
     };
 
+    std::map<const char*, std::function<int(const OverlayTheme&)>> PopupFontSizeProperties = {
+        {"Title", [](const OverlayTheme& pTheme) noexcept { return pTheme.FontSizePopupTitle(); } },
+        {"Subtitle", [](const OverlayTheme& pTheme) noexcept { return pTheme.FontSizePopupSubtitle(); } },
+        {"Detail", [](const OverlayTheme& pTheme) noexcept { return pTheme.FontSizePopupDetail(); } },
+        {"LeaderboardTitle", [](const OverlayTheme& pTheme) noexcept { return pTheme.FontSizePopupLeaderboardTitle(); } },
+        {"LeaderboardEntry", [](const OverlayTheme& pTheme) noexcept { return pTheme.FontSizePopupLeaderboardEntry(); } },
+        {"LeaderboardTracker", [](const OverlayTheme& pTheme) noexcept { return pTheme.FontSizePopupLeaderboardTracker(); } },
+    };
+
+    std::map<const char*, std::function<int(const OverlayTheme&)>> OverlayFontSizeProperties = {
+        {"Title", [](const OverlayTheme& pTheme) noexcept { return pTheme.FontSizeOverlayTitle(); } },
+        {"Header", [](const OverlayTheme& pTheme) noexcept { return pTheme.FontSizeOverlayHeader(); } },
+        {"Summary", [](const OverlayTheme& pTheme) noexcept { return pTheme.FontSizeOverlaySummary(); } },
+    };
+
 public:
     TEST_METHOD(TestLoadFromFileNoFile)
     {
@@ -60,6 +75,20 @@ public:
             const Color nDefaultColor = pair.second(defaultTheme);
             const Color nLoadedColor = pair.second(theme);
             Assert::AreEqual(nDefaultColor.ARGB, nLoadedColor.ARGB, ra::Widen(pair.first).c_str());
+        }
+
+        for (const auto& pair : PopupFontSizeProperties)
+        {
+            const auto nDefaultSize = pair.second(defaultTheme);
+            const auto nLoadedSize = pair.second(theme);
+            Assert::AreEqual(nDefaultSize, nLoadedSize, ra::Widen(pair.first).c_str());
+        }
+
+        for (const auto& pair : OverlayFontSizeProperties)
+        {
+            const auto nDefaultSize = pair.second(defaultTheme);
+            const auto nLoadedSize = pair.second(theme);
+            Assert::AreEqual(nDefaultSize, nLoadedSize, ra::Widen(pair.first).c_str());
         }
     }
 
@@ -94,7 +123,7 @@ public:
         {
             OverlayThemeHarness theme;
             theme.mockFileSystem.MockFile(L".\\Overlay\\theme.json",
-                ra::StringPrintf("{\"PopupColors\":{\"%s\":\"#123456\"}}", pair.first));
+                ra::StringPrintf("{\"Popup\":{\"Colors\":{\"%s\":\"#123456\"}}}", pair.first));
             theme.LoadFromFile();
 
             for (const auto& pair2 : PopupColorProperties)
@@ -119,7 +148,7 @@ public:
         {
             OverlayThemeHarness theme;
             theme.mockFileSystem.MockFile(L".\\Overlay\\theme.json",
-                ra::StringPrintf("{\"OverlayColors\":{\"%s\":\"#123456\"}}", pair.first));
+                ra::StringPrintf("{\"Overlay\":{\"Colors\":{\"%s\":\"#123456\"}}}", pair.first));
             theme.LoadFromFile();
 
             for (const auto& pair2 : OverlayColorProperties)
@@ -137,6 +166,72 @@ public:
                 {
                     Assert::AreEqual(nDefaultColor.ARGB, nLoadedColor.ARGB, sMessage.c_str());
                 }
+            }
+        }
+    }
+
+    TEST_METHOD(TestLoadFromFileIndividualFonts)
+    {
+        {
+            OverlayThemeHarness theme;
+            theme.mockFileSystem.MockFile(L".\\Overlay\\theme.json",
+                "{\"Popup\":{\"Font\":\"Banana\"}}");
+            theme.LoadFromFile();
+
+            Assert::AreEqual(std::string("Banana"), theme.FontPopup());
+        }
+
+        {
+            OverlayThemeHarness theme;
+            theme.mockFileSystem.MockFile(L".\\Overlay\\theme.json",
+                "{\"Overlay\":{\"Font\":\"Banana\"}}");
+            theme.LoadFromFile();
+
+            Assert::AreEqual(std::string("Banana"), theme.FontOverlay());
+        }
+    }
+
+    TEST_METHOD(TestLoadFromFileIndividualFontSizes)
+    {
+        OverlayTheme defaultTheme;
+
+        for (const auto& pair : PopupFontSizeProperties)
+        {
+            OverlayThemeHarness theme;
+            theme.mockFileSystem.MockFile(L".\\Overlay\\theme.json",
+                ra::StringPrintf("{\"Popup\":{\"FontSizes\":{\"%s\":99}}}", pair.first));
+            theme.LoadFromFile();
+
+            for (const auto& pair2 : PopupFontSizeProperties)
+            {
+                const auto nDefaultSize = pair2.second(defaultTheme);
+                const auto nLoadedSize = pair2.second(theme);
+
+                auto sMessage = ra::Widen(pair.first);
+                if (pair.first == pair2.first)
+                    Assert::AreEqual(99, nLoadedSize, sMessage.c_str());
+                else
+                    Assert::AreEqual(nDefaultSize, nLoadedSize, sMessage.c_str());
+            }
+        }
+
+        for (const auto& pair : OverlayFontSizeProperties)
+        {
+            OverlayThemeHarness theme;
+            theme.mockFileSystem.MockFile(L".\\Overlay\\theme.json",
+                ra::StringPrintf("{\"Overlay\":{\"FontSizes\":{\"%s\":99}}}", pair.first));
+            theme.LoadFromFile();
+
+            for (const auto& pair2 : OverlayFontSizeProperties)
+            {
+                const auto nDefaultSize = pair2.second(defaultTheme);
+                const auto nLoadedSize = pair2.second(theme);
+
+                auto sMessage = ra::Widen(pair.first);
+                if (pair.first == pair2.first)
+                    Assert::AreEqual(99, nLoadedSize, sMessage.c_str());
+                else
+                    Assert::AreEqual(nDefaultSize, nLoadedSize, sMessage.c_str());
             }
         }
     }

--- a/tests/ui/viewmodels/OverlayManager_Tests.cpp
+++ b/tests/ui/viewmodels/OverlayManager_Tests.cpp
@@ -46,7 +46,7 @@ private:
         OverlayManagerHarness() noexcept
             : m_Override(this)
         {
-            SetRenderRequestHandler([this]()
+            GSL_SUPPRESS_F6 SetRenderRequestHandler([this]()
             {
                 m_bRenderRequested = true;
             });
@@ -60,7 +60,7 @@ private:
             m_bRenderRequested = false;
         }
 
-        int GetOverlayRenderX() const noexcept { return m_vmOverlay.GetRenderLocationX(); }
+        int GetOverlayRenderX() const { return m_vmOverlay.GetRenderLocationX(); }
 
     private:
         bool m_bRenderRequested = false;

--- a/tests/ui/viewmodels/OverlayManager_Tests.cpp
+++ b/tests/ui/viewmodels/OverlayManager_Tests.cpp
@@ -281,6 +281,8 @@ public:
         const auto* pScoreboard = overlay.GetScoreboard(3);
         Expects(pScoreboard != nullptr);
 
+        const auto nExpectedX = 288;
+
         ra::ui::drawing::mocks::MockSurface mockSurface(800, 600);
         overlay.ResetRenderRequested();
         overlay.Render(mockSurface, false);
@@ -293,49 +295,49 @@ public:
         overlay.ResetRenderRequested();
         overlay.Render(mockSurface, false);
         Assert::IsTrue(pScoreboard->GetRenderLocationX() > 0);
-        Assert::IsTrue(pScoreboard->GetRenderLocationX() < 310);
+        Assert::IsTrue(pScoreboard->GetRenderLocationX() < nExpectedX);
         Assert::IsTrue(overlay.WasRenderRequested());
 
         // after 1 second, it should be fully on screen
         overlay.mockClock.AdvanceTime(std::chrono::milliseconds(500));
         overlay.ResetRenderRequested();
         overlay.Render(mockSurface, false);
-        Assert::AreEqual(pScoreboard->GetRenderLocationX(), 310);
+        Assert::AreEqual(nExpectedX, pScoreboard->GetRenderLocationX());
         Assert::IsTrue(overlay.WasRenderRequested());
 
         // after 2 seconds, it should be fully on screen
         overlay.mockClock.AdvanceTime(std::chrono::seconds(1));
         overlay.ResetRenderRequested();
         overlay.Render(mockSurface, false);
-        Assert::AreEqual(pScoreboard->GetRenderLocationX(), 310);
+        Assert::AreEqual(nExpectedX, pScoreboard->GetRenderLocationX());
         Assert::IsTrue(overlay.WasRenderRequested());
 
         // after 3 seconds, it should be fully on screen
         overlay.mockClock.AdvanceTime(std::chrono::seconds(1));
         overlay.ResetRenderRequested();
         overlay.Render(mockSurface, false);
-        Assert::AreEqual(pScoreboard->GetRenderLocationX(), 310);
+        Assert::AreEqual(nExpectedX, pScoreboard->GetRenderLocationX());
         Assert::IsTrue(overlay.WasRenderRequested());
 
         // after 4 seconds, it should be fully on screen
         overlay.mockClock.AdvanceTime(std::chrono::seconds(1));
         overlay.ResetRenderRequested();
         overlay.Render(mockSurface, false);
-        Assert::AreEqual(pScoreboard->GetRenderLocationX(), 310);
+        Assert::AreEqual(nExpectedX, pScoreboard->GetRenderLocationX());
         Assert::IsTrue(overlay.WasRenderRequested());
 
         // after 5 seconds, it should be fully on screen
         overlay.mockClock.AdvanceTime(std::chrono::seconds(1));
         overlay.ResetRenderRequested();
         overlay.Render(mockSurface, false);
-        Assert::AreEqual(pScoreboard->GetRenderLocationX(), 310);
+        Assert::AreEqual(nExpectedX, pScoreboard->GetRenderLocationX());
         Assert::IsTrue(overlay.WasRenderRequested());
 
         // after 6 seconds, it should be fully on screen
         overlay.mockClock.AdvanceTime(std::chrono::seconds(1));
         overlay.ResetRenderRequested();
         overlay.Render(mockSurface, false);
-        Assert::AreEqual(pScoreboard->GetRenderLocationX(), 310);
+        Assert::AreEqual(nExpectedX, pScoreboard->GetRenderLocationX());
         Assert::IsTrue(overlay.WasRenderRequested());
 
         // after 6.5 seconds, it should be starting to scroll offscreen
@@ -343,7 +345,7 @@ public:
         overlay.ResetRenderRequested();
         overlay.Render(mockSurface, false);
         Assert::IsTrue(pScoreboard->GetRenderLocationX() > 0);
-        Assert::IsTrue(pScoreboard->GetRenderLocationX() < 310);
+        Assert::IsTrue(pScoreboard->GetRenderLocationX() < nExpectedX);
         Assert::IsTrue(overlay.WasRenderRequested());
         Assert::IsNotNull(overlay.GetScoreboard(3));
 


### PR DESCRIPTION
There's still only a single font selection for all of the popups, and a second available for all of the overlay. Within each there are several sizes available for different areas of the UI.

Here's an example with a huge title font, and tiny subtitle and description values (in Forte):
![image](https://user-images.githubusercontent.com/32680403/56464130-e5ed6100-639f-11e9-91d4-dc70fa5f546c.png)

And one with a tiny title and slightly larger than normal subtitle and description (in Comic Sans MS):
![image](https://user-images.githubusercontent.com/32680403/56464134-07e6e380-63a0-11e9-93c8-3231145aad5d.png)

The layout engine is very simplistic, so using too large of fonts will cause the text to overflow the popup.