### PR TITLE
prevent leaderboard trigger when enabling hardcore

### DIFF
--- a/src/RA_Leaderboard.cpp
+++ b/src/RA_Leaderboard.cpp
@@ -65,6 +65,8 @@ void RA_Leaderboard::SetActive(bool bActive) noexcept
             {
                 auto pLeaderboard = static_cast<rc_lboard_t*>(m_pLeaderboard);
                 rc_reset_lboard(pLeaderboard);
+                pLeaderboard->submitted = 1;
+
                 pRuntime.ActivateLeaderboard(ID(), pLeaderboard);
             }
         }

--- a/src/data/GameContext.cpp
+++ b/src/data/GameContext.cpp
@@ -161,7 +161,9 @@ void GameContext::LoadGame(unsigned int nGameId, Mode nMode)
         pLeaderboard.ParseFromString(pLeaderboardData.Definition.c_str(), pLeaderboardData.Format.c_str());
     }
 
-    ActivateLeaderboards();
+    const auto& pConfiguration = ra::services::ServiceLocator::Get<ra::services::IConfiguration>();
+    if (pConfiguration.IsFeatureEnabled(ra::services::Feature::Hardcore))
+        ActivateLeaderboards();
 
     // merge local achievements
     m_nNextLocalId = GameContext::FirstLocalId;

--- a/src/ui/viewmodels/OverlayListPageViewModel.cpp
+++ b/src/ui/viewmodels/OverlayListPageViewModel.cpp
@@ -145,7 +145,7 @@ void OverlayListPageViewModel::RenderList(ra::ui::drawing::ISurface& pSurface, i
         if (nTarget != 0)
         {
             const auto nProgressBarWidth = (nWidth - nTextX - 12) * 2 / 3;
-            const auto nValue = std::max(pItem->GetProgressValue(), nTarget);
+            const auto nValue = std::min(pItem->GetProgressValue(), nTarget);
             const auto nProgressBarFillWidth = gsl::narrow_cast<int>(((static_cast<long>(nProgressBarWidth) - 2) * nValue) / nTarget);
             const auto nProgressBarPercent = gsl::narrow_cast<int>(static_cast<long>(nValue) * 100 / nTarget);
 

--- a/src/ui/viewmodels/OverlayListPageViewModel.cpp
+++ b/src/ui/viewmodels/OverlayListPageViewModel.cpp
@@ -145,7 +145,7 @@ void OverlayListPageViewModel::RenderList(ra::ui::drawing::ISurface& pSurface, i
         if (nTarget != 0)
         {
             const auto nProgressBarWidth = (nWidth - nTextX - 12) * 2 / 3;
-            const auto nValue = pItem->GetProgressValue();
+            const auto nValue = std::max(pItem->GetProgressValue(), nTarget);
             const auto nProgressBarFillWidth = gsl::narrow_cast<int>(((static_cast<long>(nProgressBarWidth) - 2) * nValue) / nTarget);
             const auto nProgressBarPercent = gsl::narrow_cast<int>(static_cast<long>(nValue) * 100 / nTarget);
 


### PR DESCRIPTION
fixes an issue where a leaderboard that was disabled when turning off hardcore may try to submit at the point when hardcore is re-enabled