### PR TITLE
Increase achievement editor Hits column width

### DIFF
--- a/src/RA_Dlg_AchEditor.cpp
+++ b/src/RA_Dlg_AchEditor.cpp
@@ -24,7 +24,7 @@
 
 inline constexpr std::array<const char*, 10> COLUMN_TITLE{"ID",  "Flag", "Type", "Size",    "Memory",
                                                           "Cmp", "Type", "Size", "Mem/Val", "Hits"};
-inline constexpr std::array<int, 10> COLUMN_WIDTH{30, 75, 42, 50, 72, 35, 42, 50, 72, 72};
+inline constexpr std::array<int, 10> COLUMN_WIDTH{30, 75, 42, 50, 72, 35, 42, 50, 72, 84};
 static_assert(ra::is_same_size_v<decltype(COLUMN_TITLE), decltype(COLUMN_WIDTH)>, "Must match!");
 static_assert(COLUMN_TITLE.size() == COLUMN_WIDTH.size());
 


### PR DESCRIPTION
This allows viewing the counted hits for a 5-digit target and on my system does not require increasing the default size of the editor window.