### PR TITLE
include playtime in mastery notification

### DIFF
--- a/src/data/GameContext.cpp
+++ b/src/data/GameContext.cpp
@@ -17,6 +17,7 @@
 #include "api\UpdateCodeNote.hh"
 
 #include "data\EmulatorContext.hh"
+#include "data\SessionTracker.hh"
 #include "data\UserContext.hh"
 
 #include "services\AchievementRuntime.hh"
@@ -603,10 +604,14 @@ void GameContext::AwardMastery() const
 
             ra::services::ServiceLocator::Get<ra::services::IAudioSystem>().PlayAudioFile(L"Overlay\\unlock.wav");
 
+            const auto nPlayTimeSeconds = ra::services::ServiceLocator::Get<ra::data::SessionTracker>().GetTotalPlaytime(m_nGameId);
+            const auto nPlayTimeMinutes = std::chrono::duration_cast<std::chrono::minutes>(nPlayTimeSeconds).count();
+
             auto& pOverlayManager = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>();
             const auto nPopup = pOverlayManager.QueueMessage(
                 ra::StringPrintf(L"%s %s", bHardcore ? L"Mastered" : L"Completed", m_sGameTitle),
                 ra::StringPrintf(L"%u achievements, %u points", nNumCoreAchievements, nTotalCoreAchievementPoints),
+                ra::StringPrintf(L"%s | Play time: %dh%02dm", pConfiguration.GetUsername(), nPlayTimeMinutes / 60, nPlayTimeMinutes % 60),
                 ra::ui::ImageType::Icon, m_sGameImage);
 
             if (pConfiguration.IsFeatureEnabled(ra::services::Feature::MasteryNotificationScreenshot))

--- a/src/data/GameContext.cpp
+++ b/src/data/GameContext.cpp
@@ -614,6 +614,10 @@ void GameContext::AwardMastery() const
                 ra::StringPrintf(L"%s | Play time: %dh%02dm", pConfiguration.GetUsername(), nPlayTimeMinutes / 60, nPlayTimeMinutes % 60),
                 ra::ui::ImageType::Icon, m_sGameImage);
 
+            auto* pPopup = pOverlayManager.GetMessage(nPopup);
+            if (pPopup != nullptr)
+                pPopup->SetIsMastery(true);
+
             if (pConfiguration.IsFeatureEnabled(ra::services::Feature::MasteryNotificationScreenshot))
             {
                 std::wstring sPath = ra::StringPrintf(L"%sGame%u.png", pConfiguration.GetScreenshotDirectory(), m_nGameId);

--- a/src/ui/OverlayTheme.cpp
+++ b/src/ui/OverlayTheme.cpp
@@ -94,6 +94,7 @@ void OverlayTheme::LoadFromFile()
             const rapidjson::Value& colors = popup["Colors"];
 
             ReadColor(m_colorBackground, colors, "Background");
+            ReadColor(m_colorMasteryBackground, colors, "MasteryBackground");
             ReadColor(m_colorBorder, colors, "Border");
             ReadColor(m_colorTextShadow, colors, "TextShadow");
             ReadColor(m_colorTitle, colors, "Title");

--- a/src/ui/OverlayTheme.hh
+++ b/src/ui/OverlayTheme.hh
@@ -30,6 +30,7 @@ public:
     int FontSizePopupLeaderboardTracker() const noexcept { return m_nFontSizePopupLeaderboardTracker; }
 
     Color ColorBackground() const noexcept { return m_colorBackground; }
+    Color ColorMasteryBackground() const noexcept { return m_colorMasteryBackground; }
     Color ColorBorder() const noexcept { return m_colorBorder; }
     Color ColorTextShadow() const noexcept { return m_colorTextShadow; }
     Color ColorTitle() const noexcept { return m_colorTitle; }
@@ -79,6 +80,7 @@ private:
     int m_nFontSizePopupLeaderboardTracker = 18;
 
     Color m_colorBackground{ 255, 64, 64, 64 };
+    Color m_colorMasteryBackground{ 255, 104, 88, 32 };
     Color m_colorBorder{ 255, 32, 32, 32 };
     Color m_colorTextShadow{ 255, 32, 32, 32 };
     Color m_colorTitle{ 255, 255, 255, 255 };

--- a/src/ui/drawing/gdi/ImageRepository.cpp
+++ b/src/ui/drawing/gdi/ImageRepository.cpp
@@ -536,7 +536,10 @@ bool ImageRepository::HasReferencedImageChanged(ImageReference& pImage) const
 bool GDISurfaceFactory::SaveImage(const ISurface& pSurface, const std::wstring& sPath) const
 {
     if (g_pIWICFactory == nullptr)
+    {
+        RA_LOG_WARN("WICFactory not initialized saving %s", sPath);
         return false;
+    }
 
     const auto* pGDIBitmapSurface = dynamic_cast<const GDIBitmapSurface*>(&pSurface);
     if (pGDIBitmapSurface == nullptr)
@@ -586,6 +589,9 @@ bool GDISurfaceFactory::SaveImage(const ISurface& pSurface, const std::wstring& 
 
     if (SUCCEEDED(hr))
         pEncoder->Commit();
+
+    if (!SUCCEEDED(hr))
+        RA_LOG_WARN("Error %08x saving %s", hr, sPath);
 
     return SUCCEEDED(hr);
 }

--- a/src/ui/viewmodels/OverlayManager.cpp
+++ b/src/ui/viewmodels/OverlayManager.cpp
@@ -486,6 +486,8 @@ void OverlayManager::CaptureScreenshot(int nMessageId, const std::wstring& sPath
         const auto& pDesktop = ra::services::ServiceLocator::Get<ra::ui::IDesktop>();
         pScreenshot.pScreen = pDesktop.CaptureClientArea(pWindowManager.Emulator);
 
+        RA_LOG_INFO("Queued screenshot %s", sPath);
+
         if (m_bProcessingScreenshots)
             return;
 
@@ -518,25 +520,28 @@ void OverlayManager::ProcessScreenshots()
                 {
                     // popup no longer available, discard request
                     iter = pScreenshot.vMessages.erase(iter);
+                    RA_LOG_INFO("Popup no longer available for %s", iter->second);
                 }
                 else
                 {
                     const auto& pImageReference = pMessage->GetImage();
                     if (pImageRepository.IsImageAvailable(pImageReference.Type(), pImageReference.Name()))
                     {
+                        RA_LOG_INFO("Rendering screenshot for %s", iter->second);
+
                         PopupMessageViewModel::RenderImageLock lock(*pMessage);
 
                         if (!pMessage->IsAnimationStarted())
-                        {
                             pMessage->BeginAnimation();
-                            pMessage->UpdateRenderImage(0.0);
-                        }
+
+                        pMessage->UpdateRenderImage(0.0);
 
                         mReady.insert_or_assign(iter->second, RenderScreenshot(*pScreenshot.pScreen, *pMessage));
                         iter = pScreenshot.vMessages.erase(iter);
                     }
                     else
                     {
+                        RA_LOG_INFO("Image no longer available for %s", iter->second);
                         ++iter;
                     }
                 }

--- a/src/ui/viewmodels/PopupMessageViewModel.cpp
+++ b/src/ui/viewmodels/PopupMessageViewModel.cpp
@@ -10,6 +10,7 @@ const StringModelProperty PopupMessageViewModel::TitleProperty("PopupMessageView
 const StringModelProperty PopupMessageViewModel::DescriptionProperty("PopupMessageViewModel", "Description", L"");
 const StringModelProperty PopupMessageViewModel::DetailProperty("PopupMessageViewModel", "Detail", L"");
 const BoolModelProperty PopupMessageViewModel::IsDetailErrorProperty("PopupMessageViewModel", "IsDetailError", false);
+const BoolModelProperty PopupMessageViewModel::IsMasteryProperty("PopupMessageViewModel", "IsMastery", false);
 
 void PopupMessageViewModel::BeginAnimation()
 {
@@ -102,9 +103,10 @@ void PopupMessageViewModel::CreateRenderImage()
     pSurface->FillRectangle(nShadowOffset, nShadowOffset, nWidth - nShadowOffset, nHeight - nShadowOffset, pOverlayTheme.ColorShadow());
 
     // frame
-    pSurface->FillRectangle(0, 0, nWidth - nShadowOffset, nHeight - nShadowOffset, pOverlayTheme.ColorBackground());
+    const auto nColorBackground = IsMastery() ? pOverlayTheme.ColorMasteryBackground() : pOverlayTheme.ColorBackground();
+    pSurface->FillRectangle(0, 0, nWidth - nShadowOffset, nHeight - nShadowOffset, nColorBackground);
     pSurface->FillRectangle(1, 1, nWidth - nShadowOffset - 2, nHeight - nShadowOffset - 2, pOverlayTheme.ColorBorder());
-    pSurface->FillRectangle(2, 2, nWidth - nShadowOffset - 4, nHeight - nShadowOffset - 4, pOverlayTheme.ColorBackground());
+    pSurface->FillRectangle(2, 2, nWidth - nShadowOffset - 4, nHeight - nShadowOffset - 4, nColorBackground);
 
     // image
     if (m_hImage.Type() != ra::ui::ImageType::None)

--- a/src/ui/viewmodels/PopupMessageViewModel.hh
+++ b/src/ui/viewmodels/PopupMessageViewModel.hh
@@ -84,6 +84,21 @@ public:
     }
 
     /// <summary>
+    /// The <see cref="ModelProperty" /> for whether or not the popup should use the Mastery style.
+    /// </summary>
+    static const BoolModelProperty IsMasteryProperty;
+
+    /// <summary>
+    /// Gets whether the popup should use the Mastery style.
+    /// </summary>
+    bool IsMastery() const { return GetValue(IsMasteryProperty); }
+
+    /// <summary>
+    /// Sets whether  the popup should use the Mastery style.
+    /// </summary>
+    void SetIsMastery(bool bValue) { SetValue(IsMasteryProperty, bValue); }
+
+    /// <summary>
     /// Gets the image to display.
     /// </summary>
     const ra::ui::ImageReference& GetImage() const noexcept { return m_hImage; }


### PR DESCRIPTION
Adds a third line to the mastery notification that includes the player name and captured play time.

The play time value matches the value shown in the achievements overlay and reflects the amount of time the player has played the game in the current emulator (times are stored locally in the RACache directory).

![image](https://user-images.githubusercontent.com/32680403/69909934-111d4180-13c0-11ea-87f7-f77d8fa55ab0.png)

Also moved the `UpdateRenderImage` call out of the `IsAnimationStarted` check to avoid a race condition where another thread was between starting the animation and rendering the image. In that situation, the image may be rendered a second time, instead of crashing the screenshot thread.