### PR TITLE
update rich presence memrefs every frame

### DIFF
--- a/src/Exports.cpp
+++ b/src/Exports.cpp
@@ -385,6 +385,7 @@ static void ProcessAchievements()
 
 API void CCONV _RA_DoAchievementsFrame()
 {
+    // make sure we process the achievements _before_ the frozen bookmarks modify the memory
     ProcessAchievements();
 
 #ifndef RA_UTEST
@@ -394,7 +395,6 @@ API void CCONV _RA_DoAchievementsFrame()
     auto& pOverlayManager = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>();
     pOverlayManager.AdvanceFrame();
 
-    // make sure we process the achievements _before_ the frozen bookmarks modify the memory
     g_MemoryDialog.Invalidate();
 #endif
 }

--- a/src/data/GameContext.cpp
+++ b/src/data/GameContext.cpp
@@ -57,6 +57,9 @@ static void CopyAchievementData(Achievement& pAchievement,
 
 void GameContext::LoadGame(unsigned int nGameId, Mode nMode)
 {
+    auto& pRuntime = ra::services::ServiceLocator::GetMutable<ra::services::AchievementRuntime>();
+    pRuntime.ActivateRichPresence(nullptr);
+
     m_nMode = nMode;
     m_sGameTitle.clear();
     m_pRichPresence = nullptr;
@@ -124,7 +127,6 @@ void GameContext::LoadGame(unsigned int nGameId, Mode nMode)
     }
 
     // achievements
-    auto& pRuntime = ra::services::ServiceLocator::GetMutable<ra::services::AchievementRuntime>();
     const bool bWasPaused = pRuntime.IsPaused();
     pRuntime.SetPaused(true);
 
@@ -919,32 +921,36 @@ void GameContext::LoadRichPresenceScript(const std::string& sRichPresenceScript)
     if (sRichPresenceScript.empty())
     {
         m_pRichPresence = nullptr;
-        return;
-    }
-
-    const int nSize = rc_richpresence_size(sRichPresenceScript.c_str());
-    if (nSize < 0)
-    {
-        // parse error occurred
-        RA_LOG("rc_richpresence_size returned %d", nSize);
-        m_pRichPresence = nullptr;
-
-        const std::string sErrorRP = ra::StringPrintf("Display:\nParse error %d\n", nSize);
-        const int nSize2 = rc_richpresence_size(sErrorRP.c_str());
-        if (nSize2 > 0)
-        {
-            m_pRichPresenceBuffer = std::make_shared<std::vector<unsigned char>>(nSize2);
-            auto* pRichPresence = rc_parse_richpresence(m_pRichPresenceBuffer->data(), sErrorRP.c_str(), nullptr, 0);
-            m_pRichPresence = pRichPresence;
-        }
     }
     else
     {
-        // allocate space and parse again
-        m_pRichPresenceBuffer = std::make_shared<std::vector<unsigned char>>(nSize);
-        auto* pRichPresence = rc_parse_richpresence(m_pRichPresenceBuffer->data(), sRichPresenceScript.c_str(), nullptr, 0);
-        m_pRichPresence = pRichPresence;
+        const int nSize = rc_richpresence_size(sRichPresenceScript.c_str());
+        if (nSize < 0)
+        {
+            // parse error occurred
+            RA_LOG("rc_richpresence_size returned %d", nSize);
+            m_pRichPresence = nullptr;
+
+            const std::string sErrorRP = ra::StringPrintf("Display:\nParse error %d\n", nSize);
+            const int nSize2 = rc_richpresence_size(sErrorRP.c_str());
+            if (nSize2 > 0)
+            {
+                m_pRichPresenceBuffer = std::make_shared<std::vector<unsigned char>>(nSize2);
+                auto* pRichPresence = rc_parse_richpresence(m_pRichPresenceBuffer->data(), sErrorRP.c_str(), nullptr, 0);
+                m_pRichPresence = pRichPresence;
+            }
+        }
+        else
+        {
+            // allocate space and parse again
+            m_pRichPresenceBuffer = std::make_shared<std::vector<unsigned char>>(nSize);
+            auto* pRichPresence = rc_parse_richpresence(m_pRichPresenceBuffer->data(), sRichPresenceScript.c_str(), nullptr, 0);
+            m_pRichPresence = pRichPresence;
+        }
     }
+
+    auto* pRichPresence = static_cast<rc_richpresence_t*>(m_pRichPresence);
+    ra::services::ServiceLocator::GetMutable<ra::services::AchievementRuntime>().ActivateRichPresence(pRichPresence);
 }
 
 bool GameContext::HasRichPresence() const noexcept
@@ -957,12 +963,20 @@ std::wstring GameContext::GetRichPresenceDisplayString() const
     if (m_pRichPresence == nullptr)
         return std::wstring(L"No Rich Presence defined.");
 
-    auto pRichPresence = static_cast<rc_richpresence_t*>(m_pRichPresence);
+    auto* pRichPresence = static_cast<rc_richpresence_t*>(m_pRichPresence);
+
+    // we evaluate the memrefs in AchievementRuntime::Process - don't evaluate them again
+    auto* pRichPresenceMemRefs = pRichPresence->memrefs;
+    pRichPresence->memrefs = nullptr;
+
     std::string sRichPresence;
     sRichPresence.resize(512);
     const auto nLength = rc_evaluate_richpresence(pRichPresence, sRichPresence.data(),
         gsl::narrow_cast<unsigned int>(sRichPresence.capacity()), rc_peek_callback, nullptr, nullptr);
     sRichPresence.resize(nLength);
+
+    // restore memrefs pointer
+    pRichPresence->memrefs = pRichPresenceMemRefs;
 
     return ra::Widen(sRichPresence);
 }

--- a/src/services/AchievementRuntime.cpp
+++ b/src/services/AchievementRuntime.cpp
@@ -198,6 +198,14 @@ _Use_decl_annotations_ void AchievementRuntime::Process(std::vector<Change>& cha
                 break;
         }
     }
+
+    if (m_pRichPresenceMemRefs)
+    {
+        // rc_update_memrefs is not exposed, create a dummy trigger with no conditions to update the memrefs
+        rc_trigger_t trigger{};
+        trigger.memrefs = m_pRichPresenceMemRefs;
+        rc_test_trigger(&trigger, rc_peek_callback, nullptr, nullptr);
+    }
 }
 
 _NODISCARD static _CONSTANT_FN ComparisonSizeToPrefix(_In_ char nSize) noexcept

--- a/src/services/AchievementRuntime.hh
+++ b/src/services/AchievementRuntime.hh
@@ -59,6 +59,15 @@ public:
         RemoveEntry(m_vActiveLeaderboards, nId);
     }
 
+    /// <summary>
+    /// Specifies the rich presence to process each frame.
+    /// </summary>
+    /// <remarks>Only updates the memrefs each frame (for deltas), the script is not processed here.</remarks>
+    void ActivateRichPresence(rc_richpresence_t* pRichPresence) noexcept
+    {
+        m_pRichPresenceMemRefs = (pRichPresence) ? pRichPresence->memrefs : nullptr;
+    }
+
     enum class ChangeType
     {
         None = 0,
@@ -168,6 +177,8 @@ protected:
     std::vector<ActiveAchievement> m_vActiveAchievementsMonitorReset;
 
     std::vector<ActiveLeaderboard> m_vActiveLeaderboards;
+
+    rc_memref_value_t* m_pRichPresenceMemRefs = nullptr;
 
     bool m_bPaused = false;
 


### PR DESCRIPTION
ensures delta values are correct whenever rich presence is evaluated. previously they were only updated when the rich presence was evaluated, which means they might be up to two minutes stale.