### PR TITLE
don't require round-trip through emulator to show achievement editor …

### DIFF
--- a/src/RA_Dlg_Achievement.cpp
+++ b/src/RA_Dlg_Achievement.cpp
@@ -848,7 +848,7 @@ INT_PTR Dlg_Achievements::AchievementsProc(HWND hDlg, UINT nMsg, WPARAM wParam, 
                     GSL_SUPPRESS_TYPE1
                     if (reinterpret_cast<LPNMITEMACTIVATE>(lParam)->iItem != -1)
                     {
-                        SendMessage(g_RAMainWnd, WM_COMMAND, IDM_RA_FILES_ACHIEVEMENTEDITOR, 0);
+                        _RA_InvokeDialog(IDM_RA_FILES_ACHIEVEMENTEDITOR);
                         GSL_SUPPRESS_TYPE1 g_AchievementEditorDialog.LoadAchievement(
                             &g_pActiveAchievements->GetAchievement(reinterpret_cast<LPNMITEMACTIVATE>(lParam)->iItem),
                             FALSE);


### PR DESCRIPTION
…on double click from achievements list

Only really a problem in RAMeka where "g_RAMainWnd" is the emulator window, but the message loop that calls RA_InvokeDialog is in the console window (where the menu is), so sending the menu event to the non-console window doesn't do anything.

There's no reason the event has to go through the message loop. The intent is simply to make sure the dialog is visible.