### PR TITLE
prevent destruction of achievement when Measured is used improperly

### DIFF
--- a/src/RA_Dlg_Achievement.cpp
+++ b/src/RA_Dlg_Achievement.cpp
@@ -283,7 +283,7 @@ _Success_(return ) _NODISCARD BOOL
 {
     for (auto& nIter : nLbxItems)
     {
-        Achievement& Ach = *g_AchievementsDialog.GetAchievementAt(nIter);
+        const Achievement& Ach = *g_AchievementsDialog.GetAchievementAt(nIter);
         if (Ach.Title().length() < 2)
         {
             ra::ui::viewmodels::MessageBoxViewModel::ShowErrorMessage(L"Achievement title too short.",


### PR DESCRIPTION
When editing an achievement, if the intermediate state is invalid, the editor throws up a Parse Error dialog, then clears out the achievement editor. This destructive behavior is undesired. Additionally, this occasionally leads to the editor crashing if it tries to show a tooltip for the no-longer-present condition.

The solution implemented here is to detect the situations where a Parse Error would result due to the intermediary state and alter the achievement to prevent the error. In this case, both errors are related to the Measured flag, so the solution is to remove the Measured flag (and tell the user). 

This problem exists because the achievement can be edited while it's active. Therefore any change has to be immediately reincorporated into the active achievement. A better solution will be implemented in the future.