### PR TITLE
Allow emulator to register new window for overlay

### DIFF
--- a/src/Exports.hh
+++ b/src/Exports.hh
@@ -68,9 +68,6 @@ extern "C" {
     // Use in special cases where the emulator contains more than one console ID.
     API void CCONV _RA_SetConsoleID(unsigned int nConsoleID);
 
-    // Deal with any HTTP results that come along. Call per-cycle from main thread.
-    API int CCONV _RA_HandleHTTPResults();
-
     // Update the title of the app
     API void CCONV _RA_UpdateAppTitle(const char* sMessage = nullptr);
 

--- a/src/Exports.hh
+++ b/src/Exports.hh
@@ -24,6 +24,9 @@ extern "C" {
     // Initialize all data related to RA Engine for offline mode. Call as early as possible.
     API int CCONV _RA_InitOffline(HWND hMainHWND, /*enum EmulatorID*/int nConsoleID, const char* sClientVersion);
 
+    // Changes the HWND for the main emulator window
+    API void CCONV _RA_UpdateHWnd(HWND hMainHWND);
+
     // Call for a tidy exit at end of app.
     API int CCONV _RA_Shutdown();
 

--- a/src/RA_Core.cpp
+++ b/src/RA_Core.cpp
@@ -63,17 +63,25 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD dwReason, _UNUSED LPVOID)
     return TRUE;
 }
 
+API void CCONV _RA_UpdateHWnd(HWND hMainHWND)
+{
+    if (hMainHWND != g_RAMainWnd)
+    {
+        auto& pDesktop = dynamic_cast<ra::ui::win32::Desktop&>(ra::services::ServiceLocator::GetMutable<ra::ui::IDesktop>());
+        pDesktop.SetMainHWnd(hMainHWND);
+        g_RAMainWnd = hMainHWND;
+
+        auto& pOverlayWindow = ra::services::ServiceLocator::GetMutable<ra::ui::win32::OverlayWindow>();
+        pOverlayWindow.CreateOverlayWindow(hMainHWND);
+    }
+}
+
 static void InitCommon(HWND hMainHWND, /*enum EmulatorID*/int nEmulatorID)
 {
     ra::services::Initialization::RegisterServices(ra::itoe<EmulatorID>(nEmulatorID));
 
     // initialize global state
-    auto& pDesktop = dynamic_cast<ra::ui::win32::Desktop&>(ra::services::ServiceLocator::GetMutable<ra::ui::IDesktop>());
-    pDesktop.SetMainHWnd(hMainHWND);
-    g_RAMainWnd = hMainHWND;
-
-    auto& pOverlayWindow = ra::services::ServiceLocator::GetMutable<ra::ui::win32::OverlayWindow>();
-    pOverlayWindow.CreateOverlayWindow(hMainHWND);
+    _RA_UpdateHWnd(hMainHWND);
 
     auto& pFileSystem = ra::services::ServiceLocator::Get<ra::services::IFileSystem>();
     g_sHomeDir = pFileSystem.BaseDirectory();

--- a/src/RA_Core.cpp
+++ b/src/RA_Core.cpp
@@ -101,6 +101,9 @@ static void InitCommon(HWND hMainHWND, /*enum EmulatorID*/int nEmulatorID)
 API BOOL CCONV _RA_InitOffline(HWND hMainHWND, /*enum EmulatorID*/int nEmulatorID, const char* /*sClientVer*/)
 {
     InitCommon(hMainHWND, nEmulatorID);
+
+    ra::services::ServiceLocator::GetMutable<ra::data::UserContext>().DisableLogin();
+
     return TRUE;
 }
 
@@ -286,7 +289,7 @@ API void CCONV _RA_ClearMemoryBanks()
 //	}
 //}
 
-API int CCONV _RA_HandleHTTPResults()
+int _RA_HandleHTTPResults_deprecated()
 {
     WaitForSingleObject(RAWeb::Mutex(), INFINITE);
 

--- a/src/RA_Interface.cpp
+++ b/src/RA_Interface.cpp
@@ -14,6 +14,7 @@ const char* (CCONV *_RA_IntegrationVersion)() = nullptr;
 const char* (CCONV *_RA_HostName)() = nullptr;
 int		(CCONV *_RA_InitI)(HWND hMainWnd, int nConsoleID, const char* sClientVer) = nullptr;
 int		(CCONV *_RA_InitOffline)(HWND hMainWnd, int nConsoleID, const char* sClientVer) = nullptr;
+void    (CCONV *_RA_UpdateHWnd)(HWND hMainHWND);
 int		(CCONV *_RA_Shutdown)() = nullptr;
 //	Load/Save
 bool    (CCONV *_RA_ConfirmLoadNewRom)(bool bQuitting) = nullptr;
@@ -76,6 +77,12 @@ bool RA_IsOverlayFullyVisible()
         return _RA_IsOverlayFullyVisible();
 
     return false;
+}
+
+void RA_UpdateHWnd(HWND hMainWnd)
+{
+    if (_RA_UpdateHWnd != nullptr)
+        _RA_UpdateHWnd(hMainWnd);
 }
 
 unsigned int RA_IdentifyRom(BYTE* pROMData, unsigned int nROMSize)
@@ -441,6 +448,7 @@ static const char* CCONV _RA_InstallIntegration()
     _RA_HostName = (const char*(CCONV *)())                                           GetProcAddress(g_hRADLL, "_RA_HostName");
     _RA_InitI = (int(CCONV *)(HWND, int, const char*))                                GetProcAddress(g_hRADLL, "_RA_InitI");
     _RA_InitOffline = (int(CCONV *)(HWND, int, const char*))                          GetProcAddress(g_hRADLL, "_RA_InitOffline");
+    _RA_UpdateHWnd = (void(CCONV *)(HWND))                                            GetProcAddress(g_hRADLL, "_RA_UpdateHWnd");
     _RA_Shutdown = (int(CCONV *)())                                                   GetProcAddress(g_hRADLL, "_RA_Shutdown");
     _RA_AttemptLogin = (void(CCONV *)(bool))                                          GetProcAddress(g_hRADLL, "_RA_AttemptLogin");
     _RA_NavigateOverlay = (void(CCONV *)(ControllerInput*))                           GetProcAddress(g_hRADLL, "_RA_NavigateOverlay");
@@ -615,6 +623,7 @@ void RA_Shutdown()
     _RA_HostName = nullptr;
     _RA_InitI = nullptr;
     _RA_InitOffline = nullptr;
+    _RA_UpdateHWnd = nullptr;
     _RA_Shutdown = nullptr;
     _RA_AttemptLogin = nullptr;
     _RA_NavigateOverlay = nullptr;

--- a/src/RA_Interface.cpp
+++ b/src/RA_Interface.cpp
@@ -34,7 +34,6 @@ void    (CCONV *_RA_AttemptLogin)(bool bBlocking) = nullptr;
 void    (CCONV *_RA_SetPaused)(bool bIsPaused) = nullptr;
 HMENU   (CCONV *_RA_CreatePopupMenu)() = nullptr;
 void    (CCONV *_RA_UpdateAppTitle)(const char* pMessage) = nullptr;
-void    (CCONV *_RA_HandleHTTPResults)(void) = nullptr;
 void    (CCONV *_RA_InvokeDialog)(LPARAM nID) = nullptr;
 void    (CCONV *_RA_InstallSharedFunctions)(bool(*)(), void(*)(), void(*)(), void(*)(), void(*)(char*), void(*)(), void(*)(const char*)) = nullptr;
 int     (CCONV *_RA_SetConsoleID)(unsigned int nConsoleID) = nullptr;
@@ -130,8 +129,6 @@ void RA_UpdateAppTitle(const char* sCustomMsg)
 
 void RA_HandleHTTPResults()
 {
-    if (_RA_HandleHTTPResults != nullptr)
-        _RA_HandleHTTPResults();
 }
 
 bool RA_ConfirmLoadNewRom(bool bIsQuitting)
@@ -461,7 +458,6 @@ static const char* CCONV _RA_InstallIntegration()
     _RA_InstallMemoryBank = (void(CCONV *)(int, void*, void*, int))                   GetProcAddress(g_hRADLL, "_RA_InstallMemoryBank");
     _RA_ClearMemoryBanks = (void(CCONV *)())                                          GetProcAddress(g_hRADLL, "_RA_ClearMemoryBanks");
     _RA_UpdateAppTitle = (void(CCONV *)(const char*))                                 GetProcAddress(g_hRADLL, "_RA_UpdateAppTitle");
-    _RA_HandleHTTPResults = (void(CCONV *)())                                         GetProcAddress(g_hRADLL, "_RA_HandleHTTPResults");
     _RA_ConfirmLoadNewRom = (bool(CCONV *)(bool))                                     GetProcAddress(g_hRADLL, "_RA_ConfirmLoadNewRom");
     _RA_CreatePopupMenu = (HMENU(CCONV *)(void))                                      GetProcAddress(g_hRADLL, "_RA_CreatePopupMenu");
     _RA_InvokeDialog = (void(CCONV *)(LPARAM))                                        GetProcAddress(g_hRADLL, "_RA_InvokeDialog");
@@ -636,7 +632,6 @@ void RA_Shutdown()
     _RA_InstallMemoryBank = nullptr;
     _RA_ClearMemoryBanks = nullptr;
     _RA_UpdateAppTitle = nullptr;
-    _RA_HandleHTTPResults = nullptr;
     _RA_ConfirmLoadNewRom = nullptr;
     _RA_CreatePopupMenu = nullptr;
     _RA_InvokeDialog = nullptr;

--- a/src/RA_Interface.h
+++ b/src/RA_Interface.h
@@ -117,6 +117,9 @@ enum ConsoleID
 //	Populates all function pointers so they can be used by the app.
 extern void RA_Init(HWND hMainHWND, /*enum ConsoleType*/ int console, const char* sClientVersion);
 
+//  Updates the handle for the emulator window.
+extern void RA_UpdateHWnd(HWND hMainHWND);
+
 //	Call with shared function pointers from app.
 extern void RA_InstallSharedFunctions(bool (*fpUnusedIsActive)(void), void (*fpCauseUnpause)(void),
                                       void (*fpCausePause)(void), void (*fpRebuildMenu)(void),

--- a/tests/RA_Interface_Tests.cpp
+++ b/tests/RA_Interface_Tests.cpp
@@ -70,6 +70,7 @@ public:
         Assert::IsNotNull((const void*)_RA_HostName);
         Assert::IsNotNull((const void*)_RA_InitI);
         Assert::IsNotNull((const void*)_RA_InitOffline);
+        Assert::IsNotNull((const void*)_RA_UpdateHWnd);
         Assert::IsNotNull((const void*)_RA_Shutdown);
         Assert::IsNotNull((const void*)_RA_AttemptLogin);
         Assert::IsNotNull((const void*)_RA_NavigateOverlay);
@@ -103,6 +104,7 @@ public:
         Assert::IsNull((const void*)_RA_HostName);
         Assert::IsNull((const void*)_RA_InitI);
         Assert::IsNull((const void*)_RA_InitOffline);
+        Assert::IsNull((const void*)_RA_UpdateHWnd);
         Assert::IsNull((const void*)_RA_Shutdown);
         Assert::IsNull((const void*)_RA_AttemptLogin);
         Assert::IsNull((const void*)_RA_NavigateOverlay);

--- a/tests/RA_Interface_Tests.cpp
+++ b/tests/RA_Interface_Tests.cpp
@@ -83,7 +83,6 @@ public:
         Assert::IsNotNull((const void*)_RA_InstallMemoryBank);
         Assert::IsNotNull((const void*)_RA_ClearMemoryBanks);
         Assert::IsNotNull((const void*)_RA_UpdateAppTitle);
-        Assert::IsNotNull((const void*)_RA_HandleHTTPResults);
         Assert::IsNotNull((const void*)_RA_ConfirmLoadNewRom);
         Assert::IsNotNull((const void*)_RA_CreatePopupMenu);
         Assert::IsNotNull((const void*)_RA_InvokeDialog);
@@ -117,7 +116,6 @@ public:
         Assert::IsNull((const void*)_RA_InstallMemoryBank);
         Assert::IsNull((const void*)_RA_ClearMemoryBanks);
         Assert::IsNull((const void*)_RA_UpdateAppTitle);
-        Assert::IsNull((const void*)_RA_HandleHTTPResults);
         Assert::IsNull((const void*)_RA_ConfirmLoadNewRom);
         Assert::IsNull((const void*)_RA_CreatePopupMenu);
         Assert::IsNull((const void*)_RA_InvokeDialog);


### PR DESCRIPTION
Requires changes in the emulators. Tested with RAVBA, which creates a new window when switching to/from fullscreen. After notifying the DLL of the new window handle (`RA_UpdateHWnd`), the overlay appears correctly both in normal and fullscreen modes. I expect similar changes will allow other emulators to also operate in fullscreen mode.