### PR TITLE
update to latest rcheevos

### DIFF
--- a/src/services/AchievementRuntime.cpp
+++ b/src/services/AchievementRuntime.cpp
@@ -167,7 +167,7 @@ _Use_decl_annotations_ void AchievementRuntime::Process(std::vector<Change>& cha
 
     for (auto& pLeaderboard : m_vActiveLeaderboards)
     {
-        unsigned int nValue;
+        int nValue;
         const int nResult = rc_evaluate_lboard(pLeaderboard.pLeaderboard, &nValue, rc_peek_callback, nullptr, nullptr);
         switch (nResult)
         {

--- a/src/services/AchievementRuntime.hh
+++ b/src/services/AchievementRuntime.hh
@@ -74,7 +74,7 @@ public:
     {
         ChangeType nType;
         unsigned int nId;
-        unsigned int nValue;
+        int nValue;
     };
 
     /// <summary>
@@ -132,7 +132,7 @@ protected:
 
         rc_lboard_t* pLeaderboard;
         unsigned int nId;
-        unsigned int nValue = 0;
+        int nValue = 0;
     };
 
     template<class TCollection, class TData>

--- a/tests/Exports_Tests.cpp
+++ b/tests/Exports_Tests.cpp
@@ -342,7 +342,7 @@ private:
     public:
         MockAchievementRuntime() noexcept : m_Override(this) {}
 
-        void QueueChange(ChangeType nType, unsigned int nId, unsigned int nValue = 0)
+        void QueueChange(ChangeType nType, unsigned int nId, int nValue = 0)
         {
             m_vChanges.emplace_back(Change{ nType, nId, nValue });
         }

--- a/tests/RA_Leaderboard_Tests.cpp
+++ b/tests/RA_Leaderboard_Tests.cpp
@@ -38,7 +38,7 @@ public:
         if (!m_pLeaderboard)
             return;
 
-        unsigned int nValue;
+        int nValue;
         const int nResult = rc_evaluate_lboard(static_cast<rc_lboard_t*>(m_pLeaderboard), &nValue, rc_peek_callback, nullptr, nullptr);
         switch (nResult)
         {
@@ -61,7 +61,7 @@ public:
 
 private:
     unsigned int m_nSubmittedScore = 0;
-    unsigned int m_nCurrentValue = 0;
+    int m_nCurrentValue = 0;
     bool m_bScoreSubmitted = false;
 };
 

--- a/tests/services/AchievementRuntime_Tests.cpp
+++ b/tests/services/AchievementRuntime_Tests.cpp
@@ -677,7 +677,7 @@ public:
         Assert::AreEqual(1U, vChanges.size());
         Assert::AreEqual(6U, vChanges.front().nId);
         Assert::AreEqual(AchievementRuntime::ChangeType::LeaderboardStarted, vChanges.front().nType);
-        Assert::AreEqual(52U, vChanges.front().nValue);
+        Assert::AreEqual(52, vChanges.front().nValue);
 
         // still active leaderboard should not notify unless the value changes
         vChanges.clear();
@@ -689,7 +689,7 @@ public:
         Assert::AreEqual(1U, vChanges.size());
         Assert::AreEqual(6U, vChanges.front().nId);
         Assert::AreEqual(AchievementRuntime::ChangeType::LeaderboardUpdated, vChanges.front().nType);
-        Assert::AreEqual(33U, vChanges.front().nValue);
+        Assert::AreEqual(33, vChanges.front().nValue);
         vChanges.clear();
 
         // leaderboard cancel condition should notify
@@ -712,7 +712,7 @@ public:
         Assert::AreEqual(1U, vChanges.size());
         Assert::AreEqual(6U, vChanges.front().nId);
         Assert::AreEqual(AchievementRuntime::ChangeType::LeaderboardStarted, vChanges.front().nType);
-        Assert::AreEqual(33U, vChanges.front().nValue);
+        Assert::AreEqual(33, vChanges.front().nValue);
         vChanges.clear();
 
         // leaderboard submit should trigger if leaderboard started
@@ -721,7 +721,7 @@ public:
         Assert::AreEqual(1U, vChanges.size());
         Assert::AreEqual(6U, vChanges.front().nId);
         Assert::AreEqual(AchievementRuntime::ChangeType::LeaderboardTriggered, vChanges.front().nType);
-        Assert::AreEqual(33U, vChanges.front().nValue);
+        Assert::AreEqual(33, vChanges.front().nValue);
         vChanges.clear();
 
         // leaderboard cancel condition should not trigger after submission
@@ -735,7 +735,7 @@ public:
         Assert::AreEqual(1U, vChanges.size());
         Assert::AreEqual(6U, vChanges.front().nId);
         Assert::AreEqual(AchievementRuntime::ChangeType::LeaderboardStarted, vChanges.front().nType);
-        Assert::AreEqual(33U, vChanges.front().nValue);
+        Assert::AreEqual(33, vChanges.front().nValue);
         vChanges.clear();
 
         // deactivated leaderboard should not trigger


### PR DESCRIPTION
includes fix for negative leaderboard values, fix for AddHits following AndNext (#422), and support for hours in time formats.

also includes support for Measured flag, which needs to be hooked up to the UI (future PR).