### PR TITLE
display dummy background if overlay background is not available

### DIFF
--- a/src/RA_Achievement.cpp
+++ b/src/RA_Achievement.cpp
@@ -245,6 +245,7 @@ static void MakeConditionGroup(ConditionSet& vConditions, rc_condset_t* pCondSet
             default:
                 ASSERT(!"Unsupported operator");
                 _FALLTHROUGH;
+            case RC_CONDITION_NONE:
             case RC_CONDITION_EQ:
                 cond.SetCompareType(ComparisonType::Equals);
                 break;


### PR DESCRIPTION
Fixes a rendering issue when the `overlay` directory is missing.

Before:
![image](https://user-images.githubusercontent.com/32680403/69883784-e97c8b00-1292-11ea-9b38-ee1879b80b2c.png)

After:
![image](https://user-images.githubusercontent.com/32680403/69883791-eed9d580-1292-11ea-8fac-f0843ec6e664.png)
