### PR TITLE
support for dynamic window resizing in MVVM dialogs

### DIFF
--- a/src/RA_Dlg_AchievementsReporter.cpp
+++ b/src/RA_Dlg_AchievementsReporter.cpp
@@ -116,7 +116,6 @@ INT_PTR CALLBACK Dlg_AchievementsReporter::AchievementsReporterProc(HWND hDlg, U
             }
 
             ListView_SetExtendedListViewStyle(hList, LVS_EX_CHECKBOXES | LVS_EX_HEADERDRAGDROP);
-            SetDlgItemText(hDlg, IDC_RA_BROKENACH_BUGREPORTER, NativeStr(ra::services::ServiceLocator::Get<ra::data::UserContext>().GetUsername()).c_str());
         }
             return FALSE;
 

--- a/src/RA_Resource.h
+++ b/src/RA_Resource.h
@@ -21,6 +21,8 @@
 #define IDC_RA_SYSTEMNAME               1036
 #define IDC_RA_LINK                     1037
 #define IDC_RA_GAMENAME                 1038
+#define IDC_RA_INFORMATION              1039
+#define IDC_RA_PROBLEMHEADER            1040
 #define IDD_RA_MEMORY                   1501
 #define IDD_RA_ACHIEVEMENTS             1502
 #define IDD_RA_ACHIEVEMENTEDITOR        1503
@@ -111,7 +113,7 @@
 #define IDC_RA_BROKENACHIEVEMENTREPORTCOMMENT 1587
 #define IDC_RA_PROBLEMTYPE1             1588
 #define IDC_RA_PROBLEMTYPE2             1589
-#define IDC_RA_BROKENACH_BUGREPORTER    1590
+#define IDC_RA_COMMENT_HEADER           1590
 #define IDC_RA_RESCAN                   1591
 #define IDC_RA_LBX_GAMELIST             1592
 #define IDC_RA_ROMDIR                   1593
@@ -159,9 +161,9 @@
 // 
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
-#define _APS_NEXT_RESOURCE_VALUE        120
+#define _APS_NEXT_RESOURCE_VALUE        121
 #define _APS_NEXT_COMMAND_VALUE         40001
-#define _APS_NEXT_CONTROL_VALUE         1039
+#define _APS_NEXT_CONTROL_VALUE         1041
 #define _APS_NEXT_SYMED_VALUE           101
 #endif
 #endif

--- a/src/RA_Shared.rc
+++ b/src/RA_Shared.rc
@@ -212,20 +212,18 @@ STYLE DS_SETFONT | DS_FIXEDSYS | WS_POPUP | WS_CAPTION | WS_SYSMENU | WS_THICKFR
 CAPTION "Report Broken Achievements"
 FONT 8, "MS Shell Dlg", 400, 0, 0x1
 BEGIN
-    DEFPUSHBUTTON   "Send Bug Report",IDOK,239,198,93,18
-    GROUPBOX        "Information:",IDC_STATIC,7,7,325,40
-    EDITTEXT        IDC_RA_BROKENACHIEVEMENTREPORTCOMMENT,45,159,287,35,ES_MULTILINE | ES_AUTOHSCROLL | ES_WANTRETURN
-    CONTROL         "Triggered at wrong time",IDC_RA_PROBLEMTYPE1,"Button",BS_AUTORADIOBUTTON | WS_GROUP | WS_TABSTOP,159,141,93,10
-    CONTROL         "Didn't trigger at all",IDC_RA_PROBLEMTYPE2,"Button",BS_AUTORADIOBUTTON,257,141,75,10
-    LTEXT           "Problem reported:",IDC_STATIC,7,141,59,8
-    LTEXT           "Comment:",IDC_STATIC,7,160,34,8
-    LTEXT           "Use this dialog to report achievements that trigger incorrectly or not at all.",IDC_STATIC,13,16,239,8
-    LTEXT           "Please check the achievement(s) that need fixing, then select a problem type below.",IDC_STATIC,13,25,272,8
-    LTEXT           "If possible, please include a comment if you can to help the developer!",IDC_STATIC,14,34,226,8
-    PUSHBUTTON      "Cancel",IDCANCEL,192,198,43,18
-    CONTROL         "",IDC_RA_REPORTBROKENACHIEVEMENTSLIST,"SysListView32",LVS_REPORT | LVS_SINGLESEL | LVS_ALIGNLEFT | WS_BORDER | WS_TABSTOP,7,49,325,87
-    LTEXT           "Reporter:",IDC_STATIC,7,204,32,8
-    EDITTEXT        IDC_RA_BROKENACH_BUGREPORTER,43,202,78,14,ES_AUTOHSCROLL | WS_DISABLED
+    GROUPBOX        "Information:",IDC_RA_INFORMATION,4,4,331,40
+    LTEXT           "Use this dialog to report achievements that trigger incorrectly or not at all.",IDC_STATIC,13,14,239,8
+    LTEXT           "Please check the achievement(s) that need fixing, then select a problem type below.",IDC_STATIC,13,23,272,8
+    LTEXT           "Use the comment field to provide additional information to help the developer diagnose the issue.",IDC_STATIC,14,32,312,8
+    CONTROL         "",IDC_RA_REPORTBROKENACHIEVEMENTSLIST,"SysListView32",LVS_REPORT | LVS_SINGLESEL | LVS_ALIGNLEFT | WS_BORDER | WS_TABSTOP,4,49,331,87
+    LTEXT           "Problem reported:",IDC_RA_PROBLEMHEADER,4,139,59,8
+    CONTROL         "Triggered at wrong time",IDC_RA_PROBLEMTYPE1,"Button",BS_AUTORADIOBUTTON | WS_GROUP | WS_TABSTOP,159,139,93,10
+    CONTROL         "Didn't trigger at all",IDC_RA_PROBLEMTYPE2,"Button",BS_AUTORADIOBUTTON,260,139,75,10
+    LTEXT           "Comment:",IDC_RA_COMMENT_HEADER,4,152,34,8
+    EDITTEXT        IDC_RA_BROKENACHIEVEMENTREPORTCOMMENT,45,151,290,47,ES_MULTILINE | ES_AUTOHSCROLL | ES_WANTRETURN
+    DEFPUSHBUTTON   "Send Bug Report",IDOK,178,201,75,17
+    PUSHBUTTON      "Cancel",IDCANCEL,259,201,76,17
 END
 
 IDD_RA_GAMELIBRARY DIALOGEX 0, 0, 380, 175
@@ -435,15 +433,16 @@ BEGIN
 
     IDD_RA_REPORTBROKENACHIEVEMENTS, DIALOG
     BEGIN
-        LEFTMARGIN, 7
-        RIGHTMARGIN, 332
+        LEFTMARGIN, 4
+        RIGHTMARGIN, 335
         VERTGUIDE, 13
-        VERTGUIDE, 83
-        VERTGUIDE, 192
-        TOPMARGIN, 7
-        BOTTOMMARGIN, 216
+        VERTGUIDE, 45
+        VERTGUIDE, 178
+        TOPMARGIN, 4
+        BOTTOMMARGIN, 218
         HORZGUIDE, 151
         HORZGUIDE, 198
+        HORZGUIDE, 201
     END
 
     IDD_RA_GAMELIBRARY, DIALOG
@@ -550,6 +549,11 @@ BEGIN
 END
 
 IDD_RA_GAMETITLESEL AFX_DIALOG_LAYOUT
+BEGIN
+    0
+END
+
+IDD_RA_REPORTBROKENACHIEVEMENTS AFX_DIALOG_LAYOUT
 BEGIN
     0
 END

--- a/src/ui/win32/BrokenAchievementsDialog.cpp
+++ b/src/ui/win32/BrokenAchievementsDialog.cpp
@@ -42,6 +42,8 @@ BrokenAchievementsDialog::BrokenAchievementsDialog(BrokenAchievementsViewModel& 
       m_bindComment(vmBrokenAchievements),
       m_bindAchievements(vmBrokenAchievements)
 {
+    m_bindWindow.SetInitialPosition(RelativePosition::Center, RelativePosition::Center, "Report Broken Achievements");
+
     m_bindWrongTime.BindCheck(BrokenAchievementsViewModel::SelectedProblemIdProperty,
         ra::etoi(ra::api::SubmitTicket::ProblemType::WrongTime));
     m_bindDidNotTrigger.BindCheck(BrokenAchievementsViewModel::SelectedProblemIdProperty,
@@ -73,6 +75,17 @@ BrokenAchievementsDialog::BrokenAchievementsDialog(BrokenAchievementsViewModel& 
     m_bindAchievements.BindColumn(3, std::move(pAchievedColumn));
 
     m_bindAchievements.BindItems(vmBrokenAchievements.Achievements());
+
+    using namespace ra::bitwise_ops;
+    SetAnchor(IDC_RA_INFORMATION, Anchor::Top | Anchor::Left | Anchor::Right);
+    SetAnchor(IDC_RA_REPORTBROKENACHIEVEMENTSLIST, Anchor::Top | Anchor::Left | Anchor::Bottom | Anchor::Right);
+    SetAnchor(IDC_RA_PROBLEMHEADER, Anchor::Bottom | Anchor::Left);
+    SetAnchor(IDC_RA_PROBLEMTYPE1, Anchor::Bottom | Anchor::Right);
+    SetAnchor(IDC_RA_PROBLEMTYPE2, Anchor::Bottom | Anchor::Right);
+    SetAnchor(IDC_RA_COMMENT_HEADER, Anchor::Left | Anchor::Bottom);
+    SetAnchor(IDC_RA_BROKENACHIEVEMENTREPORTCOMMENT, Anchor::Left | Anchor::Bottom | Anchor::Right);
+    SetAnchor(IDCANCEL, Anchor::Bottom | Anchor::Right);
+    SetAnchor(IDOK, Anchor::Bottom | Anchor::Right);
 }
 
 BOOL BrokenAchievementsDialog::OnInitDialog()

--- a/src/ui/win32/DialogBase.cpp
+++ b/src/ui/win32/DialogBase.cpp
@@ -366,8 +366,20 @@ void DialogBase::UpdateAnchoredControls()
 
 #pragma warning(pop)
 
-        ::SetWindowPos(hControl, 0, nLeft, nTop, nWidth, nHeight, SWP_NOZORDER | SWP_NOACTIVATE);
+        ::MoveWindow(hControl, nLeft, nTop, nWidth, nHeight, FALSE);
+
+        if (nWidth != rcControl.right - rcControl.left || nHeight != rcControl.bottom - rcControl.top)
+        {
+            auto* pBinding = FindControlBinding(hControl);
+            if (pBinding)
+            {
+                ra::ui::Size pNewSize{ nWidth, nHeight };
+                pBinding->OnSizeChanged(pNewSize);
+            }
+        }
     }
+
+    ::InvalidateRect(m_hWnd, NULL, TRUE);
 }
 
 } // namespace win32

--- a/src/ui/win32/DialogBase.cpp
+++ b/src/ui/win32/DialogBase.cpp
@@ -5,6 +5,8 @@
 
 #include "RA_Core.h" // g_RAMainWnd, g_hThisDLLInst
 
+#include "ra_utility.h"
+
 namespace ra {
 namespace ui {
 namespace win32 {
@@ -106,6 +108,10 @@ INT_PTR CALLBACK DialogBase::DialogProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPA
             if (m_hWnd == nullptr)
             {
                 m_hWnd = hDlg;
+
+                // binding the window will resize it, make sure to capture sizes beforehand
+                InitializeAnchors();
+
                 m_bindWindow.SetHWND(m_hWnd);
             }
 
@@ -254,7 +260,114 @@ void DialogBase::OnMove(const ra::ui::Position& oNewPosition)
 _Use_decl_annotations_
 void DialogBase::OnSize(const ra::ui::Size& oNewSize)
 {
+    UpdateAnchoredControls();
+
     m_bindWindow.OnSizeChanged(oNewSize);
+}
+
+void DialogBase::InitializeAnchors()
+{
+    if (m_vControlAnchors.empty())
+        return;
+
+    // client rect will always be (0,0)-(width,height)
+    // but child window positions will always be screen-relative, so translate the client rect
+    // to screen coordinates
+    RECT rcWindow;
+    ::GetClientRect(m_hWnd, &rcWindow);
+
+    POINT pTopLeft = { rcWindow.left, rcWindow.top };
+    ::ClientToScreen(m_hWnd, &pTopLeft);
+    ::OffsetRect(&rcWindow, pTopLeft.x, pTopLeft.y);
+
+    for (auto& info : m_vControlAnchors)
+    {
+        auto hControl = ::GetDlgItem(m_hWnd, info.nIDDlgItem);
+        if (!hControl)
+            continue;
+
+        RECT rcControl;
+        ::GetWindowRect(hControl, &rcControl);
+
+        info.nMarginLeft = rcControl.left - rcWindow.left;
+        info.nMarginTop = rcControl.top - rcWindow.top;
+        info.nMarginRight = rcWindow.right - rcControl.right;
+        info.nMarginBottom = rcWindow.bottom - rcControl.bottom;
+    }
+}
+
+void DialogBase::UpdateAnchoredControls()
+{
+    if (m_vControlAnchors.empty())
+        return;
+
+    RECT rcWindow;
+    ::GetClientRect(m_hWnd, &rcWindow);
+    const int nWindowWidth = rcWindow.right - rcWindow.left;
+    const int nWindowHeight = rcWindow.bottom - rcWindow.top;
+
+    for (const auto& info : m_vControlAnchors)
+    {
+        auto hControl = ::GetDlgItem(m_hWnd, info.nIDDlgItem);
+        if (!hControl)
+            continue;
+
+        // GetClientRect will always return screen coordinates
+        // since we're just after the width/height, that's fine
+        RECT rcControl;
+        ::GetWindowRect(hControl, &rcControl);
+
+        int nLeft = info.nMarginLeft;
+        int nTop = info.nMarginTop;
+        int nWidth = rcControl.right - rcControl.left;
+        int nHeight = rcControl.bottom - rcControl.top;
+
+#pragma warning(push)
+#pragma warning(disable : 4063) // case invalid for entry not in enum: "Left | Right" and "Top | Bottom"
+
+        using namespace ra::bitwise_ops;
+        switch (info.nAnchor & (Anchor::Left | Anchor::Right))
+        {
+            case Anchor::None:
+                nLeft = (nWindowWidth - nWidth) / 2;
+                break;
+
+            default:
+            case Anchor::Left:
+                break;
+
+            case Anchor::Right:
+                nLeft = nWindowWidth - info.nMarginRight - nWidth;
+                break;
+
+            case Anchor::Left | Anchor::Right:
+                nWidth = nWindowWidth - info.nMarginLeft - info.nMarginRight;
+                break;
+        }
+
+        switch (info.nAnchor & (Anchor::Top | Anchor::Bottom))
+        {
+            case Anchor::None:
+                nTop = (nWindowHeight - nHeight) / 2;
+                break;
+
+            default:
+            case Anchor::Top:
+                break;
+
+            case Anchor::Bottom:
+                nTop = nWindowHeight - info.nMarginBottom - nHeight;
+                break;
+
+            case Anchor::Top | Anchor::Bottom:
+                nHeight = nWindowHeight - info.nMarginTop - info.nMarginBottom;
+                break;
+        }
+
+#pragma warning(pop)
+
+        ::SetWindowPos(hControl, 0, nLeft, nTop, nWidth, nHeight, SWP_NOZORDER | SWP_NOACTIVATE);
+    }
 }
 
 } // namespace win32

--- a/src/ui/win32/DialogBase.hh
+++ b/src/ui/win32/DialogBase.hh
@@ -115,6 +115,20 @@ protected:
 
     ra::ui::WindowViewModelBase& m_vmWindow;
 
+    enum class Anchor
+    {
+        None = 0x00,
+        Left = 0x01,
+        Top = 0x02,
+        Right = 0x04,
+        Bottom = 0x08
+    };
+
+    void SetAnchor(int nIDDlgItem, Anchor nAnchor)
+    {
+        m_vControlAnchors.emplace_back(AnchorInfo{ 0, 0, 0, 0, nIDDlgItem, nAnchor });
+    }
+
 private:
     // Allows access to `DialogProc` from static helper
     friend static INT_PTR CALLBACK StaticDialogProc(_In_ HWND hDlg,
@@ -146,6 +160,20 @@ private:
     }
 
     std::unordered_map<HWND, ra::ui::win32::bindings::ControlBinding*> m_mControlBindings;
+
+    struct AnchorInfo
+    {
+        int nMarginLeft{};
+        int nMarginTop{};
+        int nMarginRight{};
+        int nMarginBottom{};
+        int nIDDlgItem{};
+        Anchor nAnchor{};
+    };
+    std::vector<AnchorInfo> m_vControlAnchors;
+
+    void InitializeAnchors();
+    void UpdateAnchoredControls();
 };
 
 } // namespace win32

--- a/src/ui/win32/bindings/ControlBinding.hh
+++ b/src/ui/win32/bindings/ControlBinding.hh
@@ -62,6 +62,11 @@ public:
     /// </summary>
     GSL_SUPPRESS_F6 virtual void OnValueChanged() {}
 
+    /// <summary>
+    /// Called when the bound control is resized.
+    /// </summary>
+    GSL_SUPPRESS_F6 virtual void OnSizeChanged(_UNUSED const ra::ui::Size& pNewSize) {}
+
 protected:
     void DisableBinding()
     {

--- a/src/ui/win32/bindings/GridBinding.hh
+++ b/src/ui/win32/bindings/GridBinding.hh
@@ -36,12 +36,15 @@ public:
 
     void OnLvnItemChanged(LPNMLISTVIEW pnmListView);
 
+    void OnSizeChanged(const ra::ui::Size&) override { UpdateLayout(); }
+
 protected:
     void UpdateLayout();
     void UpdateAllItems();
     void UpdateItems(gsl::index nColumn);
 
 private:
+    size_t m_nColumnsCreated = 0;
     std::vector<std::unique_ptr<GridColumnBinding>> m_vColumns;
     ViewModelCollectionBase* m_vmItems = nullptr;
 };


### PR DESCRIPTION
For use with the BrokenAchievements dialog/view model (which still requires a compilation flag to enable), although this does slightly modify the margins and fixes the tab order for the existing dialog.