### PR TITLE
make MakeBuildVer.bat more generic

### DIFF
--- a/MakeBuildVer.bat
+++ b/MakeBuildVer.bat
@@ -1,54 +1,89 @@
 @echo off
 setlocal
 
-if not exist MakeBuildVer.bat cd ..
+set TARGET_FILE=%1
+if "%TARGET_FILE%"=="" GOTO usage
+set GIT_TAG=%2
+if "%GIT_TAG%"=="" GOTO usage
+set DEFINE_PREFIX=%3
+if "%DEFINE_PREFIX%"=="" GOTO usage
+
+goto get_parts
+
+:usage
+echo Usage: MakeBuildVer [TargetFile] [GitTag] [DefinePrefix]
+exit
+
+:get_parts
+
+rem === Get the current branch ===
+git rev-parse --abbrev-ref HEAD > Temp.txt
+set /p ACTIVE_BRANCH=<Temp.txt
 
 rem === Get the most recent tag matching our prefix ===
-git describe --tags --match "RAIntegration.*" > Temp.txt
+git describe --tags --match "%GIT_TAG%.*" > Temp.txt 2>&1
 set /p ACTIVE_TAG=<Temp.txt
-for /f "tokens=1,2 delims=-" %%a in ("%ACTIVE_TAG:~14%") do set VERSION_TAG=%%a&set VERSION_REVISION=%%b
+if "%ACTIVE_TAG:~0,5%" == "fatal" goto no_tag
+
+rem === Get the number of commits since the tag and remove the hash PREFIX-COMMITS-HASH ===
+for /f "tokens=1,2 delims=-" %%a in ("%ACTIVE_TAG%") do set ACTIVE_TAG=%%a&set VERSION_REVISION=%%b
 if "%VERSION_REVISION%" == "" set VERSION_REVISION=0
 
 rem === Extract the major/minor/patch version from the tag (append 0s if necessary) ===
-for /f "tokens=1,2,3 delims=." %%a in ("%VERSION_TAG%.0.0") do set VERSION_MAJOR=%%a&set VERSION_MINOR=%%b&set VERSION_PATCH=%%c
+for /f "tokens=1,2,3,4 delims=." %%a in ("%ACTIVE_TAG%.0.0") do set VERSION_MAJOR=%%b&set VERSION_MINOR=%%c&set VERSION_PATCH=%%d
+for /f "tokens=1,* delims=." %%a in ("%ACTIVE_TAG%") do set VERSION_TAG=%%b
+
+goto have_parts
+
+:no_tag
+set VERSION_TAG=NO TAG
+set VERSION_MAJOR=0
+set VERSION_MINOR=0
+set VERSION_PATCH=0
+set VERSION_REVISION=0
+
+:have_parts
+
+set BRANCH_INFO=%ACTIVE_BRANCH%
+
+rem === Build the product version. If on a branch, include the branch name ===
 set VERSION_PRODUCT=%VERSION_MAJOR%.%VERSION_MINOR%
+if not "%ACTIVE_BRANCH%"=="master" (
+    set VERSION_PRODUCT=%VERSION_PRODUCT%-%ACTIVE_BRANCH%
+)
 
 rem === If there are any local modifications, increment revision ===
 git diff HEAD > Temp.txt
 for /F "usebackq" %%A in ('"Temp.txt"') do set DIFF_FILE_SIZE=%%~zA
 if %DIFF_FILE_SIZE% GTR 0 (
-    set ACTIVE_TAG=Unstaged changes
+    set BRANCH_INFO=%BRANCH_INFO% [modified]
     set /A VERSION_REVISION=VERSION_REVISION+1
 )
 
-rem === If on a branch, append the branch name to the product version ===
-git rev-parse --abbrev-ref HEAD > Temp.txt
-set /p ACTIVE_BRANCH=<Temp.txt
-if not "%ACTIVE_BRANCH%"=="master" (
-    set VERSION_PRODUCT=%VERSION_PRODUCT%-%ACTIVE_BRANCH%
-)
-
 rem === Generate a new version file ===
-@echo Tag: %ACTIVE_TAG% (%VERSION_TAG%)
+@echo Branch: %BRANCH_INFO% (%VERSION_TAG%)
 
-echo #define RA_INTEGRATION_VERSION "%VERSION_MAJOR%.%VERSION_MINOR%.%VERSION_PATCH%.%VERSION_REVISION%" > RA_BuildVer.h
-echo #define RA_INTEGRATION_VERSION_MAJOR %VERSION_MAJOR% >> RA_BuildVer.h
-echo #define RA_INTEGRATION_VERSION_MINOR %VERSION_MINOR% >> RA_BuildVer.h
-echo #define RA_INTEGRATION_VERSION_PATCH %VERSION_PATCH% >> RA_BuildVer.h
-echo #define RA_INTEGRATION_VERSION_REVISION %VERSION_REVISION% >> RA_BuildVer.h
-echo #define RA_INTEGRATION_VERSION_PRODUCT "%VERSION_PRODUCT%" >> RA_BuildVer.h
+echo #define %DEFINE_PREFIX%_VERSION "%VERSION_MAJOR%.%VERSION_MINOR%.%VERSION_PATCH%.%VERSION_REVISION%" > Temp.txt
+echo #define %DEFINE_PREFIX%_VERSION_SHORT "%VERSION_MAJOR%.%VERSION_MINOR%" >> Temp.txt
+echo #define %DEFINE_PREFIX%_VERSION_MAJOR %VERSION_MAJOR% >> Temp.txt
+echo #define %DEFINE_PREFIX%_VERSION_MINOR %VERSION_MINOR% >> Temp.txt
+echo #define %DEFINE_PREFIX%_VERSION_PATCH %VERSION_PATCH% >> Temp.txt
+echo #define %DEFINE_PREFIX%_VERSION_REVISION %VERSION_REVISION% >> Temp.txt
+echo #define %DEFINE_PREFIX%_VERSION_PRODUCT "%VERSION_PRODUCT%" >> Temp.txt
 
 rem === Update the existing file only if the new file differs ===
-if not exist src\RA_BuildVer.h goto nonexistant
-fc src\RA_BuildVer.h RA_BuildVer.h > nul
-if errorlevel 1 goto different
-del RA_BuildVer.h
-goto done
-:different
-del src\RA_BuildVer.h
-:nonexistant
-move RA_BuildVer.h src\RA_BuildVer.h > nul
-:done
+if not exist "%TARGET_FILE%" (
+    rem === File doesn't exist ===
+    move Temp.txt "%TARGET_FILE%" > nul
+) else (
+    fc "%TARGET_FILE%" Temp.txt > nul
+    if errorlevel 1 (
+        rem === File has changed ===
+        del "%TARGET_FILE%"
+        move Temp.txt "%TARGET_FILE%" > nul
+    ) else (
+        rem === File has not changed ===
+        del Temp.txt
+    )
+)
 
-rem === Clean up after ourselves ===
-del Temp.txt

--- a/src/RA_Integration.vcxproj
+++ b/src/RA_Integration.vcxproj
@@ -442,7 +442,7 @@
       <SubSystem>Windows</SubSystem>
     </Link>
     <PreBuildEvent>
-      <Command>..\MakeBuildVer.bat</Command>
+      <Command>"$(SolutionDir)MakeBuildVer.bat" "$(SolutionDir)src\RA_BuildVer.h" RAIntegration RA_INTEGRATION</Command>
     </PreBuildEvent>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -470,7 +470,7 @@
       <IgnoreSpecificDefaultLibraries>libc.lib, libcmt.lib, msvcrt.lib, libcd.lib, libcmtd.lib</IgnoreSpecificDefaultLibraries>
     </Link>
     <PreBuildEvent>
-      <Command>..\MakeBuildVer.bat</Command>
+      <Command>"$(SolutionDir)MakeBuildVer.bat" "$(SolutionDir)src\RA_BuildVer.h" RAIntegration RA_INTEGRATION</Command>
     </PreBuildEvent>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -496,7 +496,7 @@
       <SubSystem>Windows</SubSystem>
     </Link>
     <PreBuildEvent>
-      <Command>..\MakeBuildVer.bat</Command>
+      <Command>"$(SolutionDir)MakeBuildVer.bat" "$(SolutionDir)src\RA_BuildVer.h" RAIntegration RA_INTEGRATION</Command>
     </PreBuildEvent>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -521,7 +521,7 @@
       <SubSystem>Windows</SubSystem>
     </Link>
     <PreBuildEvent>
-      <Command>..\MakeBuildVer.bat</Command>
+      <Command>"$(SolutionDir)MakeBuildVer.bat" "$(SolutionDir)src\RA_BuildVer.h" RAIntegration RA_INTEGRATION</Command>
     </PreBuildEvent>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -547,7 +547,7 @@
       <GenerateDebugInformation>false</GenerateDebugInformation>
     </Link>
     <PreBuildEvent>
-      <Command>..\MakeBuildVer.bat</Command>
+      <Command>"$(SolutionDir)MakeBuildVer.bat" "$(SolutionDir)src\RA_BuildVer.h" RAIntegration RA_INTEGRATION</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseWithDebug|Win32'">
@@ -571,7 +571,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <PreBuildEvent>
-      <Command>..\MakeBuildVer.bat</Command>
+      <Command>"$(SolutionDir)MakeBuildVer.bat" "$(SolutionDir)src\RA_BuildVer.h" RAIntegration RA_INTEGRATION</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseUnicode|Win32'">
@@ -594,7 +594,7 @@
       <GenerateDebugInformation>false</GenerateDebugInformation>
     </Link>
     <PreBuildEvent>
-      <Command>..\MakeBuildVer.bat</Command>
+      <Command>"$(SolutionDir)MakeBuildVer.bat" "$(SolutionDir)src\RA_BuildVer.h" RAIntegration RA_INTEGRATION</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseWithDebugUnicode|Win32'">
@@ -617,7 +617,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <PreBuildEvent>
-      <Command>..\MakeBuildVer.bat</Command>
+      <Command>"$(SolutionDir)MakeBuildVer.bat" "$(SolutionDir)src\RA_BuildVer.h" RAIntegration RA_INTEGRATION</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />


### PR DESCRIPTION
allows for emulator builds to use this same batch file instead of each having a slightly modified copy.