### PR TITLE
ensure player score appears in scoreboard

### DIFF
--- a/src/data/GameContext.cpp
+++ b/src/data/GameContext.cpp
@@ -883,6 +883,7 @@ void GameContext::SubmitLeaderboardEntry(ra::LeaderboardID nLeaderboardId, unsig
                 vmScoreboard.SetHeaderText(ra::Widen(pLeaderboard->Title()));
 
                 const auto& pUserName = ra::services::ServiceLocator::Get<ra::data::UserContext>().GetUsername();
+                const int nEntriesDisplayed = 7; // display is currently hard-coded to show 7 entries
 
                 for (const auto& pEntry : response.TopEntries)
                 {
@@ -893,6 +894,32 @@ void GameContext::SubmitLeaderboardEntry(ra::LeaderboardID nLeaderboardId, unsig
 
                     if (pEntry.User == pUserName)
                         pEntryViewModel.SetHighlighted(true);
+
+                    if (vmScoreboard.Entries().Count() == nEntriesDisplayed)
+                        break;
+                }
+
+                if (response.NewRank >= nEntriesDisplayed)
+                {
+                    auto* pEntryViewModel = vmScoreboard.Entries().GetItemAt(6);
+                    if (pEntryViewModel != nullptr)
+                    {
+                        pEntryViewModel->SetRank(response.NewRank);
+
+                        if (response.BestScore != response.Score)
+                            pEntryViewModel->SetScore(ra::StringPrintf(L"(%s) %s", pLeaderboard->FormatScore(response.Score), pLeaderboard->FormatScore(response.BestScore)));
+                        else
+                            pEntryViewModel->SetScore(ra::Widen(pLeaderboard->FormatScore(response.BestScore)));
+
+                        pEntryViewModel->SetUserName(ra::Widen(pUserName));
+                        pEntryViewModel->SetHighlighted(true);
+                    }
+                }
+                else if (response.BestScore != response.Score)
+                {
+                    auto* pEntryViewModel = vmScoreboard.Entries().GetItemAt(response.NewRank - 1);
+                    if (pEntryViewModel != nullptr)
+                        pEntryViewModel->SetScore(ra::StringPrintf(L"(%s) %s", pLeaderboard->FormatScore(response.Score), pLeaderboard->FormatScore(response.BestScore)));
                 }
 
                 ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().QueueScoreboard(

--- a/tests/data/GameContext_Tests.cpp
+++ b/tests/data/GameContext_Tests.cpp
@@ -1147,7 +1147,7 @@ public:
         game.SetGameHash("hash");
 
         game.mockServer.HandleRequest<ra::api::SubmitLeaderboardEntry>([]
-            (const ra::api::SubmitLeaderboardEntry::Request& request, ra::api::SubmitLeaderboardEntry::Response& response)
+            (const ra::api::SubmitLeaderboardEntry::Request&, ra::api::SubmitLeaderboardEntry::Response& response)
         {
             response.Result = ra::api::ApiResult::Success;
             response.TopEntries.push_back({ 1, "George", 1000U });


### PR DESCRIPTION
The `submitlbentry` returns the player's best score and rank, so while it's not currently possible to show the [neighboring scores](https://github.com/RetroAchievements/RAWeb/issues/281), it is possible to show the player's rank/score:
![image](https://user-images.githubusercontent.com/32680403/57180870-48d40300-6e4a-11e9-8523-26e4034f9b42.png)

Additionally, if the player's score does not improve, we can display the submitted score along with the player's best:
![image](https://user-images.githubusercontent.com/32680403/57180880-5c7f6980-6e4a-11e9-82f6-dd3a5d790394.png)
