### PR TITLE
clear popups when loading state

### DIFF
--- a/src/RA_Core.cpp
+++ b/src/RA_Core.cpp
@@ -744,6 +744,8 @@ API void CCONV _RA_OnLoadState(const char* sFilename)
         }
 
         ra::services::ServiceLocator::Get<ra::services::AchievementRuntime>().LoadProgress(sFilename);
+        ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().ClearPopups();
+
         g_MemoryDialog.Invalidate();
 
         for (size_t i = 0; i < g_pActiveAchievements->NumAchievements(); ++i)


### PR DESCRIPTION
in addition to removing the unwanted leaderboard tracker popups, any other currently displayed (or queued) popups are also discarded.