### PR TITLE
add _RA_IdentifyHash API

### DIFF
--- a/src/Exports.cpp
+++ b/src/Exports.cpp
@@ -191,6 +191,11 @@ API unsigned int CCONV _RA_IdentifyRom(const BYTE* pROM, unsigned int nROMSize)
     return ra::services::ServiceLocator::GetMutable<ra::services::GameIdentifier>().IdentifyGame(pROM, nROMSize);
 }
 
+API unsigned int CCONV _RA_IdentifyHash(const char* sHash)
+{
+    return ra::services::ServiceLocator::GetMutable<ra::services::GameIdentifier>().IdentifyHash(sHash);
+}
+
 API void CCONV _RA_ActivateGame(unsigned int nGameId)
 {
     ra::services::ServiceLocator::GetMutable<ra::services::GameIdentifier>().ActivateGame(nGameId);

--- a/src/Exports.hh
+++ b/src/Exports.hh
@@ -22,10 +22,10 @@ extern "C" {
     API const char* CCONV _RA_HostUrl();
 
     // Initialize all data related to RA Engine. Call as early as possible.
-    API int CCONV _RA_InitI(HWND hMainHWND, /*enum EmulatorID*/int nConsoleID, const char* sClientVersion);
+    API int CCONV _RA_InitI(HWND hMainHWND, /*enum EmulatorID*/int nEmulatorID, const char* sClientVersion);
 
     // Initialize all data related to RA Engine for offline mode. Call as early as possible.
-    API int CCONV _RA_InitOffline(HWND hMainHWND, /*enum EmulatorID*/int nConsoleID, const char* sClientVersion);
+    API int CCONV _RA_InitOffline(HWND hMainHWND, /*enum EmulatorID*/int nEmulatorID, const char* sClientVersion);
 
     // Specifies additional information to include in the UserAgent string
     API void CCONV _RA_SetUserAgentDetail(const char* sDetail);
@@ -44,6 +44,9 @@ extern "C" {
 
     //  Gets the unique identifier of the game associated to the provided ROM data
     API unsigned int CCONV _RA_IdentifyRom(const BYTE* pROMData, unsigned int nROMSize);
+
+    //  Gets the unique identifier of the game associated to the provided file (which may already be loaded into memory)
+    API unsigned int CCONV _RA_IdentifyHash(const char* sHash);
 
     //  Downloads and activates the achievements for the specified game.
     API void CCONV _RA_ActivateGame(unsigned int nGameId);

--- a/src/services/GameIdentifier.cpp
+++ b/src/services/GameIdentifier.cpp
@@ -47,6 +47,12 @@ unsigned int GameIdentifier::IdentifyGame(const BYTE* pROM, size_t nROMSize)
         return 0U;
     }
 
+    const std::string sMD5 = RAGenerateMD5(pROM, nROMSize);
+    return IdentifyHash(sMD5);
+}
+
+unsigned int GameIdentifier::IdentifyHash(const std::string& sMD5)
+{
     if (!ra::services::ServiceLocator::Get<ra::data::UserContext>().IsLoggedIn())
     {
         ra::ui::viewmodels::MessageBoxViewModel::ShowErrorMessage(L"Cannot load achievements",
@@ -54,7 +60,6 @@ unsigned int GameIdentifier::IdentifyGame(const BYTE* pROM, size_t nROMSize)
         return 0U;
     }
 
-    const std::string sMD5 = RAGenerateMD5(pROM, nROMSize);
     unsigned int nGameId = 0U;
 
     ra::api::ResolveHash::Request request;

--- a/src/services/GameIdentifier.hh
+++ b/src/services/GameIdentifier.hh
@@ -25,6 +25,12 @@ public:
     unsigned int IdentifyGame(const BYTE* pMemory, size_t nSize);
 
     /// <summary>
+    /// Identifies a game.
+    /// </summary>
+    /// <param name="sMD5">The unique identifier of the game.</param>
+    unsigned int IdentifyHash(const std::string& sMD5);
+
+    /// <summary>
     /// Activates a game.
     /// </summary>
     /// <param name="nGameId">Unique identifier of the game to activate.</param>


### PR DESCRIPTION
Similar to the `_RA_IdentifyROM` API, but takes an externally calculated hash instead of a memory buffer.

First step toward moving the hashing logic into rcheevos. Also allows for incremental MD5 hashing instead of creating a giant buffer.