### PR TITLE
update RP memrefs on refresh

### DIFF
--- a/src/services/AchievementRuntime.cpp
+++ b/src/services/AchievementRuntime.cpp
@@ -199,6 +199,11 @@ _Use_decl_annotations_ void AchievementRuntime::Process(std::vector<Change>& cha
         }
     }
 
+    UpdateRichPresenceMemRefs();
+}
+
+void AchievementRuntime::UpdateRichPresenceMemRefs() noexcept
+{
     if (m_pRichPresenceMemRefs)
     {
         // rc_update_memrefs is not exposed, create a dummy trigger with no conditions to update the memrefs

--- a/src/services/AchievementRuntime.hh
+++ b/src/services/AchievementRuntime.hh
@@ -65,7 +65,15 @@ public:
     /// <remarks>Only updates the memrefs each frame (for deltas), the script is not processed here.</remarks>
     void ActivateRichPresence(rc_richpresence_t* pRichPresence) noexcept
     {
-        m_pRichPresenceMemRefs = (pRichPresence) ? pRichPresence->memrefs : nullptr;
+        if (pRichPresence)
+        {
+            m_pRichPresenceMemRefs = pRichPresence->memrefs;
+            UpdateRichPresenceMemRefs();
+        }
+        else
+        {
+            m_pRichPresenceMemRefs = nullptr;
+        }
     }
 
     enum class ChangeType
@@ -185,6 +193,8 @@ protected:
 private:
     bool LoadProgressV1(const std::string& sProgress, std::set<unsigned int>& vProcessedAchievementIds) const;
     bool LoadProgressV2(ra::services::TextReader& pFile, std::set<unsigned int>& vProcessedAchievementIds) const;
+
+    void UpdateRichPresenceMemRefs() noexcept;
 };
 
 } // namespace services

--- a/tests/services/AchievementRuntime_Tests.cpp
+++ b/tests/services/AchievementRuntime_Tests.cpp
@@ -783,14 +783,14 @@ public:
         memcpy(&pRichPresence2, pRichPresence, sizeof(pRichPresence2));
         pRichPresence2.memrefs = nullptr;
 
-        // memrefs haven't been updated - expect 0/0
-        rc_evaluate_richpresence(&pRichPresence2, buffer, sizeof(buffer), rc_peek_callback, nullptr, nullptr);
-        Assert::AreEqual("0 0", buffer);
-
-        // first update - updates value, but not delta
-        runtime.Process(changes);
+        // memrefs are updated by ActivateRichPresence - expect 18/0
         rc_evaluate_richpresence(&pRichPresence2, buffer, sizeof(buffer), rc_peek_callback, nullptr, nullptr);
         Assert::AreEqual("18 0", buffer);
+
+        // first update - updates value and delta
+        runtime.Process(changes);
+        rc_evaluate_richpresence(&pRichPresence2, buffer, sizeof(buffer), rc_peek_callback, nullptr, nullptr);
+        Assert::AreEqual("18 18", buffer);
 
         // second update - updates delta
         runtime.Process(changes);


### PR DESCRIPTION
fixes an issue where the RP monitor would show 0s on the first update after refreshing.