### PR TITLE
add dialog for overlay settings

### DIFF
--- a/src/RA_Core.cpp
+++ b/src/RA_Core.cpp
@@ -30,6 +30,7 @@
 #include "ui\viewmodels\LoginViewModel.hh"
 #include "ui\viewmodels\MessageBoxViewModel.hh"
 #include "ui\viewmodels\OverlayManager.hh"
+#include "ui\viewmodels\OverlaySettingsViewModel.hh"
 #include "ui\viewmodels\WindowManager.hh"
 #include "ui\win32\Desktop.hh"
 #include "ui\win32\OverlayWindow.hh"
@@ -282,7 +283,6 @@ API void CCONV _RA_OnReset()
 API HMENU CCONV _RA_CreatePopupMenu()
 {
     HMENU hRA = CreatePopupMenu();
-    HMENU hRA_LB = CreatePopupMenu();
     if (ra::services::ServiceLocator::Get<ra::data::UserContext>().IsLoggedIn())
     {
         AppendMenu(hRA, MF_STRING, IDM_RA_FILES_LOGOUT, TEXT("Log&out"));
@@ -295,28 +295,24 @@ API HMENU CCONV _RA_CreatePopupMenu()
 
         auto& pConfiguration = ra::services::ServiceLocator::Get<ra::services::IConfiguration>();
 
-        // TODO: Replace UINT_PTR{} with the _z literal after PR #23 gets accepted
         AppendMenu(hRA, nGameFlags, IDM_RA_OPENGAMEPAGE, TEXT("Open this &Game's Page"));
         AppendMenu(hRA, MF_SEPARATOR, 0U, nullptr);
+
         AppendMenu(hRA, pConfiguration.IsFeatureEnabled(ra::services::Feature::Hardcore) ? MF_CHECKED : MF_UNCHECKED, IDM_RA_HARDCORE_MODE, TEXT("&Hardcore Mode"));
         AppendMenu(hRA, pConfiguration.IsFeatureEnabled(ra::services::Feature::NonHardcoreWarning) ? MF_CHECKED : MF_UNCHECKED, IDM_RA_NON_HARDCORE_WARNING, TEXT("Non-Hardcore &Warning"));
         AppendMenu(hRA, MF_SEPARATOR, 0U, nullptr);
 
-        GSL_SUPPRESS_TYPE1 AppendMenu(hRA, MF_POPUP, reinterpret_cast<UINT_PTR>(hRA_LB), TEXT("Leaderboards"));
-        AppendMenu(hRA_LB, pConfiguration.IsFeatureEnabled(ra::services::Feature::Leaderboards) ? MF_CHECKED : MF_UNCHECKED, IDM_RA_TOGGLELEADERBOARDS, TEXT("Enable &Leaderboards"));
-        AppendMenu(hRA_LB, MF_SEPARATOR, 0U, nullptr);
-        AppendMenu(hRA_LB, pConfiguration.IsFeatureEnabled(ra::services::Feature::LeaderboardNotifications) ? MF_CHECKED : MF_UNCHECKED, IDM_RA_TOGGLE_LB_NOTIFICATIONS, TEXT("Display Start &Notification"));
-        AppendMenu(hRA_LB, pConfiguration.IsFeatureEnabled(ra::services::Feature::LeaderboardCancelNotifications) ? MF_CHECKED : MF_UNCHECKED, IDM_RA_TOGGLE_LB_CANCEL_NOTIFS, TEXT("Display Cancel N&otification"));
-        AppendMenu(hRA_LB, pConfiguration.IsFeatureEnabled(ra::services::Feature::LeaderboardCounters) ? MF_CHECKED : MF_UNCHECKED, IDM_RA_TOGGLE_LB_COUNTER, TEXT("Display Time/Score &Counter"));
-        AppendMenu(hRA_LB, pConfiguration.IsFeatureEnabled(ra::services::Feature::LeaderboardScoreboards) ? MF_CHECKED : MF_UNCHECKED, IDM_RA_TOGGLE_LB_SCOREBOARD, TEXT("Display Rank &Scoreboard"));
-
+        AppendMenu(hRA, pConfiguration.IsFeatureEnabled(ra::services::Feature::Leaderboards) ? MF_CHECKED : MF_UNCHECKED, IDM_RA_TOGGLELEADERBOARDS, TEXT("Enable &Leaderboards"));
+        AppendMenu(hRA, MF_STRING, IDM_RA_OVERLAYSETTINGS, TEXT("O&verlay Settings"));
         AppendMenu(hRA, MF_SEPARATOR, 0U, nullptr);
+
         AppendMenu(hRA, MF_STRING, IDM_RA_FILES_ACHIEVEMENTS, TEXT("Achievement &Sets"));
         AppendMenu(hRA, MF_STRING, IDM_RA_FILES_ACHIEVEMENTEDITOR, TEXT("Achievement &Editor"));
         AppendMenu(hRA, MF_STRING, IDM_RA_FILES_MEMORYFINDER, TEXT("&Memory Inspector"));
         AppendMenu(hRA, MF_STRING, IDM_RA_FILES_MEMORYBOOKMARKS, TEXT("Memory &Bookmarks"));
         AppendMenu(hRA, MF_STRING, IDM_RA_PARSERICHPRESENCE, TEXT("Rich &Presence Monitor"));
         AppendMenu(hRA, MF_SEPARATOR, 0U, nullptr);
+
         AppendMenu(hRA, MF_STRING, IDM_RA_REPORTBROKENACHIEVEMENTS, TEXT("&Report Achievement Problem"));
         AppendMenu(hRA, MF_STRING, IDM_RA_GETROMCHECKSUM, TEXT("Get ROM &Checksum"));
         //AppendMenu(hRA, MF_STRING, IDM_RA_SCANFORGAMES, TEXT("Scan &for games"));
@@ -596,43 +592,12 @@ API void CCONV _RA_InvokeDialog(LPARAM nID)
         }
         break;
 
-        case IDM_RA_TOGGLE_LB_NOTIFICATIONS:
+        case IDM_RA_OVERLAYSETTINGS:
         {
-            auto& pConfiguration = ra::services::ServiceLocator::GetMutable<ra::services::IConfiguration>();
-            pConfiguration.SetFeatureEnabled(ra::services::Feature::LeaderboardNotifications,
-                !pConfiguration.IsFeatureEnabled(ra::services::Feature::LeaderboardNotifications));
-
-            ra::services::ServiceLocator::Get<ra::data::EmulatorContext>().RebuildMenu();
-        }
-        break;
-
-        case IDM_RA_TOGGLE_LB_CANCEL_NOTIFS:
-        {
-            auto& pConfiguration = ra::services::ServiceLocator::GetMutable<ra::services::IConfiguration>();
-            pConfiguration.SetFeatureEnabled(ra::services::Feature::LeaderboardCancelNotifications,
-                !pConfiguration.IsFeatureEnabled(ra::services::Feature::LeaderboardCancelNotifications));
-
-            ra::services::ServiceLocator::Get<ra::data::EmulatorContext>().RebuildMenu();
-        }
-        break;
-
-        case IDM_RA_TOGGLE_LB_COUNTER:
-        {
-            auto& pConfiguration = ra::services::ServiceLocator::GetMutable<ra::services::IConfiguration>();
-            pConfiguration.SetFeatureEnabled(ra::services::Feature::LeaderboardCounters,
-                !pConfiguration.IsFeatureEnabled(ra::services::Feature::LeaderboardCounters));
-
-            ra::services::ServiceLocator::Get<ra::data::EmulatorContext>().RebuildMenu();
-        }
-        break;
-
-        case IDM_RA_TOGGLE_LB_SCOREBOARD:
-        {
-            auto& pConfiguration = ra::services::ServiceLocator::GetMutable<ra::services::IConfiguration>();
-            pConfiguration.SetFeatureEnabled(ra::services::Feature::LeaderboardScoreboards,
-                !pConfiguration.IsFeatureEnabled(ra::services::Feature::LeaderboardScoreboards));
-
-            ra::services::ServiceLocator::Get<ra::data::EmulatorContext>().RebuildMenu();
+            ra::ui::viewmodels::OverlaySettingsViewModel vmSettings;
+            vmSettings.Initialize();
+            if (vmSettings.ShowModal() == ra::ui::DialogResult::OK)
+                vmSettings.Commit();
         }
         break;
 

--- a/src/RA_Integration.vcxproj
+++ b/src/RA_Integration.vcxproj
@@ -98,6 +98,7 @@
     <ClCompile Include="ui\viewmodels\OverlayListPageViewModel.cpp" />
     <ClCompile Include="ui\viewmodels\OverlayManager.cpp" />
     <ClCompile Include="ui\viewmodels\OverlayRecentGamesPageViewModel.cpp" />
+    <ClCompile Include="ui\viewmodels\OverlaySettingsViewModel.cpp" />
     <ClCompile Include="ui\viewmodels\OverlayViewModel.cpp" />
     <ClCompile Include="ui\viewmodels\PopupMessageViewModel.cpp" />
     <ClCompile Include="ui\viewmodels\PopupViewModelBase.cpp" />
@@ -118,6 +119,7 @@
     <ClCompile Include="ui\win32\LoginDialog.cpp" />
     <ClCompile Include="ui\win32\MemoryBookmarksDialog.cpp" />
     <ClCompile Include="ui\win32\MessageBoxDialog.cpp" />
+    <ClCompile Include="ui\win32\OverlaySettingsDialog.cpp" />
     <ClCompile Include="ui\win32\OverlayWindow.cpp" />
     <ClCompile Include="ui\win32\RichPresenceDialog.cpp" />
     <ClCompile Include="ui\win32\UnknownGameDialog.cpp" />
@@ -240,6 +242,7 @@
     <ClInclude Include="ui\viewmodels\OverlayListPageViewModel.hh" />
     <ClInclude Include="ui\viewmodels\OverlayManager.hh" />
     <ClInclude Include="ui\viewmodels\OverlayRecentGamesPageViewModel.hh" />
+    <ClInclude Include="ui\viewmodels\OverlaySettingsViewModel.hh" />
     <ClInclude Include="ui\viewmodels\OverlayViewModel.hh" />
     <ClInclude Include="ui\viewmodels\PopupMessageViewModel.hh" />
     <ClInclude Include="ui\viewmodels\PopupViewModelBase.hh" />
@@ -270,6 +273,7 @@
     <ClInclude Include="ui\win32\LoginDialog.hh" />
     <ClInclude Include="ui\win32\MemoryBookmarksDialog.hh" />
     <ClInclude Include="ui\win32\MessageBoxDialog.hh" />
+    <ClInclude Include="ui\win32\OverlaySettingsDialog.hh" />
     <ClInclude Include="ui\win32\OverlayWindow.hh" />
     <ClInclude Include="ui\win32\RichPresenceDialog.hh" />
     <ClInclude Include="ui\win32\IDialogPresenter.hh" />

--- a/src/RA_Integration.vcxproj.filters
+++ b/src/RA_Integration.vcxproj.filters
@@ -282,6 +282,12 @@
     <ClCompile Include="ui\win32\bindings\GridAddressColumnBinding.cpp">
       <Filter>UI\Win32\Bindings</Filter>
     </ClCompile>
+    <ClCompile Include="ui\viewmodels\OverlaySettingsViewModel.cpp">
+      <Filter>UI\ViewModels</Filter>
+    </ClCompile>
+    <ClCompile Include="ui\win32\OverlaySettingsDialog.cpp">
+      <Filter>UI\Win32</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="RA_Achievement.h">
@@ -738,6 +744,12 @@
       <Filter>UI\ViewModels</Filter>
     </ClInclude>
     <ClInclude Include="ui\win32\FileDialog.hh">
+      <Filter>UI\Win32</Filter>
+    </ClInclude>
+    <ClInclude Include="ui\viewmodels\OverlaySettingsViewModel.hh">
+      <Filter>UI\ViewModels</Filter>
+    </ClInclude>
+    <ClInclude Include="ui\win32\OverlaySettingsDialog.hh">
       <Filter>UI\Win32</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/RA_Resource.h
+++ b/src/RA_Resource.h
@@ -2,28 +2,36 @@
 // Microsoft Visual C++ generated include file.
 // Used by RA_Shared.rc
 //
-#define IDD_RA_RICHPRESENCE             114
-#define IDD_RA_MEMBOOKMARK              117
-#define IDC_RA_RICHPRESENCERESULTTEXT   1022
-#define IDC_RA_LBX_ADDRESSES            1023
-#define IDC_RA_AVAILABLE1               1024 // available
-#define IDC_RA_DEL_BOOKMARK             1025
-#define IDC_RA_CLEAR_CHANGE             1026
-#define IDC_RA_MOVE_BOOKMARK_UP         1027
-#define IDC_RA_AVAILABLE2               1028 // available
-#define IDC_RA_MOVE_BOOKMARK_DOWN       1029
-#define IDC_RA_SAVEBOOKMARK             1030
-#define IDC_RA_LOADBOOKMARK             1031
-#define IDC_RA_RESULTS_BACK             1032
-#define IDC_RA_RESULTS_FORWARD          1033
-#define IDC_RA_RESULTS_REMOVE           1034
-#define IDC_RA_RESULTS_HIGHLIGHT        1035
-#define IDC_RA_SYSTEMNAME               1036
-#define IDC_RA_LINK                     1037
-#define IDC_RA_GAMENAME                 1038
-#define IDC_RA_SELECT_ACHIEVEMENTS      1039
-#define IDC_RA_PROBLEMHEADER            1040
-#define IDC_RA_BADGE_SPIN               1041
+#define IDD_RA_RICHPRESENCE             1100
+#define IDD_RA_MEMBOOKMARK              1101
+#define IDC_RA_RICHPRESENCERESULTTEXT   1102
+#define IDC_RA_LBX_ADDRESSES            1103
+#define IDC_RA_OPENPAGE                 1104
+#define IDC_RA_DEL_BOOKMARK             1105
+#define IDC_RA_CLEAR_CHANGE             1106
+#define IDC_RA_MOVE_BOOKMARK_UP         1107
+#define IDC_RA_BROWSE                   1108
+#define IDC_RA_MOVE_BOOKMARK_DOWN       1109
+#define IDC_RA_SAVEBOOKMARK             1110
+#define IDC_RA_LOADBOOKMARK             1111
+#define IDC_RA_RESULTS_BACK             1112
+#define IDC_RA_RESULTS_FORWARD          1113
+#define IDC_RA_RESULTS_REMOVE           1114
+#define IDC_RA_RESULTS_HIGHLIGHT        1115
+#define IDC_RA_SYSTEMNAME               1116
+#define IDC_RA_LINK                     1117
+#define IDC_RA_GAMENAME                 1118
+#define IDC_RA_SELECT_ACHIEVEMENTS      1119
+#define IDC_RA_PROBLEMHEADER            1120
+#define IDC_RA_BADGE_SPIN               1121
+#define IDC_RA_DISPLAY_TRIGGER          1122
+#define IDC_RA_SCREENSHOT_TRIGGER       1123
+#define IDC_RA_DISPLAY_LBOARD_START     1124
+#define IDC_RA_DISPLAY_LBOARD_CANCEL    1125
+#define IDC_RA_DISPLAY_LBOARD_VALUE     1126
+#define IDC_RA_DISPLAY_LBOARD_SCOREBOARD 1127
+#define IDC_RA_LOCATION                 1128
+#define IDC_RA_SCREENSHOT_LOCATION      1129
 #define IDD_RA_MEMORY                   1501
 #define IDD_RA_ACHIEVEMENTS             1502
 #define IDD_RA_ACHIEVEMENTEDITOR        1503
@@ -34,6 +42,7 @@
 #define IDD_RA_REPORTBROKENACHIEVEMENTS 1508
 #define IDD_RA_GAMELIBRARY              1509
 #define IDD_RA_ROMCHECKSUM              1510
+#define IDD_RA_OVERLAYSETTINGS          1511
 #define IDC_RA_TESTVAL                  1512
 #define IDC_RA_DOTEST                   1513
 #define IDC_RA_MEMSAVENOTE              1514
@@ -133,8 +142,7 @@
 #define IDC_RA_ROMCHECKSUMHEADER        1606
 #define IDM_RA_MENUSTART                1700
 #define IDM_RA_RETROACHIEVEMENTS        1700
-#define IDM_RA_FILES_TEST1              1701
-#define IDM_RA_FILES_TEST2              1702
+#define IDM_RA_OVERLAYSETTINGS          1701
 #define IDM_RA_FILES_MEMORYBOOKMARKS    1703
 #define IDM_RA_FILES_ACHIEVEMENTS       1704
 #define IDM_RA_FILES_MEMORYFINDER       1705
@@ -150,13 +158,8 @@
 #define IDM_RA_SCANFORGAMES             1715
 #define IDM_RA_PARSERICHPRESENCE        1716
 #define IDM_RA_TOGGLELEADERBOARDS       1717
-#define IDM_RA_TOGGLE_LB_NOTIFICATIONS  1718
-#define IDM_RA_TOGGLE_LB_COUNTER        1719
-#define IDM_RA_TOGGLE_LB_SCOREBOARD     1720
-#define IDM_RA_NON_HARDCORE_WARNING     1721
-#define IDM_RA_TOGGLE_LB_CANCEL_NOTIFS  1722
+#define IDM_RA_NON_HARDCORE_WARNING     1718
 #define IDM_RA_MENUEND                  1739
-#define IDC_RA_OPENPAGE                 1740
 
 // Next default values for new objects
 // 
@@ -164,7 +167,7 @@
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NEXT_RESOURCE_VALUE        121
 #define _APS_NEXT_COMMAND_VALUE         40001
-#define _APS_NEXT_CONTROL_VALUE         1042
+#define _APS_NEXT_CONTROL_VALUE         1130
 #define _APS_NEXT_SYMED_VALUE           101
 #endif
 #endif

--- a/src/RA_Shared.rc
+++ b/src/RA_Shared.rc
@@ -277,6 +277,31 @@ BEGIN
     PUSHBUTTON      "Move Down",IDC_RA_MOVE_BOOKMARK_DOWN,207,137,50,14
 END
 
+IDD_RA_OVERLAYSETTINGS DIALOGEX 0, 0, 199, 132
+STYLE DS_SYSMODAL | DS_SETFONT | DS_MODALFRAME | DS_FIXEDSYS | WS_POPUP | WS_CAPTION | WS_SYSMENU
+EXSTYLE WS_EX_TOPMOST
+CAPTION "Overlay Settings"
+FONT 8, "MS Shell Dlg", 400, 0, 0x1
+BEGIN
+    CONTROL         "Display &achievement triggered notification",IDC_RA_DISPLAY_TRIGGER,
+                    "Button",BS_AUTOCHECKBOX | BS_LEFT | WS_TABSTOP,6,6,187,10
+    CONTROL         "&Capture achievement triggered screenshot",IDC_RA_SCREENSHOT_TRIGGER,
+                    "Button",BS_AUTOCHECKBOX | BS_LEFT | WS_TABSTOP,6,17,187,10
+    CONTROL         "Display &leaderboard started notification",IDC_RA_DISPLAY_LBOARD_START,
+                    "Button",BS_AUTOCHECKBOX | BS_LEFT | WS_TABSTOP,6,34,187,10
+    CONTROL         "Display leader&board canceled notification",IDC_RA_DISPLAY_LBOARD_CANCEL,
+                    "Button",BS_AUTOCHECKBOX | BS_LEFT | WS_TABSTOP,6,45,187,10
+    CONTROL         "Display active leaderboard &time/score values",IDC_RA_DISPLAY_LBOARD_VALUE,
+                    "Button",BS_AUTOCHECKBOX | BS_LEFT | WS_TABSTOP,6,56,187,10
+    CONTROL         "Display &scoreboard after submitting leaderboard entry",IDC_RA_DISPLAY_LBOARD_SCOREBOARD,
+                    "Button",BS_AUTOCHECKBOX | BS_LEFT | WS_TABSTOP,6,67,187,10
+    LTEXT           "Screenshot &Location",IDC_RA_LOCATION,6,86,94,8
+    EDITTEXT        IDC_RA_SCREENSHOT_LOCATION,6,95,172,14,ES_AUTOHSCROLL
+    PUSHBUTTON      " ...",IDC_RA_BROWSE,178,95,15,14
+    DEFPUSHBUTTON   "OK",IDOK,100,112,44,14
+    PUSHBUTTON      "Cancel",IDCANCEL,148,112,44,14
+END
+
 
 /////////////////////////////////////////////////////////////////////////////
 //
@@ -476,6 +501,20 @@ BEGIN
         HORZGUIDE, 137
         HORZGUIDE, 151
     END
+
+    IDD_RA_OVERLAYSETTINGS, DIALOG
+    BEGIN
+        LEFTMARGIN, 6
+        RIGHTMARGIN, 193
+        VERTGUIDE, 100
+        VERTGUIDE, 144
+        VERTGUIDE, 148
+        TOPMARGIN, 6
+        BOTTOMMARGIN, 126
+        HORZGUIDE, 18
+        HORZGUIDE, 34
+        HORZGUIDE, 112
+    END
 END
 #endif    // APSTUDIO_INVOKED
 
@@ -557,6 +596,11 @@ BEGIN
 END
 
 IDD_RA_REPORTBROKENACHIEVEMENTS AFX_DIALOG_LAYOUT
+BEGIN
+    0
+END
+
+IDD_RA_OVERLAYSETTINGS AFX_DIALOG_LAYOUT
 BEGIN
     0
 END

--- a/src/data/GameContext.cpp
+++ b/src/data/GameContext.cpp
@@ -572,7 +572,7 @@ void GameContext::AwardAchievement(ra::AchievementID nAchievementId) const
         return;
 
     const auto& pConfiguration = ra::services::ServiceLocator::Get<ra::services::IConfiguration>();
-    bool bTakeScreenshot = pConfiguration.IsFeatureEnabled(ra::services::Feature::AchievementScreenshot);
+    bool bTakeScreenshot = pConfiguration.IsFeatureEnabled(ra::services::Feature::AchievementTriggeredScreenshot);
     bool bSubmit = false;
     bool bIsError = false;
 

--- a/src/services/IConfiguration.hh
+++ b/src/services/IConfiguration.hh
@@ -18,7 +18,8 @@ enum class Feature
     LeaderboardScoreboards,
     PreferDecimal,
     NonHardcoreWarning,
-    AchievementScreenshot,
+    AchievementTriggeredScreenshot,
+    AchievementTriggeredNotifications,
 };
 
 class IConfiguration

--- a/src/services/impl/JsonFileConfiguration.cpp
+++ b/src/services/impl/JsonFileConfiguration.cpp
@@ -24,6 +24,7 @@ bool JsonFileConfiguration::Load(const std::wstring& sFilename)
     m_nBackgroundThreads = 8;
     m_vEnabledFeatures =
         (1 << static_cast<int>(Feature::Hardcore)) |
+        (1 << static_cast<int>(Feature::AchievementTriggeredNotifications)) |
         (1 << static_cast<int>(Feature::Leaderboards)) |
         (1 << static_cast<int>(Feature::LeaderboardNotifications)) |
         (1 << static_cast<int>(Feature::LeaderboardCancelNotifications)) |
@@ -50,8 +51,10 @@ bool JsonFileConfiguration::Load(const std::wstring& sFilename)
     if (doc.HasMember("Non Hardcore Warning"))
         SetFeatureEnabled(Feature::NonHardcoreWarning, doc["Non Hardcore Warning"].GetBool());
 
-    if (doc.HasMember("Achievement Screenshot"))
-        SetFeatureEnabled(Feature::AchievementScreenshot, doc["Achievement Screenshot"].GetBool());
+    if (doc.HasMember("Achievement Triggered Notification Display"))
+        SetFeatureEnabled(Feature::AchievementTriggeredNotifications, doc["Achievement Triggered Notification Display"].GetBool());
+    if (doc.HasMember("Achievement Triggered Screenshot"))
+        SetFeatureEnabled(Feature::AchievementTriggeredScreenshot, doc["Achievement Triggered Screenshot"].GetBool());
     if (doc.HasMember("Screenshot Directory"))
         SetScreenshotDirectory(ra::Widen(doc["Screenshot Directory"].GetString()));
 
@@ -117,7 +120,8 @@ void JsonFileConfiguration::Save() const
     doc.AddMember("Token", rapidjson::StringRef(m_sApiToken), a);
     doc.AddMember("Hardcore Active", IsFeatureEnabled(Feature::Hardcore), a);
     doc.AddMember("Non Hardcore Warning", IsFeatureEnabled(Feature::NonHardcoreWarning), a);
-    doc.AddMember("Achievement Screenshot", IsFeatureEnabled(Feature::AchievementScreenshot), a);
+    doc.AddMember("Achievement Triggered Notification Display", IsFeatureEnabled(Feature::AchievementTriggeredNotifications), a);
+    doc.AddMember("Achievement Triggered Screenshot", IsFeatureEnabled(Feature::AchievementTriggeredScreenshot), a);
     doc.AddMember("Leaderboards Active", IsFeatureEnabled(Feature::Leaderboards), a);
     doc.AddMember("Leaderboard Notification Display", IsFeatureEnabled(Feature::LeaderboardNotifications), a);
     doc.AddMember("Leaderboard Cancel Display", IsFeatureEnabled(Feature::LeaderboardCancelNotifications), a);

--- a/src/ui/viewmodels/OverlaySettingsViewModel.cpp
+++ b/src/ui/viewmodels/OverlaySettingsViewModel.cpp
@@ -1,0 +1,63 @@
+#include "OverlaySettingsViewModel.hh"
+
+#include "services\IConfiguration.hh"
+#include "services\ServiceLocator.hh"
+
+namespace ra {
+namespace ui {
+namespace viewmodels {
+
+const BoolModelProperty OverlaySettingsViewModel::DisplayAchievementTriggerProperty("OverlaySettingsViewModel", "DisplayAchievementTrigger", true);
+const BoolModelProperty OverlaySettingsViewModel::ScreenshotAchievementTriggerProperty("OverlaySettingsViewModel", "ScreenshotAchievementTrigger", false);
+const BoolModelProperty OverlaySettingsViewModel::DisplayLeaderboardStartedProperty("OverlaySettingsViewModel", "DisplayLeaderboardStarted", true);
+const BoolModelProperty OverlaySettingsViewModel::DisplayLeaderboardCanceledProperty("OverlaySettingsViewModel", "DisplayLeaderboardCanceled", true);
+const BoolModelProperty OverlaySettingsViewModel::DisplayLeaderboardValueProperty("OverlaySettingsViewModel", "DisplayLeaderboardValue", true);
+const BoolModelProperty OverlaySettingsViewModel::DisplayLeaderboardScoreboardProperty("OverlaySettingsViewModel", "DisplayLeaderboardScoreboard", true);
+const StringModelProperty OverlaySettingsViewModel::ScreenshotLocationProperty("OverlaySettingsViewModel", "ScreenshotLocation", L"");
+
+OverlaySettingsViewModel::OverlaySettingsViewModel() noexcept
+{
+    SetWindowTitle(L"Overlay Settings");
+}
+
+void OverlaySettingsViewModel::Initialize()
+{
+    const auto& pConfiguration = ra::services::ServiceLocator::Get<ra::services::IConfiguration>();
+    SetDisplayAchievementTrigger(pConfiguration.IsFeatureEnabled(ra::services::Feature::AchievementTriggeredNotifications));
+    SetScreenshotAchievementTrigger(pConfiguration.IsFeatureEnabled(ra::services::Feature::AchievementTriggeredScreenshot));
+    SetDisplayLeaderboardStarted(pConfiguration.IsFeatureEnabled(ra::services::Feature::LeaderboardNotifications));
+    SetDisplayLeaderboardCanceled(pConfiguration.IsFeatureEnabled(ra::services::Feature::LeaderboardCancelNotifications));
+    SetDisplayLeaderboardValue(pConfiguration.IsFeatureEnabled(ra::services::Feature::LeaderboardCounters));
+    SetDisplayLeaderboardScoreboard(pConfiguration.IsFeatureEnabled(ra::services::Feature::LeaderboardScoreboards));
+
+    SetScreenshotLocation(pConfiguration.GetScreenshotDirectory());
+}
+
+void OverlaySettingsViewModel::Commit()
+{
+    auto& pConfiguration = ra::services::ServiceLocator::GetMutable<ra::services::IConfiguration>();
+
+    pConfiguration.SetFeatureEnabled(ra::services::Feature::AchievementTriggeredNotifications, DisplayAchievementTrigger());
+    pConfiguration.SetFeatureEnabled(ra::services::Feature::AchievementTriggeredScreenshot, ScreenshotAchievementTrigger());
+    pConfiguration.SetFeatureEnabled(ra::services::Feature::LeaderboardNotifications, DisplayLeaderboardStarted());
+    pConfiguration.SetFeatureEnabled(ra::services::Feature::LeaderboardCancelNotifications, DisplayLeaderboardCanceled());
+    pConfiguration.SetFeatureEnabled(ra::services::Feature::LeaderboardCounters, DisplayLeaderboardValue());
+    pConfiguration.SetFeatureEnabled(ra::services::Feature::LeaderboardScoreboards, DisplayLeaderboardScoreboard());
+
+    std::wstring sLocation = ScreenshotLocation();
+    if (!sLocation.empty() && sLocation.back() != '\\')
+        sLocation.push_back('\\');
+
+    pConfiguration.SetScreenshotDirectory(sLocation);
+
+    pConfiguration.Save();
+}
+
+void OverlaySettingsViewModel::BrowseLocation() noexcept
+{
+    // TODO
+}
+
+} // namespace viewmodels
+} // namespace ui
+} // namespace ra

--- a/src/ui/viewmodels/OverlaySettingsViewModel.hh
+++ b/src/ui/viewmodels/OverlaySettingsViewModel.hh
@@ -1,0 +1,141 @@
+#ifndef RA_UI_OVERLAYSETTINGSVIEWMODEL_H
+#define RA_UI_OVERLAYSETTINGSVIEWMODEL_H
+#pragma once
+
+#include "ui/WindowViewModelBase.hh"
+
+namespace ra {
+namespace ui {
+namespace viewmodels {
+
+class OverlaySettingsViewModel : public WindowViewModelBase
+{
+public:
+    GSL_SUPPRESS_F6 OverlaySettingsViewModel() noexcept;
+
+    /// <summary>
+    /// Sets the initial values of each checkbox from the current configuration.
+    /// </summary>
+    void Initialize();
+
+    /// <summary>
+    /// Updates the current configuration with values from the checkboxes.
+    /// </summary>
+    void Commit();
+
+    /// <summary>
+    /// The <see cref="ModelProperty" /> for whether or not the achievement triggered notification should be displayed.
+    /// </summary>
+    static const BoolModelProperty DisplayAchievementTriggerProperty;
+
+    /// <summary>
+    /// Gets whether or not the achievement triggered notification should be displayed.
+    /// </summary>
+    bool DisplayAchievementTrigger() const { return GetValue(DisplayAchievementTriggerProperty); }
+
+    /// <summary>
+    /// Sets whether or not the achievement triggered notification should be displayed.
+    /// </summary>
+    void SetDisplayAchievementTrigger(bool bValue) { SetValue(DisplayAchievementTriggerProperty, bValue); }
+
+    /// <summary>
+    /// The <see cref="ModelProperty" /> for whether or not the achievement triggered notification should be screenshoted.
+    /// </summary>
+    static const BoolModelProperty ScreenshotAchievementTriggerProperty;
+
+    /// <summary>
+    /// Gets whether or not the achievement triggered notification should be screenshoted.
+    /// </summary>
+    bool ScreenshotAchievementTrigger() const { return GetValue(ScreenshotAchievementTriggerProperty); }
+
+    /// <summary>
+    /// Sets whether or not the achievement triggered notification should be screenshoted.
+    /// </summary>
+    void SetScreenshotAchievementTrigger(bool bValue) { SetValue(ScreenshotAchievementTriggerProperty, bValue); }
+
+    /// <summary>
+    /// The <see cref="ModelProperty" /> for whether or not the leaderboard started notification should be displayed.
+    /// </summary>
+    static const BoolModelProperty DisplayLeaderboardStartedProperty;
+
+    /// <summary>
+    /// Gets whether or not the leaderboard started notification should be displayed.
+    /// </summary>
+    bool DisplayLeaderboardStarted() const { return GetValue(DisplayLeaderboardStartedProperty); }
+
+    /// <summary>
+    /// Sets whether or not the leaderboard started notification should be displayed.
+    /// </summary>
+    void SetDisplayLeaderboardStarted(bool bValue) { SetValue(DisplayLeaderboardStartedProperty, bValue); }
+
+    /// <summary>
+    /// The <see cref="ModelProperty" /> for whether or not the leaderboard canceled notification should be displayed.
+    /// </summary>
+    static const BoolModelProperty DisplayLeaderboardCanceledProperty;
+
+    /// <summary>
+    /// Gets whether or not the leaderboard canceled notification should be displayed.
+    /// </summary>
+    bool DisplayLeaderboardCanceled() const { return GetValue(DisplayLeaderboardCanceledProperty); }
+
+    /// <summary>
+    /// Sets whether or not the leaderboard canceled notification should be displayed.
+    /// </summary>
+    void SetDisplayLeaderboardCanceled(bool bValue) { SetValue(DisplayLeaderboardCanceledProperty, bValue); }
+
+    /// <summary>
+    /// The <see cref="ModelProperty" /> for whether or not the value for an active leaderboard should be displayed.
+    /// </summary>
+    static const BoolModelProperty DisplayLeaderboardValueProperty;
+
+    /// <summary>
+    /// Gets whether or not the value for an active leaderboard should be displayed.
+    /// </summary>
+    bool DisplayLeaderboardValue() const { return GetValue(DisplayLeaderboardValueProperty); }
+
+    /// <summary>
+    /// Sets whether or not the value for an active leaderboard should be displayed.
+    /// </summary>
+    void SetDisplayLeaderboardValue(bool bValue) { SetValue(DisplayLeaderboardValueProperty, bValue); }
+
+    /// <summary>
+    /// The <see cref="ModelProperty" /> for whether or not the leaderboard scoreboard should be displayed after submitting a leaderboard entry.
+    /// </summary>
+    static const BoolModelProperty DisplayLeaderboardScoreboardProperty;
+
+    /// <summary>
+    /// Gets whether or not the leaderboard scoreboard should be displayed after submitting a leaderboard entry.
+    /// </summary>
+    bool DisplayLeaderboardScoreboard() const { return GetValue(DisplayLeaderboardScoreboardProperty); }
+
+    /// <summary>
+    /// Sets whether or not the leaderboard scoreboard should be displayed after submitting a leaderboard entry.
+    /// </summary>
+    void SetDisplayLeaderboardScoreboard(bool bValue) { SetValue(DisplayLeaderboardScoreboardProperty, bValue); }
+
+    /// <summary>
+    /// The <see cref="ModelProperty" /> for the location to write screenshots.
+    /// </summary>
+    static const StringModelProperty ScreenshotLocationProperty;
+
+    /// <summary>
+    /// Gets the location to write screenshots.
+    /// </summary>
+    const std::wstring& ScreenshotLocation() const { return GetValue(ScreenshotLocationProperty); }
+
+    /// <summary>
+    /// Sets the location to write screenshots.
+    /// </summary>
+    void SetScreenshotLocation(const std::wstring& sValue) { SetValue(ScreenshotLocationProperty, sValue); }
+
+    /// <summary>
+    /// Opens the folder browser dialog to select a <see cref="ScreenshotLocation" />.
+    /// </summary>
+    void BrowseLocation() noexcept;
+};
+
+} // namespace viewmodels
+} // namespace ui
+} // namespace ra
+
+#endif !RA_UI_OVERLAYSETTINGSVIEWMODEL_H

--- a/src/ui/win32/Desktop.cpp
+++ b/src/ui/win32/Desktop.cpp
@@ -12,6 +12,7 @@
 #include "ui/win32/LoginDialog.hh"
 #include "ui/win32/MessageBoxDialog.hh"
 #include "ui/win32/MemoryBookmarksDialog.hh"
+#include "ui/win32/OverlaySettingsDialog.hh"
 #include "ui/win32/RichPresenceDialog.hh"
 #include "ui/win32/UnknownGameDialog.hh"
 
@@ -30,6 +31,7 @@ Desktop::Desktop() noexcept
     m_vDialogPresenters.emplace_back(new (std::nothrow) LoginDialog::Presenter);
     m_vDialogPresenters.emplace_back(new (std::nothrow) MemoryBookmarksDialog::Presenter);
     m_vDialogPresenters.emplace_back(new (std::nothrow) FileDialog::Presenter);
+    m_vDialogPresenters.emplace_back(new (std::nothrow) OverlaySettingsDialog::Presenter);
     m_vDialogPresenters.emplace_back(new (std::nothrow) BrokenAchievementsDialog::Presenter);
     m_vDialogPresenters.emplace_back(new (std::nothrow) UnknownGameDialog::Presenter);
 }

--- a/src/ui/win32/OverlaySettingsDialog.cpp
+++ b/src/ui/win32/OverlaySettingsDialog.cpp
@@ -1,0 +1,80 @@
+#include "OverlaySettingsDialog.hh"
+
+#include "RA_Core.h"
+#include "RA_Resource.h"
+
+namespace ra {
+namespace ui {
+namespace win32 {
+
+bool OverlaySettingsDialog::Presenter::IsSupported(const ra::ui::WindowViewModelBase& vmViewModel) noexcept
+{
+    return (dynamic_cast<const ra::ui::viewmodels::OverlaySettingsViewModel*>(&vmViewModel) != nullptr);
+}
+
+void OverlaySettingsDialog::Presenter::ShowModal(ra::ui::WindowViewModelBase& vmViewModel, HWND hParentWnd)
+{
+    auto& vmSettings = reinterpret_cast<ra::ui::viewmodels::OverlaySettingsViewModel&>(vmViewModel);
+
+    OverlaySettingsDialog oDialog(vmSettings);
+    oDialog.CreateModalWindow(MAKEINTRESOURCE(IDD_RA_OVERLAYSETTINGS), this, hParentWnd);
+}
+
+void OverlaySettingsDialog::Presenter::ShowWindow(ra::ui::WindowViewModelBase& oViewModel)
+{
+    ShowModal(oViewModel, nullptr);
+}
+
+// ------------------------------------
+
+OverlaySettingsDialog::OverlaySettingsDialog(ra::ui::viewmodels::OverlaySettingsViewModel& vmSettings)
+    : DialogBase(vmSettings),
+      m_bindDisplayAchievementTrigger(vmSettings),
+      m_bindScreenshotAchievementTrigger(vmSettings),
+      m_bindDisplayLeaderboardStarted(vmSettings),
+      m_bindDisplayLeaderboardCanceled(vmSettings),
+      m_bindDisplayLeaderboardValue(vmSettings),
+      m_bindDisplayLeaderboardScoreboards(vmSettings),
+      m_bindScreenshotLocation(vmSettings)
+{
+    m_bindWindow.SetInitialPosition(RelativePosition::Center, RelativePosition::Center);
+
+    m_bindDisplayAchievementTrigger.BindCheck(ra::ui::viewmodels::OverlaySettingsViewModel::DisplayAchievementTriggerProperty);
+    m_bindScreenshotAchievementTrigger.BindCheck(ra::ui::viewmodels::OverlaySettingsViewModel::ScreenshotAchievementTriggerProperty);
+    m_bindDisplayLeaderboardStarted.BindCheck(ra::ui::viewmodels::OverlaySettingsViewModel::DisplayLeaderboardStartedProperty);
+    m_bindDisplayLeaderboardCanceled.BindCheck(ra::ui::viewmodels::OverlaySettingsViewModel::DisplayLeaderboardCanceledProperty);
+    m_bindDisplayLeaderboardValue.BindCheck(ra::ui::viewmodels::OverlaySettingsViewModel::DisplayLeaderboardValueProperty);
+    m_bindDisplayLeaderboardScoreboards.BindCheck(ra::ui::viewmodels::OverlaySettingsViewModel::DisplayLeaderboardScoreboardProperty);
+
+    m_bindScreenshotLocation.BindText(ra::ui::viewmodels::OverlaySettingsViewModel::ScreenshotLocationProperty);
+}
+
+BOOL OverlaySettingsDialog::OnInitDialog()
+{
+    m_bindDisplayAchievementTrigger.SetControl(*this, IDC_RA_DISPLAY_TRIGGER);
+    m_bindScreenshotAchievementTrigger.SetControl(*this, IDC_RA_SCREENSHOT_TRIGGER);
+    m_bindDisplayLeaderboardStarted.SetControl(*this, IDC_RA_DISPLAY_LBOARD_START);
+    m_bindDisplayLeaderboardCanceled.SetControl(*this, IDC_RA_DISPLAY_LBOARD_CANCEL);
+    m_bindDisplayLeaderboardValue.SetControl(*this, IDC_RA_DISPLAY_LBOARD_VALUE);
+    m_bindDisplayLeaderboardScoreboards.SetControl(*this, IDC_RA_DISPLAY_LBOARD_SCOREBOARD);
+
+    m_bindScreenshotLocation.SetControl(*this, IDC_RA_SCREENSHOT_LOCATION);
+
+    return DialogBase::OnInitDialog();
+}
+
+BOOL OverlaySettingsDialog::OnCommand(WORD nCommand)
+{
+    if (nCommand == IDC_RA_BROWSE)
+    {
+        auto& vmSettings = reinterpret_cast<ra::ui::viewmodels::OverlaySettingsViewModel&>(m_vmWindow);
+        vmSettings.BrowseLocation();
+        return TRUE;
+    }
+
+    return DialogBase::OnCommand(nCommand);
+}
+
+} // namespace win32
+} // namespace ui
+} // namespace ra

--- a/src/ui/win32/OverlaySettingsDialog.hh
+++ b/src/ui/win32/OverlaySettingsDialog.hh
@@ -1,0 +1,51 @@
+#ifndef RA_UI_WIN32_DLG_OVERLAYSETTINGS_H
+#define RA_UI_WIN32_DLG_OVERLAYSETTINGS_H
+#pragma once
+
+#include "ui/viewmodels/OverlaySettingsViewModel.hh"
+#include "ui/win32/DialogBase.hh"
+#include "ui/win32/IDialogPresenter.hh"
+#include "ui/win32/bindings/CheckBoxBinding.hh"
+#include "ui/win32/bindings/TextBoxBinding.hh"
+
+namespace ra {
+namespace ui {
+namespace win32 {
+
+class OverlaySettingsDialog : public DialogBase
+{
+public:
+    explicit OverlaySettingsDialog(ra::ui::viewmodels::OverlaySettingsViewModel& vmSettings);
+    virtual ~OverlaySettingsDialog() noexcept = default;
+    OverlaySettingsDialog(const OverlaySettingsDialog&) noexcept = delete;
+    OverlaySettingsDialog& operator=(const OverlaySettingsDialog&) noexcept = delete;
+    OverlaySettingsDialog(OverlaySettingsDialog&&) noexcept = delete;
+    OverlaySettingsDialog& operator=(OverlaySettingsDialog&&) noexcept = delete;
+
+    class Presenter : public IDialogPresenter
+    {
+    public:
+        bool IsSupported(const ra::ui::WindowViewModelBase& viewModel) noexcept override;
+        void ShowWindow(ra::ui::WindowViewModelBase& viewModel) override;
+        void ShowModal(ra::ui::WindowViewModelBase& viewModel, HWND hParentWnd) override;
+    };
+
+protected:
+    BOOL OnInitDialog() override;
+    BOOL OnCommand(WORD nCommand) override;
+
+private:
+    ra::ui::win32::bindings::CheckBoxBinding m_bindDisplayAchievementTrigger;
+    ra::ui::win32::bindings::CheckBoxBinding m_bindScreenshotAchievementTrigger;
+    ra::ui::win32::bindings::CheckBoxBinding m_bindDisplayLeaderboardStarted;
+    ra::ui::win32::bindings::CheckBoxBinding m_bindDisplayLeaderboardCanceled;
+    ra::ui::win32::bindings::CheckBoxBinding m_bindDisplayLeaderboardValue;
+    ra::ui::win32::bindings::CheckBoxBinding m_bindDisplayLeaderboardScoreboards;
+    ra::ui::win32::bindings::TextBoxBinding m_bindScreenshotLocation;
+};
+
+} // namespace win32
+} // namespace ui
+} // namespace ra
+
+#endif // !RA_UI_WIN32_DLG_OVERLAYSETTINGS_H

--- a/tests/RA_Integration.Tests.vcxproj
+++ b/tests/RA_Integration.Tests.vcxproj
@@ -228,6 +228,7 @@
     <ClCompile Include="..\src\ui\viewmodels\OverlayListPageViewModel.cpp" />
     <ClCompile Include="..\src\ui\viewmodels\OverlayManager.cpp" />
     <ClCompile Include="..\src\ui\viewmodels\OverlayRecentGamesPageViewModel.cpp" />
+    <ClCompile Include="..\src\ui\viewmodels\OverlaySettingsViewModel.cpp" />
     <ClCompile Include="..\src\ui\viewmodels\OverlayViewModel.cpp" />
     <ClCompile Include="..\src\ui\viewmodels\PopupMessageViewModel.cpp" />
     <ClCompile Include="..\src\ui\viewmodels\LoginViewModel.cpp" />
@@ -279,6 +280,7 @@
     <ClCompile Include="ui\viewmodels\OverlayListPageViewModel_Tests.cpp" />
     <ClCompile Include="ui\viewmodels\OverlayManager_Tests.cpp" />
     <ClCompile Include="ui\viewmodels\OverlayRecentGamesPageViewModel_Tests.cpp" />
+    <ClCompile Include="ui\viewmodels\OverlaySettingsViewModel_Tests.cpp" />
     <ClCompile Include="ui\viewmodels\RichPresenceMonitorViewModel_Tests.cpp" />
     <ClCompile Include="ui\viewmodels\UnknownGameViewModel_Tests.cpp" />
     <ClCompile Include="ui\WindowViewModelBase_Tests.cpp" />

--- a/tests/RA_Integration.Tests.vcxproj.filters
+++ b/tests/RA_Integration.Tests.vcxproj.filters
@@ -312,6 +312,12 @@
     <ClCompile Include="..\src\ui\viewmodels\FileDialogViewModel.cpp">
       <Filter>Code</Filter>
     </ClCompile>
+    <ClCompile Include="ui\viewmodels\OverlaySettingsViewModel_Tests.cpp">
+      <Filter>Tests\UI\ViewModels</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\ui\viewmodels\OverlaySettingsViewModel.cpp">
+      <Filter>Code</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="base.props" />

--- a/tests/ui/viewmodels/OverlaySettingsViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/OverlaySettingsViewModel_Tests.cpp
@@ -1,0 +1,88 @@
+#include "CppUnitTest.h"
+
+#include "ui\viewmodels\OverlaySettingsViewModel.hh"
+
+#include "tests\RA_UnitTestHelpers.h"
+#include "tests\mocks\MockConfiguration.hh"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace ra {
+namespace ui {
+namespace viewmodels {
+namespace tests {
+
+TEST_CLASS(OverlaySettingsViewModel_Tests)
+{
+private:
+    class OverlaySettingsViewModelHarness : public OverlaySettingsViewModel
+    {
+    public:
+        ra::services::mocks::MockConfiguration mockConfiguration;
+    };
+
+    void ValidateFeatureInitialize(ra::services::Feature feature, std::function<bool(OverlaySettingsViewModel&)> fGetValue)
+    {
+        OverlaySettingsViewModelHarness vmSettings;
+        vmSettings.mockConfiguration.SetFeatureEnabled(feature, false);
+        vmSettings.Initialize();
+        Assert::IsFalse(fGetValue(vmSettings));
+
+        vmSettings.mockConfiguration.SetFeatureEnabled(feature, true);
+        vmSettings.Initialize();
+        Assert::IsTrue(fGetValue(vmSettings));
+    }
+
+    void ValidateFeatureCommit(ra::services::Feature feature, std::function<void(OverlaySettingsViewModel&, bool)> fSetValue)
+    {
+        OverlaySettingsViewModelHarness vmSettings;
+        fSetValue(vmSettings, false);
+        vmSettings.Commit();
+        Assert::IsFalse(vmSettings.mockConfiguration.IsFeatureEnabled(feature));
+
+        fSetValue(vmSettings, true);
+        vmSettings.Commit();
+        Assert::IsTrue(vmSettings.mockConfiguration.IsFeatureEnabled(feature));
+    }
+
+public:
+    TEST_METHOD(TestInitialize)
+    {
+        ValidateFeatureInitialize(ra::services::Feature::AchievementTriggeredNotifications, [](OverlaySettingsViewModel& vm) { return vm.DisplayAchievementTrigger(); });
+        ValidateFeatureInitialize(ra::services::Feature::AchievementTriggeredScreenshot, [](OverlaySettingsViewModel& vm) { return vm.ScreenshotAchievementTrigger(); });
+        ValidateFeatureInitialize(ra::services::Feature::LeaderboardNotifications, [](OverlaySettingsViewModel& vm) { return vm.DisplayLeaderboardStarted(); });
+        ValidateFeatureInitialize(ra::services::Feature::LeaderboardCancelNotifications, [](OverlaySettingsViewModel& vm) { return vm.DisplayLeaderboardCanceled(); });
+        ValidateFeatureInitialize(ra::services::Feature::LeaderboardCounters, [](OverlaySettingsViewModel& vm) { return vm.DisplayLeaderboardValue(); });
+        ValidateFeatureInitialize(ra::services::Feature::LeaderboardScoreboards, [](OverlaySettingsViewModel& vm) { return vm.DisplayLeaderboardScoreboard(); });
+
+        OverlaySettingsViewModelHarness vmSettings;
+        vmSettings.mockConfiguration.SetScreenshotDirectory(L"C:\\Screenshots\\");
+        vmSettings.Initialize();
+        Assert::AreEqual(std::wstring(L"C:\\Screenshots\\"), vmSettings.ScreenshotLocation());
+    }
+
+    TEST_METHOD(TestCommit)
+    {
+        ValidateFeatureCommit(ra::services::Feature::AchievementTriggeredNotifications, [](OverlaySettingsViewModel& vm, bool bValue) { return vm.SetDisplayAchievementTrigger(bValue); });
+        ValidateFeatureCommit(ra::services::Feature::AchievementTriggeredScreenshot, [](OverlaySettingsViewModel& vm, bool bValue) { return vm.SetScreenshotAchievementTrigger(bValue); });
+        ValidateFeatureCommit(ra::services::Feature::LeaderboardNotifications, [](OverlaySettingsViewModel& vm, bool bValue) { return vm.SetDisplayLeaderboardStarted(bValue); });
+        ValidateFeatureCommit(ra::services::Feature::LeaderboardCancelNotifications, [](OverlaySettingsViewModel& vm, bool bValue) { return vm.SetDisplayLeaderboardCanceled(bValue); });
+        ValidateFeatureCommit(ra::services::Feature::LeaderboardCounters, [](OverlaySettingsViewModel& vm, bool bValue) { return vm.SetDisplayLeaderboardValue(bValue); });
+        ValidateFeatureCommit(ra::services::Feature::LeaderboardScoreboards, [](OverlaySettingsViewModel& vm, bool bValue) { return vm.SetDisplayLeaderboardScoreboard(bValue); });
+
+        OverlaySettingsViewModelHarness vmSettings;
+        vmSettings.SetScreenshotLocation(L"C:\\Screenshots\\");
+        vmSettings.Commit();
+        Assert::AreEqual(std::wstring(L"C:\\Screenshots\\"), vmSettings.mockConfiguration.GetScreenshotDirectory());
+
+        // make sure the path ends with a slash
+        vmSettings.SetScreenshotLocation(L"C:\\Temp");
+        vmSettings.Commit();
+        Assert::AreEqual(std::wstring(L"C:\\Temp\\"), vmSettings.mockConfiguration.GetScreenshotDirectory());
+    }
+};
+
+} // namespace tests
+} // namespace viewmodels
+} // namespace ui
+} // namespace ra


### PR DESCRIPTION
Replaces the submenu for leaderboards with a new dialog and adds options for screenshots (#448)

Before:
![image](https://user-images.githubusercontent.com/32680403/65824115-23dc9400-e220-11e9-841b-c370712a6e08.png)

After:
![image](https://user-images.githubusercontent.com/32680403/65824118-3656cd80-e220-11e9-87b2-3eb4fc1cee95.png)

Dialog:
![image](https://user-images.githubusercontent.com/32680403/65824119-3bb41800-e220-11e9-8e82-0a3619286665.png)

The "..." button is currently non-functional. Will hook it up in a future PR with "browse folder" support.

The plan is to extend this dialog in the future with support for Mastery notification and screenshots.