### PR TITLE
add overlay page for recent games

### DIFF
--- a/src/RA_Integration.vcxproj
+++ b/src/RA_Integration.vcxproj
@@ -100,6 +100,7 @@
     <ClCompile Include="ui\viewmodels\OverlayLeaderboardsPageViewModel.cpp" />
     <ClCompile Include="ui\viewmodels\OverlayListPageViewModel.cpp" />
     <ClCompile Include="ui\viewmodels\OverlayManager.cpp" />
+    <ClCompile Include="ui\viewmodels\OverlayRecentGamesPageViewModel.cpp" />
     <ClCompile Include="ui\viewmodels\OverlayViewModel.cpp" />
     <ClCompile Include="ui\viewmodels\PopupMessageViewModel.cpp" />
     <ClCompile Include="ui\viewmodels\PopupViewModelBase.cpp" />
@@ -238,6 +239,7 @@
     <ClInclude Include="ui\viewmodels\OverlayLeaderboardsPageViewModel.hh" />
     <ClInclude Include="ui\viewmodels\OverlayListPageViewModel.hh" />
     <ClInclude Include="ui\viewmodels\OverlayManager.hh" />
+    <ClInclude Include="ui\viewmodels\OverlayRecentGamesPageViewModel.hh" />
     <ClInclude Include="ui\viewmodels\OverlayViewModel.hh" />
     <ClInclude Include="ui\viewmodels\PopupMessageViewModel.hh" />
     <ClInclude Include="ui\viewmodels\PopupViewModelBase.hh" />

--- a/src/RA_Integration.vcxproj.filters
+++ b/src/RA_Integration.vcxproj.filters
@@ -273,6 +273,9 @@
     <ClCompile Include="ui\viewmodels\OverlayFriendsPageViewModel.cpp">
       <Filter>UI\ViewModels</Filter>
     </ClCompile>
+    <ClCompile Include="ui\viewmodels\OverlayRecentGamesPageViewModel.cpp">
+      <Filter>UI\ViewModels</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="RA_Achievement.h">
@@ -717,6 +720,9 @@
       <Filter>API</Filter>
     </ClInclude>
     <ClInclude Include="ui\viewmodels\OverlayFriendsPageViewModel.hh">
+      <Filter>UI\ViewModels</Filter>
+    </ClInclude>
+    <ClInclude Include="ui\viewmodels\OverlayRecentGamesPageViewModel.hh">
       <Filter>UI\ViewModels</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/RA_StringUtils.cpp
+++ b/src/RA_StringUtils.cpp
@@ -109,13 +109,27 @@ std::wstring& Trim(std::wstring& str)
 }
 
 _Use_decl_annotations_
-const std::string FormatDate(time_t when)
+const std::string FormatDateTime(time_t when)
 {
     struct tm tm;
     if (localtime_s(&tm, &when) == 0)
     {
         char buffer[64];
         if (std::strftime(buffer, sizeof(buffer), "%a %e %b %Y %H:%M:%S", &tm) > 0)
+            return std::string(buffer);
+    }
+
+    return std::to_string(when);
+}
+
+_Use_decl_annotations_
+const std::string FormatDate(time_t when)
+{
+    struct tm tm;
+    if (localtime_s(&tm, &when) == 0)
+    {
+        char buffer[64];
+        if (std::strftime(buffer, sizeof(buffer), "%a %e %b %Y", &tm) > 0)
             return std::string(buffer);
     }
 

--- a/src/RA_StringUtils.h
+++ b/src/RA_StringUtils.h
@@ -174,6 +174,7 @@ _NODISCARD inline const std::wstring ToWString(_In_ const char* value) { return 
 _NODISCARD inline const std::wstring ToWString(_In_ const wchar_t* value) { return std::wstring(value); }
 
 _NODISCARD const std::string FormatDate(_In_ time_t when);
+_NODISCARD const std::string FormatDateTime(_In_ time_t when);
 _NODISCARD const std::string FormatDateRecent(_In_ time_t when);
 
 // ----- string building -----
@@ -672,7 +673,7 @@ public:
     /// <summary>
     /// If the next character is the specified character, advance the cursor over it.
     /// </summary>
-    /// <returns><c>true</c> if the next character matched and was skipped over, <c>false</c> if not.
+    /// <returns><c>true</c> if the next character matched and was skipped over, <c>false</c> if not.</returns>
     bool Consume(char c)
     {
         if (EndOfString())

--- a/src/data/SessionTracker.hh
+++ b/src/data/SessionTracker.hh
@@ -42,6 +42,18 @@ public:
     /// </summary>
     bool HasSessionData() const noexcept { return !m_vGameStats.empty(); }
 
+    struct GameStats
+    {
+        unsigned int GameId{};
+        std::chrono::seconds TotalPlayTime{};
+        std::chrono::system_clock::time_point LastSessionStart;
+    };
+
+    /// <summary>
+    /// Gets the previous session data.
+    /// </summary>
+    const std::vector<GameStats>& SessionData() const { return m_vGameStats; }
+
 protected:
     virtual void LoadSessions();
     void AddSession(unsigned int nGameId, time_t tSessionStart, std::chrono::seconds tSessionDuration);
@@ -60,13 +72,6 @@ private:
 
     std::chrono::steady_clock::time_point m_tpSessionStart{};
     time_t m_tSessionStart{};
-
-    struct GameStats
-    {
-        unsigned int GameId{};
-        std::chrono::seconds TotalPlaytime{};
-        std::chrono::system_clock::time_point LastSessionStart;
-    };
 
     std::vector<GameStats> m_vGameStats;
 

--- a/src/ui/viewmodels/OverlayAchievementsPageViewModel.cpp
+++ b/src/ui/viewmodels/OverlayAchievementsPageViewModel.cpp
@@ -180,8 +180,8 @@ void OverlayAchievementsPageViewModel::FetchItemDetail(ItemViewModel& vmItem)
         return;
 
     auto& vmAchievement = m_vAchievementDetails.emplace(vmItem.GetId(), AchievementViewModel{}).first->second;
-    vmAchievement.SetCreatedDate(ra::Widen(ra::FormatDate(pAchievement->CreatedDate())));
-    vmAchievement.SetModifiedDate(ra::Widen(ra::FormatDate(pAchievement->ModifiedDate())));
+    vmAchievement.SetCreatedDate(ra::Widen(ra::FormatDateTime(pAchievement->CreatedDate())));
+    vmAchievement.SetModifiedDate(ra::Widen(ra::FormatDateTime(pAchievement->ModifiedDate())));
 
     if (pAchievement->Category() == ra::etoi(AchievementSet::Type::Local))
     {
@@ -214,7 +214,7 @@ void OverlayAchievementsPageViewModel::FetchItemDetail(ItemViewModel& vmItem)
         {
             auto& vmWinner = vmAchievement.RecentWinners.Add();
             vmWinner.SetLabel(ra::Widen(pWinner.User));
-            vmWinner.SetDetail(ra::StringPrintf(L"%s (%s)", ra::FormatDate(pWinner.DateAwarded), ra::FormatDateRecent(pWinner.DateAwarded)));
+            vmWinner.SetDetail(ra::StringPrintf(L"%s (%s)", ra::FormatDateTime(pWinner.DateAwarded), ra::FormatDateRecent(pWinner.DateAwarded)));
 
             if (pWinner.User == sUsername)
                 vmWinner.SetDisabled(true);

--- a/src/ui/viewmodels/OverlayRecentGamesPageViewModel.cpp
+++ b/src/ui/viewmodels/OverlayRecentGamesPageViewModel.cpp
@@ -1,0 +1,111 @@
+#include "OverlayRecentGamesPageViewModel.hh"
+
+#include "RA_StringUtils.h"
+
+#include "api\FetchGameData.hh"
+#include "api\impl\OfflineServer.hh"
+
+#include "data\GameContext.hh"
+#include "data\SessionTracker.hh"
+
+#include "services\IThreadPool.hh"
+
+namespace ra {
+namespace ui {
+namespace viewmodels {
+
+void OverlayRecentGamesPageViewModel::Refresh()
+{
+    m_sTitle = L"Recent Games";
+    OverlayListPageViewModel::Refresh();
+
+    for (gsl::index nIndex = m_vItems.Count() - 1; nIndex >= 0; --nIndex)
+        m_vItems.RemoveAt(nIndex);
+
+    std::vector<unsigned int> vPendingGames;
+
+    const auto& pSessionTracker = ra::services::ServiceLocator::Get<ra::data::SessionTracker>();
+    for (const auto& pGameStats : pSessionTracker.SessionData())
+    {
+        ItemViewModel& pvmItem = m_vItems.Add();
+        pvmItem.SetId(pGameStats.GameId);
+
+        const auto tLastSessionStart = std::chrono::system_clock::to_time_t(pGameStats.LastSessionStart);
+        pvmItem.SetDetail(ra::StringPrintf(L"Last played: %s (%s)",
+            ra::FormatDate(tLastSessionStart),
+            ra::FormatDateRecent(tLastSessionStart)));
+
+        const auto& pIter2 = m_mGameBadges.find(pGameStats.GameId);
+        const auto& pIter = m_mGameNames.find(pGameStats.GameId);
+        if (pIter != m_mGameNames.end() && pIter2 != m_mGameBadges.end())
+        {
+            UpdateGameEntry(pvmItem, pIter->second, pIter2->second, pGameStats.TotalPlayTime);
+        }
+        else
+        {
+            UpdateGameEntry(pvmItem, L"Loading", "00000", pGameStats.TotalPlayTime);
+            vPendingGames.push_back(pGameStats.GameId);
+        }
+
+        if (m_vItems.Count() == 20)
+            break;
+    }
+
+    if (!vPendingGames.empty())
+    {
+        ra::services::ServiceLocator::GetMutable<ra::services::IThreadPool>().RunAsync(
+            [this, vPendingGames = std::move(vPendingGames)]()
+        {
+            ra::api::impl::OfflineServer cache;
+            for (const auto nGameId : vPendingGames)
+            {
+                ra::api::FetchGameData::Request request;
+                request.GameId = nGameId;
+                const auto response = cache.FetchGameData(request);
+                if (response.Succeeded())
+                {
+                    UpdateGameEntry(nGameId, response.Title, response.ImageIcon);
+                }
+                else
+                {
+                    request.CallAsync([this, nGameId](const ra::api::FetchGameData::Response & response)
+                    {
+                        UpdateGameEntry(nGameId, response.Title, response.ImageIcon);
+                    });
+                }
+            }
+        });
+    }
+}
+
+void OverlayRecentGamesPageViewModel::UpdateGameEntry(unsigned int nGameId, const std::wstring& sGameName, const std::string& sGameBadge)
+{
+    m_mGameNames.emplace(nGameId, sGameName);
+    m_mGameBadges.emplace(nGameId, sGameBadge);
+
+    const auto nIndex = m_vItems.FindItemIndex(ItemViewModel::IdProperty, nGameId);
+    if (nIndex != -1)
+    {
+        auto* pvmItem = m_vItems.GetItemAt(nIndex);
+        if (pvmItem)
+        {
+            const auto& pSessionTracker = ra::services::ServiceLocator::Get<ra::data::SessionTracker>();
+            const auto nPlayTimeSeconds = pSessionTracker.GetTotalPlaytime(nGameId);
+            UpdateGameEntry(*pvmItem, sGameName, sGameBadge, nPlayTimeSeconds);
+
+            ForceRedraw();
+        }
+    }
+}
+
+void OverlayRecentGamesPageViewModel::UpdateGameEntry(ItemViewModel& pvmItem,
+    const std::wstring& sGameName, const std::string& sGameBadge, std::chrono::seconds nPlayTimeSeconds)
+{
+    const auto nPlayTimeMinutes = std::chrono::duration_cast<std::chrono::minutes>(nPlayTimeSeconds).count();
+    pvmItem.SetLabel(ra::StringPrintf(L"%s - %dh%02dm", sGameName, nPlayTimeMinutes / 60, nPlayTimeMinutes % 60));
+    pvmItem.Image.ChangeReference(ra::ui::ImageType::Icon, sGameBadge);
+}
+
+} // namespace viewmodels
+} // namespace ui
+} // namespace ra

--- a/src/ui/viewmodels/OverlayRecentGamesPageViewModel.hh
+++ b/src/ui/viewmodels/OverlayRecentGamesPageViewModel.hh
@@ -1,0 +1,28 @@
+#ifndef RA_UI_OVERLAY_RECENT_GAMES_VIEWMODEL_H
+#define RA_UI_OVERLAY_RECENT_GAMES_VIEWMODEL_H
+
+#include "OverlayListPageViewModel.hh"
+
+namespace ra {
+namespace ui {
+namespace viewmodels {
+
+class OverlayRecentGamesPageViewModel : public OverlayListPageViewModel
+{
+public:
+    void Refresh() override;
+
+protected:
+    void UpdateGameEntry(ItemViewModel& pvmItem, const std::wstring& sGameName, const std::string& sGameBadge,
+                         std::chrono::seconds nPlaytimeSeconds);
+    void UpdateGameEntry(unsigned int nGameId, const std::wstring& sGameName, const std::string& sGameBadge);
+
+    std::map<unsigned int, std::wstring> m_mGameNames;
+    std::map<unsigned int, std::string> m_mGameBadges;
+};
+
+} // namespace viewmodels
+} // namespace ui
+} // namespace ra
+
+#endif // !RA_UI_OVERLAY_RECENT_GAMES_VIEWMODEL_H

--- a/src/ui/viewmodels/OverlayViewModel.cpp
+++ b/src/ui/viewmodels/OverlayViewModel.cpp
@@ -14,6 +14,7 @@
 #include "ui\viewmodels\OverlayAchievementsPageViewModel.hh"
 #include "ui\viewmodels\OverlayFriendsPageViewModel.hh"
 #include "ui\viewmodels\OverlayLeaderboardsPageViewModel.hh"
+#include "ui\viewmodels\OverlayRecentGamesPageViewModel.hh"
 #include "ui\viewmodels\OverlayManager.hh"
 #include "ui\viewmodels\WindowManager.hh"
 
@@ -337,7 +338,7 @@ void OverlayViewModel::Deactivate()
 
 void OverlayViewModel::PopulatePages()
 {
-    m_vPages.resize(3);
+    m_vPages.resize(4);
 
     auto pAchievementsPage = std::make_unique<OverlayAchievementsPageViewModel>();
     m_vPages.at(0) = std::move(pAchievementsPage);
@@ -345,8 +346,11 @@ void OverlayViewModel::PopulatePages()
     auto pLeaderboardsPage = std::make_unique<OverlayLeaderboardsPageViewModel>();
     m_vPages.at(1) = std::move(pLeaderboardsPage);
 
+    auto pRecentGamesPage = std::make_unique<OverlayRecentGamesPageViewModel>();
+    m_vPages.at(2) = std::move(pRecentGamesPage);
+
     auto pFriendsPage = std::make_unique<OverlayFriendsPageViewModel>();
-    m_vPages.at(2) = std::move(pFriendsPage);
+    m_vPages.at(3) = std::move(pFriendsPage);
 }
 
 } // namespace viewmodels

--- a/tests/RA_Integration.Tests.vcxproj
+++ b/tests/RA_Integration.Tests.vcxproj
@@ -214,6 +214,7 @@
     <ClCompile Include="..\src\ui\viewmodels\OverlayLeaderboardsPageViewModel.cpp" />
     <ClCompile Include="..\src\ui\viewmodels\OverlayListPageViewModel.cpp" />
     <ClCompile Include="..\src\ui\viewmodels\OverlayManager.cpp" />
+    <ClCompile Include="..\src\ui\viewmodels\OverlayRecentGamesPageViewModel.cpp" />
     <ClCompile Include="..\src\ui\viewmodels\OverlayViewModel.cpp" />
     <ClCompile Include="..\src\ui\viewmodels\PopupMessageViewModel.cpp" />
     <ClCompile Include="..\src\ui\viewmodels\LoginViewModel.cpp" />
@@ -264,6 +265,7 @@
     <ClCompile Include="ui\viewmodels\OverlayLeaderboardsPageViewModel_Tests.cpp" />
     <ClCompile Include="ui\viewmodels\OverlayListPageViewModel_Tests.cpp" />
     <ClCompile Include="ui\viewmodels\OverlayManager_Tests.cpp" />
+    <ClCompile Include="ui\viewmodels\OverlayRecentGamesPageViewModel_Tests.cpp" />
     <ClCompile Include="ui\viewmodels\RichPresenceMonitorViewModel_Tests.cpp" />
     <ClCompile Include="ui\viewmodels\UnknownGameViewModel_Tests.cpp" />
     <ClCompile Include="ui\WindowViewModelBase_Tests.cpp" />

--- a/tests/RA_Integration.Tests.vcxproj.filters
+++ b/tests/RA_Integration.Tests.vcxproj.filters
@@ -300,6 +300,12 @@
     <ClCompile Include="ui\viewmodels\OverlayFriendsPageViewModel_Tests.cpp">
       <Filter>Tests\UI\ViewModels</Filter>
     </ClCompile>
+    <ClCompile Include="ui\viewmodels\OverlayRecentGamesPageViewModel_Tests.cpp">
+      <Filter>Tests\UI\ViewModels</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\ui\viewmodels\OverlayRecentGamesPageViewModel.cpp">
+      <Filter>Code</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="base.props" />

--- a/tests/ui/viewmodels/OverlayRecentGamesPageViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/OverlayRecentGamesPageViewModel_Tests.cpp
@@ -1,0 +1,177 @@
+#include "CppUnitTest.h"
+
+#include "ui\viewmodels\OverlayRecentGamesPageViewModel.hh"
+
+#include "tests\mocks\MockImageRepository.hh"
+#include "tests\mocks\MockLocalStorage.hh"
+#include "tests\mocks\MockOverlayManager.hh"
+#include "tests\mocks\MockServer.hh"
+#include "tests\mocks\MockSessionTracker.hh"
+#include "tests\mocks\MockThreadPool.hh"
+#include "tests\RA_UnitTestHelpers.h"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace ra {
+namespace ui {
+namespace viewmodels {
+namespace tests {
+
+TEST_CLASS(OverlayRecentGamesPageViewModel_Tests)
+{
+private:
+    class OverlayRecentGamesPageViewModelHarness : public OverlayRecentGamesPageViewModel
+    {
+    public:
+        ra::api::mocks::MockServer mockServer;
+        ra::data::mocks::MockSessionTracker mockSessions;
+        ra::services::mocks::MockLocalStorage mockLocalStorage;
+        ra::services::mocks::MockThreadPool mockTheadPool;
+        ra::ui::mocks::MockImageRepository mockImageRepository;
+        ra::ui::viewmodels::mocks::MockOverlayManager mockOverlayManager;
+
+        ItemViewModel* GetItem(gsl::index nIndex) { return m_vItems.GetItemAt(nIndex); }
+
+        size_t GetItemCount() const { return m_vItems.Count(); }
+
+        void MockGame(unsigned int nGameId, const std::wstring& sGameName, const std::string& sGameBadge)
+        {
+            m_mGameNames.emplace(nGameId, sGameName);
+            m_mGameBadges.emplace(nGameId, sGameBadge);
+        }
+    };
+
+public:
+    TEST_METHOD(TestRefreshNoGames)
+    {
+        OverlayRecentGamesPageViewModelHarness gamesPage;
+
+        gamesPage.Refresh();
+
+        Assert::AreEqual(std::wstring(L"Recent Games"), gamesPage.GetTitle());
+        Assert::AreEqual(std::wstring(), gamesPage.GetSummary());
+        Assert::AreEqual(0U, gamesPage.GetItemCount());
+    }
+
+    TEST_METHOD(TestRefreshOneGameDataAvailable)
+    {
+        OverlayRecentGamesPageViewModelHarness gamesPage;
+        gamesPage.mockSessions.MockSession(3U, 1234567890U, std::chrono::seconds(5000));
+        gamesPage.MockGame(3U, L"Game Name", "BADGE");
+
+        gamesPage.Refresh();
+
+        Assert::AreEqual(std::wstring(L"Recent Games"), gamesPage.GetTitle());
+        Assert::AreEqual(std::wstring(), gamesPage.GetSummary());
+        Assert::AreEqual(1U, gamesPage.GetItemCount());
+
+        const auto* pItem1 = gamesPage.GetItem(0);
+        Assert::IsNotNull(pItem1);
+        Ensures(pItem1 != nullptr);
+        Assert::AreEqual(3, pItem1->GetId());
+        Assert::AreEqual(std::wstring(L"Game Name - 1h23m"), pItem1->GetLabel());
+        Assert::IsTrue(ra::StringStartsWith(pItem1->GetDetail(), std::wstring(L"Last played: Fri 13 Feb 2009 (")));
+        Assert::IsTrue(ra::StringEndsWith(pItem1->GetDetail(), std::wstring(L" ago)")));
+        Assert::AreEqual(std::string("BADGE"), pItem1->Image.Name());
+    }
+
+    TEST_METHOD(TestRefreshOneGameDataFetched)
+    {
+        OverlayRecentGamesPageViewModelHarness gamesPage;
+        gamesPage.mockSessions.MockSession(3U, 1234567890U, std::chrono::seconds(5000));
+        gamesPage.mockServer.HandleRequest<ra::api::FetchGameData>(
+            [](const ra::api::FetchGameData::Request& request, ra::api::FetchGameData::Response & response)
+        {
+            Assert::AreEqual(3U, request.GameId);
+
+            response.Result = ra::api::ApiResult::Success;
+            response.Title = L"Game Name";
+            response.ImageIcon = "BADGE";
+            return true;
+        });
+
+        gamesPage.Refresh();
+
+        Assert::AreEqual(std::wstring(L"Recent Games"), gamesPage.GetTitle());
+        Assert::AreEqual(std::wstring(), gamesPage.GetSummary());
+        Assert::AreEqual(1U, gamesPage.GetItemCount());
+
+        // data is not initially available
+        auto* pItem1 = gamesPage.GetItem(0);
+        Assert::IsNotNull(pItem1);
+        Ensures(pItem1 != nullptr);
+        Assert::AreEqual(3, pItem1->GetId());
+        Assert::AreEqual(std::wstring(L"Loading - 1h23m"), pItem1->GetLabel());
+        Assert::IsTrue(ra::StringStartsWith(pItem1->GetDetail(), std::wstring(L"Last played: Fri 13 Feb 2009 (")));
+        Assert::IsTrue(ra::StringEndsWith(pItem1->GetDetail(), std::wstring(L" ago)")));
+        Assert::AreEqual(std::string("00000"), pItem1->Image.Name());
+
+        gamesPage.mockTheadPool.ExecuteNextTask(); // scanning cache occurs on background thread
+
+        // data is not in the cache
+        pItem1 = gamesPage.GetItem(0);
+        Assert::IsNotNull(pItem1);
+        Ensures(pItem1 != nullptr);
+        Assert::AreEqual(3, pItem1->GetId());
+        Assert::AreEqual(std::wstring(L"Loading - 1h23m"), pItem1->GetLabel());
+        Assert::IsTrue(ra::StringStartsWith(pItem1->GetDetail(), std::wstring(L"Last played: Fri 13 Feb 2009 (")));
+        Assert::IsTrue(ra::StringEndsWith(pItem1->GetDetail(), std::wstring(L" ago)")));
+        Assert::AreEqual(std::string("00000"), pItem1->Image.Name());
+
+        gamesPage.mockTheadPool.ExecuteNextTask(); // request is asynchronous
+
+        // data was fetched from the server
+        Assert::AreEqual(1U, gamesPage.GetItemCount());
+        pItem1 = gamesPage.GetItem(0);
+        Assert::IsNotNull(pItem1);
+        Ensures(pItem1 != nullptr);
+        Assert::AreEqual(3, pItem1->GetId());
+        Assert::AreEqual(std::wstring(L"Game Name - 1h23m"), pItem1->GetLabel());
+        Assert::IsTrue(ra::StringStartsWith(pItem1->GetDetail(), std::wstring(L"Last played: Fri 13 Feb 2009 (")));
+        Assert::IsTrue(ra::StringEndsWith(pItem1->GetDetail(), std::wstring(L" ago)")));
+        Assert::AreEqual(std::string("BADGE"), pItem1->Image.Name());
+    }
+
+    TEST_METHOD(TestRefreshOneGameDataCached)
+    {
+        OverlayRecentGamesPageViewModelHarness gamesPage;
+        gamesPage.mockSessions.MockSession(3U, 1234567890U, std::chrono::seconds(5000));
+        gamesPage.mockServer.ExpectUncalled<ra::api::FetchGameData>();
+        gamesPage.mockLocalStorage.MockStoredData(ra::services::StorageItemType::GameData, L"3",
+            "{\"Title\":\"Game Name\", \"ConsoleID\":5, \"ImageIcon\":\"/Images/BADGE.png\", \"Achievements\":[], \"Leaderboards\":[]}");
+
+        gamesPage.Refresh();
+
+        Assert::AreEqual(std::wstring(L"Recent Games"), gamesPage.GetTitle());
+        Assert::AreEqual(std::wstring(), gamesPage.GetSummary());
+        Assert::AreEqual(1U, gamesPage.GetItemCount());
+
+        // data is not initially available
+        auto* pItem1 = gamesPage.GetItem(0);
+        Assert::IsNotNull(pItem1);
+        Ensures(pItem1 != nullptr);
+        Assert::AreEqual(3, pItem1->GetId());
+        Assert::AreEqual(std::wstring(L"Loading - 1h23m"), pItem1->GetLabel());
+        Assert::IsTrue(ra::StringStartsWith(pItem1->GetDetail(), std::wstring(L"Last played: Fri 13 Feb 2009 (")));
+        Assert::IsTrue(ra::StringEndsWith(pItem1->GetDetail(), std::wstring(L" ago)")));
+        Assert::AreEqual(std::string("00000"), pItem1->Image.Name());
+
+        gamesPage.mockTheadPool.ExecuteNextTask(); // scanning cache occurs on background thread
+
+        // data is in the cache
+        Assert::AreEqual(1U, gamesPage.GetItemCount());
+        pItem1 = gamesPage.GetItem(0);
+        Assert::IsNotNull(pItem1);
+        Ensures(pItem1 != nullptr);
+        Assert::AreEqual(3, pItem1->GetId());
+        Assert::AreEqual(std::wstring(L"Game Name - 1h23m"), pItem1->GetLabel());
+        Assert::IsTrue(ra::StringStartsWith(pItem1->GetDetail(), std::wstring(L"Last played: Fri 13 Feb 2009 (")));
+        Assert::IsTrue(ra::StringEndsWith(pItem1->GetDetail(), std::wstring(L" ago)")));
+        Assert::AreEqual(std::string("BADGE"), pItem1->Image.Name());
+    }
+};
+
+} // namespace tests
+} // namespace viewmodels
+} // namespace ui
+} // namespace ra


### PR DESCRIPTION
Limited to the last 20 titles (per emulator). Times match values displayed on the achievements list for each game, and come from locally stored data (only represents time played since 0.75, and in the current emulator).

![image](https://user-images.githubusercontent.com/32680403/57989195-965c8c80-7a54-11e9-832c-dbbe21f0e8cd.png)
