### PR TITLE
improve synchronization of memory between memory inspector and memory bookmarks

### DIFF
--- a/src/RA_Dlg_Memory.cpp
+++ b/src/RA_Dlg_Memory.cpp
@@ -349,8 +349,7 @@ bool MemoryViewerControl::OnEditInput(UINT c)
         // if a bookmark exists for the modified address, update the current value
         // if frozen, the value will be changed back!
         auto& pBookmarks = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::WindowManager>().MemoryBookmarks;
-        if (pBookmarks.HasBookmark(nByteAddress))
-            pBookmarks.DoFrame();
+        pBookmarks.OnEditMemory(nByteAddress);
 
         moveAddress(0, 1);
         Invalidate();

--- a/src/RA_Dlg_Memory.cpp
+++ b/src/RA_Dlg_Memory.cpp
@@ -347,7 +347,6 @@ bool MemoryViewerControl::OnEditInput(UINT c)
         editData(nByteAddress, bLowerNibble, value);
 
         // if a bookmark exists for the modified address, update the current value
-        // if frozen, the value will be changed back!
         auto& pBookmarks = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::WindowManager>().MemoryBookmarks;
         pBookmarks.OnEditMemory(nByteAddress);
 

--- a/src/ui/viewmodels/MemoryBookmarksViewModel.hh
+++ b/src/ui/viewmodels/MemoryBookmarksViewModel.hh
@@ -230,6 +230,11 @@ public:
     bool HasBookmark(ra::ByteAddress nAddress) const;
 
     /// <summary>
+    /// Tells the control that the user has modified memory and any associated bookmarks should be updated
+    /// </summary>
+    void OnEditMemory(ra::ByteAddress nAddress);
+
+    /// <summary>
     /// Gets the list of selectable sizes for each bookmark.
     /// </summary>
     const LookupItemViewModelCollection& Sizes() const noexcept
@@ -315,6 +320,7 @@ private:
     LookupItemViewModelCollection m_vBehaviors;
 
     unsigned int m_nLoadedGameId = 0;
+    bool m_bIgnoreValueChanged = false;
 };
 
 } // namespace viewmodels


### PR DESCRIPTION
… and between memory bookmarks

fixes #494 

Frozen bookmarks can now be updated from within the memory inspector. This is consistent with previous behavior, though the previous code was misleading. After the memory was edited, the code called "WriteFrozenValue", which did not reapply the frozen value, but instead updated it.

Additionally, modifying a bookmark within the bookmark editor will update the memory inspector and any other bookmarks the intersect with the updated memory.

For example, given this set of bookmarks all around 0x0736:
![image](https://user-images.githubusercontent.com/32680403/70203526-6a47e680-16da-11ea-8acb-d810e9aebf82.png)

Changing 0x0736:
![image](https://user-images.githubusercontent.com/32680403/70203536-72078b00-16da-11ea-814f-fcacd5eaadf2.png)

Will update all the other nearby bookmarks:
![image](https://user-images.githubusercontent.com/32680403/70203544-79c72f80-16da-11ea-88c2-0ea2e53a4883.png)

Direct edits from within the memory bookmark or memory inspector dialogs do not trigger the Frozen or Pause behaviors. Updates from advancing the frame (either manually or via the emulator running) do trigger both behaviors.
