### PR TITLE
fix SearchResults copy logic

### DIFF
--- a/src/services/SearchResults.h
+++ b/src/services/SearchResults.h
@@ -93,6 +93,8 @@ protected:
         {
             if (nSize > sizeof(m_vBytes))
                 std::memcpy(m_pBytes, other.m_pBytes, nSize);
+            else
+                std::memcpy(m_vBytes, other.m_vBytes, sizeof(m_vBytes));
         }
         MemBlock& operator=(const MemBlock&) noexcept = delete;
 


### PR DESCRIPTION
When excluding one or more addresses from a set of search results, the comparison highlighting wasn't working right.

Steps to reproduce:
1) Pause the emulator
2) New 8-bit test
3) Advance frame
4) Filter != last known value
Note: all entries are red, indicating that they don't match the filter (i.e _are_ last known value)
5) Exclude the first match
Error: some entries are no longer red.

The problem was that when the SearchResults were copied before removing the excluded addresses, the last known values weren't being copied, so the comparisons were using uninitialized memory.