### PR TITLE
Remove limit on amount of conditions per group in the achievement editor

### DIFF
--- a/src/RA_Dlg_AchEditor.h
+++ b/src/RA_Dlg_AchEditor.h
@@ -57,7 +57,6 @@ private:
 
 private:
     static constexpr std::size_t m_nNumCols = 10U;
-    static constexpr std::size_t MAX_CONDITIONS = 200U;
     static constexpr std::size_t MEM_STRING_TEXT_LEN = 80U;
 
     HWND m_hAchievementEditorDlg = nullptr;
@@ -68,10 +67,7 @@ private:
     ra::tstring m_sTooltip;
     WNDPROC m_pListViewWndProc = nullptr;
 
-    using LbxData = std::array<std::array<std::string, m_nNumCols>, MAX_CONDITIONS>;
-
-    LbxData m_lbxData{};
-    int m_nNumOccupiedRows = 0;
+    std::vector<std::array<std::string, m_nNumCols>> m_lbxData{};
 
     Achievement* m_pSelectedAchievement = nullptr;
     BOOL m_bPopulatingAchievementEditorData = FALSE;


### PR DESCRIPTION
The amount of conditions per group was being artificially limited by the
achievement editor, capped at 200. The limit has been lifted by replacing the std::array-based implementation with an std::vector-based one. There should be
no noticeable/measurable performance impact, since the vector is shared by all
uses of the achievement editor, making any allocation-related cost negligible.

Also removed some ad-hoc initialization of the std::strings in the container
that was a workaround for the fact that a preceeding ZeroMemory call messed up
their post-constructor state.

Closes #399.