### PR TITLE
Add support for changing combobox values on multiple grid items at once

### DIFF
--- a/src/services/impl/WindowsHttpRequester.cpp
+++ b/src/services/impl/WindowsHttpRequester.cpp
@@ -27,7 +27,7 @@ static bool ReadIntoString(const HINTERNET hRequest, std::string& sBuffer, DWORD
 #pragma warning(pop)
 
     // allocate enough space in the string for the whole content
-    sBuffer.resize(nContentLength + 1); // reserve space for null terminator
+    sBuffer.resize(gsl::narrow_cast<size_t>(nContentLength) + 1); // reserve space for null terminator
     sBuffer.at(nContentLength) = '\0'; // set null terminator, will fill remaining portion of buffer
     sBuffer.resize(nContentLength);
 

--- a/src/ui/drawing/gdi/GDIBitmapSurface.cpp
+++ b/src/ui/drawing/gdi/GDIBitmapSurface.cpp
@@ -66,7 +66,7 @@ void GDIBitmapSurface::FillRectangle(int nX, int nY, int nWidth, int nHeight, Co
                 *pBits++ = nColor.ARGB;
             } while (pBits < pEnd);
 
-            pBits += (nStride - nWidth);
+            pBits += gsl::narrow_cast<size_t>(nStride) - gsl::narrow_cast<size_t>(nWidth);
         }
     }
 }

--- a/src/ui/win32/DialogBase.cpp
+++ b/src/ui/win32/DialogBase.cpp
@@ -195,6 +195,23 @@ INT_PTR CALLBACK DialogBase::DialogProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPA
             GSL_SUPPRESS_TYPE1{ pnmHdr = reinterpret_cast<LPNMHDR>(lParam); }
             switch (pnmHdr->code)
             {
+                case LVN_ITEMCHANGING:
+                {
+                    ra::ui::win32::bindings::GridBinding* pGridBinding;
+                    GSL_SUPPRESS_TYPE1 pGridBinding = reinterpret_cast<ra::ui::win32::bindings::GridBinding*>(
+                        FindControlBinding(pnmHdr->hwndFrom));
+
+                    if (pGridBinding)
+                    {
+                        LPNMLISTVIEW pnmListView;
+                        GSL_SUPPRESS_TYPE1{ pnmListView = reinterpret_cast<LPNMLISTVIEW>(pnmHdr); }
+                        SetWindowLongPtr(m_hWnd, DWLP_MSGRESULT, pGridBinding->OnLvnItemChanging(pnmListView));
+                        return TRUE;
+                    }
+
+                    return FALSE;
+                }
+
                 case LVN_ITEMCHANGED:
                 {
                     ra::ui::win32::bindings::GridBinding* pGridBinding;

--- a/src/ui/win32/bindings/GridBinding.cpp
+++ b/src/ui/win32/bindings/GridBinding.cpp
@@ -237,7 +237,7 @@ void GridBinding::UpdateItems(gsl::index nColumn)
 
     if (ra::to_unsigned(nItems) > m_vmItems->Count())
     {
-        for (gsl::index i = nItems - 1; ra::to_unsigned(i) >= m_vmItems->Count(); --i)
+        for (gsl::index i = gsl::narrow_cast<gsl::index>(nItems) - 1; ra::to_unsigned(i) >= m_vmItems->Count(); --i)
             ListView_DeleteItem(m_hWnd, i);
     }
 }

--- a/src/ui/win32/bindings/GridBinding.cpp
+++ b/src/ui/win32/bindings/GridBinding.cpp
@@ -320,6 +320,26 @@ void GridBinding::OnViewModelStringValueChanged(gsl::index nIndex, const StringM
     }
 }
 
+int GridBinding::UpdateSelected(const IntModelProperty& pProperty, int nNewValue)
+{
+    if (m_pIsSelectedProperty == nullptr)
+        return 0;
+
+    int nUpdated = 0;
+
+    const auto nCount = ra::to_signed(m_vmItems->Count());
+    for (gsl::index nIndex = 0; nIndex < nCount; ++nIndex)
+    {
+        if (m_vmItems->GetItemValue(nIndex, *m_pIsSelectedProperty))
+        {
+            m_vmItems->SetItemValue(nIndex, pProperty, nNewValue);
+            ++nUpdated;
+        }
+    }
+
+    return nUpdated;
+}
+
 void GridBinding::UpdateRow(gsl::index nIndex, bool bExisting)
 {
     std::string sText;

--- a/src/ui/win32/bindings/GridBinding.hh
+++ b/src/ui/win32/bindings/GridBinding.hh
@@ -62,6 +62,8 @@ public:
     static LRESULT CloseIPE(HWND hwnd, GridColumnBinding::InPlaceEditorInfo* pInfo);
     static GridColumnBinding::InPlaceEditorInfo* GetIPEInfo(HWND hwnd) noexcept;
 
+    int UpdateSelected(const IntModelProperty& pProperty, int nNewValue);
+
 protected:
     void UpdateLayout();
     void UpdateAllItems();

--- a/src/ui/win32/bindings/GridBinding.hh
+++ b/src/ui/win32/bindings/GridBinding.hh
@@ -44,6 +44,7 @@ public:
     void BindIsSelected(const BoolModelProperty& pIsSelectedProperty) noexcept;
     void BindRowColor(const IntModelProperty& pRowColorProperty) noexcept;
 
+    GSL_SUPPRESS_CON3 LRESULT OnLvnItemChanging(const LPNMLISTVIEW pnmListView);
     GSL_SUPPRESS_CON3 void OnLvnItemChanged(const LPNMLISTVIEW pnmListView);
     GSL_SUPPRESS_CON3 void OnLvnColumnClick(const LPNMLISTVIEW pnmListView);
     void OnNmClick(const NMITEMACTIVATE* pnmItemActivate);

--- a/src/ui/win32/bindings/GridLookupColumnBinding.cpp
+++ b/src/ui/win32/bindings/GridLookupColumnBinding.cpp
@@ -24,7 +24,8 @@ static LRESULT NotifySelection(HWND hwnd, GridColumnBinding::InPlaceEditorInfo* 
 
     GridBinding* gridBinding = static_cast<GridBinding*>(pInfo->pGridBinding);
     Expects(gridBinding != nullptr);
-    gridBinding->GetItems().SetItemValue(pInfo->nItemIndex, pColumnBinding->GetBoundProperty(), nValue);
+    if (gridBinding->UpdateSelected(pColumnBinding->GetBoundProperty(), nValue) == 0)
+        gridBinding->GetItems().SetItemValue(pInfo->nItemIndex, pColumnBinding->GetBoundProperty(), nValue);
 
     return GridBinding::CloseIPE(hwnd, pInfo);
 }

--- a/src/ui/win32/bindings/GridTextColumnBinding.cpp
+++ b/src/ui/win32/bindings/GridTextColumnBinding.cpp
@@ -25,7 +25,7 @@ static LRESULT NotifySelection(HWND hwnd, GridColumnBinding::InPlaceEditorInfo* 
 
     const auto nLength = Edit_GetTextLength(hwnd);
     std::wstring sValue;
-    sValue.resize(nLength + 1);
+    sValue.resize(gsl::narrow_cast<size_t>(nLength) + 1);
     GetWindowTextW(hwnd, sValue.data(), nLength + 1);
     sValue.resize(nLength);
 

--- a/src/ui/win32/bindings/TextBoxBinding.hh
+++ b/src/ui/win32/bindings/TextBoxBinding.hh
@@ -62,7 +62,7 @@ private:
         const int nLength = GetWindowTextLengthW(m_hWnd);
 
         std::wstring sBuffer;
-        sBuffer.resize(nLength + 1);
+        sBuffer.resize(gsl::narrow_cast<size_t>(nLength) + 1);
         GetWindowTextW(m_hWnd, sBuffer.data(), gsl::narrow_cast<int>(sBuffer.capacity()));
         sBuffer.resize(nLength);
 


### PR DESCRIPTION
If the combobox is opened while the Ctrl or Shift keys are being held down, the existing multi-select within the grid will be maintained and the selected dropdown item will be applied to all selected items.

I could not make this work without holding down the Ctrl or Shift keys. Despite my best efforts to tell the control not to deselect things, it would often think they were deselected even if they didn't appear that way, so attempting to change the selection normally wouldn't unselect some of the previously selected items. If the combobox is opened without holding down Ctrl or Shift, all but the current item will be unselected (normal behavior) before the combobox is opened.

Additionally, this does not currently work with non-combobox fields as the validation for those is currently tied into the update.