### PR TITLE
add option to warn if user is loading a game with achievements in non-hardcore mode

### DIFF
--- a/src/RA_Core.cpp
+++ b/src/RA_Core.cpp
@@ -358,14 +358,15 @@ API HMENU CCONV _RA_CreatePopupMenu()
         AppendMenu(hRA, nGameFlags, IDM_RA_OPENGAMEPAGE, TEXT("Open this &Game's Page"));
         AppendMenu(hRA, MF_SEPARATOR, 0U, nullptr);
         AppendMenu(hRA, pConfiguration.IsFeatureEnabled(ra::services::Feature::Hardcore) ? MF_CHECKED : MF_UNCHECKED, IDM_RA_HARDCORE_MODE, TEXT("&Hardcore Mode"));
+        AppendMenu(hRA, pConfiguration.IsFeatureEnabled(ra::services::Feature::NonHardcoreWarning) ? MF_CHECKED : MF_UNCHECKED, IDM_RA_NON_HARDCORE_WARNING, TEXT("Non-Hardcore &Warning"));
         AppendMenu(hRA, MF_SEPARATOR, 0U, nullptr);
 
         GSL_SUPPRESS_TYPE1 AppendMenu(hRA, MF_POPUP, reinterpret_cast<UINT_PTR>(hRA_LB), TEXT("Leaderboards"));
         AppendMenu(hRA_LB, pConfiguration.IsFeatureEnabled(ra::services::Feature::Leaderboards) ? MF_CHECKED : MF_UNCHECKED, IDM_RA_TOGGLELEADERBOARDS, TEXT("Enable &Leaderboards"));
         AppendMenu(hRA_LB, MF_SEPARATOR, 0U, nullptr);
-        AppendMenu(hRA_LB, pConfiguration.IsFeatureEnabled(ra::services::Feature::LeaderboardNotifications) ? MF_CHECKED : MF_UNCHECKED, IDM_RA_TOGGLE_LB_NOTIFICATIONS, TEXT("Display Challenge Notification"));
-        AppendMenu(hRA_LB, pConfiguration.IsFeatureEnabled(ra::services::Feature::LeaderboardCounters) ? MF_CHECKED : MF_UNCHECKED, IDM_RA_TOGGLE_LB_COUNTER, TEXT("Display Time/Score Counter"));
-        AppendMenu(hRA_LB, pConfiguration.IsFeatureEnabled(ra::services::Feature::LeaderboardScoreboards) ? MF_CHECKED : MF_UNCHECKED, IDM_RA_TOGGLE_LB_SCOREBOARD, TEXT("Display Rank Scoreboard"));
+        AppendMenu(hRA_LB, pConfiguration.IsFeatureEnabled(ra::services::Feature::LeaderboardNotifications) ? MF_CHECKED : MF_UNCHECKED, IDM_RA_TOGGLE_LB_NOTIFICATIONS, TEXT("Display Challenge &Notification"));
+        AppendMenu(hRA_LB, pConfiguration.IsFeatureEnabled(ra::services::Feature::LeaderboardCounters) ? MF_CHECKED : MF_UNCHECKED, IDM_RA_TOGGLE_LB_COUNTER, TEXT("Display Time/Score &Counter"));
+        AppendMenu(hRA_LB, pConfiguration.IsFeatureEnabled(ra::services::Feature::LeaderboardScoreboards) ? MF_CHECKED : MF_UNCHECKED, IDM_RA_TOGGLE_LB_SCOREBOARD, TEXT("Display Rank &Scoreboard"));
 
         AppendMenu(hRA, MF_SEPARATOR, 0U, nullptr);
         AppendMenu(hRA, MF_STRING, IDM_RA_FILES_ACHIEVEMENTS, TEXT("Achievement &Sets"));
@@ -553,6 +554,16 @@ API void CCONV _RA_InvokeDialog(LPARAM nID)
                 if (!pEmulatorContext.EnableHardcoreMode())
                     break;
             }
+        }
+        break;
+
+        case IDM_RA_NON_HARDCORE_WARNING:
+        {
+            auto& pConfiguration = ra::services::ServiceLocator::GetMutable<ra::services::IConfiguration>();
+            pConfiguration.SetFeatureEnabled(ra::services::Feature::NonHardcoreWarning,
+                !pConfiguration.IsFeatureEnabled(ra::services::Feature::NonHardcoreWarning));
+
+            ra::services::ServiceLocator::Get<ra::data::EmulatorContext>().RebuildMenu();
         }
         break;
 

--- a/src/RA_Resource.h
+++ b/src/RA_Resource.h
@@ -150,6 +150,7 @@
 #define IDM_RA_TOGGLE_LB_NOTIFICATIONS  1718
 #define IDM_RA_TOGGLE_LB_COUNTER        1719
 #define IDM_RA_TOGGLE_LB_SCOREBOARD     1720
+#define IDM_RA_NON_HARDCORE_WARNING     1721
 #define IDM_RA_MENUEND                  1739
 #define IDC_RA_OPENPAGE                 1740
 

--- a/src/data/EmulatorContext.cpp
+++ b/src/data/EmulatorContext.cpp
@@ -263,7 +263,7 @@ void EmulatorContext::DisableHardcoreMode()
     }
 }
 
-bool EmulatorContext::EnableHardcoreMode()
+bool EmulatorContext::EnableHardcoreMode(bool bShowWarning)
 {
     auto& pConfiguration = ra::services::ServiceLocator::GetMutable<ra::services::IConfiguration>();
     if (pConfiguration.IsFeatureEnabled(ra::services::Feature::Hardcore))
@@ -291,7 +291,7 @@ bool EmulatorContext::EnableHardcoreMode()
 
     // The user is on the latest verion
     auto& pGameContext = ra::services::ServiceLocator::GetMutable<ra::data::GameContext>();
-    if (pGameContext.GameId() != 0)
+    if (pGameContext.GameId() != 0 && bShowWarning)
     {
         ra::ui::viewmodels::MessageBoxViewModel vmMessageBox;
         vmMessageBox.SetHeader(L"Enable hardcore mode?");

--- a/src/data/EmulatorContext.hh
+++ b/src/data/EmulatorContext.hh
@@ -60,14 +60,16 @@ public:
     /// <summary>
     /// Disables hardcore mode and notifies other services of that fact.
     /// </summary>
-    void DisableHardcoreMode();
+    virtual void DisableHardcoreMode();
 
     /// <summary>
     /// Enables hardcore mode and notifies other services of that fact.
     /// </summary>
-    /// <returns><c>true</c> if hardcore mode was enabled, <c>false</c> if the user chose not to based on prompts they
-    /// were given.</returns>
-    bool EnableHardcoreMode();
+    /// <param name="bShowWarning">If <c>true</c>, the user will be prompted to confirm the switch to hardcore mode</param>
+    /// <returns>
+    /// <c>true</c> if hardcore mode was enabled, <c>false</c> if the user chose not to based on prompts they were given.
+    /// </returns>
+    virtual bool EnableHardcoreMode(bool bShowWarning = true);
 
     /// <summary>
     /// Builds a string for displaying in the title bar of the emulator.

--- a/src/services/IConfiguration.hh
+++ b/src/services/IConfiguration.hh
@@ -16,6 +16,7 @@ enum class Feature
     LeaderboardCounters,
     LeaderboardScoreboards,
     PreferDecimal,
+    NonHardcoreWarning,
 };
 
 class IConfiguration

--- a/src/services/impl/JsonFileConfiguration.cpp
+++ b/src/services/impl/JsonFileConfiguration.cpp
@@ -45,6 +45,8 @@ bool JsonFileConfiguration::Load(const std::wstring& sFilename)
         m_sApiToken = doc["Token"].GetString();
     if (doc.HasMember("Hardcore Active"))
         SetFeatureEnabled(Feature::Hardcore, doc["Hardcore Active"].GetBool());
+    if (doc.HasMember("Non Hardcore Warning"))
+        SetFeatureEnabled(Feature::NonHardcoreWarning, doc["Non Hardcore Warning"].GetBool());
 
     if (doc.HasMember("Leaderboards Active"))
         SetFeatureEnabled(Feature::Leaderboards, doc["Leaderboards Active"].GetBool());
@@ -105,6 +107,7 @@ void JsonFileConfiguration::Save() const
     doc.AddMember("Username", rapidjson::StringRef(m_sUsername), a);
     doc.AddMember("Token", rapidjson::StringRef(m_sApiToken), a);
     doc.AddMember("Hardcore Active", IsFeatureEnabled(Feature::Hardcore), a);
+    doc.AddMember("Non Hardcore Warning", IsFeatureEnabled(Feature::NonHardcoreWarning), a);
     doc.AddMember("Leaderboards Active", IsFeatureEnabled(Feature::Leaderboards), a);
     doc.AddMember("Leaderboard Notification Display", IsFeatureEnabled(Feature::LeaderboardNotifications), a);
     doc.AddMember("Leaderboard Counter Display", IsFeatureEnabled(Feature::LeaderboardCounters), a);

--- a/tests/mocks/MockEmulatorContext.hh
+++ b/tests/mocks/MockEmulatorContext.hh
@@ -29,6 +29,19 @@ public:
         SetGetGameTitleFunction([sTitle](char* sBuffer) noexcept { strcpy_s(sBuffer, 64, sTitle); });
     }
 
+    void DisableHardcoreMode() override
+    {
+        auto& pConfiguration = ra::services::ServiceLocator::GetMutable<ra::services::IConfiguration>();
+        pConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, false);
+    }
+
+    bool EnableHardcoreMode(bool) override
+    {
+        auto& pConfiguration = ra::services::ServiceLocator::GetMutable<ra::services::IConfiguration>();
+        pConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, true);
+        return true;
+    }
+
 private:
     ra::services::ServiceLocator::ServiceOverride<ra::data::EmulatorContext> m_Override;
 };


### PR DESCRIPTION
Adds a menu option which is off by default:
![image](https://user-images.githubusercontent.com/32680403/57180233-de1fc900-6e43-11e9-85c3-3556bb4c5703.png)

Enabling the menu option, then trying to load a game with achievements will present this dialog:
![image](https://user-images.githubusercontent.com/32680403/57180241-ea0b8b00-6e43-11e9-9b17-c3e092fca77f.png)

If the game doesn't have any Core achievements, the dialog will not be shown, allowing the dev to continue working on their new set without having to dismiss the dialog.

The setting is stored in the `RAPrefs_` file and will be remembered between sessions.