### PR TITLE
add Pause on Change bookmark behavior

### DIFF
--- a/src/ui/viewmodels/MemoryBookmarksViewModel.hh
+++ b/src/ui/viewmodels/MemoryBookmarksViewModel.hh
@@ -36,6 +36,7 @@ public:
     {
         None = 0,
         Frozen,
+        PauseOnChange,
     };
 
     class MemoryBookmarkViewModel : public LookupItemViewModel

--- a/src/ui/win32/bindings/GridBinding.cpp
+++ b/src/ui/win32/bindings/GridBinding.cpp
@@ -244,6 +244,12 @@ void GridBinding::UpdateItems(gsl::index nColumn)
 
 void GridBinding::OnViewModelIntValueChanged(gsl::index nIndex, const IntModelProperty::ChangeArgs& args)
 {
+    if (m_pRowColorProperty && *m_pRowColorProperty == args.Property)
+    {
+        ListView_RedrawItems(m_hWnd, nIndex, nIndex);
+        return;
+    }
+
     std::string sText;
     LV_ITEM item{};
     item.mask = LVIF_TEXT;

--- a/tests/mocks/MockDesktop.hh
+++ b/tests/mocks/MockDesktop.hh
@@ -84,6 +84,8 @@ public:
         m_vHandlers.emplace_back(pHandler);
     }
 
+    void ResetExpectedWindows() noexcept { m_vHandlers.clear(); }
+
     std::string GetRunningExecutable() const override { return m_sExecutable; }
     void SetRunningExecutable(const std::string& sExecutable) { m_sExecutable = sExecutable; }
 


### PR DESCRIPTION
Implements #151 

When the "Pause" behavior is associated to a bookmark, the emulator will be paused when the bookmarked value changes (Changes counter increases). In addition to pausing the emulator, a dialog will appear to inform the user that the emulator has been paused, indicating which bookmark(s) caused the pause, and the associated bookmarks will be highlighted in the dialog. On the next frame (emulator is unpaused or frame advance'd), the highlight will be cleared.

![image](https://user-images.githubusercontent.com/32680403/67626183-0aba0980-f805-11e9-85b9-366cba8ece64.png)

![image](https://user-images.githubusercontent.com/32680403/67626184-11e11780-f805-11e9-9619-f01f537aff31.png)
