### PR TITLE
fix clipping when overlays overlap

### DIFF
--- a/src/ui/drawing/ISurface.hh
+++ b/src/ui/drawing/ISurface.hh
@@ -93,8 +93,20 @@ public:
     /// </summary>
     /// <param name="nX">The x coordinate to draw at.</param>
     /// <param name="nY">The y coordinate to draw at.</param>
-    /// <param name="pImage">The surface to draw.</param>
+    /// <param name="pSurface">The surface to draw.</param>
     virtual void DrawSurface(int nX, int nY, const ISurface& pSurface) = 0;
+
+    /// <summary>
+    /// Draws part of a secondary surface onto the surface.
+    /// </summary>
+    /// <param name="nX">The x coordinate to draw at.</param>
+    /// <param name="nY">The y coordinate to draw at.</param>
+    /// <param name="pSurface">The surface to draw.</param>
+    /// <param name="nSurfaceX">The x coordinate to copy from.</param>
+    /// <param name="nSurfaceY">The y coordinate to copy from.</param>
+    /// <param name="nWidth">The width to copy.</param>
+    /// <param name="nHeight">The height to copy.</param>
+    virtual void DrawSurface(int nX, int nY, const ISurface& pSurface, int nSurfaceX, int nSurfaceY, int nWidth, int nHeight) = 0;
 
     /// <summary>
     /// Sets the alpha value of anything that's not currently transparent to the specified value.

--- a/src/ui/drawing/gdi/GDISurface.cpp
+++ b/src/ui/drawing/gdi/GDISurface.cpp
@@ -125,6 +125,16 @@ void GDISurface::DrawSurface(int nX, int nY, const ISurface& pSurface)
     }
 }
 
+void GDISurface::DrawSurface(int nX, int nY, const ISurface& pSurface, int nSurfaceX, int nSurfaceY, int nWidth, int nHeight)
+{
+    assert(dynamic_cast<const GDIAlphaBitmapSurface*>(&pSurface) == nullptr); // clipped alpha blend not currently supported
+
+    auto* pGDISurface = dynamic_cast<const GDISurface*>(&pSurface);
+    assert(pGDISurface != nullptr);
+    if (pGDISurface != nullptr)
+        ::BitBlt(m_hDC, nX, nY, nWidth, nHeight, pGDISurface->m_hDC, nSurfaceX, nSurfaceY, SRCCOPY);
+}
+
 } // namespace gdi
 } // namespace drawing
 } // namespace ui

--- a/src/ui/drawing/gdi/GDISurface.hh
+++ b/src/ui/drawing/gdi/GDISurface.hh
@@ -36,6 +36,7 @@ public:
     void DrawImage(int nX, int nY, int nWidth, int nHeight, const ImageReference& pImage) override;
     void DrawImageStretched(int nX, int nY, int nWidth, int nHeight, const ImageReference& pImage) override;
     void DrawSurface(int nX, int nY, const ISurface& pSurface) override;
+    void DrawSurface(int nX, int nY, const ISurface& pSurface, int nSurfaceX, int nSurfaceY, int nWidth, int nHeight) override;
 
     GSL_SUPPRESS_F6 void SetOpacity(_UNUSED double) override { assert("This surface does not support opacity"); }
 

--- a/src/ui/viewmodels/OverlayManager.hh
+++ b/src/ui/viewmodels/OverlayManager.hh
@@ -216,6 +216,7 @@ protected:
     std::vector<std::unique_ptr<ScoreTrackerViewModel>> m_vScoreTrackers;
     std::deque<ScoreboardViewModel> m_vScoreboards;
 
+    bool m_bIsRendering = false;
     bool m_bRenderRequestPending = false;
 
     void OnImageChanged(ImageType, const std::string&) override
@@ -232,7 +233,6 @@ private:
     void UpdateOverlay(ra::ui::drawing::ISurface& pSurface, double fElapsed);
 
     bool m_bRedrawAll = false;
-    bool m_bIsRendering = false;
     std::chrono::steady_clock::time_point m_tLastRender{};
     std::function<void()> m_fHandleRenderRequest;
 

--- a/tests/mocks/MockSurface.hh
+++ b/tests/mocks/MockSurface.hh
@@ -34,6 +34,7 @@ public:
     void DrawImage(int, int, int, int, const ImageReference&) noexcept override {}
     void DrawImageStretched(int, int, int, int, const ImageReference&) noexcept override {}
     void DrawSurface(int, int, const ISurface&) noexcept override {}
+    void DrawSurface(int, int, const ISurface&, int, int, int, int) noexcept override {}
     void SetOpacity(double) noexcept override {}
 
 private:

--- a/tests/ui/viewmodels/OverlayManager_Tests.cpp
+++ b/tests/ui/viewmodels/OverlayManager_Tests.cpp
@@ -56,6 +56,7 @@ private:
 
         void ResetRenderRequested() noexcept
         {
+            m_bIsRendering = false;
             m_bRenderRequestPending = false;
             m_bRenderRequested = false;
         }
@@ -142,7 +143,7 @@ public:
         overlay.Render(mockSurface, false);
         Assert::AreEqual(pPopup->GetRenderLocationY(), 0);
         // no time has elapsed since the popup was queued, we're still waiting for the first render
-        Assert::IsFalse(overlay.WasRenderRequested());
+        Assert::IsTrue(overlay.WasRenderRequested());
 
         // 0.8 seconds to fully visualize, expect it to be partially onscreen after 0.5 seconds
         overlay.mockClock.AdvanceTime(std::chrono::milliseconds(500));
@@ -159,21 +160,21 @@ public:
         Assert::AreEqual(pPopup->GetRenderLocationY(), 80);
         Assert::IsTrue(overlay.WasRenderRequested());
 
-        // after 2 seconds, it should be fully on screen
+        // after 2 seconds, it should still be fully on screen
         overlay.mockClock.AdvanceTime(std::chrono::seconds(1));
         overlay.ResetRenderRequested();
         overlay.Render(mockSurface, false);
         Assert::AreEqual(pPopup->GetRenderLocationY(), 80);
         Assert::IsTrue(overlay.WasRenderRequested());
 
-        // after 3 seconds, it should be fully on screen
+        // after 3 seconds, it should still be fully on screen
         overlay.mockClock.AdvanceTime(std::chrono::seconds(1));
         overlay.ResetRenderRequested();
         overlay.Render(mockSurface, false);
         Assert::AreEqual(pPopup->GetRenderLocationY(), 80);
         Assert::IsTrue(overlay.WasRenderRequested());
 
-        // after 4 seconds, it should be fully on screen
+        // after 4 seconds, it should still be fully on screen
         overlay.mockClock.AdvanceTime(std::chrono::seconds(1));
         overlay.ResetRenderRequested();
         overlay.Render(mockSurface, false);
@@ -194,7 +195,7 @@ public:
         overlay.mockClock.AdvanceTime(std::chrono::milliseconds(500));
         overlay.ResetRenderRequested();
         overlay.Render(mockSurface, false);
-        Assert::IsFalse(overlay.WasRenderRequested());
+        Assert::IsTrue(overlay.WasRenderRequested());
         Assert::IsNull(overlay.GetMessage(nId));
     }
 
@@ -288,7 +289,7 @@ public:
         overlay.Render(mockSurface, false);
         Assert::AreEqual(pScoreboard->GetRenderLocationX(), 0);
         // no time has elapsed since the popup was queued, we're still waiting for the first render
-        Assert::IsFalse(overlay.WasRenderRequested());
+        Assert::IsTrue(overlay.WasRenderRequested());
 
         // 0.8 seconds to fully visualize, expect it to be partially onscreen after 0.5 seconds
         overlay.mockClock.AdvanceTime(std::chrono::milliseconds(500));
@@ -305,35 +306,35 @@ public:
         Assert::AreEqual(nExpectedX, pScoreboard->GetRenderLocationX());
         Assert::IsTrue(overlay.WasRenderRequested());
 
-        // after 2 seconds, it should be fully on screen
+        // after 2 seconds, it should still be fully on screen
         overlay.mockClock.AdvanceTime(std::chrono::seconds(1));
         overlay.ResetRenderRequested();
         overlay.Render(mockSurface, false);
         Assert::AreEqual(nExpectedX, pScoreboard->GetRenderLocationX());
         Assert::IsTrue(overlay.WasRenderRequested());
 
-        // after 3 seconds, it should be fully on screen
+        // after 3 seconds, it should still be fully on screen
         overlay.mockClock.AdvanceTime(std::chrono::seconds(1));
         overlay.ResetRenderRequested();
         overlay.Render(mockSurface, false);
         Assert::AreEqual(nExpectedX, pScoreboard->GetRenderLocationX());
         Assert::IsTrue(overlay.WasRenderRequested());
 
-        // after 4 seconds, it should be fully on screen
+        // after 4 seconds, it should still be fully on screen
         overlay.mockClock.AdvanceTime(std::chrono::seconds(1));
         overlay.ResetRenderRequested();
         overlay.Render(mockSurface, false);
         Assert::AreEqual(nExpectedX, pScoreboard->GetRenderLocationX());
         Assert::IsTrue(overlay.WasRenderRequested());
 
-        // after 5 seconds, it should be fully on screen
+        // after 5 seconds, it should still be fully on screen
         overlay.mockClock.AdvanceTime(std::chrono::seconds(1));
         overlay.ResetRenderRequested();
         overlay.Render(mockSurface, false);
         Assert::AreEqual(nExpectedX, pScoreboard->GetRenderLocationX());
         Assert::IsTrue(overlay.WasRenderRequested());
 
-        // after 6 seconds, it should be fully on screen
+        // after 6 seconds, it should still be fully on screen
         overlay.mockClock.AdvanceTime(std::chrono::seconds(1));
         overlay.ResetRenderRequested();
         overlay.Render(mockSurface, false);
@@ -354,7 +355,7 @@ public:
         overlay.mockClock.AdvanceTime(std::chrono::milliseconds(500));
         overlay.ResetRenderRequested();
         overlay.Render(mockSurface, false);
-        Assert::IsFalse(overlay.WasRenderRequested());
+        Assert::IsTrue(overlay.WasRenderRequested());
         Assert::IsNull(overlay.GetScoreboard(3));
     }
 
@@ -395,12 +396,12 @@ public:
         Assert::IsTrue(overlay.GetOverlayRenderX() > -800);
         Assert::IsTrue(overlay.WasRenderRequested());
 
-        // after 1 second, it should be fully on screen
+        // after 1 second, it should be fully off screen
         overlay.mockClock.AdvanceTime(std::chrono::milliseconds(500));
         overlay.ResetRenderRequested();
         overlay.Render(mockSurface, false);
         Assert::AreEqual(-800, overlay.GetOverlayRenderX());
-        Assert::IsFalse(overlay.WasRenderRequested());
+        Assert::IsTrue(overlay.WasRenderRequested());
 
         Assert::IsFalse(overlay.IsOverlayFullyVisible());
     }


### PR DESCRIPTION
Most noticable when full-screen overlay is closing and a popup is present. In this case, the popup flashes over the overlay as it closes.

Also noticable when scoreboard and popup are overlapping and either starts closing. In this case, the obscured part of the non-closing popup is not redrawn.

Both cases described above have been fixed.

