### PR TITLE
add project to validate compilation of RA_Interface.cpp

### DIFF
--- a/RA_Integration.sln
+++ b/RA_Integration.sln
@@ -16,6 +16,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "RA_Integration.Tests", "tes
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "rcheevos", "src\rcheevos.vcxproj", "{9D55EBE7-1392-4FA1-A9B9-F022F764CE35}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "RA_Interface.Tests", "tests\RA_Interface.Tests.vcxproj", "{F78C2C8B-55DD-4252-A38F-F4D252D14DF8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Analysis|Win32 = Analysis|Win32
@@ -55,6 +57,15 @@ Global
 		{9D55EBE7-1392-4FA1-A9B9-F022F764CE35}.Release|Win32.Build.0 = Release|Win32
 		{9D55EBE7-1392-4FA1-A9B9-F022F764CE35}.ReleaseWithDebug|Win32.ActiveCfg = Release|Win32
 		{9D55EBE7-1392-4FA1-A9B9-F022F764CE35}.ReleaseWithDebug|Win32.Build.0 = Release|Win32
+		{F78C2C8B-55DD-4252-A38F-F4D252D14DF8}.Analysis|Win32.ActiveCfg = Release|Win32
+		{F78C2C8B-55DD-4252-A38F-F4D252D14DF8}.AnalysisUnicode|Win32.ActiveCfg = Release|Win32
+		{F78C2C8B-55DD-4252-A38F-F4D252D14DF8}.AnalysisUnicode|Win32.Build.0 = Release|Win32
+		{F78C2C8B-55DD-4252-A38F-F4D252D14DF8}.Debug|Win32.ActiveCfg = Debug|Win32
+		{F78C2C8B-55DD-4252-A38F-F4D252D14DF8}.Debug|Win32.Build.0 = Debug|Win32
+		{F78C2C8B-55DD-4252-A38F-F4D252D14DF8}.Release|Win32.ActiveCfg = Release|Win32
+		{F78C2C8B-55DD-4252-A38F-F4D252D14DF8}.Release|Win32.Build.0 = Release|Win32
+		{F78C2C8B-55DD-4252-A38F-F4D252D14DF8}.ReleaseWithDebug|Win32.ActiveCfg = Release|Win32
+		{F78C2C8B-55DD-4252-A38F-F4D252D14DF8}.ReleaseWithDebug|Win32.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/RA_Integration.vcxproj
+++ b/src/RA_Integration.vcxproj
@@ -67,7 +67,6 @@
     <ClCompile Include="RA_Dlg_Memory.cpp" />
     <ClCompile Include="RA_httpthread.cpp" />
     <ClCompile Include="RA_ImageFactory.cpp" />
-    <ClCompile Include="RA_Interface.cpp" />
     <ClCompile Include="RA_Json.cpp" />
     <ClCompile Include="RA_Leaderboard.cpp" />
     <ClCompile Include="RA_md5factory.cpp" />

--- a/src/RA_Integration.vcxproj.filters
+++ b/src/RA_Integration.vcxproj.filters
@@ -87,9 +87,6 @@
     <ClCompile Include="RA_md5factory.cpp">
       <Filter>Services</Filter>
     </ClCompile>
-    <ClCompile Include="RA_Interface.cpp">
-      <Filter>Interface</Filter>
-    </ClCompile>
     <ClCompile Include="RA_Core.cpp">
       <Filter>Interface</Filter>
     </ClCompile>

--- a/src/RA_Interface.cpp
+++ b/src/RA_Interface.cpp
@@ -1,7 +1,5 @@
 #include "RA_Interface.h"
 
-#ifndef RA_EXPORTS
-
 #include <winhttp.h>
 #include <cassert>
 #include <stdexcept>
@@ -346,6 +344,7 @@ static BOOL DoBlockingHttpGetWithRetry(const char* sHostName, const char* sReque
     return FALSE;
 }
 
+#ifndef RA_UTEST
 static std::wstring GetIntegrationPath()
 {
     wchar_t sBuffer[2048];
@@ -356,6 +355,7 @@ static std::wstring GetIntegrationPath()
 
     return std::wstring(sBuffer);
 }
+#endif
 
 static void WriteBufferToFile(const std::wstring& sFile, const char* sBuffer, int nBytes)
 {
@@ -502,11 +502,11 @@ void RA_Init(HWND hMainHWND, int nConsoleID, const char* sClientVersion)
 
     char sHostName[256] = "";
     if (_RA_HostName != nullptr)
-        strcpy(sHostName, _RA_HostName());
+        strcpy_s(sHostName, sizeof(sHostName), _RA_HostName());
 
     if (!sHostName[0])
     {
-        strcpy(sHostName, "www.retroachievements.org");
+        strcpy_s(sHostName, sizeof(sHostName), "www.retroachievements.org");
     }
     else if (_RA_InitOffline != nullptr && strcmp(sHostName, "OFFLINE") == 0)
     {
@@ -612,11 +612,15 @@ void RA_Shutdown()
 
     //	Clear func ptrs
     _RA_IntegrationVersion = nullptr;
+    _RA_HostName = nullptr;
     _RA_InitI = nullptr;
+    _RA_InitOffline = nullptr;
     _RA_Shutdown = nullptr;
+    _RA_AttemptLogin = nullptr;
     _RA_NavigateOverlay = nullptr;
     _RA_UpdateOverlay = nullptr;
     _RA_RenderOverlay = nullptr;
+    _RA_IsOverlayFullyVisible = nullptr;
     _RA_OnLoadNewRom = nullptr;
     _RA_IdentifyRom = nullptr;
     _RA_ActivateGame = nullptr;
@@ -632,12 +636,10 @@ void RA_Shutdown()
     _RA_OnSaveState = nullptr;
     _RA_OnReset = nullptr;
     _RA_DoAchievementsFrame = nullptr;
-    _RA_InstallSharedFunctions = nullptr;
-
     _RA_SetConsoleID = nullptr;
     _RA_HardcoreModeIsActive = nullptr;
     _RA_WarnDisableHardcore = nullptr;
-    _RA_AttemptLogin = nullptr;
+    _RA_InstallSharedFunctions = nullptr;
 
     //	Uninstall DLL
     if (g_hRADLL)
@@ -646,5 +648,3 @@ void RA_Shutdown()
         g_hRADLL = nullptr;
     }
 }
-
-#endif //RA_EXPORTS

--- a/tests/RA_Interface.Tests.vcxproj
+++ b/tests/RA_Interface.Tests.vcxproj
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>15.0</VCProjectVersion>
+    <ProjectGuid>{F78C2C8B-55DD-4252-A38F-F4D252D14DF8}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>RA_InterfaceTests</RootNamespace>
+    <ProjectSubType>NativeUnitTestProject</ProjectSubType>
+    <WindowsTargetPlatformVersion>7.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141_xp</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+    <UseOfMfc>false</UseOfMfc>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141_xp</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+    <UseOfMfc>false</UseOfMfc>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)bin\$(Configuration)\tests\RA_Interface\</OutDir>
+    <IntDir>$(SolutionDir)obj\$(Configuration)\tests\RA_Interface\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)bin\$(Configuration)\tests\RA_Interface\</OutDir>
+    <IntDir>$(SolutionDir)obj\$(Configuration)\tests\RA_Interface\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include\;$(SolutionDir)src\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;RA_UTEST;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <UseFullPaths>true</UseFullPaths>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <ShowIncludes>false</ShowIncludes>
+      <ConformanceMode>true</ConformanceMode>
+      <DisableSpecificWarnings>4201</DisableSpecificWarnings>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeaderFile />
+      <PrecompiledHeaderOutputFile />
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
+      <AdditionalDependencies>kernel32.lib;user32.lib;Winhttp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <UseFullPaths>true</UseFullPaths>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include\;$(SolutionDir)src\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;RA_UTEST;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <UseFullPaths>true</UseFullPaths>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <DisableSpecificWarnings>4201</DisableSpecificWarnings>
+      <AdditionalOptions>/w45045 %(AdditionalOptions)</AdditionalOptions>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeaderFile />
+      <PrecompiledHeaderOutputFile />
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>kernel32.lib;user32.lib;Winhttp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <UseFullPaths>true</UseFullPaths>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="RA_Interface_Tests.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/tests/RA_Interface.Tests.vcxproj.filters
+++ b/tests/RA_Interface.Tests.vcxproj.filters
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="RA_Interface_Tests.cpp" />
+  </ItemGroup>
+</Project>

--- a/tests/RA_Interface_Tests.cpp
+++ b/tests/RA_Interface_Tests.cpp
@@ -1,0 +1,151 @@
+#include "CppUnitTest.h"
+
+// this has to be forward declared - not sure why - including the header file doesn't work
+struct IUnknown;
+
+// NOTE: most of RA_Interface is not actually testable, the purpose of this project is to
+// ensure it compiles as the file is not used by the DLL directly. The emulators compile
+// the file directly into their code and it handles downloading and hooking up the DLL.
+// Those functions which can be mocked will be redefined here and eliminated from the CPP
+// file via a "#ifndef RA_UTEST".
+
+// these functions are redefined for the unit tests
+static std::wstring GetIntegrationPath();
+
+// ALSO NOTE: the cpp file is pulled in directly, instead of using the header file so we
+// can access the file-scoped methods and variables. The cpp file will include the header
+//file, so both are tested.
+#include "RA_Interface.cpp"
+
+#include "RA_BuildVer.h"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+static std::wstring GetIntegrationPath()
+{
+    // attempt to locate the DLL. assume it lives in a folder above the test folder:
+    // - bin/release/RA_Integration.dll
+    // - bin/release/tests/RA_Interface.tests.dll
+
+    wchar_t sBuffer[2048];
+
+    HMODULE hm;
+    if (!GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+        (LPCSTR)&GetIntegrationPath, &hm))
+    {
+        swprintf_s(sBuffer, sizeof(sBuffer) / sizeof(sBuffer[0]), L"GetModuleHandle failed with error %d", GetLastError());
+        Assert::Fail(sBuffer);
+    }
+    else
+    {
+        DWORD iIndex = GetModuleFileNameW(hm, sBuffer, 2048);
+        do
+        {
+            while (iIndex > 0 && sBuffer[iIndex - 1] != '\\' && sBuffer[iIndex - 1] != '/')
+                --iIndex;
+            wcscpy_s(&sBuffer[iIndex], sizeof(sBuffer) / sizeof(sBuffer[0]) - iIndex, L"RA_Integration.dll");
+
+            DWORD dwAttrib = GetFileAttributesW(sBuffer);
+            if (dwAttrib != INVALID_FILE_ATTRIBUTES)
+                return std::wstring(sBuffer);
+        } while (iIndex-- > 0);
+
+        Assert::Fail(L"Could not find RA_Integration.dll");
+    }
+
+    return L"";
+}
+
+namespace ra {
+namespace tests {
+
+TEST_CLASS(RA_Interface_Tests)
+{
+public:
+    static void AssertInstalled()
+    {
+        Assert::IsNotNull(g_hRADLL);
+
+        Assert::IsNotNull((const void*)_RA_IntegrationVersion);
+        Assert::IsNotNull((const void*)_RA_HostName);
+        Assert::IsNotNull((const void*)_RA_InitI);
+        Assert::IsNotNull((const void*)_RA_InitOffline);
+        Assert::IsNotNull((const void*)_RA_Shutdown);
+        Assert::IsNotNull((const void*)_RA_AttemptLogin);
+        Assert::IsNotNull((const void*)_RA_NavigateOverlay);
+        Assert::IsNotNull((const void*)_RA_UpdateOverlay);
+        Assert::IsNotNull((const void*)_RA_RenderOverlay);
+        Assert::IsNotNull((const void*)_RA_IsOverlayFullyVisible);
+        Assert::IsNotNull((const void*)_RA_OnLoadNewRom);
+        Assert::IsNotNull((const void*)_RA_IdentifyRom);
+        Assert::IsNotNull((const void*)_RA_ActivateGame);
+        Assert::IsNotNull((const void*)_RA_InstallMemoryBank);
+        Assert::IsNotNull((const void*)_RA_ClearMemoryBanks);
+        Assert::IsNotNull((const void*)_RA_UpdateAppTitle);
+        Assert::IsNotNull((const void*)_RA_HandleHTTPResults);
+        Assert::IsNotNull((const void*)_RA_ConfirmLoadNewRom);
+        Assert::IsNotNull((const void*)_RA_CreatePopupMenu);
+        Assert::IsNotNull((const void*)_RA_InvokeDialog);
+        Assert::IsNotNull((const void*)_RA_SetPaused);
+        Assert::IsNotNull((const void*)_RA_OnLoadState);
+        Assert::IsNotNull((const void*)_RA_OnSaveState);
+        Assert::IsNotNull((const void*)_RA_OnReset);
+        Assert::IsNotNull((const void*)_RA_DoAchievementsFrame);
+        Assert::IsNotNull((const void*)_RA_SetConsoleID);
+        Assert::IsNotNull((const void*)_RA_HardcoreModeIsActive);
+        Assert::IsNotNull((const void*)_RA_WarnDisableHardcore);
+        Assert::IsNotNull((const void*)_RA_InstallSharedFunctions);
+    }
+
+    void AssertShutdown()
+    {
+        Assert::IsNull((const void*)_RA_IntegrationVersion);
+        Assert::IsNull((const void*)_RA_HostName);
+        Assert::IsNull((const void*)_RA_InitI);
+        Assert::IsNull((const void*)_RA_InitOffline);
+        Assert::IsNull((const void*)_RA_Shutdown);
+        Assert::IsNull((const void*)_RA_AttemptLogin);
+        Assert::IsNull((const void*)_RA_NavigateOverlay);
+        Assert::IsNull((const void*)_RA_UpdateOverlay);
+        Assert::IsNull((const void*)_RA_RenderOverlay);
+        Assert::IsNull((const void*)_RA_IsOverlayFullyVisible);
+        Assert::IsNull((const void*)_RA_OnLoadNewRom);
+        Assert::IsNull((const void*)_RA_IdentifyRom);
+        Assert::IsNull((const void*)_RA_ActivateGame);
+        Assert::IsNull((const void*)_RA_InstallMemoryBank);
+        Assert::IsNull((const void*)_RA_ClearMemoryBanks);
+        Assert::IsNull((const void*)_RA_UpdateAppTitle);
+        Assert::IsNull((const void*)_RA_HandleHTTPResults);
+        Assert::IsNull((const void*)_RA_ConfirmLoadNewRom);
+        Assert::IsNull((const void*)_RA_CreatePopupMenu);
+        Assert::IsNull((const void*)_RA_InvokeDialog);
+        Assert::IsNull((const void*)_RA_SetPaused);
+        Assert::IsNull((const void*)_RA_OnLoadState);
+        Assert::IsNull((const void*)_RA_OnSaveState);
+        Assert::IsNull((const void*)_RA_OnReset);
+        Assert::IsNull((const void*)_RA_DoAchievementsFrame);
+        Assert::IsNull((const void*)_RA_SetConsoleID);
+        Assert::IsNull((const void*)_RA_HardcoreModeIsActive);
+        Assert::IsNull((const void*)_RA_WarnDisableHardcore);
+        Assert::IsNull((const void*)_RA_InstallSharedFunctions);
+
+        Assert::IsNull(g_hRADLL);
+    }
+
+    TEST_METHOD(TestInitializeShutdownInterface)
+    {
+        // ensure all pointers are initially set to null
+        AssertShutdown();
+
+        // load the dll, and make sure all pointers are set
+        Assert::AreEqual(RA_INTEGRATION_VERSION, _RA_InstallIntegration());
+        AssertInstalled();
+
+        // unload the dll, and make sure all pointers are set back to null
+        RA_Shutdown();
+        AssertShutdown();
+    }
+};
+
+} // namespace tests
+} // namespace ra

--- a/tests/base.props
+++ b/tests/base.props
@@ -40,7 +40,7 @@
       </Command>
     </PostBuildEvent>
     <Link>
-      <ProgramDatabaseFile>$(LocalDebuggerWorkingDirectory)\$(TargetName).pdb</ProgramDatabaseFile>
+      <ProgramDatabaseFile>$(OutDir)\$(TargetName).pdb</ProgramDatabaseFile>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
Secondary unit test project that only builds RA_Interface.cpp (without RA_EXPORTS defined) as if it were part of an emulator. Should prevent issues like #335 where a code change to the interface is incomplete.

Also has a single unit test that loads and releases the DLL. More unit tests may be possible in the future, but as RA_Interface.cpp is a single file loaded into external projects, there aren't really any points to mock the I/O.