### PR TITLE
report achievement/leaderboard parse error to user

### DIFF
--- a/src/RA_Achievement.cpp
+++ b/src/RA_Achievement.cpp
@@ -8,6 +8,8 @@
 #include "services\AchievementRuntime.hh"
 #include "services\ServiceLocator.hh"
 
+#include "ui\viewmodels\MessageBoxViewModel.hh"
+
 #ifndef RA_UTEST
 #include "RA_ImageFactory.h"
 #endif
@@ -281,6 +283,10 @@ void Achievement::ParseTrigger(const char* sTrigger)
         // parse error occurred
         RA_LOG("rc_parse_trigger returned %d", nSize);
         m_pTrigger = nullptr;
+
+        ra::ui::viewmodels::MessageBoxViewModel::ShowWarningMessage(
+            ra::StringPrintf(L"Unable to activate achievement: %s", Title()),
+            ra::StringPrintf(L"Parse error %d", nSize));
     }
     else
     {

--- a/src/RA_Leaderboard.cpp
+++ b/src/RA_Leaderboard.cpp
@@ -6,6 +6,7 @@
 #include "services\AchievementRuntime.hh"
 #include "services\ServiceLocator.hh"
 
+#include "ui\viewmodels\MessageBoxViewModel.hh"
 #include "ui\viewmodels\OverlayManager.hh"
 
 #include <ctime>
@@ -31,6 +32,10 @@ void RA_Leaderboard::ParseFromString(const char* sBuffer, const char* sFormat)
         // parse error occurred
         RA_LOG("rc_parse_lboard returned %d", nSize);
         m_pLeaderboard = nullptr;
+
+        ra::ui::viewmodels::MessageBoxViewModel::ShowWarningMessage(
+            ra::StringPrintf(L"Unable to activate leaderboard: %s", Title()),
+            ra::StringPrintf(L"Parse error %d", nSize));
     }
     else
     {

--- a/src/data/GameContext.cpp
+++ b/src/data/GameContext.cpp
@@ -917,7 +917,7 @@ void GameContext::LoadRichPresenceScript(const std::string& sRichPresenceScript)
         RA_LOG("rc_richpresence_size returned %d", nSize);
         m_pRichPresence = nullptr;
 
-        const std::string sErrorRP = ra::StringPrintf("Display:\nParse Error %d\n", nSize);
+        const std::string sErrorRP = ra::StringPrintf("Display:\nParse error %d\n", nSize);
         const int nSize2 = rc_richpresence_size(sErrorRP.c_str());
         if (nSize2 > 0)
         {

--- a/tests/RA_RichPresence_Tests.cpp
+++ b/tests/RA_RichPresence_Tests.cpp
@@ -268,7 +268,7 @@ public:
         RichPresenceInterpreterHarness rp;
         rp.LoadTest("Display:\n?0xH0000=0?Zero");
 
-        Assert::AreEqual("Parse Error -18", rp.GetRichPresenceString().c_str()); // RC_MISSING_DISPLAY_STRING
+        Assert::AreEqual("Parse error -18", rp.GetRichPresenceString().c_str()); // RC_MISSING_DISPLAY_STRING
     }
 
     TEST_METHOD(TestConditionalDisplaySharedLookup)
@@ -347,7 +347,7 @@ public:
         RichPresenceInterpreterHarness rp;
         rp.LoadTest("Lookup:Location\n0x00=Zero\n0x01=One\n\nDisplay:\n?BANANA?At @Location(0xH0000)\nNear @Location(0xH0000)");
 
-        Assert::AreEqual("Parse Error -2", rp.GetRichPresenceString().c_str()); // RC_INVALID_MEMORY_OPERAND
+        Assert::AreEqual("Parse error -2", rp.GetRichPresenceString().c_str()); // RC_INVALID_MEMORY_OPERAND
     }
 
     TEST_METHOD(TestUndefinedTag)
@@ -371,7 +371,7 @@ public:
         RichPresenceInterpreterHarness rp;
         rp.LoadTest("Format:Points\nFormatType=VALUE\n\nDisplay:\n@Points Points");
 
-        Assert::AreEqual("Parse Error -16", rp.GetRichPresenceString().c_str()); // RC_MISSING_VALUE
+        Assert::AreEqual("Parse error -16", rp.GetRichPresenceString().c_str()); // RC_MISSING_VALUE
     }
 
     TEST_METHOD(TestEscapedComment)

--- a/tests/data/GameContext_Tests.cpp
+++ b/tests/data/GameContext_Tests.cpp
@@ -379,14 +379,14 @@ public:
             lb1.Id = 7U;
             lb1.Title = "LB1";
             lb1.Description = "Desc1";
-            lb1.Definition = "STA:1=1:CAN:1=1:SUB:1=1:VAL:1";
+            lb1.Definition = "STA:1=1::CAN:1=1::SUB:1=1::VAL:1";
             lb1.Format = "SECS";
 
             auto& lb2 = response.Leaderboards.emplace_back();
             lb2.Id = 8U;
             lb2.Title = "LB2";
             lb2.Description = "Desc2";
-            lb2.Definition = "STA:1=1:CAN:1=1:SUB:1=1:VAL:1";
+            lb2.Definition = "STA:1=1::CAN:1=1::SUB:1=1::VAL:1";
             lb2.Format = "FRAMES";
 
             return true;


### PR DESCRIPTION
When loading a game where a leaderboard or achievement fails to parse, the following dialog will be displayed:
![image](https://user-images.githubusercontent.com/32680403/57180061-10c8c200-6e42-11e9-839f-9f4dc7e07943.png)

The user must acknowledge this before continuing, so hopefully they'll report the problem and we can fix it. For new sets, the dev should be the only one impacted.