### PR TITLE
add _RA_SetUserAgentDetail API

### DIFF
--- a/src/Exports.cpp
+++ b/src/Exports.cpp
@@ -168,6 +168,12 @@ API void CCONV _RA_SetConsoleID(unsigned int nConsoleId)
 #endif
 }
 
+API void CCONV _RA_SetUserAgentDetail(const char* sDetail)
+{
+    auto& pEmulatorContext = ra::services::ServiceLocator::GetMutable<ra::data::EmulatorContext>();
+    pEmulatorContext.SetClientUserAgentDetail(sDetail);
+}
+
 API void CCONV _RA_InstallMemoryBank(int nBankID, void* pReader, void* pWriter, int nBankSize)
 {
     ra::services::ServiceLocator::GetMutable<ra::data::EmulatorContext>().AddMemoryBlock(nBankID, nBankSize,

--- a/src/Exports.hh
+++ b/src/Exports.hh
@@ -27,6 +27,9 @@ extern "C" {
     // Initialize all data related to RA Engine for offline mode. Call as early as possible.
     API int CCONV _RA_InitOffline(HWND hMainHWND, /*enum EmulatorID*/int nConsoleID, const char* sClientVersion);
 
+    // Specifies additional information to include in the UserAgent string
+    API void CCONV _RA_SetUserAgentDetail(const char* sDetail);
+
     // Changes the HWND for the main emulator window
     API void CCONV _RA_UpdateHWnd(HWND hMainHWND);
 

--- a/src/RA_Core.cpp
+++ b/src/RA_Core.cpp
@@ -104,83 +104,12 @@ API BOOL CCONV _RA_InitOffline(HWND hMainHWND, /*enum EmulatorID*/int nEmulatorI
     return TRUE;
 }
 
-static void AppendIntegrationVersion(_Inout_ std::string& sUserAgent)
-{
-    sUserAgent.append(ra::StringPrintf("%d.%d.%d.%d", RA_INTEGRATION_VERSION_MAJOR,
-        RA_INTEGRATION_VERSION_MINOR, RA_INTEGRATION_VERSION_PATCH,
-        RA_INTEGRATION_VERSION_REVISION));
-
-    if constexpr (_CONSTANT_LOC pos{ std::string_view{ RA_INTEGRATION_VERSION_PRODUCT }.find('-') }; pos != std::string_view::npos)
-    {
-        constexpr std::string_view sAppend{ RA_INTEGRATION_VERSION_PRODUCT };
-        sUserAgent.append(sAppend, pos);
-    }
-}
-
-static void AppendNTVersion(_Inout_ std::string& sUserAgent)
-{
-    // https://msdn.microsoft.com/en-us/library/windows/desktop/ms724832(v=vs.85).aspx
-    // https://msdn.microsoft.com/en-us/library/windows/desktop/ms724429(v=vs.85).aspx
-    // https://github.com/DarthTon/Blackbone/blob/master/contrib/VersionHelpers.h
-#ifndef NTSTATUS
-    using NTSTATUS = __success(return >= 0) LONG;
-#endif
-    if (const auto ntModule{ ::GetModuleHandleW(L"ntdll.dll") }; ntModule)
-    {
-        RTL_OSVERSIONINFOEXW osVersion{ sizeof(RTL_OSVERSIONINFOEXW) };
-        using fnRtlGetVersion = NTSTATUS(NTAPI*)(PRTL_OSVERSIONINFOEXW);
-
-        fnRtlGetVersion RtlGetVersion{};
-        GSL_SUPPRESS_TYPE1 RtlGetVersion =
-            reinterpret_cast<fnRtlGetVersion>(::GetProcAddress(ntModule, "RtlGetVersion"));
-
-        if (RtlGetVersion)
-        {
-            RtlGetVersion(&osVersion);
-            if (osVersion.dwMajorVersion > 0UL)
-            {
-                sUserAgent.append(ra::StringPrintf("WindowsNT %lu.%lu", osVersion.dwMajorVersion,
-                    osVersion.dwMinorVersion));
-            }
-        }
-    }
-}
-
-static void SetUserAgentString()
-{
-    std::string sUserAgent;
-    sUserAgent.reserve(128U);
-
-    const auto& pEmulatorContext = ra::services::ServiceLocator::Get<ra::data::EmulatorContext>();
-    const auto& sClientName = pEmulatorContext.GetClientName();
-    if (!sClientName.empty())
-    {
-        sUserAgent.append(sClientName);
-        sUserAgent.append("/");
-    }
-    else
-    {
-        sUserAgent.append("UnknownClient/");
-    }
-    sUserAgent.append(pEmulatorContext.GetClientVersion());
-    sUserAgent.append(" (");
-
-    AppendNTVersion(sUserAgent);
-    sUserAgent.append(") Integration/");
-    AppendIntegrationVersion(sUserAgent);
-
-    RA_LOG("User-Agent: %s", sUserAgent.c_str());
-
-    ra::services::ServiceLocator::GetMutable<ra::services::IHttpRequester>().SetUserAgent(sUserAgent);
-}
-
 API BOOL CCONV _RA_InitI(HWND hMainHWND, /*enum EmulatorID*/int nEmulatorID, const char* sClientVer)
 {
     InitCommon(hMainHWND, nEmulatorID);
 
     // Set the client version and User-Agent string
     ra::services::ServiceLocator::GetMutable<ra::data::EmulatorContext>().SetClientVersion(sClientVer);
-    SetUserAgentString();
 
     // validate version (async call)
     ra::services::ServiceLocator::GetMutable<ra::services::IThreadPool>().RunAsync([]

--- a/src/RA_StringUtils.cpp
+++ b/src/RA_StringUtils.cpp
@@ -17,15 +17,12 @@ std::string Narrow(std::wstring&& wstr) noexcept
 _Use_decl_annotations_
 std::string Narrow(const wchar_t* wstr)
 {
-    const auto len{ ra::to_signed(std::wcslen(wstr)) };
-
-    const auto needed{
-        ::WideCharToMultiByte(CP_UTF8, 0, wstr, len + 1, nullptr, 0, nullptr, nullptr)
-    };
+    const auto len = gsl::narrow_cast<int>(std::wcslen(wstr));
+    const auto needed = ::WideCharToMultiByte(CP_UTF8, 0, wstr, len + 1, nullptr, 0, nullptr, nullptr);
 
     std::string str(ra::to_unsigned(needed), '\000'); // allocate required space (including terminator)
-    ::WideCharToMultiByte(CP_UTF8, 0, wstr, len + 1, str.data(), ra::to_signed(str.capacity()),
-                          nullptr, nullptr);
+    ::WideCharToMultiByte(CP_UTF8, 0, wstr, len + 1, str.data(), gsl::narrow_cast<unsigned int>(str.capacity()),
+        nullptr, nullptr);
     str.resize(ra::to_unsigned(needed - 1)); // terminator is not actually part of the string
     return str;
 }
@@ -45,12 +42,12 @@ std::wstring Widen(std::string&& str) noexcept
 _Use_decl_annotations_
 std::wstring Widen(const char* str)
 {
-    const auto len{ ra::to_signed(std::strlen(str)) };
-    const auto needed{ ::MultiByteToWideChar(CP_UTF8, 0, str, len + 1, nullptr, 0) };
+    const auto len = gsl::narrow_cast<int>(std::strlen(str));
+    const auto needed = ::MultiByteToWideChar(CP_UTF8, 0, str, len + 1, nullptr, 0);
     // doesn't seem wchar_t is treated like a character type by default
     std::wstring wstr(ra::to_unsigned(needed), L'\x0');
     ::MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, str, len + 1, wstr.data(),
-                          ra::to_signed(wstr.capacity()));
+        gsl::narrow_cast<unsigned int>(wstr.capacity()));
     wstr.resize(ra::to_unsigned(needed - 1));
 
     return wstr;

--- a/src/RA_StringUtils.h
+++ b/src/RA_StringUtils.h
@@ -290,7 +290,7 @@ public:
         {
             if (sFormat.back() == 'f' || sFormat.back() == 'F')
             {
-                const int nIndex = sFormat.find('.');
+                const auto nIndex = sFormat.find('.');
                 if (nIndex != std::string::npos)
                 {
                     int nPrecision = std::stoi(sFormat.c_str() + nIndex + 1);
@@ -319,7 +319,7 @@ public:
         }
         else
         {
-            const int nLength = strlen(arg);
+            const int nLength = gsl::narrow_cast<int>(strlen(arg));
             int nPadding = std::stoi(sFormat.c_str());
             nPadding -= nLength;
             if (nPadding > 0)

--- a/src/RA_md5factory.cpp
+++ b/src/RA_md5factory.cpp
@@ -21,7 +21,7 @@ std::string RAGenerateMD5(const std::string& sStringToMD5)
     memcpy(pDataBuffer, sStringToMD5.c_str(), sStringToMD5.length());
 
     md5_init(&pms);
-    md5_append(&pms, pDataBuffer, sStringToMD5.length());
+    md5_append(&pms, pDataBuffer, gsl::narrow_cast<int>(sStringToMD5.length()));
     md5_finish(&pms, digest);
 
     memset(buffer, 0, MD5_STRING_LEN + 1);
@@ -47,7 +47,7 @@ std::string RAGenerateMD5(const BYTE* pRawData, size_t nDataLen)
     static_assert(sizeof(md5_byte_t) == sizeof(BYTE), "Must be equivalent for the MD5 to work!");
 
     md5_init(&pms);
-    md5_append(&pms, pRawData, nDataLen);
+    md5_append(&pms, pRawData, gsl::narrow_cast<int>(nDataLen));
     md5_finish(&pms, digest);
 
     memset(buffer, 0, MD5_STRING_LEN + 1);

--- a/src/data/EmulatorContext.hh
+++ b/src/data/EmulatorContext.hh
@@ -29,7 +29,7 @@ public:
     /// <summary>
     /// Sets the client version.
     /// </summary>
-    void SetClientVersion(const std::string& sVersion) { m_sVersion = sVersion; }
+    void SetClientVersion(const std::string& sVersion) { m_sVersion = sVersion; UpdateUserAgent(); }
 
     /// <summary>
     /// Gets the version of the emulator this context was initialized with.
@@ -58,6 +58,11 @@ public:
     /// Gets the client name for the emulator this context was initialized with.
     /// </summary>
     const std::string& GetClientName() const noexcept { return m_sClientName; }
+
+    /// <summary>
+    /// Sets the client version.
+    /// </summary>
+    void SetClientUserAgentDetail(const std::string& sDetail) { m_sClientUserAgentDetail = sDetail; UpdateUserAgent(); }
 
     /// <summary>
     /// Disables hardcore mode and notifies other services of that fact.
@@ -199,11 +204,14 @@ public:
     void WriteMemory(ra::ByteAddress nAddress, MemSize nSize, uint32_t nValue) const noexcept;
 
 protected:
+    void UpdateUserAgent();
+
     EmulatorID m_nEmulatorId = EmulatorID::UnknownEmulator;
     std::string m_sVersion;
     std::string m_sLatestVersion;
     std::string m_sLatestVersionError;
     std::string m_sClientName;
+    std::string m_sClientUserAgentDetail;
     const wchar_t* m_sAcceptButtonText = L"\u24B6"; // encircled A
     const wchar_t* m_sCancelButtonText = L"\u24B7"; // encircled B
 

--- a/src/services/impl/StringTextWriter.hh
+++ b/src/services/impl/StringTextWriter.hh
@@ -26,7 +26,7 @@ public:
 
     void Write(_In_ const std::string& sText) override
     {
-        if (m_nWritePosition < m_sOutput.length())
+        if (m_nWritePosition < gsl::narrow_cast<std::size_t>(m_sOutput.length()))
         {
             m_sOutput.replace(gsl::narrow_cast<std::size_t>(m_nWritePosition), sText.length(), sText.c_str());
             m_nWritePosition += sText.length();

--- a/src/services/impl/WindowsHttpRequester.cpp
+++ b/src/services/impl/WindowsHttpRequester.cpp
@@ -38,7 +38,7 @@ static bool ReadIntoString(const HINTERNET hRequest, std::string& sBuffer, DWORD
     while (nAvailableBytes > 0)
     {
         DWORD nBytesFetched = 0U;
-        const DWORD nBytesToRead = sBuffer.capacity() - nInsertAt;
+        const DWORD nBytesToRead = gsl::narrow_cast<DWORD>(sBuffer.capacity()) - nInsertAt;
         if (WinHttpReadData(hRequest, &sBuffer.at(nInsertAt), nBytesToRead, &nBytesFetched))
         {
             nInsertAt += nBytesFetched;
@@ -172,7 +172,7 @@ unsigned int WindowsHttpRequester::Request(const Http::Request& pRequest, TextWr
                 if (sPostData.empty())
                 {
                     bResults = WinHttpSendRequest(hRequest,
-                        sHeaders.c_str(), sHeaders.length(),
+                        sHeaders.c_str(), gsl::narrow_cast<int>(sHeaders.length()),
                         WINHTTP_NO_REQUEST_DATA,
                         0, 0,
                         0);
@@ -180,9 +180,9 @@ unsigned int WindowsHttpRequester::Request(const Http::Request& pRequest, TextWr
                 else
                 {
                     bResults = WinHttpSendRequest(hRequest,
-                        sHeaders.c_str(), sHeaders.length(),
+                        sHeaders.c_str(), gsl::narrow_cast<int>(sHeaders.length()),
                         static_cast<LPVOID>(sPostData.data()),
-                        sPostData.length(), sPostData.length(),
+                        gsl::narrow_cast<int>(sPostData.length()), gsl::narrow_cast<int>(sPostData.length()),
                         0);
                 }
 

--- a/src/ui/IDesktop.hh
+++ b/src/ui/IDesktop.hh
@@ -48,6 +48,11 @@ public:
     virtual std::string GetRunningExecutable() const = 0;
 
     /// <summary>
+    /// Gets a string representing the current operating system and its version.
+    /// <summary>
+    virtual std::string GetOSVersionString() const = 0;
+
+    /// <summary>
     /// Opens the specified URL using the default browser.
     /// </summary>
     /// <param name="sUrl">The URL to open.</param>

--- a/src/ui/win32/Desktop.hh
+++ b/src/ui/win32/Desktop.hh
@@ -27,6 +27,7 @@ public:
 
     void SetMainHWnd(HWND hWnd);
     std::string GetRunningExecutable() const override;
+    std::string GetOSVersionString() const override;
 
 private:
     _Success_(return != nullptr)

--- a/tests/RA_Interface_Tests.cpp
+++ b/tests/RA_Interface_Tests.cpp
@@ -14,7 +14,7 @@ static std::wstring GetIntegrationPath();
 
 // ALSO NOTE: the cpp file is pulled in directly, instead of using the header file so we
 // can access the file-scoped methods and variables. The cpp file will include the header
-//file, so both are tested.
+// file, so both are tested.
 #include "..\RAInterface\RA_Interface.cpp"
 
 #include "RA_BuildVer.h"
@@ -70,6 +70,7 @@ public:
         Assert::IsNotNull((const void*)_RA_HostName);
         Assert::IsNotNull((const void*)_RA_InitI);
         Assert::IsNotNull((const void*)_RA_InitOffline);
+        Assert::IsNotNull((const void*)_RA_SetUserAgentDetail);
         Assert::IsNotNull((const void*)_RA_UpdateHWnd);
         Assert::IsNotNull((const void*)_RA_Shutdown);
         Assert::IsNotNull((const void*)_RA_AttemptLogin);
@@ -103,6 +104,7 @@ public:
         Assert::IsNull((const void*)_RA_HostName);
         Assert::IsNull((const void*)_RA_InitI);
         Assert::IsNull((const void*)_RA_InitOffline);
+        Assert::IsNull((const void*)_RA_SetUserAgentDetail);
         Assert::IsNull((const void*)_RA_UpdateHWnd);
         Assert::IsNull((const void*)_RA_Shutdown);
         Assert::IsNull((const void*)_RA_AttemptLogin);

--- a/tests/mocks/MockDesktop.hh
+++ b/tests/mocks/MockDesktop.hh
@@ -77,6 +77,8 @@ public:
     std::string GetRunningExecutable() const override { return m_sExecutable; }
     void SetRunningExecutable(const std::string& sExecutable) { m_sExecutable = sExecutable; }
 
+    std::string GetOSVersionString() const override { return "UnitTests"; }
+
 private:
     ra::ui::DialogResult Handle(WindowViewModelBase& vmViewModel) const
     {

--- a/tests/mocks/MockHttpRequester.hh
+++ b/tests/mocks/MockHttpRequester.hh
@@ -17,7 +17,8 @@ public:
     {
     }
 
-    void SetUserAgent([[maybe_unused]] const std::string& /*sUserAgent*/) noexcept override {}
+    void SetUserAgent(const std::string& sUserAgent) override { m_sUserAgent = sUserAgent; }
+    const std::string& GetUserAgent() const noexcept { return m_sUserAgent; }
 
     unsigned int Request(const Http::Request& pRequest, TextWriter& pContentWriter) const override
     {
@@ -33,6 +34,7 @@ public:
 
 private:
     ServiceLocator::ServiceOverride<IHttpRequester> m_Override;
+    std::string m_sUserAgent;
 
     std::function<Http::Response(const Http::Request&)> m_fHandler;
 };


### PR DESCRIPTION
Allows client to pass additional information to be included in the User-Agent string for server requests. Primarily intended for RALibRetro core versions.