### PR TITLE
prevent error re-registering class when dll is unloaded and reloaded

### DIFF
--- a/src/ui/win32/OverlayWindow.cpp
+++ b/src/ui/win32/OverlayWindow.cpp
@@ -129,8 +129,22 @@ void OverlayWindow::CreateOverlayWindow()
         wndEx.hInstance = GetModuleHandle(nullptr);
         if (!RegisterClassEx(&wndEx))
         {
-            MessageBox(m_hWnd, TEXT("Failed to register overlay window class"), TEXT("Error"), MB_OK);
-            return;
+            // if the class already exists, assume the DLL was shutdown and restarted. Unregister the old one and reregister the new one
+            bool bSuccess = false;
+            if (GetLastError() == ERROR_CLASS_ALREADY_EXISTS)
+            {
+                if (UnregisterClass(wndEx.lpszClassName, wndEx.hInstance))
+                {
+                    if (RegisterClassEx(&wndEx))
+                        bSuccess = true;
+                }
+            }
+
+            if (!bSuccess)
+            {
+                MessageBox(m_hWnd, TEXT("Failed to register overlay window class"), TEXT("Error"), MB_OK);
+                return;
+            }
         }
 
         bClassRegistered = true;


### PR DESCRIPTION
When the DLL is unloaded and reloaded (emu calls `RA_Shutdown` then `RA_Init` a second time), the static variable keeping the class from being re-registered gets reset, allowing the code to attempt to re-register the overlay window class, but this fails as it has already been loaded into the process by the first `RA_Init` call. This change detects the specific "class already registered" error, unregisters it, then re-registers the class. The error dialog is not shown if that succeeds.