### PR TITLE
framework support for taking screenshots on achievement trigger

### DIFF
--- a/src/Exports.cpp
+++ b/src/Exports.cpp
@@ -391,6 +391,9 @@ API void CCONV _RA_DoAchievementsFrame()
     auto& vmBookmarks = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::WindowManager>().MemoryBookmarks;
     vmBookmarks.DoFrame();
 
+    auto& pOverlayManager = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>();
+    pOverlayManager.AdvanceFrame();
+
     // make sure we process the achievements _before_ the frozen bookmarks modify the memory
     g_MemoryDialog.Invalidate();
 #endif

--- a/src/Exports.cpp
+++ b/src/Exports.cpp
@@ -94,15 +94,15 @@ static void HandleLoginResponse(const ra::api::Login::Response& response)
         // show the welcome message
         ra::services::ServiceLocator::Get<ra::services::IAudioSystem>().PlayAudioFile(L"Overlay\\login.wav");
 
-        ra::ui::viewmodels::PopupMessageViewModel message;
-        message.SetTitle(ra::StringPrintf(L"Welcome %s%s", pSessionTracker.HasSessionData() ? L"back " : L"",
+        std::unique_ptr<ra::ui::viewmodels::PopupMessageViewModel> vmMessage(new ra::ui::viewmodels::PopupMessageViewModel);
+        vmMessage->SetTitle(ra::StringPrintf(L"Welcome %s%s", pSessionTracker.HasSessionData() ? L"back " : L"",
             response.Username.c_str()));
-        message.SetDescription((response.NumUnreadMessages == 1)
+        vmMessage->SetDescription((response.NumUnreadMessages == 1)
             ? L"You have 1 new message"
             : ra::StringPrintf(L"You have %u new messages", response.NumUnreadMessages));
-        message.SetDetail(ra::StringPrintf(L"%u points", response.Score));
-        message.SetImage(ra::ui::ImageType::UserPic, response.Username);
-        ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().QueueMessage(std::move(message));
+        vmMessage->SetDetail(ra::StringPrintf(L"%u points", response.Score));
+        vmMessage->SetImage(ra::ui::ImageType::UserPic, response.Username);
+        ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().QueueMessage(vmMessage);
 
         // notify the client to update the RetroAchievements menu
         ra::services::ServiceLocator::Get<ra::data::EmulatorContext>().RebuildMenu();

--- a/src/RA_Dlg_GameLibrary.cpp
+++ b/src/RA_Dlg_GameLibrary.cpp
@@ -637,7 +637,7 @@ INT_PTR CALLBACK Dlg_GameLibrary::GameLibraryProc(HWND hDlg, UINT uMsg, WPARAM w
                 {
                     std::string sROMDirLocation = GetFolderFromDialog();
                     auto& pConfiguration = ra::services::ServiceLocator::GetMutable<ra::services::IConfiguration>();
-                    pConfiguration.SetRomDirectory(sROMDirLocation);
+                    pConfiguration.SetRomDirectory(ra::Widen(sROMDirLocation));
                     RA_LOG("Selected Folder: %s\n", sROMDirLocation.c_str());
                     SetDlgItemText(hDlg, IDC_RA_ROMDIR, NativeStr(sROMDirLocation).c_str());
                     return FALSE;

--- a/src/data/ConsoleContext.cpp
+++ b/src/data/ConsoleContext.cpp
@@ -570,7 +570,7 @@ std::unique_ptr<ConsoleContext> ConsoleContext::GetContext(ConsoleID nId)
             return std::make_unique<MegaDriveConsoleContext>(ConsoleID::Sega32X, L"SEGA 32X");
 
         case ConsoleID::SegaCD:
-            return std::make_unique<ConsoleContext>(nId, L"SEGA CD");
+            return std::make_unique<MegaDriveConsoleContext>(ConsoleID::SegaCD, L"SEGA CD");
 
         case ConsoleID::SG1000:
             return std::make_unique<SG1000ConsoleContext>();

--- a/src/services/IConfiguration.hh
+++ b/src/services/IConfiguration.hh
@@ -18,6 +18,7 @@ enum class Feature
     LeaderboardScoreboards,
     PreferDecimal,
     NonHardcoreWarning,
+    AchievementScreenshot,
 };
 
 class IConfiguration
@@ -64,8 +65,11 @@ public:
     /// </summary>
     virtual unsigned int GetNumBackgroundThreads() const = 0;
 
-    virtual const std::string& GetRomDirectory() const = 0;
-    virtual void SetRomDirectory(const std::string& sValue) = 0;
+    virtual const std::wstring& GetRomDirectory() const = 0;
+    virtual void SetRomDirectory(const std::wstring& sValue) = 0;
+
+    virtual const std::wstring& GetScreenshotDirectory() const = 0;
+    virtual void SetScreenshotDirectory(const std::wstring& sValue) = 0;
 
     /// <summary>
     /// Gets the remembered position of the window identified by <paramref name="sPositionKey"/>.

--- a/src/services/impl/JsonFileConfiguration.cpp
+++ b/src/services/impl/JsonFileConfiguration.cpp
@@ -50,6 +50,11 @@ bool JsonFileConfiguration::Load(const std::wstring& sFilename)
     if (doc.HasMember("Non Hardcore Warning"))
         SetFeatureEnabled(Feature::NonHardcoreWarning, doc["Non Hardcore Warning"].GetBool());
 
+    if (doc.HasMember("Achievement Screenshot"))
+        SetFeatureEnabled(Feature::AchievementScreenshot, doc["Achievement Screenshot"].GetBool());
+    if (doc.HasMember("Screenshot Directory"))
+        SetScreenshotDirectory(ra::Widen(doc["Screenshot Directory"].GetString()));
+
     if (doc.HasMember("Leaderboards Active"))
         SetFeatureEnabled(Feature::Leaderboards, doc["Leaderboards Active"].GetBool());
     if (doc.HasMember("Leaderboard Notification Display"))
@@ -67,7 +72,7 @@ bool JsonFileConfiguration::Load(const std::wstring& sFilename)
     if (doc.HasMember("Num Background Threads"))
         m_nBackgroundThreads = doc["Num Background Threads"].GetUint();
     if (doc.HasMember("ROM Directory"))
-        m_sRomDirectory = doc["ROM Directory"].GetString();
+        m_sRomDirectory = ra::Widen(doc["ROM Directory"].GetString());
 
     if (doc.HasMember("Window Positions"))
     {
@@ -112,6 +117,7 @@ void JsonFileConfiguration::Save() const
     doc.AddMember("Token", rapidjson::StringRef(m_sApiToken), a);
     doc.AddMember("Hardcore Active", IsFeatureEnabled(Feature::Hardcore), a);
     doc.AddMember("Non Hardcore Warning", IsFeatureEnabled(Feature::NonHardcoreWarning), a);
+    doc.AddMember("Achievement Screenshot", IsFeatureEnabled(Feature::AchievementScreenshot), a);
     doc.AddMember("Leaderboards Active", IsFeatureEnabled(Feature::Leaderboards), a);
     doc.AddMember("Leaderboard Notification Display", IsFeatureEnabled(Feature::LeaderboardNotifications), a);
     doc.AddMember("Leaderboard Cancel Display", IsFeatureEnabled(Feature::LeaderboardCancelNotifications), a);
@@ -121,7 +127,10 @@ void JsonFileConfiguration::Save() const
     doc.AddMember("Num Background Threads", m_nBackgroundThreads, a);
 
     if (!m_sRomDirectory.empty())
-        doc.AddMember("ROM Directory", rapidjson::StringRef(m_sRomDirectory), a);
+        doc.AddMember("ROM Directory", ra::Narrow(m_sRomDirectory), a);
+
+    if (!m_sScreenshotDirectory.empty())
+        doc.AddMember("Screenshot Directory", ra::Narrow(m_sScreenshotDirectory), a);
 
     rapidjson::Value positions(rapidjson::kObjectType);
     for (WindowPositionMap::const_iterator iter = m_mWindowPositions.begin(); iter != m_mWindowPositions.end(); ++iter)

--- a/src/services/impl/JsonFileConfiguration.hh
+++ b/src/services/impl/JsonFileConfiguration.hh
@@ -22,8 +22,12 @@ public:
     void SetFeatureEnabled(Feature nFeature, bool bEnabled) noexcept override;
 
     unsigned int GetNumBackgroundThreads() const noexcept override { return m_nBackgroundThreads; }
-    const std::string& GetRomDirectory() const noexcept override { return m_sRomDirectory; }
-    void SetRomDirectory(const std::string& sValue) override { m_sRomDirectory = sValue; }
+
+    const std::wstring& GetRomDirectory() const noexcept override { return m_sRomDirectory; }
+    void SetRomDirectory(const std::wstring& sValue) override { m_sRomDirectory = sValue; }
+
+    const std::wstring& GetScreenshotDirectory() const noexcept override { return m_sScreenshotDirectory; }
+    void SetScreenshotDirectory(const std::wstring& sValue) override { m_sScreenshotDirectory = sValue; }
 
     ra::ui::Position GetWindowPosition(const std::string& sPositionKey) const override;
     void SetWindowPosition(const std::string& sPositionKey, const ra::ui::Position& oPosition) override;
@@ -46,7 +50,8 @@ private:
     int m_vEnabledFeatures = 0;
 
     unsigned int m_nBackgroundThreads = 8;
-    std::string m_sRomDirectory;
+    std::wstring m_sRomDirectory;
+    std::wstring m_sScreenshotDirectory;
 
     typedef struct WindowPosition
     {

--- a/src/ui/IDesktop.hh
+++ b/src/ui/IDesktop.hh
@@ -2,6 +2,7 @@
 #define RA_UI_DESKTOP
 
 #include "ui/WindowViewModelBase.hh"
+#include "ui/drawing/ISurface.hh"
 
 namespace ra {
 namespace ui {
@@ -57,6 +58,11 @@ public:
     /// </summary>
     /// <param name="sUrl">The URL to open.</param>
     virtual void OpenUrl(const std::string& sUrl) const = 0;
+
+    /// <summary>
+    /// Captures the currently displayed contents of the specified window in an <see cref="ISurface" />
+    /// </summary>
+    virtual std::unique_ptr<ra::ui::drawing::ISurface> CaptureClientArea(const WindowViewModelBase& vmViewModel) const = 0;
 
     virtual void Shutdown() = 0;
 

--- a/src/ui/ImageReference.hh
+++ b/src/ui/ImageReference.hh
@@ -157,7 +157,7 @@ public:
 private:
     ImageType m_nType{};
     std::string m_sName;
-    mutable unsigned long m_nData{};
+    mutable unsigned long long m_nData{};
     friend class drawing::gdi::ImageRepository;
 };
 

--- a/src/ui/drawing/ISurface.hh
+++ b/src/ui/drawing/ISurface.hh
@@ -23,12 +23,12 @@ public:
     /// <summary>
     /// Gets the width of the surface.
     /// </summary>
-    virtual size_t GetWidth() const = 0;
+    virtual unsigned int GetWidth() const = 0;
 
     /// <summary>
     /// Gets the height of the surface.
     /// </summary>
-    virtual size_t GetHeight() const = 0;
+    virtual unsigned int GetHeight() const = 0;
 
     /// <summary>
     /// Draws a solid rectangle.

--- a/src/ui/drawing/ISurface.hh
+++ b/src/ui/drawing/ISurface.hh
@@ -137,6 +137,11 @@ public:
     /// </summary>
     virtual std::unique_ptr<ISurface> CreateTransparentSurface(int nWidth, int nHeight) const = 0;
 
+    /// <summary>
+    /// Saves the provided surface to the specified file.
+    /// </summary>
+    virtual bool SaveImage(const ISurface& pSurface, const std::wstring& sPath) const = 0;
+
 protected:
     ISurfaceFactory() noexcept = default;
 };

--- a/src/ui/drawing/gdi/GDIBitmapSurface.cpp
+++ b/src/ui/drawing/gdi/GDIBitmapSurface.cpp
@@ -7,7 +7,12 @@ namespace ui {
 namespace drawing {
 namespace gdi {
 
-void GDIAlphaBitmapSurface::FillRectangle(int nX, int nY, int nWidth, int nHeight, Color nColor) noexcept
+void GDIBitmapSurface::CopyFromWindow(HDC hDC, int srcX, int srcY, int srcWidth, int srcHeight, int dstX, int dstY)
+{
+    ::BitBlt(m_hMemDC, dstX, dstY, srcWidth, srcHeight, hDC, srcX, srcY, SRCCOPY);
+}
+
+void GDIBitmapSurface::FillRectangle(int nX, int nY, int nWidth, int nHeight, Color nColor) noexcept
 {
     // clip to surface
     auto nStride = ra::to_signed(GetWidth());
@@ -71,7 +76,7 @@ static constexpr uint8_t BlendPixel(std::uint8_t nTarget, std::uint8_t nBlend, s
     return gsl::narrow_cast<std::uint8_t>(((nBlend * nAlpha) + (nTarget * (256 - nAlpha))) / 256);
 }
 
-void GDIAlphaBitmapSurface::WriteText(int nX, int nY, int nFont, Color nColor, const std::wstring& sText)
+void GDIBitmapSurface::WriteText(int nX, int nY, int nFont, Color nColor, const std::wstring& sText)
 {
     if (sText.empty())
         return;

--- a/src/ui/drawing/gdi/GDIBitmapSurface.cpp
+++ b/src/ui/drawing/gdi/GDIBitmapSurface.cpp
@@ -7,7 +7,7 @@ namespace ui {
 namespace drawing {
 namespace gdi {
 
-void GDIBitmapSurface::CopyFromWindow(HDC hDC, int srcX, int srcY, int srcWidth, int srcHeight, int dstX, int dstY)
+void GDIBitmapSurface::CopyFromWindow(HDC hDC, int srcX, int srcY, int srcWidth, int srcHeight, int dstX, int dstY) noexcept
 {
     ::BitBlt(m_hMemDC, dstX, dstY, srcWidth, srcHeight, hDC, srcX, srcY, SRCCOPY);
 }
@@ -91,7 +91,7 @@ void GDIBitmapSurface::WriteText(int nX, int nY, int nFont, Color nColor, const 
     SwitchFont(nFont);
 
     SIZE szText;
-    GetTextExtentPoint32W(m_hDC, sText.c_str(), sText.length(), &szText);
+    GetTextExtentPoint32W(m_hDC, sText.c_str(), gsl::narrow_cast<int>(sText.length()), &szText);
 
     // clip to surface
     if (szText.cx > nStride - nX)
@@ -127,7 +127,7 @@ void GDIBitmapSurface::WriteText(int nX, int nY, int nFont, Color nColor, const 
     SetTextColor(hMemDC, RGB(255, 255, 255));
     SetBkMode(hMemDC, TRANSPARENT);
     RECT rcRect{0, 0, szText.cx, szText.cy};
-    TextOutW(hMemDC, 0, 0, sText.c_str(), sText.length());
+    TextOutW(hMemDC, 0, 0, sText.c_str(), gsl::narrow_cast<int>(sText.length()));
 
     // copy the greyscale text to the forground using the grey value as the alpha for antialiasing
     auto nFirstScanline = (GetHeight() - nY - szText.cy); // bitmap memory starts with the bottom scanline

--- a/src/ui/drawing/gdi/GDIBitmapSurface.hh
+++ b/src/ui/drawing/gdi/GDIBitmapSurface.hh
@@ -38,6 +38,13 @@ public:
             DeleteDC(m_hMemDC);
     }
 
+    void CopyFromWindow(HDC hDC, int srcX, int srcY, int srcWidth, int srcHeight, int dstX, int dstY);
+
+    void FillRectangle(int nX, int nY, int nWidth, int nHeight, Color nColor) noexcept override;
+    void WriteText(int nX, int nY, int nFont, Color nColor, const std::wstring& sText) override;
+
+    HBITMAP GetHBitmap() const noexcept { return m_hBitmap; }
+
 protected:
     std::uint32_t* m_pBits; // see note below about initializing this
 
@@ -93,9 +100,6 @@ public:
     GDIAlphaBitmapSurface(GDIAlphaBitmapSurface&&) noexcept = delete;
     GDIAlphaBitmapSurface& operator=(GDIAlphaBitmapSurface&&) noexcept = delete;
 
-    void FillRectangle(int nX, int nY, int nWidth, int nHeight, Color nColor) noexcept override;
-    void WriteText(int nX, int nY, int nFont, Color nColor, const std::wstring& sText) override;
-
     void Blend(HDC hTargetDC, int nX, int nY) const noexcept;
 
     void SetOpacity(double fAlpha) override;
@@ -118,6 +122,8 @@ public:
         auto pSurface = std::make_unique<GDIAlphaBitmapSurface>(nWidth, nHeight, m_oResourceRepository);
         return std::unique_ptr<ISurface>(pSurface.release());
     }
+
+    bool SaveImage(const ISurface& pSurface, const std::wstring& sPath) const;
 
 private:
     mutable ResourceRepository m_oResourceRepository;

--- a/src/ui/drawing/gdi/GDIBitmapSurface.hh
+++ b/src/ui/drawing/gdi/GDIBitmapSurface.hh
@@ -38,7 +38,7 @@ public:
             DeleteDC(m_hMemDC);
     }
 
-    void CopyFromWindow(HDC hDC, int srcX, int srcY, int srcWidth, int srcHeight, int dstX, int dstY);
+    void CopyFromWindow(HDC hDC, int srcX, int srcY, int srcWidth, int srcHeight, int dstX, int dstY) noexcept;
 
     void FillRectangle(int nX, int nY, int nWidth, int nHeight, Color nColor) noexcept override;
     void WriteText(int nX, int nY, int nFont, Color nColor, const std::wstring& sText) override;
@@ -123,7 +123,7 @@ public:
         return std::unique_ptr<ISurface>(pSurface.release());
     }
 
-    bool SaveImage(const ISurface& pSurface, const std::wstring& sPath) const;
+    bool SaveImage(const ISurface& pSurface, const std::wstring& sPath) const override;
 
 private:
     mutable ResourceRepository m_oResourceRepository;

--- a/src/ui/drawing/gdi/GDISurface.cpp
+++ b/src/ui/drawing/gdi/GDISurface.cpp
@@ -18,8 +18,10 @@ GDISurface::GDISurface(HDC hDC, const RECT& rcDEST, ResourceRepository& pResourc
 void GDISurface::FillRectangle(int nX, int nY, int nWidth, int nHeight, Color nColor) noexcept
 {
     assert(nColor.Channel.A == 0xFF || nColor.Channel.A == 0x00);
-    SetDCBrushColor(m_hDC, RGB(nColor.Channel.R, nColor.Channel.G, nColor.Channel.B));
-    SetDCPenColor(m_hDC, RGB(nColor.Channel.R, nColor.Channel.G, nColor.Channel.B));
+
+    COLORREF pColorRef = RGB(nColor.Channel.R, nColor.Channel.G, nColor.Channel.B);
+    SetDCBrushColor(m_hDC, pColorRef);
+    SetDCPenColor(m_hDC, pColorRef);
     Rectangle(m_hDC, nX, nY, nX + nWidth, nY + nHeight);
 }
 

--- a/src/ui/drawing/gdi/GDISurface.cpp
+++ b/src/ui/drawing/gdi/GDISurface.cpp
@@ -19,7 +19,7 @@ void GDISurface::FillRectangle(int nX, int nY, int nWidth, int nHeight, Color nC
 {
     assert(nColor.Channel.A == 0xFF || nColor.Channel.A == 0x00);
 
-    COLORREF pColorRef = RGB(nColor.Channel.R, nColor.Channel.G, nColor.Channel.B);
+    const COLORREF pColorRef = RGB(nColor.Channel.R, nColor.Channel.G, nColor.Channel.B);
     SetDCBrushColor(m_hDC, pColorRef);
     SetDCPenColor(m_hDC, pColorRef);
     Rectangle(m_hDC, nX, nY, nX + nWidth, nY + nHeight);
@@ -35,7 +35,7 @@ ra::ui::Size GDISurface::MeasureText(int nFont, const std::wstring& sText) const
     SwitchFont(nFont);
 
     SIZE szText;
-    GetTextExtentPoint32W(m_hDC, sText.c_str(), sText.length(), &szText);
+    GetTextExtentPoint32W(m_hDC, sText.c_str(), gsl::narrow_cast<int>(sText.length()), &szText);
 
     return ra::ui::Size{ szText.cx, szText.cy };
 }
@@ -51,7 +51,7 @@ void GDISurface::WriteText(int nX, int nY, int nFont, Color nColor, const std::w
     }
 
     SetBkMode(m_hDC, TRANSPARENT);
-    TextOutW(m_hDC, nX, nY, sText.c_str(), sText.length());
+    TextOutW(m_hDC, nX, nY, sText.c_str(), gsl::narrow_cast<int>(sText.length()));
 }
 
 void GDISurface::SwitchFont(int nFont) const

--- a/src/ui/drawing/gdi/GDISurface.hh
+++ b/src/ui/drawing/gdi/GDISurface.hh
@@ -24,8 +24,8 @@ public:
 
     ~GDISurface() noexcept = default;
 
-    size_t GetWidth() const noexcept override { return m_nWidth; }
-    size_t GetHeight() const noexcept override { return m_nHeight; }
+    unsigned int GetWidth() const noexcept override { return m_nWidth; }
+    unsigned int GetHeight() const noexcept override { return m_nHeight; }
 
     void FillRectangle(int nX, int nY, int nWidth, int nHeight, Color nColor) noexcept override;
 
@@ -50,8 +50,8 @@ protected:
     ResourceRepository& m_pResourceRepository;
 
 private:
-    int m_nWidth{};
-    int m_nHeight{};
+    unsigned int m_nWidth{};
+    unsigned int m_nHeight{};
 
     ResourceRepository m_oResourceRepository;
 

--- a/src/ui/drawing/gdi/ImageRepository.cpp
+++ b/src/ui/drawing/gdi/ImageRepository.cpp
@@ -1,5 +1,7 @@
 #include "ImageRepository.hh"
 
+#include "GDIBitmapSurface.hh"
+
 #include "RA_Core.h"
 
 #include "services\Http.hh"
@@ -513,6 +515,62 @@ bool ImageRepository::HasReferencedImageChanged(ImageReference& pImage) const
     const auto hBitmapBefore = pImage.m_nData;
     GetHBitmap(pImage); // TBD: Is the return value supposed to be discarded?
     return (pImage.m_nData != hBitmapBefore);
+}
+
+bool GDISurfaceFactory::SaveImage(const ISurface& pSurface, const std::wstring& sPath) const
+{
+    if (g_pIWICFactory == nullptr)
+        return false;
+
+    const auto* pGDIBitmapSurface = dynamic_cast<const GDIBitmapSurface*>(&pSurface);
+    if (pGDIBitmapSurface == nullptr)
+        return false;
+
+    // create a PNG encoder
+    CComPtr<IWICBitmapEncoder> pEncoder;
+    HRESULT hr = g_pIWICFactory->CreateEncoder(GUID_ContainerFormatPng, NULL, &pEncoder);
+
+    // open the file stream
+    CComPtr<IWICStream> pStream;
+    if (SUCCEEDED(hr))
+        hr = g_pIWICFactory->CreateStream(&pStream);
+
+    if (SUCCEEDED(hr))
+        hr = pStream->InitializeFromFilename(sPath.c_str(), GENERIC_WRITE);
+
+    if (SUCCEEDED(hr))
+        hr = pEncoder->Initialize(pStream, WICBitmapEncoderNoCache);
+
+    // convert the image to a WICBitmap
+    CComPtr<IWICBitmapFrameEncode> pFrameEncode;
+    if (SUCCEEDED(hr))
+        hr = pEncoder->CreateNewFrame(&pFrameEncode, NULL);
+
+    if (SUCCEEDED(hr))
+        hr = pFrameEncode->Initialize(NULL);
+
+    if (SUCCEEDED(hr))
+        hr = pFrameEncode->SetSize(pSurface.GetWidth(), pSurface.GetHeight());
+
+    WICPixelFormatGUID pixelFormat = GUID_WICPixelFormatDontCare;
+    if (SUCCEEDED(hr))
+        hr = pFrameEncode->SetPixelFormat(&pixelFormat);
+
+    CComPtr<IWICBitmap> pWicBitmap;
+    if (SUCCEEDED(hr))
+        hr = g_pIWICFactory->CreateBitmapFromHBITMAP(pGDIBitmapSurface->GetHBitmap(), NULL, WICBitmapIgnoreAlpha, &pWicBitmap);
+
+    // write the image to the file
+    if (SUCCEEDED(hr))
+        hr = pFrameEncode->WriteSource(pWicBitmap, NULL);
+
+    if (SUCCEEDED(hr))
+        pFrameEncode->Commit();
+
+    if (SUCCEEDED(hr))
+        pEncoder->Commit();
+
+    return SUCCEEDED(hr);
 }
 
 } // namespace gdi

--- a/src/ui/drawing/gdi/ImageRepository.cpp
+++ b/src/ui/drawing/gdi/ImageRepository.cpp
@@ -335,7 +335,7 @@ static HRESULT CreateDIBFromBitmapSource(_In_ IWICBitmapSource* pToRenderBitmapS
     return hr;
 }
 
-HBITMAP ImageRepository::LoadLocalPNG(const std::wstring& sFilename, size_t nWidth, size_t nHeight)
+HBITMAP ImageRepository::LoadLocalPNG(const std::wstring& sFilename, unsigned int nWidth, unsigned int nHeight)
 {
     if (g_pIWICFactory == nullptr)
         return nullptr;
@@ -429,7 +429,7 @@ HBITMAP ImageRepository::GetImage(ImageType nType, const std::string& sName)
         return nullptr;
     }
 
-    const size_t nSize = (nType == ImageType::Local) ? 0 : 64;
+    const unsigned int nSize = (nType == ImageType::Local) ? 0 : 64;
     HBITMAP hBitmap = LoadLocalPNG(sFilename, nSize, nSize);
     if (hBitmap != nullptr)
     {
@@ -456,7 +456,7 @@ HBITMAP ImageRepository::GetHBitmap(const ImageReference& pImage)
             if (hBitmap == nullptr)
                 return pImageRepository->GetDefaultImage(pImage.Type());
 
-            GSL_SUPPRESS_TYPE1 pImage.m_nData = reinterpret_cast<unsigned long>(hBitmap);
+            GSL_SUPPRESS_TYPE1 pImage.m_nData = reinterpret_cast<unsigned long long>(hBitmap);
 
             // ImageReference will release the reference
             pImageRepository->AddReference(pImage);
@@ -528,7 +528,7 @@ bool GDISurfaceFactory::SaveImage(const ISurface& pSurface, const std::wstring& 
 
     // create a PNG encoder
     CComPtr<IWICBitmapEncoder> pEncoder;
-    HRESULT hr = g_pIWICFactory->CreateEncoder(GUID_ContainerFormatPng, NULL, &pEncoder);
+    HRESULT hr = g_pIWICFactory->CreateEncoder(GUID_ContainerFormatPng, nullptr, &pEncoder);
 
     // open the file stream
     CComPtr<IWICStream> pStream;
@@ -544,25 +544,26 @@ bool GDISurfaceFactory::SaveImage(const ISurface& pSurface, const std::wstring& 
     // convert the image to a WICBitmap
     CComPtr<IWICBitmapFrameEncode> pFrameEncode;
     if (SUCCEEDED(hr))
-        hr = pEncoder->CreateNewFrame(&pFrameEncode, NULL);
+        hr = pEncoder->CreateNewFrame(&pFrameEncode, nullptr);
 
     if (SUCCEEDED(hr))
-        hr = pFrameEncode->Initialize(NULL);
+        hr = pFrameEncode->Initialize(nullptr);
 
     if (SUCCEEDED(hr))
         hr = pFrameEncode->SetSize(pSurface.GetWidth(), pSurface.GetHeight());
 
-    WICPixelFormatGUID pixelFormat = GUID_WICPixelFormatDontCare;
+    WICPixelFormatGUID pixelFormat;
+    GSL_SUPPRESS_CON4 pixelFormat = GUID_WICPixelFormatDontCare;
     if (SUCCEEDED(hr))
         hr = pFrameEncode->SetPixelFormat(&pixelFormat);
 
     CComPtr<IWICBitmap> pWicBitmap;
     if (SUCCEEDED(hr))
-        hr = g_pIWICFactory->CreateBitmapFromHBITMAP(pGDIBitmapSurface->GetHBitmap(), NULL, WICBitmapIgnoreAlpha, &pWicBitmap);
+        hr = g_pIWICFactory->CreateBitmapFromHBITMAP(pGDIBitmapSurface->GetHBitmap(), nullptr, WICBitmapIgnoreAlpha, &pWicBitmap);
 
     // write the image to the file
     if (SUCCEEDED(hr))
-        hr = pFrameEncode->WriteSource(pWicBitmap, NULL);
+        hr = pFrameEncode->WriteSource(pWicBitmap, nullptr);
 
     if (SUCCEEDED(hr))
         pFrameEncode->Commit();

--- a/src/ui/drawing/gdi/ImageRepository.hh
+++ b/src/ui/drawing/gdi/ImageRepository.hh
@@ -48,7 +48,7 @@ public:
 
 private:
     static std::wstring GetFilename(ImageType nType, const std::string& sName);
-    static HBITMAP LoadLocalPNG(const std::wstring& sFilename, size_t nWidth, size_t nHeight);
+    static HBITMAP LoadLocalPNG(const std::wstring& sFilename, unsigned int nWidth, unsigned int nHeight);
 
     HBITMAP GetImage(ImageType nType, const std::string& sName);
     HBITMAP GetDefaultImage(ImageType nType);

--- a/src/ui/drawing/gdi/ResourceRepository.hh
+++ b/src/ui/drawing/gdi/ResourceRepository.hh
@@ -50,7 +50,7 @@ public:
         if (hFont)
         {
             m_vFonts.emplace_back(sFont, nFontSize, nStyle, hFont);
-            return m_vFonts.size();
+            return gsl::narrow_cast<int>(m_vFonts.size());
         }
 
         return 0;

--- a/src/ui/viewmodels/OverlayManager.cpp
+++ b/src/ui/viewmodels/OverlayManager.cpp
@@ -16,7 +16,7 @@ namespace ra {
 namespace ui {
 namespace viewmodels {
 
-static int GetAbsolutePosition(int nValue, RelativePosition nRelativePosition, size_t nFarValue) noexcept
+static int GetAbsolutePosition(int nValue, RelativePosition nRelativePosition, unsigned int nFarValue) noexcept
 {
     switch (nRelativePosition)
     {
@@ -331,6 +331,7 @@ void OverlayManager::UpdateActiveMessage(ra::ui::drawing::ISurface& pSurface, do
     assert(!m_vPopupMessages.empty());
 
     auto* pActiveMessage = m_vPopupMessages.front().get();
+    Expects(pActiveMessage != nullptr);
     UpdatePopup(pSurface, fElapsed, *pActiveMessage);
 
     while (pActiveMessage->IsAnimationComplete() || pActiveMessage->IsDestroyPending())
@@ -340,6 +341,7 @@ void OverlayManager::UpdateActiveMessage(ra::ui::drawing::ISurface& pSurface, do
             break;
 
         pActiveMessage = m_vPopupMessages.front().get();
+        Expects(pActiveMessage != nullptr);
         pActiveMessage->BeginAnimation();
         pActiveMessage->UpdateRenderImage(0.0);
     }
@@ -582,7 +584,7 @@ std::unique_ptr<ra::ui::drawing::ISurface> OverlayManager::RenderScreenshot(cons
     {
         auto pTransparentPopup = pSurfaceFactory.CreateTransparentSurface(pPopupImage.GetWidth(), pPopupImage.GetHeight());
         pTransparentPopup->DrawSurface(0, 0, pPopupImage);
-        pTransparentPopup->SetOpacity(0.85);
+        pTransparentPopup->SetOpacity(0.90);
         pSurface->DrawSurface(nX, nY, *pTransparentPopup);
     }
     else

--- a/src/ui/viewmodels/OverlayManager.hh
+++ b/src/ui/viewmodels/OverlayManager.hh
@@ -149,6 +149,16 @@ public:
     }
 
     /// <summary>
+    /// Captures a screenshot with the associated message
+    /// </summary>
+    void CaptureScreenshot(int nMessageId, const std::wstring& sPath);
+
+    /// <summary>
+    /// Advances the frame counter to indicate the capture screen is no longer valid.
+    /// </summary>
+    void AdvanceFrame() noexcept { ++m_nFrameId; }
+
+    /// <summary>
     /// Adds a score tracker for a leaderboard.
     /// </summary>
     ScoreTrackerViewModel& AddScoreTracker(ra::LeaderboardID nLeaderboardId);
@@ -228,6 +238,9 @@ public:
         m_fHandleHideRequest = std::move(fHandleHideRequest);
     }
 
+    /// <summary>
+    /// Gets whether or not there is something visible to render on the overlay
+    /// </summary>
     bool NeedsRender() const noexcept;
 
 protected:
@@ -252,6 +265,9 @@ private:
 
     void UpdateOverlay(ra::ui::drawing::ISurface& pSurface, double fElapsed);
 
+    void ProcessScreenshots();
+    std::unique_ptr<ra::ui::drawing::ISurface> RenderScreenshot(const ra::ui::drawing::ISurface& pClientSurface, const PopupMessageViewModel& vmPopup);
+
     bool m_bRedrawAll = false;
     std::chrono::steady_clock::time_point m_tLastRender{};
     std::function<void()> m_fHandleRenderRequest;
@@ -259,6 +275,18 @@ private:
     std::function<void()> m_fHandleHideRequest;
 
     std::atomic<int> m_nPopupId{ 0 };
+
+    int m_nFrameId = 0;
+
+    struct Screenshot
+    {
+        int nFrameId;
+        std::unique_ptr<ra::ui::drawing::ISurface> pScreen;
+        std::map<int, std::wstring> vMessages;
+    };
+    std::vector<Screenshot> m_vScreenshotQueue;
+    std::mutex m_pScreenshotQueueMutex;
+    bool m_bProcessingScreenshots = false;
 };
 
 } // namespace viewmodels

--- a/src/ui/viewmodels/OverlayManager.hh
+++ b/src/ui/viewmodels/OverlayManager.hh
@@ -280,7 +280,7 @@ private:
 
     struct Screenshot
     {
-        int nFrameId;
+        int nFrameId = 0;
         std::unique_ptr<ra::ui::drawing::ISurface> pScreen;
         std::map<int, std::wstring> vMessages;
     };

--- a/src/ui/viewmodels/OverlayManager.hh
+++ b/src/ui/viewmodels/OverlayManager.hh
@@ -82,17 +82,17 @@ public:
     /// <summary>
     /// Queues a popup message.
     /// </summary>
-    int QueueMessage(PopupMessageViewModel&& pMessage);
+    int QueueMessage(std::unique_ptr<PopupMessageViewModel>& pMessage);
 
     /// <summary>
     /// Queues a popup message.
     /// </summary>
     int QueueMessage(const std::wstring& sTitle, const std::wstring& sDescription)
     {
-        PopupMessageViewModel vmMessage;
-        vmMessage.SetTitle(sTitle);
-        vmMessage.SetDescription(sDescription);
-        return QueueMessage(std::move(vmMessage));
+        std::unique_ptr<PopupMessageViewModel> vmMessage(new PopupMessageViewModel);
+        vmMessage->SetTitle(sTitle);
+        vmMessage->SetDescription(sDescription);
+        return QueueMessage(vmMessage);
     }
 
     /// <summary>
@@ -100,11 +100,11 @@ public:
     /// </summary>
     int QueueMessage(const std::wstring& sTitle, const std::wstring& sDescription, const std::wstring& sDetail)
     {
-        PopupMessageViewModel vmMessage;
-        vmMessage.SetTitle(sTitle);
-        vmMessage.SetDescription(sDescription);
-        vmMessage.SetDetail(sDetail);
-        return QueueMessage(std::move(vmMessage));
+        std::unique_ptr<PopupMessageViewModel> vmMessage(new PopupMessageViewModel);
+        vmMessage->SetTitle(sTitle);
+        vmMessage->SetDescription(sDescription);
+        vmMessage->SetDetail(sDetail);
+        return QueueMessage(vmMessage);
     }
 
     /// <summary>
@@ -112,11 +112,11 @@ public:
     /// </summary>
     int QueueMessage(const std::wstring& sTitle, const std::wstring& sDescription, ra::ui::ImageType nImageType, const std::string& sImageName)
     {
-        PopupMessageViewModel vmMessage;
-        vmMessage.SetTitle(sTitle);
-        vmMessage.SetDescription(sDescription);
-        vmMessage.SetImage(nImageType, sImageName);
-        return QueueMessage(std::move(vmMessage));
+        std::unique_ptr<PopupMessageViewModel> vmMessage(new PopupMessageViewModel);
+        vmMessage->SetTitle(sTitle);
+        vmMessage->SetDescription(sDescription);
+        vmMessage->SetImage(nImageType, sImageName);
+        return QueueMessage(vmMessage);
     }
 
     /// <summary>
@@ -124,12 +124,12 @@ public:
     /// </summary>
     int QueueMessage(const std::wstring& sTitle, const std::wstring& sDescription, const std::wstring& sDetail, ra::ui::ImageType nImageType, const std::string& sImageName)
     {
-        PopupMessageViewModel vmMessage;
-        vmMessage.SetTitle(sTitle);
-        vmMessage.SetDescription(sDescription);
-        vmMessage.SetDetail(sDetail);
-        vmMessage.SetImage(nImageType, sImageName);
-        return QueueMessage(std::move(vmMessage));
+        std::unique_ptr<PopupMessageViewModel> vmMessage(new PopupMessageViewModel);
+        vmMessage->SetTitle(sTitle);
+        vmMessage->SetDescription(sDescription);
+        vmMessage->SetDetail(sDetail);
+        vmMessage->SetImage(nImageType, sImageName);
+        return QueueMessage(vmMessage);
     }
 
     /// <summary>
@@ -141,8 +141,8 @@ public:
     {
         for (auto& pMessage : m_vPopupMessages)
         {
-            if (pMessage.GetPopupId() == nId)
-                return &pMessage;
+            if (pMessage->GetPopupId() == nId)
+                return pMessage.get();
         }
 
         return nullptr;
@@ -245,7 +245,7 @@ public:
 
 protected:
     ra::ui::viewmodels::OverlayViewModel m_vmOverlay;
-    std::deque<PopupMessageViewModel> m_vPopupMessages;
+    std::deque<std::unique_ptr<PopupMessageViewModel>> m_vPopupMessages;
     std::vector<std::unique_ptr<ScoreTrackerViewModel>> m_vScoreTrackers;
     std::deque<ScoreboardViewModel> m_vScoreboards;
 

--- a/src/ui/viewmodels/PopupMessageViewModel.cpp
+++ b/src/ui/viewmodels/PopupMessageViewModel.cpp
@@ -137,7 +137,7 @@ void PopupMessageViewModel::CreateRenderImage()
     }
 
     {
-        RenderImageLock(*this);
+        RenderImageLock lock(*this);
 
         m_pSurface = std::move(pSurface);
     }

--- a/src/ui/viewmodels/PopupMessageViewModel.cpp
+++ b/src/ui/viewmodels/PopupMessageViewModel.cpp
@@ -93,48 +93,53 @@ void PopupMessageViewModel::CreateRenderImage()
     const int nHeight = 4 + nImageSize + 4 + nShadowOffset;
 
     pSurface = pSurfaceFactory.CreateSurface(nWidth, nHeight);
-    m_pSurface = std::move(pSurface);
 
     int nX = 4;
     int nY = 4;
 
     // background
-    m_pSurface->FillRectangle(0, 0, m_pSurface->GetWidth(), m_pSurface->GetHeight(), ra::ui::Color::Transparent);
-    m_pSurface->FillRectangle(nShadowOffset, nShadowOffset, m_pSurface->GetWidth() - nShadowOffset, m_pSurface->GetHeight() - nShadowOffset, pOverlayTheme.ColorShadow());
+    pSurface->FillRectangle(0, 0, nWidth, nHeight, ra::ui::Color::Transparent);
+    pSurface->FillRectangle(nShadowOffset, nShadowOffset, nWidth - nShadowOffset, nHeight - nShadowOffset, pOverlayTheme.ColorShadow());
 
     // frame
-    m_pSurface->FillRectangle(0, 0, m_pSurface->GetWidth() - nShadowOffset, m_pSurface->GetHeight() - nShadowOffset, pOverlayTheme.ColorBackground());
-    m_pSurface->FillRectangle(1, 1, m_pSurface->GetWidth() - nShadowOffset - 2, m_pSurface->GetHeight() - nShadowOffset - 2, pOverlayTheme.ColorBorder());
-    m_pSurface->FillRectangle(2, 2, m_pSurface->GetWidth() - nShadowOffset - 4, m_pSurface->GetHeight() - nShadowOffset - 4, pOverlayTheme.ColorBackground());
+    pSurface->FillRectangle(0, 0, nWidth - nShadowOffset, nHeight - nShadowOffset, pOverlayTheme.ColorBackground());
+    pSurface->FillRectangle(1, 1, nWidth - nShadowOffset - 2, nHeight - nShadowOffset - 2, pOverlayTheme.ColorBorder());
+    pSurface->FillRectangle(2, 2, nWidth - nShadowOffset - 4, nHeight - nShadowOffset - 4, pOverlayTheme.ColorBackground());
 
     // image
     if (m_hImage.Type() != ra::ui::ImageType::None)
     {
-        m_pSurface->DrawImage(nX, nY, nImageSize, nImageSize, m_hImage);
+        pSurface->DrawImage(nX, nY, nImageSize, nImageSize, m_hImage);
         nX += nImageSize;
     }
     nX += 6;
 
     // title
     nY -= 1;
-    m_pSurface->WriteText(nX + 2, nY + 2, nFontTitle, pOverlayTheme.ColorTextShadow(), sTitle);
-    m_pSurface->WriteText(nX, nY, nFontTitle, pOverlayTheme.ColorTitle(), sTitle);
+    pSurface->WriteText(nX + 2, nY + 2, nFontTitle, pOverlayTheme.ColorTextShadow(), sTitle);
+    pSurface->WriteText(nX, nY, nFontTitle, pOverlayTheme.ColorTitle(), sTitle);
     nX += nSubTitleIndent;
 
     // subtitle
     nY += pOverlayTheme.FontSizePopupTitle() - 1;
     if (!sSubTitle.empty())
     {
-        m_pSurface->WriteText(nX + 2, nY + 2, nFontSubtitle, pOverlayTheme.ColorTextShadow(), sSubTitle);
-        m_pSurface->WriteText(nX, nY, nFontSubtitle, pOverlayTheme.ColorDescription(), sSubTitle);
+        pSurface->WriteText(nX + 2, nY + 2, nFontSubtitle, pOverlayTheme.ColorTextShadow(), sSubTitle);
+        pSurface->WriteText(nX, nY, nFontSubtitle, pOverlayTheme.ColorDescription(), sSubTitle);
     }
 
     // detail
     nY += pOverlayTheme.FontSizePopupSubtitle();
     if (!sDetail.empty())
     {
-        m_pSurface->WriteText(nX + 2, nY + 2, nFontDetail, pOverlayTheme.ColorTextShadow(), sDetail);
-        m_pSurface->WriteText(nX, nY, nFontDetail, IsDetailError() ? pOverlayTheme.ColorError() : pOverlayTheme.ColorDetail(), sDetail);
+        pSurface->WriteText(nX + 2, nY + 2, nFontDetail, pOverlayTheme.ColorTextShadow(), sDetail);
+        pSurface->WriteText(nX, nY, nFontDetail, IsDetailError() ? pOverlayTheme.ColorError() : pOverlayTheme.ColorDetail(), sDetail);
+    }
+
+    {
+        RenderImageLock(*this);
+
+        m_pSurface = std::move(pSurface);
     }
 }
 

--- a/src/ui/viewmodels/PopupMessageViewModel.hh
+++ b/src/ui/viewmodels/PopupMessageViewModel.hh
@@ -11,12 +11,6 @@ namespace viewmodels {
 class PopupMessageViewModel : public PopupViewModelBase
 {
 public:
-    PopupMessageViewModel() = default;
-    PopupMessageViewModel(const PopupMessageViewModel&) = delete;
-    PopupMessageViewModel& operator=(const PopupMessageViewModel&) = delete;
-    PopupMessageViewModel(PopupMessageViewModel&&) = default;
-    PopupMessageViewModel& operator=(PopupMessageViewModel&&) = default;
-
     /// <summary>
     /// The <see cref="ModelProperty" /> for the title message.
     /// </summary>

--- a/src/ui/viewmodels/PopupMessageViewModel.hh
+++ b/src/ui/viewmodels/PopupMessageViewModel.hh
@@ -119,6 +119,11 @@ public:
         return (m_fAnimationProgress >= TOTAL_ANIMATION_TIME);
     }
 
+    /// <summary>
+    /// Gets the final Y location to render the popup at.
+    /// </summary>
+    int GetRenderTargetY() const noexcept { return m_nTargetY; }
+
 private:
     void CreateRenderImage();
     bool m_bSurfaceStale = false;

--- a/src/ui/viewmodels/PopupMessageViewModel.hh
+++ b/src/ui/viewmodels/PopupMessageViewModel.hh
@@ -11,6 +11,12 @@ namespace viewmodels {
 class PopupMessageViewModel : public PopupViewModelBase
 {
 public:
+    PopupMessageViewModel() = default;
+    PopupMessageViewModel(const PopupMessageViewModel&) = delete;
+    PopupMessageViewModel& operator=(const PopupMessageViewModel&) = delete;
+    PopupMessageViewModel(PopupMessageViewModel&&) = default;
+    PopupMessageViewModel& operator=(PopupMessageViewModel&&) = default;
+
     /// <summary>
     /// The <see cref="ModelProperty" /> for the title message.
     /// </summary>
@@ -124,9 +130,22 @@ public:
     /// </summary>
     int GetRenderTargetY() const noexcept { return m_nTargetY; }
 
+    class RenderImageLock
+    {
+    public:
+        RenderImageLock(PopupMessageViewModel& owner)
+            : m_pLock(owner.m_pSurfaceMutex)
+        {
+        }
+
+    private:
+        std::lock_guard<std::recursive_mutex> m_pLock;
+    };
+
 private:
     void CreateRenderImage();
     bool m_bSurfaceStale = false;
+    std::recursive_mutex m_pSurfaceMutex;
 
     double m_fAnimationProgress = -1.0;
     int m_nInitialY = 0;

--- a/src/ui/viewmodels/ScoreboardViewModel.cpp
+++ b/src/ui/viewmodels/ScoreboardViewModel.cpp
@@ -97,7 +97,7 @@ bool ScoreboardViewModel::UpdateRenderImage(double fElapsed)
             // get width of largest displayed rank so other ranks can be right-aligned with it
             const auto nRankSize = m_pSurface->MeasureText(nFontText, ra::ToWString(m_vEntries.GetItemAt(m_vEntries.Count() - 1)->GetRank()));
 
-            size_t nY = 4 + pTheme.FontSizePopupLeaderboardTitle() + 2;
+            int nY = 4 + pTheme.FontSizePopupLeaderboardTitle() + 2;
             size_t i = 0;
             while (i < NUM_ENTRIES && i < m_vEntries.Count())
             {

--- a/src/ui/win32/Desktop.cpp
+++ b/src/ui/win32/Desktop.cpp
@@ -2,6 +2,8 @@
 
 // Win32 specific implementation of Desktop.hh
 
+#include "ui/drawing/gdi/GDIBitmapSurface.hh"
+
 #include "ui/viewmodels/WindowManager.hh"
 
 #include "ui/win32/BrokenAchievementsDialog.hh"
@@ -168,6 +170,36 @@ void Desktop::OpenUrl(const std::string& sUrl) const noexcept
 {
     ShellExecute(nullptr, TEXT("open"), sUrl.c_str(), nullptr, nullptr, SW_SHOWNORMAL);
 }
+
+std::unique_ptr<ra::ui::drawing::ISurface> Desktop::CaptureClientArea(const WindowViewModelBase& vmViewModel) const
+{
+    std::unique_ptr<ra::ui::drawing::ISurface> pSurface;
+
+    const auto* const pBinding = ra::ui::win32::bindings::WindowBinding::GetBindingFor(vmViewModel);
+    if (pBinding != nullptr)
+    {
+        RECT rcClientArea;
+        ::GetClientRect(pBinding->GetHWnd(), &rcClientArea);
+
+        const auto& pSurfaceFactory = ra::services::ServiceLocator::Get<ra::ui::drawing::ISurfaceFactory>();
+        pSurface = pSurfaceFactory.CreateSurface(rcClientArea.right - rcClientArea.left, rcClientArea.bottom - rcClientArea.top);
+
+        auto* pGDISurface = dynamic_cast<ra::ui::drawing::gdi::GDIBitmapSurface*>(pSurface.get());
+        if (pGDISurface == nullptr)
+        {
+            pSurface.reset();
+        }
+        else
+        {
+            HDC hDC = GetDC(pBinding->GetHWnd());
+            pGDISurface->CopyFromWindow(hDC, 0, 0, pSurface->GetWidth(), pSurface->GetHeight(), 0, 0);
+            ReleaseDC(pBinding->GetHWnd(), hDC);
+        }
+    }
+
+    return pSurface;
+}
+
 
 void Desktop::Shutdown() noexcept
 {

--- a/src/ui/win32/Desktop.hh
+++ b/src/ui/win32/Desktop.hh
@@ -29,6 +29,8 @@ public:
     std::string GetRunningExecutable() const override;
     std::string GetOSVersionString() const override;
 
+    std::unique_ptr<ra::ui::drawing::ISurface> CaptureClientArea(const WindowViewModelBase& vmViewModel) const override;
+
 private:
     _Success_(return != nullptr)
     _NODISCARD IDialogPresenter* GetDialogPresenter(_In_ const WindowViewModelBase& oViewModel) const;

--- a/src/ui/win32/OverlayWindow.cpp
+++ b/src/ui/win32/OverlayWindow.cpp
@@ -105,7 +105,7 @@ DWORD OverlayWindow::OverlayWindowThread()
     }
 
     m_hOverlayWndThread = nullptr;
-    return msg.wParam;
+    return gsl::narrow_cast<DWORD>(msg.wParam);
 }
 
 void OverlayWindow::CreateOverlayWindow()

--- a/tests/mocks/MockConfiguration.hh
+++ b/tests/mocks/MockConfiguration.hh
@@ -38,8 +38,11 @@ public:
 
     unsigned int GetNumBackgroundThreads() const noexcept override { return m_nBackgroundThreads; }
 
-    const std::string& GetRomDirectory() const noexcept override { return m_sRomDirectory; }
-    void SetRomDirectory(const std::string& sValue) override { m_sRomDirectory = sValue; }
+    const std::wstring& GetRomDirectory() const noexcept override { return m_sRomDirectory; }
+    void SetRomDirectory(const std::wstring& sValue) override { m_sRomDirectory = sValue; }
+
+    const std::wstring& GetScreenshotDirectory() const noexcept override { return m_sScreenshotDirectory; }
+    void SetScreenshotDirectory(const std::wstring& sValue) override { m_sScreenshotDirectory = sValue; }
 
     ra::ui::Position GetWindowPosition([[maybe_unused]] const std::string& /*sPositionKey*/) const override
     {
@@ -87,7 +90,8 @@ private:
 
     std::string m_sUsername;
     std::string m_sApiToken;
-    std::string m_sRomDirectory;
+    std::wstring m_sRomDirectory;
+    std::wstring m_sScreenshotDirectory;
     std::string m_sHostName;
     std::string m_sHostUrl;
     std::string m_sImageHostUrl;

--- a/tests/mocks/MockDesktop.hh
+++ b/tests/mocks/MockDesktop.hh
@@ -55,6 +55,11 @@ public:
         m_sLastOpenedUrl = sUrl;
     }
 
+    std::unique_ptr<ra::ui::drawing::ISurface> CaptureClientArea(const WindowViewModelBase&) const override
+    {
+        return {};
+    }
+
     const std::string& LastOpenedUrl() const noexcept { return m_sLastOpenedUrl; }
 
     void Shutdown() noexcept override {}

--- a/tests/mocks/MockDesktop.hh
+++ b/tests/mocks/MockDesktop.hh
@@ -55,7 +55,7 @@ public:
         m_sLastOpenedUrl = sUrl;
     }
 
-    std::unique_ptr<ra::ui::drawing::ISurface> CaptureClientArea(const WindowViewModelBase&) const override
+    std::unique_ptr<ra::ui::drawing::ISurface> CaptureClientArea(const WindowViewModelBase&) const noexcept override
     {
         return {};
     }

--- a/tests/mocks/MockSurface.hh
+++ b/tests/mocks/MockSurface.hh
@@ -57,6 +57,11 @@ public:
         return std::make_unique<MockSurface>(nWidth, nHeight);
     }
 
+    bool SaveImage(const ISurface&, const std::wstring&) const
+    {
+        return false;
+    }
+
 private:
     ra::services::ServiceLocator::ServiceOverride<ISurfaceFactory> m_Override;
 };

--- a/tests/mocks/MockSurface.hh
+++ b/tests/mocks/MockSurface.hh
@@ -14,20 +14,20 @@ namespace mocks {
 class MockSurface : public ISurface
 {
 public:
-    MockSurface(size_t nWidth, size_t nHeight) noexcept
+    MockSurface(unsigned int nWidth, unsigned int nHeight) noexcept
         : m_nWidth(nWidth), m_nHeight(nHeight)
     {
     }
 
-    size_t GetWidth() const noexcept override { return m_nWidth; }
-    size_t GetHeight() const noexcept override { return m_nHeight; }
+    unsigned int GetWidth() const noexcept override { return m_nWidth; }
+    unsigned int GetHeight() const noexcept override { return m_nHeight; }
 
     void FillRectangle(int, int, int, int, Color) noexcept override {}
     int LoadFont(const std::string&, int, FontStyles) noexcept override { return 1; }
 
     ra::ui::Size MeasureText(int, const std::wstring& sText) const noexcept override
     {
-        return { ra::to_signed(sText.length()), 1 };
+        return { gsl::narrow_cast<int>(sText.length()), 1 };
     }
 
     void WriteText(int, int, int, Color, const std::wstring&) noexcept override {}
@@ -38,8 +38,8 @@ public:
     void SetOpacity(double) noexcept override {}
 
 private:
-    size_t m_nWidth;
-    size_t m_nHeight;
+    unsigned int m_nWidth;
+    unsigned int m_nHeight;
 };
 
 class MockSurfaceFactory : public ISurfaceFactory
@@ -57,7 +57,7 @@ public:
         return std::make_unique<MockSurface>(nWidth, nHeight);
     }
 
-    bool SaveImage(const ISurface&, const std::wstring&) const
+    bool SaveImage(const ISurface&, const std::wstring&) const noexcept override
     {
         return false;
     }


### PR DESCRIPTION
Currently requires manually editing the prefs file to enable. A future PR will will allow the user to enable the functionality and specify a location where the screenshots should be saved. Screenshots will not be taken for local unlocks or unlocks for modified achievements.

The screenshot captures the _client area_ of the window and the overlay. It does not capture the window frame/titlebar. It also currently uses the achievement ID as the filename. I want to change that to use the achievement title. However, there may be issues with validating the characters in the title, or uniqueness between games.

![83383](https://user-images.githubusercontent.com/32680403/64933322-efb9aa00-d801-11e9-8db4-46acdf0439ca.png)


