### PR TITLE
Hook up the UI for the Measured flag

### DIFF
--- a/src/RA_Achievement.cpp
+++ b/src/RA_Achievement.cpp
@@ -570,12 +570,18 @@ void Achievement::CopyFrom(const Achievement& rRHS)
 
 unsigned int Achievement::MeasuredTarget() const noexcept
 {
+    if (m_pTrigger == nullptr)
+        return 0;
+
     rc_trigger_t* pTrigger = static_cast<rc_trigger_t*>(m_pTrigger);
     return pTrigger->measured_target;
 }
 
 unsigned int Achievement::MeasuredValue() const noexcept
 {
+    if (m_pTrigger == nullptr)
+        return 0;
+
     rc_trigger_t* pTrigger = static_cast<rc_trigger_t*>(m_pTrigger);
     return pTrigger->measured_value;
 }

--- a/src/RA_Achievement.cpp
+++ b/src/RA_Achievement.cpp
@@ -573,7 +573,7 @@ unsigned int Achievement::MeasuredTarget() const noexcept
     if (m_pTrigger == nullptr)
         return 0;
 
-    rc_trigger_t* pTrigger = static_cast<rc_trigger_t*>(m_pTrigger);
+    const auto* pTrigger = static_cast<rc_trigger_t*>(m_pTrigger);
     return pTrigger->measured_target;
 }
 
@@ -582,6 +582,6 @@ unsigned int Achievement::MeasuredValue() const noexcept
     if (m_pTrigger == nullptr)
         return 0;
 
-    rc_trigger_t* pTrigger = static_cast<rc_trigger_t*>(m_pTrigger);
+    const auto* pTrigger = static_cast<rc_trigger_t*>(m_pTrigger);
     return pTrigger->measured_value;
 }

--- a/src/RA_Achievement.cpp
+++ b/src/RA_Achievement.cpp
@@ -291,6 +291,9 @@ static void MakeConditionGroup(ConditionSet& vConditions, rc_condset_t* pCondSet
             case RC_CONDITION_AND_NEXT:
                 cond.SetConditionType(Condition::Type::AndNext);
                 break;
+            case RC_CONDITION_MEASURED:
+                cond.SetConditionType(Condition::Type::Measured);
+                break;
         }
 
         cond.SetRequiredHits(pCondition->required_hits);
@@ -563,4 +566,16 @@ void Achievement::CopyFrom(const Achievement& rRHS)
     ParseTrigger(rRHS.CreateMemString().c_str());
 
     SetDirtyFlag(DirtyFlags::All);
+}
+
+unsigned int Achievement::MeasuredTarget() const noexcept
+{
+    rc_trigger_t* pTrigger = static_cast<rc_trigger_t*>(m_pTrigger);
+    return pTrigger->measured_target;
+}
+
+unsigned int Achievement::MeasuredValue() const noexcept
+{
+    rc_trigger_t* pTrigger = static_cast<rc_trigger_t*>(m_pTrigger);
+    return pTrigger->measured_value;
 }

--- a/src/RA_Achievement.h
+++ b/src/RA_Achievement.h
@@ -84,6 +84,9 @@ public:
     inline time_t ModifiedDate() const noexcept { return m_nTimestampModified; }
     void SetModifiedDate(time_t nTimeModified) noexcept { m_nTimestampModified = nTimeModified; }
 
+    unsigned int MeasuredValue() const noexcept;
+    unsigned int MeasuredTarget() const noexcept;
+
     inline unsigned short Upvotes() const noexcept { return m_nUpvotes; }
     inline unsigned short Downvotes() const noexcept { return m_nDownvotes; }
 

--- a/src/RA_Achievement.h
+++ b/src/RA_Achievement.h
@@ -87,16 +87,6 @@ public:
     unsigned int MeasuredValue() const noexcept;
     unsigned int MeasuredTarget() const noexcept;
 
-    inline unsigned short Upvotes() const noexcept { return m_nUpvotes; }
-    inline unsigned short Downvotes() const noexcept { return m_nDownvotes; }
-
-    inline const std::string& Progress() const noexcept { return m_sProgress; }
-    void SetProgressIndicator(const std::string& sProgress) { m_sProgress = sProgress; }
-    inline const std::string& ProgressMax() const noexcept { return m_sProgressMax; }
-    void SetProgressIndicatorMax(const std::string& sProgressMax) { m_sProgressMax = sProgressMax; }
-    inline const std::string& ProgressFmt() const noexcept { return m_sProgressFmt; }
-    void SetProgressIndicatorFormat(const std::string& sProgressFmt) { m_sProgressFmt = sProgressFmt; }
-
     void AddAltGroup() noexcept;
     void RemoveAltGroup(gsl::index nIndex);
 
@@ -133,6 +123,9 @@ public:
 
     void RebuildTrigger();
 
+    // for unit tests
+    void* GetRawTrigger() const noexcept { return m_pTrigger; }
+
     const std::wstring& GetUnlockRichPresence() const noexcept { return m_sUnlockRichPresence; }
     void SetUnlockRichPresence(const std::wstring& sValue) { m_sUnlockRichPresence = sValue; }
 
@@ -163,13 +156,6 @@ private:
     BOOL m_bPauseOnTrigger{};
     BOOL m_bPauseOnReset{};
 
-    // Progress:
-    BOOL m_bProgressEnabled{}; // on/off
-
-    std::string m_sProgress;    // How to calculate the progress so far (syntactical)
-    std::string m_sProgressMax; // Upper limit of the progress (syntactical? value?)
-    std::string m_sProgressFmt; // Format of the progress to be shown (currency? step?)
-
     std::wstring m_sUnlockRichPresence;
 
     float m_fProgressLastShown{}; // The last shown progress
@@ -178,9 +164,6 @@ private:
 
     time_t m_nTimestampCreated{};
     time_t m_nTimestampModified{};
-
-    unsigned short m_nUpvotes{};
-    unsigned short m_nDownvotes{};
 };
 
 #endif // !RA_ACHIEVEMENT_H

--- a/src/RA_Condition.cpp
+++ b/src/RA_Condition.cpp
@@ -60,6 +60,9 @@ void Condition::SerializeAppend(std::string& buffer) const
         case Type::AndNext:
             buffer.append("N:");
             break;
+        case Type::Measured:
+            buffer.append("M:");
+            break;
         default:
             break;
     }

--- a/src/RA_Condition.h
+++ b/src/RA_Condition.h
@@ -83,11 +83,12 @@ public:
         AddSource,
         SubSource,
         AddHits,
-        AndNext
+        AndNext,
+        Measured
     };
 
-    inline static constexpr std::array<LPCTSTR, 7> TYPE_STR{
-        _T(""), _T("Pause If"), _T("Reset If"), _T("Add Source"), _T("Sub Source"), _T("Add Hits"), _T("And Next")};
+    inline static constexpr std::array<LPCTSTR, 8> TYPE_STR{
+        _T(""), _T("Pause If"), _T("Reset If"), _T("Add Source"), _T("Sub Source"), _T("Add Hits"), _T("And Next"), _T("Measured")};
 
     void SerializeAppend(std::string& buffer) const;
 

--- a/src/RA_Dlg_Achievement.cpp
+++ b/src/RA_Dlg_Achievement.cpp
@@ -317,6 +317,13 @@ _Success_(return ) _NODISCARD BOOL
                 for (size_t nCondition = 0; nCondition < Ach.NumConditions(nGroup); ++nCondition)
                 {
                     const auto& pCondition = Ach.GetCondition(nGroup, nCondition);
+
+                    if (pCondition.GetConditionType() == Condition::Type::Measured)
+                    {
+                        ra::ui::viewmodels::MessageBoxViewModel::ShowErrorMessage(L"Achievement contains pre-release logic.", L"* Measured");
+                        return FALSE;
+                    }
+
                     if (pCondition.CompSource().GetSize() == MemSize::TwentyFourBit ||
                         pCondition.CompTarget().GetSize() == MemSize::TwentyFourBit)
                     {

--- a/src/ui/drawing/gdi/GDIBitmapSurface.cpp
+++ b/src/ui/drawing/gdi/GDIBitmapSurface.cpp
@@ -41,7 +41,7 @@ void GDIBitmapSurface::FillRectangle(int nX, int nY, int nWidth, int nHeight, Co
         return;
 
     // fill rectangle
-    auto nFirstScanline = (GetHeight() - nY - nHeight); // bitmap memory starts with the bottom scanline
+    size_t nFirstScanline = (gsl::narrow_cast<size_t>(GetHeight()) - nY - nHeight); // bitmap memory starts with the bottom scanline
     GSL_SUPPRESS_F6 Expects(m_pBits != nullptr);
     auto pBits = m_pBits + nStride * nFirstScanline + nX;
     GSL_SUPPRESS_F6 Ensures(pBits != nullptr);
@@ -49,7 +49,7 @@ void GDIBitmapSurface::FillRectangle(int nX, int nY, int nWidth, int nHeight, Co
     if (nStride == nWidth)
     {
         // doing full scanlines, just bulk fill
-        const std::uint32_t* pEnd = pBits + nWidth * nHeight;
+        const std::uint32_t* pEnd = pBits + gsl::narrow_cast<size_t>(nWidth) * gsl::narrow_cast<size_t>(nHeight);
         do
         {
             *pBits++ = nColor.ARGB;
@@ -133,7 +133,7 @@ void GDIBitmapSurface::WriteText(int nX, int nY, int nFont, Color nColor, const 
     auto nFirstScanline = (GetHeight() - nY - szText.cy); // bitmap memory starts with the bottom scanline
     Expects(ra::to_signed(nFirstScanline) >= 0);
     Expects(m_pBits != nullptr);
-    auto pBits = m_pBits + nStride * nFirstScanline + nX;
+    auto pBits = m_pBits + gsl::narrow_cast<size_t>(nStride) * nFirstScanline + nX;
     Ensures(pBits != nullptr);
 
     // clip to surface
@@ -165,7 +165,7 @@ void GDIBitmapSurface::WriteText(int nX, int nY, int nFont, Color nColor, const 
             ++pBits;
         } while (pBits < pEnd);
 
-        pBits += (nStride - szText.cx);
+        pBits += (gsl::narrow_cast<size_t>(nStride) - szText.cx);
     }
 
     DeleteBitmap(hBitmap);
@@ -191,7 +191,7 @@ void GDIAlphaBitmapSurface::Blend(HDC hTargetDC, int nX, int nY) const
     GSL_SUPPRESS_TYPE1 pSrcBits = reinterpret_cast<std::uint8_t*>(m_pBits);
     Expects(pSrcBits != nullptr);
 
-    const std::uint8_t* pEnd = pSrcBits + (nWidth * nHeight * 4);
+    const std::uint8_t* pEnd = pSrcBits + (gsl::narrow_cast<size_t>(nWidth) * nHeight * 4);
     while (pSrcBits < pEnd)
     {
         const auto nAlpha = pSrcBits[3];
@@ -231,7 +231,7 @@ void GDIAlphaBitmapSurface::SetOpacity(double fAlpha)
     Expects(nAlpha > 0.0); // setting opacity to 0 is irreversible - caller should just not draw it
 
     const std::uint8_t* pEnd{};
-    GSL_SUPPRESS_TYPE1 pEnd = reinterpret_cast<const std::uint8_t*>(m_pBits + GetWidth() * GetHeight());
+    GSL_SUPPRESS_TYPE1 pEnd = reinterpret_cast<const std::uint8_t*>(m_pBits + static_cast<size_t>(GetWidth()) * GetHeight());
 
     std::uint8_t* pBits{};
     GSL_SUPPRESS_TYPE1 pBits = reinterpret_cast<std::uint8_t*>(m_pBits) + 3;

--- a/src/ui/drawing/gdi/ResourceRepository.hh
+++ b/src/ui/drawing/gdi/ResourceRepository.hh
@@ -59,7 +59,7 @@ public:
     HFONT GetHFont(int nFont)
     {
         if (nFont > 0 && ra::to_unsigned(nFont) <= m_vFonts.size())
-            return m_vFonts.at(nFont - 1).hFont;
+            return m_vFonts.at(gsl::narrow_cast<size_t>(nFont) - 1).hFont;
 
         return nullptr;
     }

--- a/src/ui/viewmodels/OverlayAchievementsPageViewModel.cpp
+++ b/src/ui/viewmodels/OverlayAchievementsPageViewModel.cpp
@@ -71,6 +71,17 @@ void OverlayAchievementsPageViewModel::Refresh()
             }
         }
 
+        if (pAchievement.Active())
+        {
+            pvmAchievement->SetProgressMaximum(pAchievement.MeasuredTarget());
+            pvmAchievement->SetProgressValue(pAchievement.MeasuredValue());
+        }
+        else
+        {
+            pvmAchievement->SetProgressMaximum(0);
+            pvmAchievement->SetProgressValue(0);
+        }
+
         return true;
     });
 

--- a/src/ui/viewmodels/OverlayListPageViewModel.cpp
+++ b/src/ui/viewmodels/OverlayListPageViewModel.cpp
@@ -17,6 +17,8 @@ const IntModelProperty OverlayListPageViewModel::SelectedItemIndexProperty("Over
 
 const StringModelProperty OverlayListPageViewModel::ItemViewModel::DetailProperty("ItemViewModel", "Detail", L"");
 const BoolModelProperty OverlayListPageViewModel::ItemViewModel::IsDisabledProperty("ItemViewModel", "IsDisabled", false);
+const IntModelProperty OverlayListPageViewModel::ItemViewModel::ProgressMaximumProperty("ItemViewModel", "ProgressMaximum", 0);
+const IntModelProperty OverlayListPageViewModel::ItemViewModel::ProgressValueProperty("ItemViewModel", "ProgressValue", 0);
 
 void OverlayListPageViewModel::Refresh()
 {
@@ -106,7 +108,7 @@ void OverlayListPageViewModel::RenderList(ra::ui::drawing::ISurface& pSurface, i
         nX += 20;
     }
 
-    // achievements list
+    // items list
     while (nHeight >= nItemSize)
     {
         const auto* pItem = m_vItems.GetItemAt(nIndex);
@@ -135,8 +137,19 @@ void OverlayListPageViewModel::RenderList(ra::ui::drawing::ISurface& pSurface, i
             nTextColor = pTheme.ColorOverlayDisabledText();
         }
 
-        pSurface.WriteText(nTextX + 12, nY + 4, nFont, nTextColor, pItem->GetLabel());
-        pSurface.WriteText(nTextX + 12, nY + 4 + 26, nSubFont, nSubTextColor, pItem->GetDetail());
+        pSurface.WriteText(nTextX + 12, nY + 1, nFont, nTextColor, pItem->GetLabel());
+        pSurface.WriteText(nTextX + 12, nY + 1 + 26, nSubFont, nSubTextColor, pItem->GetDetail());
+
+        const auto nTarget = pItem->GetProgressMaximum();
+        if (nTarget != 0)
+        {
+            const auto nProgressBarWidth = (nWidth - nTextX - 12) * 2 / 3;
+            const auto nValue = pItem->GetProgressValue();
+            const auto nProgressBarFillWidth = (nProgressBarWidth - 2) * nValue / nTarget;
+
+            pSurface.FillRectangle(nTextX + 12, nY + 1 + 26 + 25, nProgressBarWidth, 8, pTheme.ColorOverlayScrollBar());
+            pSurface.FillRectangle(nTextX + 12 + 2, nY + 1 + 26 + 25 + 2, nProgressBarFillWidth - 4, 8 - 4, pTheme.ColorOverlayScrollBarGripper());
+        }
 
         nIndex++;
         nY += nItemSize + nItemSpacing;

--- a/src/ui/viewmodels/OverlayListPageViewModel.cpp
+++ b/src/ui/viewmodels/OverlayListPageViewModel.cpp
@@ -166,12 +166,12 @@ bool OverlayListPageViewModel::ProcessInput(const ControllerInput& pInput)
         {
             SetSelectedItemIndex(nSelectedItemIndex + 1);
 
-            if (nSelectedItemIndex + 1 - m_nScrollOffset == ra::to_signed(m_nVisibleItems))
+            if (gsl::narrow_cast<size_t>(nSelectedItemIndex) + 1 - m_nScrollOffset == gsl::narrow_cast<size_t>(m_nVisibleItems))
                 ++m_nScrollOffset;
 
             if (m_bDetail)
             {
-                auto* vmItem = m_vItems.GetItemAt(nSelectedItemIndex + 1);
+                auto* vmItem = m_vItems.GetItemAt(gsl::narrow_cast<size_t>(nSelectedItemIndex) + 1);
                 if (vmItem != nullptr)
                     FetchItemDetail(*vmItem);
             }
@@ -191,7 +191,7 @@ bool OverlayListPageViewModel::ProcessInput(const ControllerInput& pInput)
 
             if (m_bDetail)
             {
-                auto* vmItem = m_vItems.GetItemAt(nSelectedItemIndex - 1);
+                auto* vmItem = m_vItems.GetItemAt(gsl::narrow_cast<size_t>(nSelectedItemIndex) - 1);
                 if (vmItem != nullptr)
                     FetchItemDetail(*vmItem);
             }

--- a/src/ui/viewmodels/OverlayListPageViewModel.hh
+++ b/src/ui/viewmodels/OverlayListPageViewModel.hh
@@ -97,6 +97,36 @@ public:
         void SetDisabled(bool bValue) { SetValue(IsDisabledProperty, bValue); }
 
         ImageReference Image{};
+
+        /// <summary>
+        /// The <see cref="ModelProperty" /> for the maximum progress bar value.
+        /// </summary>
+        static const IntModelProperty ProgressMaximumProperty;
+
+        /// <summary>
+        /// Gets the maximum progress bar value.
+        /// </summary>
+        unsigned int GetProgressMaximum() const { return ra::to_unsigned(GetValue(ProgressMaximumProperty)); }
+
+        /// <summary>
+        /// Sets the maximum progress bar value.
+        /// </summary>
+        void SetProgressMaximum(unsigned int nValue) { SetValue(ProgressMaximumProperty, ra::to_signed(nValue)); }
+
+        /// <summary>
+        /// The <see cref="ModelProperty" /> for the current progress bar value.
+        /// </summary>
+        static const IntModelProperty ProgressValueProperty;
+
+        /// <summary>
+        /// Gets the current progress bar value.
+        /// </summary>
+        unsigned int GetProgressValue() const { return ra::to_unsigned(GetValue(ProgressValueProperty)); }
+
+        /// <summary>
+        /// Sets the current progress bar value.
+        /// </summary>
+        void SetProgressValue(unsigned int nValue) { SetValue(ProgressValueProperty, ra::to_signed(nValue)); }
     };
 
 protected:

--- a/tests/ui/viewmodels/OverlayFriendsPageViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/OverlayFriendsPageViewModel_Tests.cpp
@@ -59,7 +59,7 @@ public:
         friendsPage.mockTheadPool.ExecuteNextTask(); // fetch friends list is async
 
         Assert::AreEqual(std::wstring(), friendsPage.GetSummary());
-        Assert::AreEqual(0U, friendsPage.GetItemCount());
+        Assert::AreEqual({ 0U }, friendsPage.GetItemCount());
     }
 
     TEST_METHOD(TestRefreshSeveralFriends)
@@ -122,7 +122,7 @@ public:
         friendsPage.mockTheadPool.ExecuteNextTask(); // fetch friends list is async
 
         Assert::AreEqual(std::wstring(L"Failed to find friends"), friendsPage.GetSummary());
-        Assert::AreEqual(0U, friendsPage.GetItemCount());
+        Assert::AreEqual({ 0U }, friendsPage.GetItemCount());
     }
 
     TEST_METHOD(TestRefreshTimer)
@@ -144,7 +144,7 @@ public:
         Assert::AreEqual(std::wstring(), friendsPage.GetSummary());
 
         friendsPage.mockTheadPool.ExecuteNextTask(); // fetch friends list is async
-        Assert::AreEqual(3U, friendsPage.GetItemCount());
+        Assert::AreEqual({ 3U }, friendsPage.GetItemCount());
 
         // two friends updated, one added
         friendsPage.mockServer.HandleRequest<ra::api::FetchUserFriends>(
@@ -160,18 +160,18 @@ public:
 
         friendsPage.Refresh();
         friendsPage.mockTheadPool.ExecuteNextTask(); // fetch friends list is async
-        Assert::AreEqual(3U, friendsPage.GetItemCount()); // refresh should not have occured
+        Assert::AreEqual({ 3U }, friendsPage.GetItemCount()); // refresh should not have occured
 
         friendsPage.mockClock.AdvanceTime(std::chrono::minutes(1));
         friendsPage.Refresh();
         friendsPage.mockTheadPool.ExecuteNextTask(); // fetch friends list is async
-        Assert::AreEqual(3U, friendsPage.GetItemCount()); // refresh should not have occured
+        Assert::AreEqual({ 3U }, friendsPage.GetItemCount()); // refresh should not have occured
 
 
         friendsPage.mockClock.AdvanceTime(std::chrono::minutes(1));
         friendsPage.Refresh();
         friendsPage.mockTheadPool.ExecuteNextTask(); // fetch friends list is async
-        Assert::AreEqual(4U, friendsPage.GetItemCount()); // refresh should have occured
+        Assert::AreEqual({ 4U }, friendsPage.GetItemCount()); // refresh should have occured
 
         const auto* pFriend1 = friendsPage.GetItem(0);
         Assert::IsNotNull(pFriend1);

--- a/tests/ui/viewmodels/OverlayLeaderboardsPageViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/OverlayLeaderboardsPageViewModel_Tests.cpp
@@ -111,13 +111,13 @@ public:
 
         auto* pDetail = leaderboardsPage.GetRanks(1);
         Expects(pDetail != nullptr);
-        Assert::AreEqual(0U, pDetail->Count());
+        Assert::AreEqual({ 0U }, pDetail->Count());
 
         leaderboardsPage.mockThreadPool.ExecuteNextTask();
         pDetail = leaderboardsPage.GetRanks(1);
         Expects(pDetail != nullptr);
 
-        Assert::AreEqual(3U, pDetail->Count());
+        Assert::AreEqual({ 3U }, pDetail->Count());
         auto* pItem = pDetail->GetItemAt(0);
         Expects(pItem != nullptr);
         Assert::AreEqual(std::wstring(L"User1"), pItem->GetLabel());

--- a/tests/ui/viewmodels/OverlayListPageViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/OverlayListPageViewModel_Tests.cpp
@@ -72,9 +72,9 @@ public:
     TEST_METHOD(TestInitialValues)
     {
         OverlayListPageViewModelHarness vmListPage;
-        Assert::AreEqual(0, vmListPage.GetScrollOffset());
+        Assert::AreEqual({ 0 }, vmListPage.GetScrollOffset());
         Assert::AreEqual(0, vmListPage.GetSelectedItemIndex());
-        Assert::AreEqual(0U, vmListPage.GetItemCount());
+        Assert::AreEqual({ 0U }, vmListPage.GetItemCount());
         Assert::IsFalse(vmListPage.IsDetail());
         Assert::AreEqual(std::wstring(), vmListPage.GetTitle());
         Assert::AreEqual(std::wstring(), vmListPage.GetListTitle());
@@ -86,9 +86,9 @@ public:
         OverlayListPageViewModelHarness vmListPage;
         vmListPage.Refresh();
 
-        Assert::AreEqual(0, vmListPage.GetScrollOffset());
+        Assert::AreEqual({ 0 }, vmListPage.GetScrollOffset());
         Assert::AreEqual(0, vmListPage.GetSelectedItemIndex());
-        Assert::AreEqual(12U, vmListPage.GetItemCount());
+        Assert::AreEqual({ 12U }, vmListPage.GetItemCount());
         Assert::IsFalse(vmListPage.IsDetail());
         Assert::AreEqual(std::wstring(L"Title"), vmListPage.GetTitle());
         Assert::AreEqual(std::wstring(), vmListPage.GetListTitle());
@@ -172,106 +172,106 @@ public:
         pInput.m_bDownPressed = true;
         Assert::IsTrue(vmListPage.ProcessInput(pInput));
         Assert::AreEqual(1, vmListPage.GetSelectedItemIndex());
-        Assert::AreEqual(0, vmListPage.GetScrollOffset());
+        Assert::AreEqual({ 0 }, vmListPage.GetScrollOffset());
 
         Assert::IsTrue(vmListPage.ProcessInput(pInput));
         Assert::AreEqual(2, vmListPage.GetSelectedItemIndex());
-        Assert::AreEqual(0, vmListPage.GetScrollOffset());
+        Assert::AreEqual({ 0 }, vmListPage.GetScrollOffset());
 
         Assert::IsTrue(vmListPage.ProcessInput(pInput));
         Assert::AreEqual(3, vmListPage.GetSelectedItemIndex());
-        Assert::AreEqual(0, vmListPage.GetScrollOffset());
+        Assert::AreEqual({ 0 }, vmListPage.GetScrollOffset());
 
         Assert::IsTrue(vmListPage.ProcessInput(pInput));
         Assert::AreEqual(4, vmListPage.GetSelectedItemIndex());
-        Assert::AreEqual(0, vmListPage.GetScrollOffset());
+        Assert::AreEqual({ 0 }, vmListPage.GetScrollOffset());
 
         Assert::IsTrue(vmListPage.ProcessInput(pInput));
         Assert::AreEqual(5, vmListPage.GetSelectedItemIndex());
-        Assert::AreEqual(1, vmListPage.GetScrollOffset());
+        Assert::AreEqual({ 1 }, vmListPage.GetScrollOffset());
 
         // five visible items, list should start scrolling now
         Assert::IsTrue(vmListPage.ProcessInput(pInput));
         Assert::AreEqual(6, vmListPage.GetSelectedItemIndex());
-        Assert::AreEqual(2, vmListPage.GetScrollOffset());
+        Assert::AreEqual({ 2 }, vmListPage.GetScrollOffset());
 
         Assert::IsTrue(vmListPage.ProcessInput(pInput));
         Assert::AreEqual(7, vmListPage.GetSelectedItemIndex());
-        Assert::AreEqual(3, vmListPage.GetScrollOffset());
+        Assert::AreEqual({ 3 }, vmListPage.GetScrollOffset());
 
         Assert::IsTrue(vmListPage.ProcessInput(pInput));
         Assert::AreEqual(8, vmListPage.GetSelectedItemIndex());
-        Assert::AreEqual(4, vmListPage.GetScrollOffset());
+        Assert::AreEqual({ 4 }, vmListPage.GetScrollOffset());
 
         Assert::IsTrue(vmListPage.ProcessInput(pInput));
         Assert::AreEqual(9, vmListPage.GetSelectedItemIndex());
-        Assert::AreEqual(5, vmListPage.GetScrollOffset());
+        Assert::AreEqual({ 5 }, vmListPage.GetScrollOffset());
 
         Assert::IsTrue(vmListPage.ProcessInput(pInput));
         Assert::AreEqual(10, vmListPage.GetSelectedItemIndex());
-        Assert::AreEqual(6, vmListPage.GetScrollOffset());
+        Assert::AreEqual({ 6 }, vmListPage.GetScrollOffset());
 
         Assert::IsTrue(vmListPage.ProcessInput(pInput));
         Assert::AreEqual(11, vmListPage.GetSelectedItemIndex());
-        Assert::AreEqual(7, vmListPage.GetScrollOffset());
+        Assert::AreEqual({ 7 }, vmListPage.GetScrollOffset());
 
         // end of list
         Assert::IsFalse(vmListPage.ProcessInput(pInput));
         Assert::AreEqual(11, vmListPage.GetSelectedItemIndex());
-        Assert::AreEqual(7, vmListPage.GetScrollOffset());
+        Assert::AreEqual({ 7 }, vmListPage.GetScrollOffset());
 
         // going up shouldn't immediately update the scroll offset
         pInput.m_bDownPressed = false;
         pInput.m_bUpPressed = true;
         Assert::IsTrue(vmListPage.ProcessInput(pInput));
         Assert::AreEqual(10, vmListPage.GetSelectedItemIndex());
-        Assert::AreEqual(7, vmListPage.GetScrollOffset());
+        Assert::AreEqual({ 7 }, vmListPage.GetScrollOffset());
 
         Assert::IsTrue(vmListPage.ProcessInput(pInput));
         Assert::AreEqual(9, vmListPage.GetSelectedItemIndex());
-        Assert::AreEqual(7, vmListPage.GetScrollOffset());
+        Assert::AreEqual({ 7 }, vmListPage.GetScrollOffset());
 
         Assert::IsTrue(vmListPage.ProcessInput(pInput));
         Assert::AreEqual(8, vmListPage.GetSelectedItemIndex());
-        Assert::AreEqual(7, vmListPage.GetScrollOffset());
+        Assert::AreEqual({ 7 }, vmListPage.GetScrollOffset());
 
         Assert::IsTrue(vmListPage.ProcessInput(pInput));
         Assert::AreEqual(7, vmListPage.GetSelectedItemIndex());
-        Assert::AreEqual(7, vmListPage.GetScrollOffset());
+        Assert::AreEqual({ 7 }, vmListPage.GetScrollOffset());
 
         Assert::IsTrue(vmListPage.ProcessInput(pInput));
         Assert::AreEqual(6, vmListPage.GetSelectedItemIndex());
-        Assert::AreEqual(6, vmListPage.GetScrollOffset());
+        Assert::AreEqual({ 6 }, vmListPage.GetScrollOffset());
 
         // now we should start scrolling again
         Assert::IsTrue(vmListPage.ProcessInput(pInput));
         Assert::AreEqual(5, vmListPage.GetSelectedItemIndex());
-        Assert::AreEqual(5, vmListPage.GetScrollOffset());
+        Assert::AreEqual({ 5 }, vmListPage.GetScrollOffset());
 
         Assert::IsTrue(vmListPage.ProcessInput(pInput));
         Assert::AreEqual(4, vmListPage.GetSelectedItemIndex());
-        Assert::AreEqual(4, vmListPage.GetScrollOffset());
+        Assert::AreEqual({ 4 }, vmListPage.GetScrollOffset());
 
         Assert::IsTrue(vmListPage.ProcessInput(pInput));
         Assert::AreEqual(3, vmListPage.GetSelectedItemIndex());
-        Assert::AreEqual(3, vmListPage.GetScrollOffset());
+        Assert::AreEqual({ 3 }, vmListPage.GetScrollOffset());
 
         Assert::IsTrue(vmListPage.ProcessInput(pInput));
         Assert::AreEqual(2, vmListPage.GetSelectedItemIndex());
-        Assert::AreEqual(2, vmListPage.GetScrollOffset());
+        Assert::AreEqual({ 2 }, vmListPage.GetScrollOffset());
 
         Assert::IsTrue(vmListPage.ProcessInput(pInput));
         Assert::AreEqual(1, vmListPage.GetSelectedItemIndex());
-        Assert::AreEqual(1, vmListPage.GetScrollOffset());
+        Assert::AreEqual({ 1 }, vmListPage.GetScrollOffset());
 
         Assert::IsTrue(vmListPage.ProcessInput(pInput));
         Assert::AreEqual(0, vmListPage.GetSelectedItemIndex());
-        Assert::AreEqual(0, vmListPage.GetScrollOffset());
+        Assert::AreEqual({ 0 }, vmListPage.GetScrollOffset());
 
         // end of list
         Assert::IsFalse(vmListPage.ProcessInput(pInput));
         Assert::AreEqual(0, vmListPage.GetSelectedItemIndex());
-        Assert::AreEqual(0, vmListPage.GetScrollOffset());
+        Assert::AreEqual({ 0 }, vmListPage.GetScrollOffset());
     }
 
     TEST_METHOD(TestProcessInputDetailToggle)

--- a/tests/ui/viewmodels/OverlayRecentGamesPageViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/OverlayRecentGamesPageViewModel_Tests.cpp
@@ -50,7 +50,7 @@ public:
 
         Assert::AreEqual(std::wstring(L"Recent Games"), gamesPage.GetTitle());
         Assert::AreEqual(std::wstring(), gamesPage.GetSummary());
-        Assert::AreEqual(0U, gamesPage.GetItemCount());
+        Assert::AreEqual({ 0U }, gamesPage.GetItemCount());
     }
 
     TEST_METHOD(TestRefreshOneGameDataAvailable)
@@ -63,7 +63,7 @@ public:
 
         Assert::AreEqual(std::wstring(L"Recent Games"), gamesPage.GetTitle());
         Assert::AreEqual(std::wstring(), gamesPage.GetSummary());
-        Assert::AreEqual(1U, gamesPage.GetItemCount());
+        Assert::AreEqual({ 1U }, gamesPage.GetItemCount());
 
         const auto* pItem1 = gamesPage.GetItem(0);
         Assert::IsNotNull(pItem1);
@@ -94,7 +94,7 @@ public:
 
         Assert::AreEqual(std::wstring(L"Recent Games"), gamesPage.GetTitle());
         Assert::AreEqual(std::wstring(), gamesPage.GetSummary());
-        Assert::AreEqual(1U, gamesPage.GetItemCount());
+        Assert::AreEqual({ 1U }, gamesPage.GetItemCount());
 
         // data is not initially available
         auto* pItem1 = gamesPage.GetItem(0);
@@ -121,7 +121,7 @@ public:
         gamesPage.mockTheadPool.ExecuteNextTask(); // request is asynchronous
 
         // data was fetched from the server
-        Assert::AreEqual(1U, gamesPage.GetItemCount());
+        Assert::AreEqual({ 1U }, gamesPage.GetItemCount());
         pItem1 = gamesPage.GetItem(0);
         Assert::IsNotNull(pItem1);
         Ensures(pItem1 != nullptr);
@@ -144,7 +144,7 @@ public:
 
         Assert::AreEqual(std::wstring(L"Recent Games"), gamesPage.GetTitle());
         Assert::AreEqual(std::wstring(), gamesPage.GetSummary());
-        Assert::AreEqual(1U, gamesPage.GetItemCount());
+        Assert::AreEqual({ 1U }, gamesPage.GetItemCount());
 
         // data is not initially available
         auto* pItem1 = gamesPage.GetItem(0);
@@ -159,7 +159,7 @@ public:
         gamesPage.mockTheadPool.ExecuteNextTask(); // scanning cache occurs on background thread
 
         // data is in the cache
-        Assert::AreEqual(1U, gamesPage.GetItemCount());
+        Assert::AreEqual({ 1U }, gamesPage.GetItemCount());
         pItem1 = gamesPage.GetItem(0);
         Assert::IsNotNull(pItem1);
         Ensures(pItem1 != nullptr);


### PR DESCRIPTION
Active achievements with a Measured field will be reflected in the overlay:

![image](https://user-images.githubusercontent.com/32680403/68079244-935c1b00-fdac-11e9-9324-cd66fe7ebda6.png)

Inactive (previously triggered) achievements with a Measured flag will not show a progress bar. Achievements without a Measured flag will not show a progress bar. 

Only one Measured field may be present in an achievement (this includes across alts). If more than one is present, a "Parse Error -22" will occur.