### PR TITLE
match multi-byte code notes in search results

### DIFF
--- a/src/RA_Dlg_MemBookmark.cpp
+++ b/src/RA_Dlg_MemBookmark.cpp
@@ -470,7 +470,7 @@ BOOL Dlg_MemBookmark::IsActive() const noexcept
     return (g_MemBookmarkDialog.GetHWND() != nullptr) && (IsWindowVisible(g_MemBookmarkDialog.GetHWND()));
 }
 
-static MemSize TypeToMemSize(unsigned int type)
+static MemSize TypeToMemSize(unsigned int type) noexcept
 {
     switch (type)
     {

--- a/src/RA_Dlg_Memory.cpp
+++ b/src/RA_Dlg_Memory.cpp
@@ -910,7 +910,7 @@ INT_PTR Dlg_Memory::MemoryProc(HWND hDlg, UINT nMsg, WPARAM wParam, LPARAM lPara
                         unsigned int nVal = 0;
                         UpdateSearchResult(result, nVal, sValue);
                         const auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::GameContext>();
-                        const auto* pNote = pGameContext.FindCodeNote(result.nAddress);
+                        auto sNote = pGameContext.FindCodeNote(result.nAddress, result.nSize);
 
                         HBRUSH hBrush{};
                         COLORREF color{};
@@ -931,7 +931,7 @@ INT_PTR Dlg_Memory::MemoryProc(HWND hDlg, UINT nMsg, WPARAM wParam, LPARAM lPara
                             }
                             else if (g_MemBookmarkDialog.BookmarkExists(result.nAddress))
                                 color = RGB(220, 255, 220); // Green if Bookmark is found.
-                            else if (pNote != nullptr)
+                            else if (!sNote.empty())
                                 color = RGB(220, 240, 255); // Blue if Code Note is found.
                             else if (currentSearch.WasModified(result.nAddress))
                                 color = RGB(240, 240, 240); // Grey if still valid, but has changed
@@ -986,12 +986,7 @@ INT_PTR Dlg_Memory::MemoryProc(HWND hDlg, UINT nMsg, WPARAM wParam, LPARAM lPara
                         DrawTextW(pDIS->hDC, sValue.c_str(), sValue.length(), &rcValue,
                             DT_SINGLELINE | DT_LEFT | DT_NOPREFIX | DT_NOCLIP | DT_VCENTER);
 
-                        std::wstring sNote;
-                        if (pNote && !pNote->empty())
-                        {
-                            sNote = ra::Widen(*pNote);
-                        }
-                        else
+                        if (sNote.empty())
                         {
                             const auto* pRegion = ra::services::ServiceLocator::Get<ra::data::ConsoleContext>().GetMemoryRegion(result.nAddress);
                             if (pRegion)

--- a/src/data/GameContext.hh
+++ b/src/data/GameContext.hh
@@ -207,6 +207,15 @@ public:
     /// <summary>
     /// Returns the note associated with the specified address.
     /// </summary>
+    /// <returns>
+    ///  The note associated to the address or neighboring addresses based on <paramref name="nSize" />.
+    ///  Returns an empty string if no note is associated to the address.
+    /// </returns>
+    std::wstring FindCodeNote(ra::ByteAddress nAddress, MemSize nSize) const;
+
+    /// <summary>
+    /// Returns the note associated with the specified address.
+    /// </summary>
     /// <param name="nAddress">The address to look up.</param>
     /// <param name="sAuthor">The author associated to the address.</param>
     /// <returns>The note associated to the address, <c>nullptr</c> if no note is associated to the address.</returns>
@@ -276,6 +285,7 @@ protected:
     {
         std::string Author;
         std::wstring Note;
+        unsigned int Bytes;
     };
     std::map<ra::ByteAddress, CodeNote> m_mCodeNotes;
 };


### PR DESCRIPTION
Improves search result tagging so a partial match on data associated to a multi-byte code note indicates that it _is_ associated to known data.

Looks for several variations of "XX-bit" and "XX-byte" to identify code notes that span multiple bytes.

In this example, there's a code note at $80AC that contains "16-Bit". When a search result matches $80AD, which doesn't have an explicit code note, the search result shows the derived note instead:

![image](https://user-images.githubusercontent.com/32680403/62827587-15aeb780-bb8f-11e9-9192-5fccd59391c7.png)
