### PR TITLE
add more thread safety to image access

### DIFF
--- a/src/ui/drawing/gdi/ImageRepository.hh
+++ b/src/ui/drawing/gdi/ImageRepository.hh
@@ -60,7 +60,7 @@ private:
 
     HBitmapMap* GetBitmapMap(ImageType nType) noexcept;
 
-    std::mutex m_oMutex;
+    mutable std::mutex m_oMutex;
     std::set<std::wstring> m_vRequestedImages;
     bool m_bShutdownCOM = false;
 };


### PR DESCRIPTION
extends the existing mutex used for fetching images to the reference counting logic

presumably fixes an issue I encountered where the image being shared by the screenshot code and the notification popup went away before both were done with it.