### PR TITLE
let Windows know the memory editor wants to handle character and navigation input

### DIFF
--- a/src/RA_Dlg_Memory.cpp
+++ b/src/RA_Dlg_Memory.cpp
@@ -97,6 +97,9 @@ LRESULT CALLBACK MemoryViewerControl::s_MemoryDrawProc(HWND hDlg, UINT uMsg, WPA
 
         case WM_CHAR:
             return (!OnEditInput(static_cast<UINT>(LOWORD(wParam))));
+
+        case WM_GETDLGCODE:
+            return DLGC_WANTCHARS | DLGC_WANTARROWS;
     }
 
     return DefWindowProc(hDlg, uMsg, wParam, lParam);


### PR DESCRIPTION
Fixes an issue where the emulator's primary message loop contains a call to `IsDialogMessage`:
```
while(GetMessage(msg, NULL, 0, 0) > 0)
{
    if(!IsDialogMessage(msg->hwnd, msg)) 
    {
        TranslateMessage(msg);
        DispatchMessage(msg);
    }
}
```
With the code written this way, the `IsDialogMessage` will ask the Memory Editor control if it cares about the key press before turning it into a dialog navigation event (arrowing between fields in a manner similar to tabbing between fields - I'm not sure why it also eats all the other keypresses). Since the Memory Editor wasn't specifying interest, all keyboard inputs were being swallowed, preventing the user from navigating or editing memory.

As this code happens to be in a third-party UI library, we can't just patch the emulator. Besides, this is the correct solution and we just happened to get by without it for this long. Unfortunately, that means this code must be patched into a version of thee 0.76 DLL in order to release the emulator.