### PR TITLE
don't limit text input by size of control

### DIFF
--- a/src/RA_Dlg_AchEditor.cpp
+++ b/src/RA_Dlg_AchEditor.cpp
@@ -645,7 +645,7 @@ BOOL CreateIPE(int nItem, CondSubItems nSubItem)
             }
 
             g_hIPEEdit = CreateWindowEx(WS_EX_CLIENTEDGE, TEXT("EDIT"), TEXT(""),
-                                        WS_CHILD | WS_VISIBLE | WS_POPUPWINDOW | WS_BORDER | ES_WANTRETURN,
+                                        WS_CHILD | WS_VISIBLE | WS_POPUPWINDOW | WS_BORDER | ES_WANTRETURN | ES_AUTOHSCROLL,
                                         rcSubItem.left, rcSubItem.top, nWidth, ra::ftoi(1.5f * nHeight),
                                         g_AchievementEditorDialog.GetHWND(), nullptr, GetModuleHandle(nullptr), nullptr);
 

--- a/src/ui/win32/bindings/GridTextColumnBinding.cpp
+++ b/src/ui/win32/bindings/GridTextColumnBinding.cpp
@@ -80,7 +80,7 @@ HWND GridTextColumnBindingBase::CreateInPlaceEditor(HWND hParent, InPlaceEditorI
 {
     HWND hInPlaceEditor =
         CreateWindowEx(WS_EX_CLIENTEDGE, TEXT("EDIT"), TEXT(""),
-            WS_CHILD | WS_VISIBLE | WS_POPUPWINDOW | WS_BORDER | ES_WANTRETURN,
+            WS_CHILD | WS_VISIBLE | WS_POPUPWINDOW | WS_BORDER | ES_WANTRETURN | ES_AUTOHSCROLL,
             pInfo.rcSubItem.left, pInfo.rcSubItem.top, pInfo.rcSubItem.right - pInfo.rcSubItem.left,
             pInfo.rcSubItem.bottom - pInfo.rcSubItem.top,
             hParent, nullptr, GetModuleHandle(nullptr), nullptr);


### PR DESCRIPTION
The in-place editor for text fields limits input to the size of the control. For most use cases, this is sufficient, but if users adjust their system fonts/DPI settings, the control may no longer be big enough. 

While there's probably much more significant changes necessary to truly support custom DPI settings, this allows the user to type in longer strings. The existing range validation should disallow values that are too long.