### PR TITLE
delay mastery check to allow unlock calls to complete

### DIFF
--- a/tests/RA_Leaderboard_Tests.cpp
+++ b/tests/RA_Leaderboard_Tests.cpp
@@ -147,7 +147,7 @@ public:
         lb.Test();
         Assert::IsTrue(lb.IsActive());
 
-        Assert::AreEqual("000018 Points", lb.FormatScore(18).c_str());
+        Assert::AreEqual("000018", lb.FormatScore(18).c_str());
     }
 
     TEST_METHOD(TestStartAndCancelSameFrame)

--- a/tests/data/GameContext_Tests.cpp
+++ b/tests/data/GameContext_Tests.cpp
@@ -1142,6 +1142,7 @@ public:
 
         game.mockThreadPool.ExecuteNextTask(); // award achievement 1
         game.mockThreadPool.ExecuteNextTask(); // award achievement 2
+        game.mockThreadPool.AdvanceTime(std::chrono::milliseconds(500)); // mastery unlock check is delayed
         game.mockThreadPool.ExecuteNextTask(); // check unlocks
 
         Assert::IsTrue(game.mockAudioSystem.WasAudioFilePlayed(L"Overlay\\unlock.wav"));
@@ -1202,6 +1203,7 @@ public:
 
         game.mockThreadPool.ExecuteNextTask(); // award achievement 1
         game.mockThreadPool.ExecuteNextTask(); // award achievement 2
+        game.mockThreadPool.AdvanceTime(std::chrono::milliseconds(500)); // mastery unlock check is delayed
         game.mockThreadPool.ExecuteNextTask(); // check unlocks
 
         Assert::IsTrue(game.mockAudioSystem.WasAudioFilePlayed(L"Overlay\\unlock.wav"));


### PR DESCRIPTION
without the delay, both the final unlock and the check for mastery are sent to the server at the same time. if the check completes before the unlock, the mastery would not pop.