### PR TITLE
always assume addresses are in hex

### DIFF
--- a/src/RA_Defs.cpp
+++ b/src/RA_Defs.cpp
@@ -23,18 +23,12 @@ ByteAddress ByteAddressFromString(const std::string& sByteAddress) noexcept
     if (!ra::StringStartsWith(sByteAddress, "-")) // negative addresses not supported
     {
         char* pEnd;
-        address = std::strtoul(sByteAddress.c_str(), &pEnd, 10);
+        address = std::strtoul(sByteAddress.c_str(), &pEnd, 16);
         assert(pEnd != nullptr);
         if (*pEnd)
         {
-            // decimal parse failed, try hex
-            address = std::strtoul(sByteAddress.c_str(), &pEnd, 16);
-            assert(pEnd != nullptr);
-            if (*pEnd)
-            {
-                // hex parse failed
-                address = {};
-            }
+            // hex parse failed
+            address = {};
         }
     }
 


### PR DESCRIPTION
Modified `ByteAddressFromString` to always assume hex, and updated the search filter value logic to do its own decimal or hex logic.

There are two other places still using `ByteAddressFromString` (not related to the Watching field):
* reading notes from server
* reading .rap files

In both cases, the addresses are being written in "0x" notation so are not affected.