### PR TITLE
render memory viewer to image to reduce time spent painting

### DIFF
--- a/src/RA_Dlg_Memory.cpp
+++ b/src/RA_Dlg_Memory.cpp
@@ -82,6 +82,14 @@ LRESULT CALLBACK MemoryViewerControl::s_MemoryDrawProc(HWND hDlg, UINT uMsg, WPA
         case WM_CHAR:
             return (!OnEditInput(static_cast<UINT>(LOWORD(wParam))));
 
+        case WM_SETFOCUS:
+            g_pMemoryViewer->OnGotFocus();
+            return FALSE;
+
+        case WM_KILLFOCUS:
+            g_pMemoryViewer->OnLostFocus();
+            return FALSE;
+
         case WM_GETDLGCODE:
             return DLGC_WANTCHARS | DLGC_WANTARROWS;
     }
@@ -148,7 +156,7 @@ bool MemoryViewerControl::OnKeyDown(UINT nChar)
             if (bControlHeld)
             {
                 const auto& pEmulatorContext = ra::services::ServiceLocator::Get<ra::data::EmulatorContext>();
-                const auto nTotalBytes = pEmulatorContext.TotalMemorySize();
+                const auto nTotalBytes = gsl::narrow<ra::ByteAddress>(pEmulatorContext.TotalMemorySize());
 
                 g_pMemoryViewer->SetFirstAddress(nTotalBytes & ~0x0F);
                 g_pMemoryViewer->SetAddress(nTotalBytes - 1);

--- a/src/RA_Dlg_Memory.cpp
+++ b/src/RA_Dlg_Memory.cpp
@@ -163,7 +163,20 @@ bool MemoryViewerControl::OnKeyDown(UINT nChar)
             }
             else
             {
-                g_pMemoryViewer->SetAddress(g_pMemoryViewer->GetAddress() | 0x0F);
+                switch (g_pMemoryViewer->GetSize())
+                {
+                    case MemSize::ThirtyTwoBit:
+                        g_pMemoryViewer->SetAddress((g_pMemoryViewer->GetAddress() & ~0x0F) | 0x0C);
+                        break;
+
+                    case MemSize::SixteenBit:
+                        g_pMemoryViewer->SetAddress((g_pMemoryViewer->GetAddress() & ~0x0F) | 0x0E);
+                        break;
+
+                    default:
+                        g_pMemoryViewer->SetAddress(g_pMemoryViewer->GetAddress() | 0x0F);
+                        break;
+                }
             }
             return true;
     }

--- a/src/RA_Dlg_Memory.h
+++ b/src/RA_Dlg_Memory.h
@@ -26,7 +26,6 @@ public:
     static void setAddress(unsigned int nAddr);
     static void setWatchedAddress(unsigned int nAddr);
     static unsigned int getWatchedAddress() noexcept { return m_nWatchedAddress; }
-    static void moveAddress(int offset, int nibbleOff);
     static void editData(unsigned int nByteAddress, bool bLowerNibble, unsigned int value);
     static void Invalidate();
 

--- a/src/RA_Dlg_Memory.h
+++ b/src/RA_Dlg_Memory.h
@@ -14,40 +14,12 @@ public:
 public:
     static void RenderMemViewer(HWND hTarget);
 
-    static void createEditCaret(int w, int h) noexcept;
-    static void destroyEditCaret() noexcept;
-    static void SetCaretPos();
     static void OnClick(POINT point);
 
     static bool OnKeyDown(UINT nChar);
     static bool OnEditInput(UINT c);
 
-    static void setAddress(unsigned int nAddr);
-    static unsigned int getWatchedAddress() noexcept { return m_nWatchedAddress; }
-
-    static void SetDataSize(MemSize value)
-    {
-        m_nDataSize = value;
-    }
-    static MemSize GetDataSize() noexcept { return m_nDataSize; }
-
-public:
-    static unsigned short m_nActiveMemBank;
-    static unsigned int m_nDisplayedLines;
-
-private:
-    static HFONT m_hViewerFont;
-    static SIZE m_szFontSize;
-    static unsigned int m_nDataStartXOffset;
-    static unsigned int m_nAddressOffset;
-    static unsigned int m_nWatchedAddress;
-    static MemSize m_nDataSize;
-    static unsigned int m_nEditAddress;
-    static unsigned int m_nEditNibble;
-
-    static bool m_bHasCaret;
-    static unsigned int m_nCaretWidth;
-    static unsigned int m_nCaretHeight;
+    static MemSize GetDataSize();
 };
 
 struct SearchResult

--- a/src/RA_Dlg_Memory.h
+++ b/src/RA_Dlg_Memory.h
@@ -4,6 +4,8 @@
 
 #include "services/SearchResults.h"
 
+#include "ui/ViewModelBase.hh"
+
 class MemoryViewerControl
 {
 public:
@@ -69,7 +71,7 @@ struct SearchResult
     }
 };
 
-class Dlg_Memory
+class Dlg_Memory : protected ra::ui::ViewModelBase::NotifyTarget
 {
 public:
     void Init() noexcept;
@@ -98,6 +100,9 @@ public:
     BOOL IsActive() const noexcept;
 
     void GenerateResizes(HWND hDlg);
+
+protected:
+    void OnViewModelIntValueChanged(const ra::ui::IntModelProperty::ChangeArgs& args) override;
 
 private:
     bool GetSelectedMemoryRange(ra::ByteAddress& start, ra::ByteAddress& end);

--- a/src/RA_Dlg_Memory.h
+++ b/src/RA_Dlg_Memory.h
@@ -24,12 +24,10 @@ public:
 
     static void setAddress(unsigned int nAddr);
     static unsigned int getWatchedAddress() noexcept { return m_nWatchedAddress; }
-    static void Invalidate();
 
     static void SetDataSize(MemSize value)
     {
         m_nDataSize = value;
-        Invalidate();
     }
     static MemSize GetDataSize() noexcept { return m_nDataSize; }
 
@@ -106,6 +104,8 @@ private:
 
     static void UpdateSearchResult(const ra::services::SearchResults::Result& result, _Out_ unsigned int& nMemVal, std::wstring& sBuffer);
     bool CompareSearchResult(unsigned int nCurVal, unsigned int nPrevVal);
+
+    void InvalidateMemoryViewer();
 
     static HWND m_hWnd;
 

--- a/src/RA_Dlg_Memory.h
+++ b/src/RA_Dlg_Memory.h
@@ -19,6 +19,8 @@ public:
     static bool OnKeyDown(UINT nChar);
     static bool OnEditInput(UINT c);
 
+    static void Invalidate();
+
     static MemSize GetDataSize();
 };
 
@@ -76,8 +78,6 @@ private:
 
     static void UpdateSearchResult(const ra::services::SearchResults::Result& result, _Out_ unsigned int& nMemVal, std::wstring& sBuffer);
     bool CompareSearchResult(unsigned int nCurVal, unsigned int nPrevVal);
-
-    void InvalidateMemoryViewer();
 
     static HWND m_hWnd;
 

--- a/src/RA_Dlg_Memory.h
+++ b/src/RA_Dlg_Memory.h
@@ -22,11 +22,8 @@ public:
     static bool OnKeyDown(UINT nChar);
     static bool OnEditInput(UINT c);
 
-    static void gotoAddress(unsigned int nAddr);
     static void setAddress(unsigned int nAddr);
-    static void setWatchedAddress(unsigned int nAddr);
     static unsigned int getWatchedAddress() noexcept { return m_nWatchedAddress; }
-    static void editData(unsigned int nByteAddress, bool bLowerNibble, unsigned int value);
     static void Invalidate();
 
     static void SetDataSize(MemSize value)

--- a/src/RA_Integration.vcxproj
+++ b/src/RA_Integration.vcxproj
@@ -131,6 +131,7 @@
     <ClCompile Include="ui\viewmodels\LoginViewModel.cpp" />
     <ClCompile Include="ui\viewmodels\LookupItemViewModel.cpp" />
     <ClCompile Include="ui\viewmodels\MemoryBookmarksViewModel.cpp" />
+    <ClCompile Include="ui\viewmodels\MemoryViewerViewModel.cpp" />
     <ClCompile Include="ui\viewmodels\MessageBoxViewModel.cpp" />
     <ClCompile Include="ui\viewmodels\OverlayAchievementsPageViewModel.cpp" />
     <ClCompile Include="ui\viewmodels\OverlayFriendsPageViewModel.cpp" />
@@ -276,6 +277,7 @@
     <ClInclude Include="ui\viewmodels\LoginViewModel.hh" />
     <ClInclude Include="ui\viewmodels\LookupItemViewModel.hh" />
     <ClInclude Include="ui\viewmodels\MemoryBookmarksViewModel.hh" />
+    <ClInclude Include="ui\viewmodels\MemoryViewerViewModel.hh" />
     <ClInclude Include="ui\viewmodels\MessageBoxViewModel.hh" />
     <ClInclude Include="ui\viewmodels\OverlayAchievementsPageViewModel.hh" />
     <ClInclude Include="ui\viewmodels\OverlayFriendsPageViewModel.hh" />

--- a/src/RA_Integration.vcxproj.filters
+++ b/src/RA_Integration.vcxproj.filters
@@ -291,6 +291,9 @@
     <ClCompile Include="ui\win32\OverlaySettingsDialog.cpp">
       <Filter>UI\Win32</Filter>
     </ClCompile>
+    <ClCompile Include="ui\viewmodels\MemoryViewerViewModel.cpp">
+      <Filter>UI\ViewModels</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="RA_Achievement.h">
@@ -754,6 +757,9 @@
     </ClInclude>
     <ClInclude Include="ui\win32\OverlaySettingsDialog.hh">
       <Filter>UI\Win32</Filter>
+    </ClInclude>
+    <ClInclude Include="ui\viewmodels\MemoryViewerViewModel.hh">
+      <Filter>UI\ViewModels</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/RA_StringUtils.cpp
+++ b/src/RA_StringUtils.cpp
@@ -76,7 +76,7 @@ std::string Narrow(const std::string& str)
 }
 
 _Use_decl_annotations_
-std::string& TrimLineEnding(std::string& str)
+std::string& TrimLineEnding(std::string& str) noexcept
 {
     if (!str.empty())
     {

--- a/src/RA_StringUtils.h
+++ b/src/RA_StringUtils.h
@@ -24,7 +24,7 @@ _NODISCARD std::string Narrow(_In_ const std::string& wstr);
 /// Removes one "\r", "\n", or "\r\n" from the end of a string.
 /// </summary>
 /// <returns>Reference to <paramref name="str" /> for chaining.</returns>
-std::string& TrimLineEnding(_Inout_ std::string& str);
+std::string& TrimLineEnding(_Inout_ std::string& str) noexcept;
 
 /// <summary>
 /// Removes all whitespace characters from the front and back of a string.

--- a/src/data/EmulatorContext.cpp
+++ b/src/data/EmulatorContext.cpp
@@ -464,6 +464,19 @@ void EmulatorContext::AddMemoryBlock(gsl::index nIndex, size_t nBytes,
         pBlock.write = pWriter;
 
         m_nTotalMemorySize += nBytes;
+
+        OnTotalMemorySizeChanged();
+    }
+}
+
+void EmulatorContext::OnTotalMemorySizeChanged()
+{
+    // create a copy of the list of pointers in case it's modified by one of the callbacks
+    NotifyTargetSet vNotifyTargets(m_vNotifyTargets);
+    for (NotifyTarget* target : vNotifyTargets)
+    {
+        Expects(target != nullptr);
+        target->OnTotalMemorySizeChanged();
     }
 }
 
@@ -586,6 +599,15 @@ void EmulatorContext::WriteMemoryByte(ra::ByteAddress nAddress, uint8_t nValue) 
         {
             pBlock.write(nAddress, nValue);
             m_bMemoryModified = true;
+
+            // create a copy of the list of pointers in case it's modified by one of the callbacks
+            NotifyTargetSet vNotifyTargets(m_vNotifyTargets);
+            for (NotifyTarget* target : vNotifyTargets)
+            {
+                Expects(target != nullptr);
+                target->OnByteWritten(nAddress, nValue);
+            }
+
             return;
         }
 

--- a/src/data/EmulatorContext.cpp
+++ b/src/data/EmulatorContext.cpp
@@ -493,6 +493,7 @@ uint8_t EmulatorContext::ReadMemoryByte(ra::ByteAddress nAddress) const noexcept
     return 0U;
 }
 
+_Use_decl_annotations_
 void EmulatorContext::ReadMemory(ra::ByteAddress nAddress, uint8_t pBuffer[], size_t nCount) const
 {
     Expects(pBuffer != nullptr);
@@ -591,7 +592,7 @@ uint32_t EmulatorContext::ReadMemory(ra::ByteAddress nAddress, MemSize nSize) co
     }
 }
 
-void EmulatorContext::WriteMemoryByte(ra::ByteAddress nAddress, uint8_t nValue) const noexcept
+void EmulatorContext::WriteMemoryByte(ra::ByteAddress nAddress, uint8_t nValue) const
 {
     for (const auto& pBlock : m_vMemoryBlocks)
     {
@@ -615,7 +616,7 @@ void EmulatorContext::WriteMemoryByte(ra::ByteAddress nAddress, uint8_t nValue) 
     }
 }
 
-void EmulatorContext::WriteMemory(ra::ByteAddress nAddress, MemSize nSize, uint32_t nValue) const noexcept
+void EmulatorContext::WriteMemory(ra::ByteAddress nAddress, MemSize nSize, uint32_t nValue) const
 {
     switch (nSize)
     {

--- a/src/data/EmulatorContext.hh
+++ b/src/data/EmulatorContext.hh
@@ -15,7 +15,7 @@ namespace data {
 class EmulatorContext
 {
 public:
-    EmulatorContext() noexcept = default;
+    GSL_SUPPRESS_F6 EmulatorContext() = default;
     virtual ~EmulatorContext() noexcept = default;
     EmulatorContext(const EmulatorContext&) noexcept = delete;
     EmulatorContext& operator=(const EmulatorContext&) noexcept = delete;
@@ -171,7 +171,12 @@ public:
     void ClearMemoryBlocks() noexcept
     {
         m_vMemoryBlocks.clear();
-        m_nTotalMemorySize = 0U;
+
+        if (m_nTotalMemorySize != 0U)
+        {
+            m_nTotalMemorySize = 0U;
+            OnTotalMemorySizeChanged();
+        }
     }
 
     /// <summary>
@@ -219,8 +224,30 @@ public:
     /// </summary>
     void ResetMemoryModified() noexcept { m_bMemoryModified = false; }
 
+    class NotifyTarget
+    {
+    public:
+        NotifyTarget() noexcept = default;
+        virtual ~NotifyTarget() noexcept = default;
+        NotifyTarget(const NotifyTarget&) noexcept = delete;
+        NotifyTarget& operator=(const NotifyTarget&) noexcept = delete;
+        NotifyTarget(NotifyTarget&&) noexcept = default;
+        NotifyTarget& operator=(NotifyTarget&&) noexcept = default;
+
+        virtual void OnTotalMemorySizeChanged() noexcept(false) {}
+        virtual void OnByteWritten(ra::ByteAddress, uint8_t) noexcept(false) {}
+    };
+
+    void AddNotifyTarget(NotifyTarget& pTarget) noexcept { GSL_SUPPRESS_F6 m_vNotifyTargets.insert(&pTarget); }
+    void RemoveNotifyTarget(NotifyTarget& pTarget) noexcept { GSL_SUPPRESS_F6 m_vNotifyTargets.erase(&pTarget); }
+
+private:
+    using NotifyTargetSet = std::set<NotifyTarget*>;
+    NotifyTargetSet m_vNotifyTargets;
+
 protected:
     void UpdateUserAgent();
+    void OnTotalMemorySizeChanged();
 
     EmulatorID m_nEmulatorId = EmulatorID::UnknownEmulator;
     std::string m_sVersion;

--- a/src/data/EmulatorContext.hh
+++ b/src/data/EmulatorContext.hh
@@ -168,7 +168,7 @@ public:
     /// <summary>
     /// Clears all registered memory blocks so they can be rebuilt.
     /// </summary>
-    void ClearMemoryBlocks() noexcept
+    void ClearMemoryBlocks()
     {
         m_vMemoryBlocks.clear();
 
@@ -197,17 +197,17 @@ public:
     /// <summary>
     /// Reads memory from the emulator.
     /// </summary>
-    void ReadMemory(ra::ByteAddress nAddress, uint8_t pBuffer[], size_t nCount) const;
+    void ReadMemory(ra::ByteAddress nAddress, _Out_writes_(nCount) uint8_t pBuffer[], size_t nCount) const;
 
     /// <summary>
     /// Writes memory to the emulator.
     /// </summary>
-    void WriteMemoryByte(ra::ByteAddress nAddress, uint8_t nValue) const noexcept;
+    void WriteMemoryByte(ra::ByteAddress nAddress, uint8_t nValue) const;
 
     /// <summary>
     /// Writes memory to the emulator.
     /// </summary>
-    void WriteMemory(ra::ByteAddress nAddress, MemSize nSize, uint32_t nValue) const noexcept;
+    void WriteMemory(ra::ByteAddress nAddress, MemSize nSize, uint32_t nValue) const;
 
     /// <summary>
     /// Gets whether or not memory has been modified.

--- a/src/ui/drawing/gdi/ResourceRepository.hh
+++ b/src/ui/drawing/gdi/ResourceRepository.hh
@@ -45,7 +45,7 @@ public:
         const auto nStrikeOut = ((nStyle & FontStyles::Strikethrough) == FontStyles::Strikethrough) ? TRUE : FALSE;
 
         HFONT hFont = CreateFontA(nFontSize, 0, 0, 0, nWeight, nItalic, nUnderline, nStrikeOut,
-            DEFAULT_CHARSET, OUT_DEFAULT_PRECIS, CLIP_CHARACTER_PRECIS, ANTIALIASED_QUALITY, DEFAULT_PITCH, sFont.c_str());
+            DEFAULT_CHARSET, OUT_DEFAULT_PRECIS, CLIP_CHARACTER_PRECIS, CLEARTYPE_NATURAL_QUALITY, DEFAULT_PITCH, sFont.c_str());
 
         if (hFont)
         {

--- a/src/ui/viewmodels/MemoryBookmarksViewModel.cpp
+++ b/src/ui/viewmodels/MemoryBookmarksViewModel.cpp
@@ -380,6 +380,18 @@ bool MemoryBookmarksViewModel::HasBookmark(ra::ByteAddress nAddress) const
     return (m_vBookmarks.FindItemIndex(MemoryBookmarkViewModel::AddressProperty, nAddress) >= 0);
 }
 
+bool MemoryBookmarksViewModel::HasFrozenBookmark(ra::ByteAddress nAddress) const
+{
+    for (size_t nIndex = 0; nIndex < m_vBookmarks.Count(); ++nIndex)
+    {
+        const auto* pBookmark = m_vBookmarks.GetItemAt(nIndex);
+        if (pBookmark != nullptr && pBookmark->GetBehavior() == BookmarkBehavior::Frozen && pBookmark->GetAddress() == nAddress)
+            return true;
+    }
+
+    return false;
+}
+
 void MemoryBookmarksViewModel::OnEditMemory(ra::ByteAddress nAddress)
 {
     // this function is very similar to DoFrame, but does not trigger behaviors.

--- a/src/ui/viewmodels/MemoryBookmarksViewModel.cpp
+++ b/src/ui/viewmodels/MemoryBookmarksViewModel.cpp
@@ -4,10 +4,6 @@
 #include "RA_Json.h"
 #include "RA_StringUtils.h"
 
-#ifndef RA_UTEST
-#include "RA_Dlg_Memory.h"
-#endif
-
 #include "data\EmulatorContext.hh"
 
 #include "services\IConfiguration.hh"
@@ -89,11 +85,6 @@ void MemoryBookmarksViewModel::OnViewModelIntValueChanged(gsl::index nIndex, con
                     MemoryBookmarkViewModel::RowColorProperty.GetDefaultValue());
                 break;
         }
-
-#ifndef RA_UTEST
-        // force memory view to repaint - different behaviors appear as different colors
-        MemoryViewerControl::Invalidate();
-#endif
     }
     else if (args.Property == MemoryBookmarkViewModel::CurrentValueProperty)
     {
@@ -119,31 +110,8 @@ void MemoryBookmarksViewModel::OnViewModelIntValueChanged(gsl::index nIndex, con
                         break;
                 }
             }
-
-#ifndef RA_UTEST
-            // force memory view to repaint - important if the edited memory was on screen
-            MemoryViewerControl::Invalidate();
-#endif
         }
     }
-}
-
-GSL_SUPPRESS_F6
-void MemoryBookmarksViewModel::OnViewModelAdded(gsl::index)
-{
-#ifndef RA_UTEST
-    // force memory view to repaint - bookmarked items appear as different colors
-    MemoryViewerControl::Invalidate();
-#endif
-}
-
-GSL_SUPPRESS_F6
-void MemoryBookmarksViewModel::OnViewModelRemoved(gsl::index)
-{
-#ifndef RA_UTEST
-    // force memory view to repaint - bookmarked items appear as different colors
-    MemoryViewerControl::Invalidate();
-#endif
 }
 
 void MemoryBookmarksViewModel::OnViewModelStringValueChanged(gsl::index nIndex, const StringModelProperty::ChangeArgs& args)

--- a/src/ui/viewmodels/MemoryBookmarksViewModel.hh
+++ b/src/ui/viewmodels/MemoryBookmarksViewModel.hh
@@ -309,8 +309,6 @@ protected:
     // ViewModelCollectionBase::NotifyTarget
     void OnViewModelIntValueChanged(gsl::index nIndex, const IntModelProperty::ChangeArgs& args) override;
     void OnViewModelStringValueChanged(gsl::index nIndex, const StringModelProperty::ChangeArgs& args) override;
-    void OnViewModelAdded([[maybe_unused]] gsl::index nIndex) override;
-    void OnViewModelRemoved([[maybe_unused]] gsl::index nIndex) override;
 
     // ra::data::GameContext::NotifyTarget
     void OnActiveGameChanged() override;

--- a/src/ui/viewmodels/MemoryBookmarksViewModel.hh
+++ b/src/ui/viewmodels/MemoryBookmarksViewModel.hh
@@ -230,6 +230,11 @@ public:
     bool HasBookmark(ra::ByteAddress nAddress) const;
 
     /// <summary>
+    /// Determines if a bookmark that is frozen exists for the specified address.
+    /// </summary>
+    bool HasFrozenBookmark(ra::ByteAddress nAddress) const;
+
+    /// <summary>
     /// Tells the control that the user has modified memory and any associated bookmarks should be updated
     /// </summary>
     void OnEditMemory(ra::ByteAddress nAddress);

--- a/src/ui/viewmodels/MemoryViewerViewModel.cpp
+++ b/src/ui/viewmodels/MemoryViewerViewModel.cpp
@@ -700,6 +700,18 @@ bool MemoryViewerViewModel::OnChar(char c)
     return true;
 }
 
+void MemoryViewerViewModel::OnGotFocus()
+{
+    m_bHasFocus = true;
+    UpdateHighlight(GetAddress(), NibblesPerWord() / 2, 0);
+}
+
+void MemoryViewerViewModel::OnLostFocus()
+{
+    m_bHasFocus = false;
+    UpdateHighlight(GetAddress(), NibblesPerWord() / 2, 0);
+}
+
 void MemoryViewerViewModel::DoFrame()
 {
     uint8_t pMemory[MaxLines * 16];
@@ -818,7 +830,7 @@ void MemoryViewerViewModel::UpdateRenderImage()
             const int nByteOffset = ((nBytesPerWord - 1) - (i % nBytesPerWord));
             nX += (nByteOffset * 2) * m_szChar.Width;
 
-            if (nColorUpper == TextColor::Red && !m_bReadOnly)
+            if (nColorUpper == TextColor::Red && m_bHasFocus && !m_bReadOnly)
             {
                 if (m_nSelectedNibble / 2 == nByteOffset)
                 {
@@ -831,7 +843,7 @@ void MemoryViewerViewModel::UpdateRenderImage()
         }
         else
         {
-            if (nColorUpper == TextColor::Red && !m_bReadOnly)
+            if (nColorUpper == TextColor::Red && m_bHasFocus && !m_bReadOnly)
             {
                 if (m_nSelectedNibble == 0)
                     nColorUpper = TextColor::RedOnBlack;

--- a/src/ui/viewmodels/MemoryViewerViewModel.cpp
+++ b/src/ui/viewmodels/MemoryViewerViewModel.cpp
@@ -1,0 +1,323 @@
+#include "MemoryViewerViewModel.hh"
+
+#include "RA_Defs.h"
+
+#include "data\EmulatorContext.hh"
+#include "data\GameContext.hh"
+
+#include "ui\viewmodels\WindowManager.hh"
+
+namespace ra {
+namespace ui {
+namespace viewmodels {
+
+const IntModelProperty MemoryViewerViewModel::AddressProperty("MemoryViewerViewModel", "Address", 0);
+const IntModelProperty MemoryViewerViewModel::FirstAddressProperty("MemoryViewerViewModel", "FirstAddress", 0);
+const IntModelProperty MemoryViewerViewModel::NumVisibleLinesProperty("MemoryViewerViewModel", "NumVisibleLines", 8);
+
+constexpr unsigned char HIGHLIGHTED_COLOR = 0x80 | gsl::narrow_cast<unsigned char>(ra::etoi(MemoryViewerViewModel::TextColor::Red));
+
+MemoryViewerViewModel::MemoryViewerViewModel() noexcept
+{
+    m_pBuffer.reset(new unsigned char[MaxLines * 16 * 2]);
+
+    m_pMemory = m_pBuffer.get();
+    memset(m_pMemory, 0, MaxLines * 16);
+
+    m_pColor = m_pMemory + MaxLines * 16;
+    memset(m_pColor, 0x80, MaxLines * 16);
+
+    m_pColor[0] = HIGHLIGHTED_COLOR;
+
+    AddNotifyTarget(*this);
+}
+
+static MemoryViewerViewModel::TextColor GetColor(ra::ByteAddress nAddress,
+    const ra::ui::viewmodels::MemoryBookmarksViewModel& pBookmarksViewModel,
+    const ra::data::GameContext& pGameContext)
+{
+    if (pBookmarksViewModel.HasBookmark(nAddress))
+    {
+        if (pBookmarksViewModel.HasFrozenBookmark(nAddress))
+            return MemoryViewerViewModel::TextColor::Yellow;
+
+        return MemoryViewerViewModel::TextColor::Green;
+    }
+
+    if (pGameContext.FindCodeNote(nAddress) != nullptr)
+        return MemoryViewerViewModel::TextColor::Blue;
+
+    return MemoryViewerViewModel::TextColor::Black;
+}
+
+void MemoryViewerViewModel::UpdateColors()
+{
+    const auto& pBookmarksViewModel = ra::services::ServiceLocator::Get<ra::ui::viewmodels::WindowManager>().MemoryBookmarks;
+    const auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::GameContext>();
+
+    const auto nVisibleLines = GetNumVisibleLines();
+    const auto nFirstAddress = GetFirstAddress();
+
+    for (int i = 0; i < nVisibleLines * 16; ++i)
+        m_pColor[i] = 0x80 | gsl::narrow_cast<unsigned char>(ra::etoi(GetColor(nFirstAddress + i, pBookmarksViewModel, pGameContext)));
+
+    const auto nAddress = GetAddress();
+    if (nAddress >= nFirstAddress && nAddress < nFirstAddress + nVisibleLines * 16)
+        m_pColor[nAddress - nFirstAddress] = HIGHLIGHTED_COLOR;
+
+    m_bNeedsRedraw = true;
+}
+
+void MemoryViewerViewModel::OnViewModelIntValueChanged(const IntModelProperty::ChangeArgs& args)
+{
+    if (args.Property == AddressProperty)
+    {
+        const auto& pBookmarksViewModel = ra::services::ServiceLocator::Get<ra::ui::viewmodels::WindowManager>().MemoryBookmarks;
+        const auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::GameContext>();
+
+        auto nFirstAddress = GetFirstAddress();
+        m_pColor[args.tOldValue - nFirstAddress] = 0x80 | gsl::narrow_cast<unsigned char>(ra::etoi(GetColor(args.tOldValue, pBookmarksViewModel, pGameContext)));
+
+        const auto nVisibleLines = GetNumVisibleLines();
+        if (args.tNewValue >= ra::to_signed(nFirstAddress + nVisibleLines * 16))
+        {
+            nFirstAddress = (args.tNewValue & ~0x0F) - ((nVisibleLines / 2) * 16);
+            SetFirstAddress(nFirstAddress);
+
+            nFirstAddress = GetFirstAddress();
+        }
+
+        m_pColor[args.tNewValue - nFirstAddress] = HIGHLIGHTED_COLOR;
+        m_bNeedsRedraw = true;
+
+        if (m_pSurface != nullptr)
+        {
+            RenderAddresses();
+            RenderHeader();
+        }
+    }
+    else if (args.Property == FirstAddressProperty)
+    {
+        const auto& pEmulatorContext = ra::services::ServiceLocator::Get<ra::data::EmulatorContext>();
+        const auto nVisibleLines = GetNumVisibleLines();
+        const auto nMaxFirstAddress = ra::to_signed((pEmulatorContext.TotalMemorySize() + 15) & ~0x0F) - (nVisibleLines * 16);
+        if (args.tNewValue > nMaxFirstAddress)
+        {
+            SetFirstAddress(std::max(0, nMaxFirstAddress));
+        }
+        else if (args.tNewValue < 0)
+        {
+            SetFirstAddress(0);
+        }
+        else
+        {
+            if (m_pSurface != nullptr)
+                RenderAddresses();
+
+            UpdateColors();
+        }
+    }
+    else if (args.Property == NumVisibleLinesProperty)
+    {
+        m_pSurface.reset();
+        m_bNeedsRedraw = true;
+    }
+}
+
+void MemoryViewerViewModel::OnClick(int nX, int nY)
+{
+    const int nRow = nY / m_szChar.Height;
+    if (nRow == 0)
+        return;
+
+    const int nColumn = (nX + m_szChar.Width / 2) / m_szChar.Width;
+    if (nColumn < 10)
+        return;
+
+    const auto& pEmulatorContext = ra::services::ServiceLocator::Get<ra::data::EmulatorContext>();
+
+    const auto nNewAddress = GetFirstAddress() + (nRow - 1) * 16 + (nColumn - 10) / 3;
+    if (nNewAddress < pEmulatorContext.TotalMemorySize())
+        SetAddress(nNewAddress);
+}
+
+void MemoryViewerViewModel::OnResized(_UNUSED int nWidth, int nHeight)
+{
+    if (m_pFontSurface == nullptr)
+        BuildFontSurface();
+
+    SetNumVisibleLines((nHeight / m_szChar.Height) - 1);
+}
+
+void MemoryViewerViewModel::DoFrame()
+{
+    unsigned char pMemory[MaxLines * 16];
+    const auto nAddress = GetFirstAddress();
+    const auto nVisibleLines = GetNumVisibleLines();
+
+    const auto& pEmulatorContext = ra::services::ServiceLocator::Get<ra::data::EmulatorContext>();
+    pEmulatorContext.ReadMemory(nAddress, pMemory, nVisibleLines * 16);
+
+    for (auto nIndex = 0; nIndex < nVisibleLines * 16; ++nIndex)
+    {
+        if (m_pMemory[nIndex] != pMemory[nIndex])
+        {
+            m_pMemory[nIndex] = pMemory[nIndex];
+            m_pColor[nIndex] |= 0x80;
+            m_bNeedsRedraw = true;
+        }
+    }
+}
+
+void MemoryViewerViewModel::BuildFontSurface()
+{
+    const auto& pSurfaceFactory = ra::services::ServiceLocator::Get<ra::ui::drawing::ISurfaceFactory>();
+    auto pSurface = pSurfaceFactory.CreateSurface(1, 1);
+
+    m_nFont = pSurface->LoadFont("Consolas", 17, ra::ui::FontStyles::Normal);
+    m_szChar = pSurface->MeasureText(m_nFont, L"0");
+    m_szChar.Height--; // don't need space for dangly bits
+
+    m_pFontSurface = pSurfaceFactory.CreateSurface(m_szChar.Width * 16, m_szChar.Height * ra::etoi(TextColor::NumColors));
+    m_pFontSurface->FillRectangle(0, 0, m_pFontSurface->GetWidth(), m_pFontSurface->GetHeight(), ra::ui::Color(0xFFFFFFFF));
+
+    m_pFontSurface->FillRectangle(0, m_szChar.Height * ra::etoi(TextColor::RedOnBlack),
+        m_pFontSurface->GetWidth(), m_szChar.Height, ra::ui::Color(0xFF000000));
+
+    constexpr wchar_t m_sHexChars[] = L"0123456789abcdef";
+    std::wstring sHexChar = L"0";
+    ra::ui::Color nColor(0);
+    for (int i = 0; i < ra::etoi(TextColor::NumColors); ++i)
+    {
+        switch ((TextColor)i)
+        {
+            case TextColor::Black:  nColor.ARGB = 0xFF000000; break;
+            case TextColor::Blue:   nColor.ARGB = 0xFF0000FF; break;
+            case TextColor::Green:  nColor.ARGB = 0xFF00A000; break;
+            case TextColor::RedOnBlack:
+            case TextColor::Red:    nColor.ARGB = 0xFFFF0000; break;
+            case TextColor::Yellow: nColor.ARGB = 0xFFFFC800; break;
+        }
+
+        for (int j = 0; j < 16; ++j)
+        {
+            sHexChar[0] = m_sHexChars[j];
+            m_pFontSurface->WriteText(j * m_szChar.Width, i * m_szChar.Height - 1, m_nFont, nColor, sHexChar);
+        }
+    }
+}
+
+#pragma warning(push)
+#pragma warning(disable : 5045)
+
+void MemoryViewerViewModel::UpdateRenderImage()
+{
+    if (!m_bNeedsRedraw)
+        return;
+
+    auto nVisibleLines = GetNumVisibleLines();
+
+    if (m_pSurface == nullptr)
+    {
+        if (m_pFontSurface == nullptr)
+            BuildFontSurface();
+
+        const int nWidth = (16 * 3 + 1 + 8) * m_szChar.Width;
+        const int nHeight = (nVisibleLines + 1) * m_szChar.Height;
+
+        m_pSurface = ra::services::ServiceLocator::Get<ra::ui::drawing::ISurfaceFactory>().CreateSurface(nWidth, nHeight);
+        m_pSurface->FillRectangle(0, 0, m_pSurface->GetWidth(), m_pSurface->GetHeight(), ra::ui::Color(0xFFFFFFFF));
+
+        RenderAddresses();
+
+        m_pSurface->FillRectangle(9 * m_szChar.Width, m_szChar.Height, 1, nHeight, ra::ui::Color(0xFFC0C0C0));
+
+        RenderHeader();
+    }
+
+    const auto& pEmulatorContext = ra::services::ServiceLocator::Get<ra::data::EmulatorContext>();
+    const auto nFirstAddress = GetFirstAddress();
+    if (nFirstAddress + nVisibleLines * 16 > pEmulatorContext.TotalMemorySize())
+        nVisibleLines = (pEmulatorContext.TotalMemorySize() - nFirstAddress) / 16;
+
+    unsigned char* pMemory = m_pMemory;
+    unsigned char* pColor = m_pColor;
+
+    for (int i = 0; i < nVisibleLines * 16; ++i)
+    {
+        if (pColor[i] & 0x80)
+        {
+            const unsigned char nColor = pColor[i] & 0x0F;
+            pColor[i] = nColor;
+
+            TextColor nColorUpper = ra::itoe<TextColor>(nColor);
+            TextColor nColorLower = nColorUpper;
+
+            if (nColorUpper == TextColor::Red)
+            {
+                if (m_bUpperNibbleSelected)
+                    nColorUpper = TextColor::RedOnBlack;
+                else
+                    nColorLower = TextColor::RedOnBlack;
+            }
+
+            const int nX = ((i & 0x0F) * 3 + 10) * m_szChar.Width;
+            const int nY = ((i >> 4) + 1) * m_szChar.Height;
+
+            const auto nValue = pMemory[i];
+            WriteChar(nX, nY, nColorUpper, nValue >> 4);
+            WriteChar(nX + m_szChar.Width, nY, nColorLower, nValue & 0x0F);
+        }
+    }
+}
+
+#pragma warning(pop)
+
+void MemoryViewerViewModel::RenderAddresses()
+{
+    auto nVisibleLines = GetNumVisibleLines();
+    const auto nCursorAddress = GetAddress() & ~0x0F;
+    auto nAddress = GetFirstAddress();
+    int nY = m_szChar.Height;
+
+    m_pSurface->FillRectangle(0, 0, m_szChar.Width * 8, nVisibleLines * m_szChar.Height, ra::ui::Color(0xFFFFFFFF));
+
+    const auto& pEmulatorContext = ra::services::ServiceLocator::Get<ra::data::EmulatorContext>();
+    if (nAddress + nVisibleLines * 16 > pEmulatorContext.TotalMemorySize())
+        nVisibleLines = (pEmulatorContext.TotalMemorySize() - nAddress) / 16;
+
+    for (int i = 0; i < nVisibleLines; ++i)
+    {
+        const auto nColor = (nCursorAddress == nAddress) ? ra::ui::Color(0xFFFF8080) : ra::ui::Color(0xFF808080);
+        const auto sAddress = ra::StringPrintf(L"0x%06x", nAddress);
+        nAddress += 16;
+
+        m_pSurface->WriteText(0, nY, m_nFont, nColor, sAddress);
+        nY += m_szChar.Height;
+    }
+}
+
+void MemoryViewerViewModel::WriteChar(int nX, int nY, TextColor nColor, int hexChar)
+{
+    m_pSurface->DrawSurface(nX, nY, *m_pFontSurface, hexChar * m_szChar.Width, (int)nColor * m_szChar.Height, m_szChar.Width, m_szChar.Height);
+}
+
+void MemoryViewerViewModel::RenderHeader()
+{
+    const auto nCursorAddress = ra::to_signed(GetAddress() & 0x0F);
+
+    auto nX = 10 * m_szChar.Width;
+    m_pSurface->FillRectangle(nX, 0, 16 * 3 * m_szChar.Width, m_szChar.Height, ra::ui::Color(0xFFFFFFFF));
+
+    for (int i = 0; i < 16; ++i)
+    {
+        const auto nColor = (nCursorAddress == i) ? ra::ui::Color(0xFFFF8080) : ra::ui::Color(0xFF808080);
+        const auto sValue = ra::StringPrintf(L"%02x", i);
+        m_pSurface->WriteText(nX, 0, m_nFont, nColor, sValue);
+        nX += m_szChar.Width * 3;
+    }
+}
+
+} // namespace viewmodels
+} // namespace ui
+} // namespace ra

--- a/src/ui/viewmodels/MemoryViewerViewModel.cpp
+++ b/src/ui/viewmodels/MemoryViewerViewModel.cpp
@@ -65,6 +65,11 @@ protected:
             if (pBookmark != nullptr)
                 m_pOwner.UpdateColor(pBookmark->GetAddress());
         }
+        else if (args.Property == ra::ui::viewmodels::MemoryBookmarksViewModel::MemoryBookmarkViewModel::AddressProperty)
+        {
+            m_pOwner.UpdateColor(static_cast<ra::ByteAddress>(args.tOldValue));
+            m_pOwner.UpdateColor(static_cast<ra::ByteAddress>(args.tNewValue));
+        }
     }
 
 private:

--- a/src/ui/viewmodels/MemoryViewerViewModel.cpp
+++ b/src/ui/viewmodels/MemoryViewerViewModel.cpp
@@ -220,7 +220,7 @@ void MemoryViewerViewModel::BuildFontSurface()
     m_pFontSurface->FillRectangle(0, 0, m_pFontSurface->GetWidth(), m_pFontSurface->GetHeight(), ra::ui::Color(0xFFFFFFFF));
 
     m_pFontSurface->FillRectangle(0, m_szChar.Height * ra::etoi(TextColor::RedOnBlack),
-        m_pFontSurface->GetWidth(), m_szChar.Height, ra::ui::Color(0xFF000000));
+        m_pFontSurface->GetWidth(), m_szChar.Height, ra::ui::Color(0xFFC0C0C0));
 
     constexpr wchar_t m_sHexChars[] = L"0123456789abcdef";
     std::wstring sHexChar = L"0";

--- a/src/ui/viewmodels/MemoryViewerViewModel.cpp
+++ b/src/ui/viewmodels/MemoryViewerViewModel.cpp
@@ -92,6 +92,12 @@ MemoryViewerViewModel::MemoryViewerViewModel() noexcept
     AddNotifyTarget(*this);
 
 #ifndef RA_UTEST
+    InitNotifyTargets();
+#endif
+}
+
+void MemoryViewerViewModel::InitializeNotifyTargets()
+{
     auto& pEmulatorContext = ra::services::ServiceLocator::GetMutable<ra::data::EmulatorContext>();
     pEmulatorContext.AddNotifyTarget(*this);
 
@@ -103,7 +109,6 @@ MemoryViewerViewModel::MemoryViewerViewModel() noexcept
     m_bReadOnly = (pGameContext.GameId() == 0);
 
     m_pBookmarkMonitor.reset(new MemoryBookmarkMonitor(*this));
-#endif
 }
 
 MemoryViewerViewModel::~MemoryViewerViewModel()
@@ -369,7 +374,7 @@ void MemoryViewerViewModel::AdvanceCursorPage()
 
         const auto nFirstAddress = GetFirstAddress();
         const auto nMaxFirstAddress = m_nTotalMemorySize - nVisibleLines * 16;
-        const auto nNewFirstAddress = std::min(nFirstAddress + (nVisibleLines - 1) * 16, nMaxFirstAddress);
+        const auto nNewFirstAddress = std::min(gsl::narrow<size_t>(nFirstAddress) + (nVisibleLines - 1) * 16, nMaxFirstAddress);
         SetFirstAddress(nNewFirstAddress);
 
         auto nNewAddress = nAddress + (nVisibleLines - 1) * 16;

--- a/src/ui/viewmodels/MemoryViewerViewModel.hh
+++ b/src/ui/viewmodels/MemoryViewerViewModel.hh
@@ -137,6 +137,8 @@ public:
     void OnClick(int nX, int nY);
     void OnResized(_UNUSED int nWidth, int nHeight);
     bool OnChar(char c);
+    void OnGotFocus();
+    void OnLostFocus();
 
     void AdvanceCursor();
     void RetreatCursor();
@@ -167,6 +169,7 @@ protected:
     bool m_bNeedsRedraw = true;
     ra::ByteAddress m_nTotalMemorySize = 0;
     bool m_bReadOnly = true;
+    bool m_bHasFocus = false;
 
     static constexpr int MaxLines = 128;
 

--- a/src/ui/viewmodels/MemoryViewerViewModel.hh
+++ b/src/ui/viewmodels/MemoryViewerViewModel.hh
@@ -2,6 +2,7 @@
 #define RA_UI_MEMORYVIEWERVIEWMODEL_H
 #pragma once
 
+#include "data\EmulatorContext.hh"
 #include "data\GameContext.hh"
 #include "data\Types.hh"
 
@@ -17,12 +18,12 @@ namespace viewmodels {
 
 class MemoryViewerViewModel : public ViewModelBase,
                               protected ViewModelBase::NotifyTarget,
-                              protected ra::data::GameContext::NotifyTarget
+                              protected ra::data::GameContext::NotifyTarget,
+                              protected ra::data::EmulatorContext::NotifyTarget
 {
 public:
     MemoryViewerViewModel() noexcept;
-    MemoryViewerViewModel(ra::data::GameContext& pGameContext) noexcept;
-    ~MemoryViewerViewModel() = default;
+    ~MemoryViewerViewModel();
 
     MemoryViewerViewModel(const MemoryViewerViewModel&) noexcept = delete;
     MemoryViewerViewModel& operator=(const MemoryViewerViewModel&) noexcept = delete;
@@ -153,8 +154,12 @@ protected:
     void OnActiveGameChanged() override;
     void OnCodeNoteChanged(ra::ByteAddress, const std::wstring&) override;
 
-    unsigned char* m_pMemory;
-    unsigned char* m_pColor;
+    // EmulatorContext::NotifyTarget
+    void OnTotalMemorySizeChanged() override;
+    void OnByteWritten(ra::ByteAddress nAddress, uint8_t nValue) override;
+
+    uint8_t* m_pMemory;
+    uint8_t* m_pColor;
 
     int m_nSelectedNibble = 0;
     bool m_bNeedsRedraw = true;
@@ -168,17 +173,23 @@ private:
     void RenderAddresses();
     void RenderHeader();
     void WriteChar(int nX, int nY, TextColor nColor, int hexChar);
+
+    void UpdateColor(ra::ByteAddress nAddress);
     void UpdateColors();
 
     int NibblesPerWord() const;
 
     std::unique_ptr<ra::ui::drawing::ISurface> m_pSurface;
     std::unique_ptr<ra::ui::drawing::ISurface> m_pFontSurface;
-    std::unique_ptr<unsigned char[]> m_pBuffer;
+    std::unique_ptr<uint8_t[]> m_pBuffer;
 
     ra::ui::Size m_szChar;
 
     int m_nFont = 0;
+
+    class MemoryBookmarkMonitor;
+    friend class MemoryBookmarkMonitor;
+    std::unique_ptr<MemoryBookmarkMonitor> m_pBookmarkMonitor;
 };
 
 } // namespace viewmodels

--- a/src/ui/viewmodels/MemoryViewerViewModel.hh
+++ b/src/ui/viewmodels/MemoryViewerViewModel.hh
@@ -159,6 +159,7 @@ protected:
     int m_nSelectedNibble = 0;
     bool m_bNeedsRedraw = true;
     size_t m_nTotalMemorySize = 0;
+    bool m_bReadOnly = true;
 
     static constexpr int MaxLines = 128;
 
@@ -178,7 +179,6 @@ private:
     ra::ui::Size m_szChar;
 
     int m_nFont = 0;
-    bool m_bReadOnly = true;
 };
 
 } // namespace viewmodels

--- a/src/ui/viewmodels/MemoryViewerViewModel.hh
+++ b/src/ui/viewmodels/MemoryViewerViewModel.hh
@@ -165,7 +165,7 @@ protected:
 
     int m_nSelectedNibble = 0;
     bool m_bNeedsRedraw = true;
-    size_t m_nTotalMemorySize = 0;
+    ra::ByteAddress m_nTotalMemorySize = 0;
     bool m_bReadOnly = true;
 
     static constexpr int MaxLines = 128;
@@ -178,8 +178,10 @@ private:
 
     void UpdateColor(ra::ByteAddress nAddress);
     void UpdateColors();
+    void UpdateHighlight(ra::ByteAddress nAddress, int nNewLength, int nOldLength);
 
     int NibblesPerWord() const;
+    void UpdateSelectedNibble(int nNewNibble);
 
     std::unique_ptr<ra::ui::drawing::ISurface> m_pSurface;
     std::unique_ptr<ra::ui::drawing::ISurface> m_pFontSurface;

--- a/src/ui/viewmodels/MemoryViewerViewModel.hh
+++ b/src/ui/viewmodels/MemoryViewerViewModel.hh
@@ -15,9 +15,9 @@ namespace ra {
 namespace ui {
 namespace viewmodels {
 
-class MemoryViewerViewModel : public ViewModelBase, 
-    protected ViewModelBase::NotifyTarget,
-    protected ra::data::GameContext::NotifyTarget
+class MemoryViewerViewModel : public ViewModelBase,
+                              protected ViewModelBase::NotifyTarget,
+                              protected ra::data::GameContext::NotifyTarget
 {
 public:
     MemoryViewerViewModel() noexcept;
@@ -46,12 +46,12 @@ public:
 
     enum class TextColor
     {
-        Black = 0, // default
-        Red,       // selected
-        RedOnBlack,// selected and highlighted
-        Blue,      // has notes
-        Green,     // has bookmark
-        Yellow,    // has frozen bookmark
+        Black = 0,  // default
+        Red,        // selected
+        RedOnBlack, // selected and highlighted
+        Blue,       // has notes
+        Green,      // has bookmark
+        Yellow,     // has frozen bookmark
 
         NumColors
     };
@@ -69,7 +69,16 @@ public:
     /// <summary>
     /// Sets the address of the selected byte.
     /// </summary>
-    void SetAddress(ByteAddress value) { SetValue(AddressProperty, value); }
+    void SetAddress(ByteAddress value)
+    {
+        int nSignedValue = ra::to_signed(value);
+        if (nSignedValue < 0)
+            nSignedValue = 0;
+        else if (nSignedValue >= gsl::narrow_cast<int>(m_nTotalMemorySize))
+            nSignedValue = gsl::narrow_cast<int>(m_nTotalMemorySize) - 1;
+
+        SetValue(AddressProperty, nSignedValue);
+    }
 
     /// <summary>
     /// The <see cref="ModelProperty" /> for address of the first visible byte.
@@ -84,7 +93,7 @@ public:
     /// <summary>
     /// Sets the address of the first visible byte.
     /// </summary>
-    void SetFirstAddress(ByteAddress value) { SetValue(FirstAddressProperty, value); }
+    void SetFirstAddress(ByteAddress value);
 
     /// <summary>
     /// The <see cref="ModelProperty" /> for the number of visible lines.
@@ -99,7 +108,15 @@ public:
     /// <summary>
     /// Sets the number of visible lines.
     /// </summary>
-    void SetNumVisibleLines(int value) { SetValue(NumVisibleLinesProperty, value); }
+    void SetNumVisibleLines(int value)
+    {
+        if (value > MaxLines)
+            value = MaxLines;
+        else if (value < 1)
+            value = 1;
+
+        SetValue(NumVisibleLinesProperty, value);
+    }
 
     /// <summary>
     /// The <see cref="ModelProperty" /> for the memory word size.
@@ -161,7 +178,7 @@ private:
     ra::ui::Size m_szChar;
 
     int m_nFont = 0;
-    bool m_bGameLoaded = false;
+    bool m_bReadOnly = true;
 };
 
 } // namespace viewmodels

--- a/src/ui/viewmodels/MemoryViewerViewModel.hh
+++ b/src/ui/viewmodels/MemoryViewerViewModel.hh
@@ -20,14 +20,15 @@ class MemoryViewerViewModel : public ViewModelBase,
     protected ra::data::GameContext::NotifyTarget
 {
 public:
-    GSL_SUPPRESS_F6 MemoryViewerViewModel() noexcept;
+    MemoryViewerViewModel() noexcept;
+    MemoryViewerViewModel(ra::data::GameContext& pGameContext) noexcept;
     ~MemoryViewerViewModel() = default;
 
     MemoryViewerViewModel(const MemoryViewerViewModel&) noexcept = delete;
     MemoryViewerViewModel& operator=(const MemoryViewerViewModel&) noexcept = delete;
     MemoryViewerViewModel(MemoryViewerViewModel&&) noexcept = delete;
     MemoryViewerViewModel& operator=(MemoryViewerViewModel&&) noexcept = delete;
-    
+
     void DoFrame();
 
     bool NeedsRedraw() const { return m_bNeedsRedraw; }
@@ -100,6 +101,20 @@ public:
     /// </summary>
     void SetNumVisibleLines(int value) { SetValue(NumVisibleLinesProperty, value); }
 
+    /// <summary>
+    /// The <see cref="ModelProperty" /> for the memory word size.
+    /// </summary>
+    static const IntModelProperty SizeProperty;
+
+    /// <summary>
+    /// Gets the memory word size.
+    /// </summary>
+    MemSize GetSize() const { return ra::itoe<MemSize>(GetValue(SizeProperty)); }
+
+    /// <summary>
+    /// Sets the memory word size.
+    /// </summary>
+    void SetSize(MemSize value) { SetValue(SizeProperty, ra::etoi(value)); }
 
     void OnClick(int nX, int nY);
     void OnResized(_UNUSED int nWidth, int nHeight);
@@ -123,6 +138,10 @@ protected:
     unsigned char* m_pMemory;
     unsigned char* m_pColor;
 
+    int m_nSelectedNibble = 0;
+    bool m_bNeedsRedraw = true;
+    size_t m_nTotalMemorySize = 0;
+
     static constexpr int MaxLines = 128;
 
 private:
@@ -132,15 +151,14 @@ private:
     void WriteChar(int nX, int nY, TextColor nColor, int hexChar);
     void UpdateColors();
 
+    int NibblesPerWord() const;
+
     std::unique_ptr<ra::ui::drawing::ISurface> m_pSurface;
     std::unique_ptr<ra::ui::drawing::ISurface> m_pFontSurface;
     std::unique_ptr<unsigned char[]> m_pBuffer;
 
     ra::ui::Size m_szChar;
 
-    bool m_bNeedsRedraw = true;
-    bool m_bUpperNibbleSelected = true;
-    size_t m_nTotalMemorySize = 0;
     int m_nFont = 0;
 };
 

--- a/src/ui/viewmodels/MemoryViewerViewModel.hh
+++ b/src/ui/viewmodels/MemoryViewerViewModel.hh
@@ -1,0 +1,135 @@
+#ifndef RA_UI_MEMORYVIEWERVIEWMODEL_H
+#define RA_UI_MEMORYVIEWERVIEWMODEL_H
+#pragma once
+
+#include "data\Types.hh"
+
+#include "ui\WindowViewModelBase.hh"
+
+#include "ui\drawing\ISurface.hh"
+
+#include "ui\viewmodels\LookupItemViewModel.hh"
+
+namespace ra {
+namespace ui {
+namespace viewmodels {
+
+class MemoryViewerViewModel : public ViewModelBase, protected ViewModelBase::NotifyTarget
+{
+public:
+    GSL_SUPPRESS_F6 MemoryViewerViewModel() noexcept;
+    ~MemoryViewerViewModel() = default;
+
+    MemoryViewerViewModel(const MemoryViewerViewModel&) noexcept = delete;
+    MemoryViewerViewModel& operator=(const MemoryViewerViewModel&) noexcept = delete;
+    MemoryViewerViewModel(MemoryViewerViewModel&&) noexcept = delete;
+    MemoryViewerViewModel& operator=(MemoryViewerViewModel&&) noexcept = delete;
+    
+    void DoFrame();
+
+    bool NeedsRedraw() const { return m_bNeedsRedraw; }
+
+    void UpdateRenderImage();
+
+    /// <summary>
+    /// Gets the image to render.
+    /// </summary>
+    const ra::ui::drawing::ISurface& GetRenderImage() const
+    {
+        Expects(m_pSurface != nullptr);
+        return *m_pSurface;
+    }
+
+    enum class TextColor
+    {
+        Black = 0, // default
+        Red,       // selected
+        RedOnBlack,// selected and highlighted
+        Blue,      // has notes
+        Green,     // has bookmark
+        Yellow,    // has frozen bookmark
+
+        NumColors
+    };
+
+    /// <summary>
+    /// The <see cref="ModelProperty" /> for address of the selected byte.
+    /// </summary>
+    static const IntModelProperty AddressProperty;
+
+    /// <summary>
+    /// Gets the address of the selected byte.
+    /// </summary>
+    ByteAddress GetAddress() const { return GetValue(AddressProperty); }
+
+    /// <summary>
+    /// Sets the address of the selected byte.
+    /// </summary>
+    void SetAddress(ByteAddress value) { SetValue(AddressProperty, value); }
+
+    /// <summary>
+    /// The <see cref="ModelProperty" /> for address of the first visible byte.
+    /// </summary>
+    static const IntModelProperty FirstAddressProperty;
+
+    /// <summary>
+    /// Gets the address of the first visible byte.
+    /// </summary>
+    ByteAddress GetFirstAddress() const { return GetValue(FirstAddressProperty); }
+
+    /// <summary>
+    /// Sets the address of the first visible byte.
+    /// </summary>
+    void SetFirstAddress(ByteAddress value) { SetValue(FirstAddressProperty, value); }
+
+    /// <summary>
+    /// The <see cref="ModelProperty" /> for the number of visible lines.
+    /// </summary>
+    static const IntModelProperty NumVisibleLinesProperty;
+
+    /// <summary>
+    /// Gets the number of visible lines.
+    /// </summary>
+    int GetNumVisibleLines() const { return GetValue(NumVisibleLinesProperty); }
+
+    /// <summary>
+    /// Sets the number of visible lines.
+    /// </summary>
+    void SetNumVisibleLines(int value) { SetValue(NumVisibleLinesProperty, value); }
+
+
+    void OnClick(int nX, int nY);
+
+    void OnResized(int nWidth, int nHeight);
+
+protected:
+    void OnViewModelIntValueChanged(const IntModelProperty::ChangeArgs& args) override;
+
+    unsigned char* m_pMemory;
+    unsigned char* m_pColor;
+
+    static constexpr int MaxLines = 128;
+
+private:
+    void BuildFontSurface();
+    void RenderAddresses();
+    void RenderHeader();
+    void WriteChar(int nX, int nY, TextColor nColor, int hexChar);
+    void UpdateColors();
+
+    std::unique_ptr<ra::ui::drawing::ISurface> m_pSurface;
+    std::unique_ptr<ra::ui::drawing::ISurface> m_pFontSurface;
+    std::unique_ptr<unsigned char[]> m_pBuffer;
+
+    ra::ui::Size m_szChar;
+
+    bool m_bNeedsRedraw = true;
+    bool m_bUpperNibbleSelected = true;
+    int m_nFont = 0;
+};
+
+} // namespace viewmodels
+} // namespace ui
+} // namespace ra
+
+#endif !RA_UI_MEMORYVIEWERVIEWMODEL_H

--- a/src/ui/viewmodels/MemoryViewerViewModel.hh
+++ b/src/ui/viewmodels/MemoryViewerViewModel.hh
@@ -118,6 +118,7 @@ public:
 
     void OnClick(int nX, int nY);
     void OnResized(_UNUSED int nWidth, int nHeight);
+    bool OnChar(char c);
 
     void AdvanceCursor();
     void RetreatCursor();
@@ -160,6 +161,7 @@ private:
     ra::ui::Size m_szChar;
 
     int m_nFont = 0;
+    bool m_bGameLoaded = false;
 };
 
 } // namespace viewmodels

--- a/src/ui/viewmodels/MemoryViewerViewModel.hh
+++ b/src/ui/viewmodels/MemoryViewerViewModel.hh
@@ -32,7 +32,7 @@ public:
 
     void DoFrame();
 
-    bool NeedsRedraw() const { return m_bNeedsRedraw; }
+    bool NeedsRedraw() const { return (m_nNeedsRedraw != 0); }
 
     void UpdateRenderImage();
 
@@ -166,10 +166,15 @@ protected:
     uint8_t* m_pColor;
 
     int m_nSelectedNibble = 0;
-    bool m_bNeedsRedraw = true;
     ra::ByteAddress m_nTotalMemorySize = 0;
     bool m_bReadOnly = true;
     bool m_bHasFocus = false;
+
+    static constexpr int REDRAW_MEMORY = 1;
+    static constexpr int REDRAW_ADDRESSES = 2;
+    static constexpr int REDRAW_HEADERS = 4;
+    static constexpr int REDRAW_ALL = REDRAW_MEMORY | REDRAW_ADDRESSES | REDRAW_HEADERS;
+    int m_nNeedsRedraw = REDRAW_ALL;
 
     static constexpr int MaxLines = 128;
 
@@ -177,6 +182,7 @@ private:
     void BuildFontSurface();
     void RenderAddresses();
     void RenderHeader();
+    void RenderMemory();
     void WriteChar(int nX, int nY, TextColor nColor, int hexChar);
 
     void UpdateColor(ra::ByteAddress nAddress);

--- a/src/ui/viewmodels/MemoryViewerViewModel.hh
+++ b/src/ui/viewmodels/MemoryViewerViewModel.hh
@@ -102,8 +102,16 @@ public:
 
 
     void OnClick(int nX, int nY);
-
     void OnResized(_UNUSED int nWidth, int nHeight);
+
+    void AdvanceCursor();
+    void RetreatCursor();
+    void AdvanceCursorWord();
+    void RetreatCursorWord();
+    void AdvanceCursorLine();
+    void RetreatCursorLine();
+    void AdvanceCursorPage();
+    void RetreatCursorPage();
 
 protected:
     void OnViewModelIntValueChanged(const IntModelProperty::ChangeArgs& args) override;

--- a/src/ui/viewmodels/MemoryViewerViewModel.hh
+++ b/src/ui/viewmodels/MemoryViewerViewModel.hh
@@ -148,6 +148,8 @@ public:
     void RetreatCursorPage();
 
 protected:
+    void InitializeNotifyTargets();
+
     void OnViewModelIntValueChanged(const IntModelProperty::ChangeArgs& args) override;
 
     // GameContext::NotifyTarget

--- a/src/ui/viewmodels/MemoryViewerViewModel.hh
+++ b/src/ui/viewmodels/MemoryViewerViewModel.hh
@@ -2,6 +2,7 @@
 #define RA_UI_MEMORYVIEWERVIEWMODEL_H
 #pragma once
 
+#include "data\GameContext.hh"
 #include "data\Types.hh"
 
 #include "ui\WindowViewModelBase.hh"
@@ -14,7 +15,9 @@ namespace ra {
 namespace ui {
 namespace viewmodels {
 
-class MemoryViewerViewModel : public ViewModelBase, protected ViewModelBase::NotifyTarget
+class MemoryViewerViewModel : public ViewModelBase, 
+    protected ViewModelBase::NotifyTarget,
+    protected ra::data::GameContext::NotifyTarget
 {
 public:
     GSL_SUPPRESS_F6 MemoryViewerViewModel() noexcept;
@@ -100,10 +103,14 @@ public:
 
     void OnClick(int nX, int nY);
 
-    void OnResized(int nWidth, int nHeight);
+    void OnResized(_UNUSED int nWidth, int nHeight);
 
 protected:
     void OnViewModelIntValueChanged(const IntModelProperty::ChangeArgs& args) override;
+
+    // GameContext::NotifyTarget
+    void OnActiveGameChanged() override;
+    void OnCodeNoteChanged(ra::ByteAddress, const std::wstring&) override;
 
     unsigned char* m_pMemory;
     unsigned char* m_pColor;
@@ -125,6 +132,7 @@ private:
 
     bool m_bNeedsRedraw = true;
     bool m_bUpperNibbleSelected = true;
+    size_t m_nTotalMemorySize = 0;
     int m_nFont = 0;
 };
 

--- a/src/ui/viewmodels/MemoryViewerViewModel.hh
+++ b/src/ui/viewmodels/MemoryViewerViewModel.hh
@@ -22,7 +22,7 @@ class MemoryViewerViewModel : public ViewModelBase,
                               protected ra::data::EmulatorContext::NotifyTarget
 {
 public:
-    MemoryViewerViewModel() noexcept;
+    GSL_SUPPRESS_F6 MemoryViewerViewModel();
     ~MemoryViewerViewModel();
 
     MemoryViewerViewModel(const MemoryViewerViewModel&) noexcept = delete;
@@ -32,7 +32,7 @@ public:
 
     void DoFrame();
 
-    bool NeedsRedraw() const { return (m_nNeedsRedraw != 0); }
+    bool NeedsRedraw() const noexcept { return (m_nNeedsRedraw != 0); }
 
     void UpdateRenderImage();
 

--- a/src/ui/viewmodels/PopupViewModelBase.hh
+++ b/src/ui/viewmodels/PopupViewModelBase.hh
@@ -112,7 +112,7 @@ public:
     /// Updates the image to render.
     /// </summary>
     /// <param name="fElapsed">The fractional of seconds that have passed.</param>
-    /// <returns><c>true</c> if the image or location was updatedm <c>false</c> if not.</returns>
+    /// <returns><c>true</c> if the image or location was updated, <c>false</c> if not.</returns>
     virtual bool UpdateRenderImage(double fElapsed) = 0;
 
     /// <summary>

--- a/tests/RA_Integration.Tests.vcxproj
+++ b/tests/RA_Integration.Tests.vcxproj
@@ -296,6 +296,7 @@
     <ClCompile Include="..\src\ui\viewmodels\FileDialogViewModel.cpp" />
     <ClCompile Include="..\src\ui\viewmodels\LookupItemViewModel.cpp" />
     <ClCompile Include="..\src\ui\viewmodels\MemoryBookmarksViewModel.cpp" />
+    <ClCompile Include="..\src\ui\viewmodels\MemoryViewerViewModel.cpp" />
     <ClCompile Include="..\src\ui\viewmodels\OverlayAchievementsPageViewModel.cpp" />
     <ClCompile Include="..\src\ui\viewmodels\OverlayFriendsPageViewModel.cpp" />
     <ClCompile Include="..\src\ui\viewmodels\OverlayLeaderboardsPageViewModel.cpp" />
@@ -347,6 +348,7 @@
     <ClCompile Include="ui\viewmodels\GameChecksumViewModel_Tests.cpp" />
     <ClCompile Include="ui\viewmodels\LoginViewModel_Tests.cpp" />
     <ClCompile Include="ui\viewmodels\MemoryBookmarksViewModel_Tests.cpp" />
+    <ClCompile Include="ui\viewmodels\MemoryViewerViewModel_Tests.cpp" />
     <ClCompile Include="ui\viewmodels\MessageBoxViewModel_Tests.cpp" />
     <ClCompile Include="ui\viewmodels\OverlayAchievementsPageViewModel_Tests.cpp" />
     <ClCompile Include="ui\viewmodels\OverlayFriendsPageViewModel_Tests.cpp" />

--- a/tests/RA_Integration.Tests.vcxproj.filters
+++ b/tests/RA_Integration.Tests.vcxproj.filters
@@ -318,6 +318,12 @@
     <ClCompile Include="..\src\ui\viewmodels\OverlaySettingsViewModel.cpp">
       <Filter>Code</Filter>
     </ClCompile>
+    <ClCompile Include="ui\viewmodels\MemoryViewerViewModel_Tests.cpp">
+      <Filter>Tests\UI\ViewModels</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\ui\viewmodels\MemoryViewerViewModel.cpp">
+      <Filter>Code</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="base.props" />

--- a/tests/mocks/MockEmulatorContext.hh
+++ b/tests/mocks/MockEmulatorContext.hh
@@ -66,6 +66,12 @@ public:
         m_bMemoryModified = bModified;
     }
 
+    void MockTotalMemorySizeChanged(size_t nNewSize)
+    {
+        m_nTotalMemorySize = nNewSize;
+        OnTotalMemorySizeChanged();
+    }
+
 private:
     static uint8_t ReadMemoryHelper(uint32_t nAddress) noexcept
     {

--- a/tests/mocks/MockOverlayManager.hh
+++ b/tests/mocks/MockOverlayManager.hh
@@ -18,7 +18,7 @@ public:
     {
     }
 
-    void ClearPopups() override
+    void ClearPopups() noexcept override
     {
         // base implementation only queues the popups to be destroyed
 

--- a/tests/ui/viewmodels/MemoryViewerViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/MemoryViewerViewModel_Tests.cpp
@@ -1,0 +1,603 @@
+#include "CppUnitTest.h"
+
+#include "ui\viewmodels\MemoryViewerViewModel.hh"
+
+#include "services\ServiceLocator.hh"
+
+#include "tests\RA_UnitTestHelpers.h"
+#include "tests\mocks\MockEmulatorContext.hh"
+#include "tests\mocks\MockGameContext.hh"
+#include "tests\mocks\MockWindowManager.hh"
+
+#undef GetMessage
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace ra {
+namespace ui {
+namespace viewmodels {
+namespace tests {
+
+constexpr unsigned char COLOR_RED = gsl::narrow_cast<unsigned char>(ra::etoi(MemoryViewerViewModel::TextColor::Red));
+constexpr unsigned char COLOR_BLACK = gsl::narrow_cast<unsigned char>(ra::etoi(MemoryViewerViewModel::TextColor::Black));
+constexpr unsigned char COLOR_REDRAW = 0x80;
+
+TEST_CLASS(MemoryViewerViewModel_Tests)
+{
+private:
+    class MemoryViewerViewModelHarness : public MemoryViewerViewModel
+    {
+    public:
+        ra::data::mocks::MockEmulatorContext mockEmulatorContext;
+        ra::data::mocks::MockGameContext mockGameContext;
+        ra::ui::viewmodels::mocks::MockWindowManager mockWindowManager;
+
+        MemoryViewerViewModelHarness() : MemoryViewerViewModel()
+        {
+            mockGameContext.AddNotifyTarget(*this);
+        }
+
+        int GetSelectedNibble() const { return m_nSelectedNibble; }
+
+        size_t GetTotalMemorySize() const { return m_nTotalMemorySize; }
+
+        unsigned char GetByte(ra::ByteAddress nAddress) const
+        {
+            return m_pMemory[nAddress - GetFirstAddress()];
+        }
+
+        unsigned char GetColor(ra::ByteAddress nAddress) const
+        {
+            return gsl::narrow_cast<unsigned char>(ra::itoe<TextColor>(m_pColor[nAddress - GetFirstAddress()]));
+        }
+
+        void InitializeMemory(size_t nSize)
+        {
+            unsigned char* pBytes = new unsigned char[nSize];
+            m_pBytes.reset(pBytes);
+            for (size_t i = 0; i < nSize; ++i)
+                pBytes[i] = gsl::narrow_cast<unsigned char>(i & 0xFF);
+
+            mockEmulatorContext.MockMemory(pBytes, nSize);
+
+            DoFrame(); // populates m_nTotalMemorySize, m_pMemory, and m_pColor
+        }
+
+        void MockRender()
+        {
+            for (size_t i = 0; i < m_nTotalMemorySize; ++i)
+                m_pColor[i] &= 0x0F;
+
+            m_bNeedsRedraw = false;
+        }
+
+    private:
+        std::unique_ptr<unsigned char[]> m_pBytes;
+    };
+
+public:
+    TEST_METHOD(TestInitialValues)
+    {
+        MemoryViewerViewModelHarness viewer;
+
+        Assert::AreEqual({ 0U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ 0U }, viewer.GetFirstAddress());
+        Assert::AreEqual({ 0U }, viewer.GetTotalMemorySize());
+        Assert::AreEqual({ 8U }, viewer.GetNumVisibleLines());
+        Assert::AreEqual(MemSize::EightBit, viewer.GetSize());
+        Assert::IsTrue(viewer.NeedsRedraw());
+
+        viewer.InitializeMemory(128);
+        Assert::AreEqual({ 0U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ 0U }, viewer.GetFirstAddress());
+        Assert::AreEqual({ 128U }, viewer.GetTotalMemorySize());
+        Assert::AreEqual({ 8U }, viewer.GetNumVisibleLines());
+        Assert::AreEqual(MemSize::EightBit, viewer.GetSize());
+        Assert::IsTrue(viewer.NeedsRedraw());
+
+        Assert::AreEqual({ 0U }, viewer.GetByte(0U));
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(0U));
+
+        for (int i = 1; i < 128; ++i)
+        {
+            Assert::AreEqual(gsl::narrow_cast<unsigned char>(i), viewer.GetByte(i));
+            Assert::AreEqual({ COLOR_BLACK | COLOR_REDRAW }, viewer.GetColor(i));
+        }
+    }
+
+    TEST_METHOD(TestFirstAddressLimits)
+    {
+        MemoryViewerViewModelHarness viewer;
+
+        viewer.InitializeMemory(1024);
+        Assert::AreEqual({ 0U }, viewer.GetFirstAddress());
+
+        viewer.SetFirstAddress(512);
+        Assert::AreEqual({ 512U }, viewer.GetFirstAddress());
+
+        viewer.SetFirstAddress(0xFFFFFFFF); // -1
+        Assert::AreEqual({ 0U }, viewer.GetFirstAddress());
+
+        // 128 bytes visible in viewer, so maximum first address is 1024 - 128
+        viewer.SetFirstAddress(0xFFFF);
+        Assert::AreEqual({ 1024U - 128U }, viewer.GetFirstAddress());
+
+        viewer.SetFirstAddress(0);
+        Assert::AreEqual({ 0U }, viewer.GetFirstAddress());
+
+        viewer.SetFirstAddress(1000);
+        Assert::AreEqual({ 1024U - 128U }, viewer.GetFirstAddress());
+    }
+
+    TEST_METHOD(TestSetAddress)
+    {
+        MemoryViewerViewModelHarness viewer;
+
+        viewer.InitializeMemory(1024);
+        viewer.MockRender();
+
+        Assert::AreEqual({ 0U }, viewer.GetFirstAddress());
+        Assert::AreEqual({ 0U }, viewer.GetAddress());
+        Assert::AreEqual(COLOR_RED, viewer.GetColor(0U));
+        Assert::AreEqual(COLOR_BLACK, viewer.GetColor(36U));
+        Assert::IsFalse(viewer.NeedsRedraw());
+
+        // address in viewing window, first address should not change
+        viewer.SetAddress(36U);
+        Assert::AreEqual({ 0U }, viewer.GetFirstAddress());
+        Assert::AreEqual({ 36U }, viewer.GetAddress());
+        Assert::AreEqual({ COLOR_BLACK | COLOR_REDRAW }, viewer.GetColor(0U));
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(36U));
+        for (size_t i = 1; i < 128; ++i)
+        {
+            if (i != 36)
+                Assert::AreEqual(COLOR_BLACK, viewer.GetColor(i));
+        }
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        // address after viewing window, first address should change to center new address in viewing window
+        viewer.SetAddress(444U);
+        Assert::AreEqual({ 368U }, viewer.GetFirstAddress()); // (444 & 0x0F) - 4 * 16
+        Assert::AreEqual({ 444U }, viewer.GetAddress());
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(444U));
+        for (size_t i = 1; i < 128; ++i)
+        {
+            if (i != 444 - 368)
+                Assert::AreEqual({ COLOR_BLACK | COLOR_REDRAW }, viewer.GetColor(i + 368));
+        }
+        Assert::IsTrue(viewer.NeedsRedraw());
+
+        // address before viewing window, first address should change to center new address in viewing window
+        viewer.SetAddress(360U);
+        Assert::AreEqual({ 288U }, viewer.GetFirstAddress()); // (360U & 0x0F) - 4 * 16
+        Assert::AreEqual({ 360U }, viewer.GetAddress());
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(360U));
+        for (size_t i = 1; i < 128; ++i)
+        {
+            if (i != 360 - 288)
+                Assert::AreEqual({ COLOR_BLACK | COLOR_REDRAW }, viewer.GetColor(i + 288));
+        }
+        Assert::IsTrue(viewer.NeedsRedraw());
+    }
+
+    TEST_METHOD(TestAdvanceCursorEightBit)
+    {
+        MemoryViewerViewModelHarness viewer;
+        viewer.InitializeMemory(256);
+        viewer.MockRender();
+
+        Assert::AreEqual({ 0U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::IsFalse(viewer.NeedsRedraw());
+
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 0U }, viewer.GetAddress());
+        Assert::AreEqual({ 1U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(0U));
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 1U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ COLOR_BLACK | COLOR_REDRAW }, viewer.GetColor(0U));
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(1U));
+        Assert::IsTrue(viewer.NeedsRedraw());
+
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 1U }, viewer.GetAddress());
+        Assert::AreEqual({ 1U }, viewer.GetSelectedNibble());
+
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 2U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+
+        Assert::AreEqual({ 0U }, viewer.GetFirstAddress());
+
+        // last visible byte
+        viewer.SetAddress(127U);
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 127U }, viewer.GetAddress());
+        Assert::AreEqual({ 1U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ 0U }, viewer.GetFirstAddress());
+
+        // beyond visible range, will scroll one line
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 128U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ 16U }, viewer.GetFirstAddress());
+
+        // jump to last address - cannot advance past last nibble
+        viewer.SetAddress(255U);
+        Assert::AreEqual({ 255U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 255U }, viewer.GetAddress());
+        Assert::AreEqual({ 1U }, viewer.GetSelectedNibble());
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 255U }, viewer.GetAddress());
+        Assert::AreEqual({ 1U }, viewer.GetSelectedNibble());
+        Assert::IsFalse(viewer.NeedsRedraw());
+    }
+
+    TEST_METHOD(TestRetreatCursorEightBit)
+    {
+        MemoryViewerViewModelHarness viewer;
+        viewer.InitializeMemory(256);
+        viewer.SetFirstAddress(128U);
+        viewer.SetAddress(130U);
+        viewer.MockRender();
+
+        Assert::AreEqual({ 130U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::IsFalse(viewer.NeedsRedraw());
+
+        viewer.RetreatCursor();
+        Assert::AreEqual({ 129U }, viewer.GetAddress());
+        Assert::AreEqual({ 1U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(129U));
+        Assert::AreEqual({ COLOR_BLACK | COLOR_REDRAW }, viewer.GetColor(130U));
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        viewer.RetreatCursor();
+        Assert::AreEqual({ 129U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(129U));
+        Assert::IsTrue(viewer.NeedsRedraw());
+
+        viewer.RetreatCursor();
+        Assert::AreEqual({ 128U }, viewer.GetAddress());
+        Assert::AreEqual({ 1U }, viewer.GetSelectedNibble());
+
+        viewer.RetreatCursor();
+        Assert::AreEqual({ 128U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+
+        Assert::AreEqual({ 128U }, viewer.GetFirstAddress());
+
+        // beyond visible range, will scroll one line
+        viewer.RetreatCursor();
+        Assert::AreEqual({ 127U }, viewer.GetAddress());
+        Assert::AreEqual({ 1U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ 112U }, viewer.GetFirstAddress());
+
+        // jump to first address - cannot retreat beyond first nibble
+        viewer.SetAddress(0U);
+        Assert::AreEqual({ 0U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        viewer.MockRender();
+
+        viewer.RetreatCursor();
+        Assert::AreEqual({ 0U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::IsFalse(viewer.NeedsRedraw());
+    }
+
+    TEST_METHOD(TestAdvanceCursorWordEightBit)
+    {
+        MemoryViewerViewModelHarness viewer;
+        viewer.InitializeMemory(256);
+        viewer.MockRender();
+
+        Assert::AreEqual({ 0U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::IsFalse(viewer.NeedsRedraw());
+
+        viewer.AdvanceCursorWord();
+        Assert::AreEqual({ 1U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ COLOR_BLACK | COLOR_REDRAW }, viewer.GetColor(0U));
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(1U));
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        // mid-word jumps to start of next word
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 1U }, viewer.GetAddress());
+        Assert::AreEqual({ 1U }, viewer.GetSelectedNibble());
+
+        viewer.AdvanceCursorWord();
+        Assert::AreEqual({ 2U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+
+        // beyond visible range, will scroll one line
+        viewer.SetAddress(127U);
+        viewer.AdvanceCursorWord();
+        Assert::AreEqual({ 128U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ 16U }, viewer.GetFirstAddress());
+
+        // jump to last address - cannot advance past last byte
+        viewer.SetAddress(255U);
+        Assert::AreEqual({ 255U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        viewer.AdvanceCursorWord();
+        Assert::AreEqual({ 255U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::IsFalse(viewer.NeedsRedraw());
+    }
+
+    TEST_METHOD(TestRetreatCursorWordEightBit)
+    {
+        MemoryViewerViewModelHarness viewer;
+        viewer.InitializeMemory(256);
+        viewer.SetFirstAddress(128U);
+        viewer.SetAddress(130U);
+        viewer.MockRender();
+
+        Assert::AreEqual({ 130U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::IsFalse(viewer.NeedsRedraw());
+
+        viewer.RetreatCursorWord();
+        Assert::AreEqual({ 129U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(129U));
+        Assert::AreEqual({ COLOR_BLACK | COLOR_REDRAW }, viewer.GetColor(130U));
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        // mid-word jumps to start of current word
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 129U }, viewer.GetAddress());
+        Assert::AreEqual({ 1U }, viewer.GetSelectedNibble());
+        viewer.MockRender();
+
+        viewer.RetreatCursorWord();
+        Assert::AreEqual({ 129U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(129U));
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        viewer.RetreatCursorWord();
+        Assert::AreEqual({ 128U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ 128U }, viewer.GetFirstAddress());
+
+        // beyond visible range, will scroll one line
+        viewer.RetreatCursorWord();
+        Assert::AreEqual({ 127U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ 112U }, viewer.GetFirstAddress());
+
+        // jump to first address - cannot retreat beyond first nibble
+        viewer.SetAddress(0U);
+        Assert::AreEqual({ 0U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        viewer.MockRender();
+
+        viewer.RetreatCursorWord();
+        Assert::AreEqual({ 0U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::IsFalse(viewer.NeedsRedraw());
+    }
+
+    TEST_METHOD(TestAdvanceCursorLine)
+    {
+        MemoryViewerViewModelHarness viewer;
+        viewer.InitializeMemory(256);
+        viewer.SetAddress(4U);
+        viewer.MockRender();
+
+        Assert::AreEqual({ 4U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::IsFalse(viewer.NeedsRedraw());
+
+        viewer.AdvanceCursorLine();
+        Assert::AreEqual({ 20U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ COLOR_BLACK | COLOR_REDRAW }, viewer.GetColor(4U));
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(20U));
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        // mid-word is remembered
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 20U }, viewer.GetAddress());
+        Assert::AreEqual({ 1U }, viewer.GetSelectedNibble());
+
+        viewer.AdvanceCursorLine();
+        Assert::AreEqual({ 36U }, viewer.GetAddress());
+        Assert::AreEqual({ 1U }, viewer.GetSelectedNibble());
+
+        // beyond visible range, will scroll one line
+        viewer.SetAddress(120U);
+        viewer.AdvanceCursorLine();
+        Assert::AreEqual({ 136U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ 16U }, viewer.GetFirstAddress());
+
+        // jump to last line - cannot advance past last line
+        viewer.SetAddress(250U);
+        Assert::AreEqual({ 250U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        viewer.AdvanceCursorLine();
+        Assert::AreEqual({ 250U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::IsFalse(viewer.NeedsRedraw());
+    }
+
+    TEST_METHOD(TestRetreatCursorLine)
+    {
+        MemoryViewerViewModelHarness viewer;
+        viewer.InitializeMemory(256);
+        viewer.SetFirstAddress(128U);
+        viewer.SetAddress(170U);
+        viewer.MockRender();
+
+        Assert::AreEqual({ 170U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::IsFalse(viewer.NeedsRedraw());
+
+        viewer.RetreatCursorLine();
+        Assert::AreEqual({ 154U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(154U));
+        Assert::AreEqual({ COLOR_BLACK | COLOR_REDRAW }, viewer.GetColor(170U));
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        // mid-word is remembered
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 154U }, viewer.GetAddress());
+        Assert::AreEqual({ 1U }, viewer.GetSelectedNibble());
+        viewer.MockRender();
+
+        viewer.RetreatCursorLine();
+        Assert::AreEqual({ 138U }, viewer.GetAddress());
+        Assert::AreEqual({ 1U }, viewer.GetSelectedNibble());
+
+        // beyond visible range, will scroll one line
+        viewer.RetreatCursorLine();
+        Assert::AreEqual({ 122U }, viewer.GetAddress());
+        Assert::AreEqual({ 1U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ 112U }, viewer.GetFirstAddress());
+
+        // jump to first line - cannot retreat beyond first nibble
+        viewer.SetAddress(8U);
+        Assert::AreEqual({ 8U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        viewer.MockRender();
+
+        viewer.RetreatCursorLine();
+        Assert::AreEqual({ 8U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::IsFalse(viewer.NeedsRedraw());
+    }
+
+    TEST_METHOD(TestAdvanceCursorPage)
+    {
+        MemoryViewerViewModelHarness viewer;
+        viewer.InitializeMemory(256);
+        viewer.SetAddress(4U);
+        viewer.MockRender();
+
+        Assert::AreEqual({ 4U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::IsFalse(viewer.NeedsRedraw());
+
+        viewer.AdvanceCursorPage();
+        Assert::AreEqual({ 116U }, viewer.GetAddress());
+        Assert::AreEqual({ 112U }, viewer.GetFirstAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(116U));
+        Assert::IsTrue(viewer.NeedsRedraw());
+
+        // mid-word is remembered
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 116U }, viewer.GetAddress());
+        Assert::AreEqual({ 1U }, viewer.GetSelectedNibble());
+
+        viewer.AdvanceCursorPage();
+        Assert::AreEqual({ 228U }, viewer.GetAddress());
+        Assert::AreEqual({ 1U }, viewer.GetSelectedNibble());
+
+        // max scroll reached
+        Assert::AreEqual({ 128U }, viewer.GetFirstAddress());
+
+        // cannot page past end of memory - stop at last line
+        viewer.AdvanceCursorPage();
+        Assert::AreEqual({ 244U }, viewer.GetAddress());
+        Assert::AreEqual({ 1U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ 128U }, viewer.GetFirstAddress());
+        viewer.MockRender();
+
+        // at last line - do nothing
+        viewer.AdvanceCursorPage();
+        Assert::AreEqual({ 244U }, viewer.GetAddress());
+        Assert::AreEqual({ 1U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ 128U }, viewer.GetFirstAddress());
+        Assert::IsFalse(viewer.NeedsRedraw());
+    }
+
+    TEST_METHOD(TestRetreatCursorPage)
+    {
+        MemoryViewerViewModelHarness viewer;
+        viewer.InitializeMemory(256);
+        viewer.SetFirstAddress(128U);
+        viewer.SetAddress(244U);
+        viewer.MockRender();
+
+        Assert::AreEqual({ 244U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::IsFalse(viewer.NeedsRedraw());
+
+        viewer.RetreatCursorPage();
+        Assert::AreEqual({ 132U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ 16U }, viewer.GetFirstAddress());
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(132U));
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        // mid-word is remembered
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 132U }, viewer.GetAddress());
+        Assert::AreEqual({ 1U }, viewer.GetSelectedNibble());
+        viewer.MockRender();
+
+        viewer.RetreatCursorPage();
+        Assert::AreEqual({ 20U }, viewer.GetAddress());
+        Assert::AreEqual({ 1U }, viewer.GetSelectedNibble());
+
+        // max scroll reached
+        Assert::AreEqual({ 0U }, viewer.GetFirstAddress());
+
+        // cannot page past beginning of memory - stop at first line
+        viewer.RetreatCursorLine();
+        Assert::AreEqual({ 4U }, viewer.GetAddress());
+        Assert::AreEqual({ 1U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ 0U }, viewer.GetFirstAddress());
+        viewer.MockRender();
+
+        // at first line - do nothing
+        viewer.RetreatCursorLine();
+        Assert::AreEqual({ 4U }, viewer.GetAddress());
+        Assert::AreEqual({ 1U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ 0U }, viewer.GetFirstAddress());
+        Assert::IsFalse(viewer.NeedsRedraw());
+    }
+
+};
+
+} // namespace tests
+} // namespace viewmodels
+} // namespace ui
+} // namespace ra

--- a/tests/ui/viewmodels/MemoryViewerViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/MemoryViewerViewModel_Tests.cpp
@@ -34,7 +34,7 @@ private:
 
         MemoryViewerViewModelHarness() : MemoryViewerViewModel()
         {
-            mockGameContext.AddNotifyTarget(*this);
+            InitializeNotifyTargets();
         }
 
         int GetSelectedNibble() const { return m_nSelectedNibble; }
@@ -63,7 +63,7 @@ private:
 
             mockEmulatorContext.MockMemory(pBytes, nSize);
 
-            DoFrame(); // populates m_nTotalMemorySize, m_pMemory, and m_pColor
+            DoFrame(); // populates m_pMemory and m_pColor
         }
 
         void MockRender()

--- a/tests/ui/viewmodels/MemoryViewerViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/MemoryViewerViewModel_Tests.cpp
@@ -153,7 +153,7 @@ public:
         Assert::AreEqual({ 36U }, viewer.GetAddress());
         Assert::AreEqual({ COLOR_BLACK | COLOR_REDRAW }, viewer.GetColor(0U));
         Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(36U));
-        for (size_t i = 1; i < 128; ++i)
+        for (ra::ByteAddress i = 1; i < 128; ++i)
         {
             if (i != 36)
                 Assert::AreEqual(COLOR_BLACK, viewer.GetColor(i));
@@ -166,7 +166,7 @@ public:
         Assert::AreEqual({ 368U }, viewer.GetFirstAddress()); // (444 & 0x0F) - 4 * 16
         Assert::AreEqual({ 444U }, viewer.GetAddress());
         Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(444U));
-        for (size_t i = 1; i < 128; ++i)
+        for (ra::ByteAddress i = 1; i < 128; ++i)
         {
             if (i != 444 - 368)
                 Assert::AreEqual({ COLOR_BLACK | COLOR_REDRAW }, viewer.GetColor(i + 368));
@@ -178,7 +178,7 @@ public:
         Assert::AreEqual({ 288U }, viewer.GetFirstAddress()); // (360U & 0x0F) - 4 * 16
         Assert::AreEqual({ 360U }, viewer.GetAddress());
         Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(360U));
-        for (size_t i = 1; i < 128; ++i)
+        for (ra::ByteAddress i = 1; i < 128; ++i)
         {
             if (i != 360 - 288)
                 Assert::AreEqual({ COLOR_BLACK | COLOR_REDRAW }, viewer.GetColor(i + 288));
@@ -621,6 +621,7 @@ public:
         Assert::AreEqual({ 0U }, viewer.GetAddress());
         Assert::AreEqual({ 1U }, viewer.GetSelectedNibble());
         Assert::AreEqual({ 0x60U }, viewer.GetByte(0U));
+        Assert::AreEqual({ 0x60U }, viewer.mockEmulatorContext.ReadMemoryByte(0U));
         Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(0U));
         Assert::IsTrue(viewer.NeedsRedraw());
         viewer.MockRender();
@@ -630,6 +631,7 @@ public:
         Assert::AreEqual({ 0U }, viewer.GetAddress());
         Assert::AreEqual({ 1U }, viewer.GetSelectedNibble());
         Assert::AreEqual({ 0x60U }, viewer.GetByte(0U));
+        Assert::AreEqual({ 0x60U }, viewer.mockEmulatorContext.ReadMemoryByte(0U));
         Assert::AreEqual({ COLOR_RED }, viewer.GetColor(0U));
         Assert::IsFalse(viewer.NeedsRedraw());
 
@@ -638,6 +640,7 @@ public:
         Assert::AreEqual({ 1U }, viewer.GetAddress());
         Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
         Assert::AreEqual({ 0x6BU }, viewer.GetByte(0U));
+        Assert::AreEqual({ 0x6BU }, viewer.mockEmulatorContext.ReadMemoryByte(0U));
         Assert::AreEqual({ 0x01U }, viewer.GetByte(1U));
         Assert::AreEqual({ COLOR_BLACK | COLOR_REDRAW }, viewer.GetColor(0U));
         Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(1U));
@@ -649,6 +652,7 @@ public:
         Assert::AreEqual({ 1U }, viewer.GetAddress());
         Assert::AreEqual({ 1U }, viewer.GetSelectedNibble());
         Assert::AreEqual({ 0xF1U }, viewer.GetByte(1U));
+        Assert::AreEqual({ 0xF1U }, viewer.mockEmulatorContext.ReadMemoryByte(1U));
 
         // jump to last address - cannot advance past last nibble
         viewer.SetAddress(255U);
@@ -662,6 +666,7 @@ public:
         Assert::AreEqual({ 255U }, viewer.GetAddress());
         Assert::AreEqual({ 1U }, viewer.GetSelectedNibble());
         Assert::AreEqual({ 0x0FU }, viewer.GetByte(255U));
+        Assert::AreEqual({ 0x0FU }, viewer.mockEmulatorContext.ReadMemoryByte(255U));
         Assert::IsTrue(viewer.NeedsRedraw());
         viewer.MockRender();
 
@@ -669,6 +674,7 @@ public:
         Assert::AreEqual({ 255U }, viewer.GetAddress());
         Assert::AreEqual({ 1U }, viewer.GetSelectedNibble());
         Assert::AreEqual({ 0x09U }, viewer.GetByte(255U));
+        Assert::AreEqual({ 0x09U }, viewer.mockEmulatorContext.ReadMemoryByte(255U));
         Assert::IsTrue(viewer.NeedsRedraw());
         viewer.MockRender();
 
@@ -676,7 +682,857 @@ public:
         Assert::AreEqual({ 255U }, viewer.GetAddress());
         Assert::AreEqual({ 1U }, viewer.GetSelectedNibble());
         Assert::AreEqual({ 0x0AU }, viewer.GetByte(255U));
+        Assert::AreEqual({ 0x0AU }, viewer.mockEmulatorContext.ReadMemoryByte(255U));
         Assert::IsTrue(viewer.NeedsRedraw());
+    }
+
+    TEST_METHOD(TestAdvanceCursorSixteenBit)
+    {
+        MemoryViewerViewModelHarness viewer;
+        viewer.InitializeMemory(256);
+        viewer.SetSize(MemSize::SixteenBit);
+        viewer.MockRender();
+
+        Assert::AreEqual({ 0U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::IsFalse(viewer.NeedsRedraw());
+
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 0U }, viewer.GetAddress());
+        Assert::AreEqual({ 1U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(1U));
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 0U }, viewer.GetAddress());
+        Assert::AreEqual({ 2U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(0U));
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(1U));
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 0U }, viewer.GetAddress());
+        Assert::AreEqual({ 3U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(0U));
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 2U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ COLOR_BLACK | COLOR_REDRAW }, viewer.GetColor(0U));
+        Assert::AreEqual({ COLOR_BLACK | COLOR_REDRAW }, viewer.GetColor(1U));
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(2U));
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(3U));
+        Assert::IsTrue(viewer.NeedsRedraw());
+
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 2U }, viewer.GetAddress());
+        Assert::AreEqual({ 1U }, viewer.GetSelectedNibble());
+
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 2U }, viewer.GetAddress());
+        Assert::AreEqual({ 2U }, viewer.GetSelectedNibble());
+
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 2U }, viewer.GetAddress());
+        Assert::AreEqual({ 3U }, viewer.GetSelectedNibble());
+
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 4U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+
+        Assert::AreEqual({ 0U }, viewer.GetFirstAddress());
+
+        // last visible word
+        viewer.SetAddress(126U);
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 126U }, viewer.GetAddress());
+        Assert::AreEqual({ 1U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ 0U }, viewer.GetFirstAddress());
+
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 126U }, viewer.GetAddress());
+        Assert::AreEqual({ 2U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ 0U }, viewer.GetFirstAddress());
+
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 126U }, viewer.GetAddress());
+        Assert::AreEqual({ 3U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ 0U }, viewer.GetFirstAddress());
+
+        // beyond visible range, will scroll one line
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 128U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ 16U }, viewer.GetFirstAddress());
+
+        // jump to last address - cannot advance past last nibble
+        viewer.SetAddress(254U);
+        Assert::AreEqual({ 254U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 254U }, viewer.GetAddress());
+        Assert::AreEqual({ 1U }, viewer.GetSelectedNibble());
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 254U }, viewer.GetAddress());
+        Assert::AreEqual({ 2U }, viewer.GetSelectedNibble());
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 254U }, viewer.GetAddress());
+        Assert::AreEqual({ 3U }, viewer.GetSelectedNibble());
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 254U }, viewer.GetAddress());
+        Assert::AreEqual({ 3U }, viewer.GetSelectedNibble());
+        Assert::IsFalse(viewer.NeedsRedraw());
+
+        // address not aligned - advance jumps to next aligned address
+        viewer.SetAddress(251U);
+        Assert::AreEqual({ 251U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 252U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+    }
+
+    TEST_METHOD(TestRetreatCursorSixteenBit)
+    {
+        MemoryViewerViewModelHarness viewer;
+        viewer.InitializeMemory(256);
+        viewer.SetFirstAddress(128U);
+        viewer.SetSize(MemSize::SixteenBit);
+        viewer.SetAddress(130U);
+        viewer.MockRender();
+
+        Assert::AreEqual({ 130U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::IsFalse(viewer.NeedsRedraw());
+
+        viewer.RetreatCursor();
+        Assert::AreEqual({ 128U }, viewer.GetAddress());
+        Assert::AreEqual({ 3U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(128U));
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(129U));
+        Assert::AreEqual({ COLOR_BLACK | COLOR_REDRAW }, viewer.GetColor(130U));
+        Assert::AreEqual({ COLOR_BLACK | COLOR_REDRAW }, viewer.GetColor(131U));
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        viewer.RetreatCursor();
+        Assert::AreEqual({ 128U }, viewer.GetAddress());
+        Assert::AreEqual({ 2U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(128U));
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        viewer.RetreatCursor();
+        Assert::AreEqual({ 128U }, viewer.GetAddress());
+        Assert::AreEqual({ 1U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(128U));
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(129U));
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        viewer.RetreatCursor();
+        Assert::AreEqual({ 128U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(129U));
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+        Assert::AreEqual({ 128U }, viewer.GetFirstAddress());
+
+        // beyond visible range, will scroll one line
+        viewer.RetreatCursor();
+        Assert::AreEqual({ 126U }, viewer.GetAddress());
+        Assert::AreEqual({ 3U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ 112U }, viewer.GetFirstAddress());
+
+        // jump to first address - cannot retreat beyond first nibble
+        viewer.SetAddress(0U);
+        Assert::AreEqual({ 0U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        viewer.MockRender();
+
+        viewer.RetreatCursor();
+        Assert::AreEqual({ 0U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::IsFalse(viewer.NeedsRedraw());
+
+        // address not aligned - retreat jumps to aligned address
+        viewer.SetAddress(3U);
+        Assert::AreEqual({ 3U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+
+        viewer.RetreatCursor();
+        Assert::AreEqual({ 2U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+    }
+
+    TEST_METHOD(TestAdvanceCursorWordSixteenBit)
+    {
+        MemoryViewerViewModelHarness viewer;
+        viewer.InitializeMemory(256);
+        viewer.SetSize(MemSize::SixteenBit);
+        viewer.MockRender();
+
+        Assert::AreEqual({ 0U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::IsFalse(viewer.NeedsRedraw());
+
+        viewer.AdvanceCursorWord();
+        Assert::AreEqual({ 2U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ COLOR_BLACK | COLOR_REDRAW }, viewer.GetColor(0U));
+        Assert::AreEqual({ COLOR_BLACK | COLOR_REDRAW }, viewer.GetColor(1U));
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(2U));
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(3U));
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        // mid-word jumps to start of next word
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 2U }, viewer.GetAddress());
+        Assert::AreEqual({ 1U }, viewer.GetSelectedNibble());
+
+        viewer.AdvanceCursorWord();
+        Assert::AreEqual({ 4U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+
+        viewer.SetAddress(5U);
+        viewer.AdvanceCursorWord();
+        Assert::AreEqual({ 6U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+
+        // beyond visible range, will scroll one line
+        viewer.SetAddress(126U);
+        viewer.AdvanceCursorWord();
+        Assert::AreEqual({ 128U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ 16U }, viewer.GetFirstAddress());
+
+        // jump to last address - cannot advance past last byte
+        viewer.SetAddress(254U);
+        Assert::AreEqual({ 254U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        viewer.AdvanceCursorWord();
+        Assert::AreEqual({ 254U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::IsFalse(viewer.NeedsRedraw());
+    }
+
+    TEST_METHOD(TestRetreatCursorWordSixteenBit)
+    {
+        MemoryViewerViewModelHarness viewer;
+        viewer.InitializeMemory(256);
+        viewer.SetFirstAddress(128U);
+        viewer.SetSize(MemSize::SixteenBit);
+        viewer.SetAddress(130U);
+        viewer.MockRender();
+
+        Assert::AreEqual({ 130U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::IsFalse(viewer.NeedsRedraw());
+
+        viewer.RetreatCursorWord();
+        Assert::AreEqual({ 128U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(128U));
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(129U));
+        Assert::AreEqual({ COLOR_BLACK | COLOR_REDRAW }, viewer.GetColor(130U));
+        Assert::AreEqual({ COLOR_BLACK | COLOR_REDRAW }, viewer.GetColor(131U));
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        // mid-word jumps to start of current word
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 128U }, viewer.GetAddress());
+        Assert::AreEqual({ 1U }, viewer.GetSelectedNibble());
+        viewer.MockRender();
+
+        viewer.RetreatCursorWord();
+        Assert::AreEqual({ 128U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(129U));
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        viewer.SetAddress(129U);
+        viewer.RetreatCursorWord();
+        Assert::AreEqual({ 128U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+
+        // beyond visible range, will scroll one line
+        viewer.RetreatCursorWord();
+        Assert::AreEqual({ 126U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ 112U }, viewer.GetFirstAddress());
+
+        // jump to first address - cannot retreat beyond first nibble
+        viewer.SetAddress(0U);
+        Assert::AreEqual({ 0U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        viewer.MockRender();
+
+        viewer.RetreatCursorWord();
+        Assert::AreEqual({ 0U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::IsFalse(viewer.NeedsRedraw());
+    }
+
+    TEST_METHOD(TestAdvanceCursorThirtyTwoBit)
+    {
+        MemoryViewerViewModelHarness viewer;
+        viewer.InitializeMemory(256);
+        viewer.SetSize(MemSize::ThirtyTwoBit);
+        viewer.MockRender();
+
+        Assert::AreEqual({ 0U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::IsFalse(viewer.NeedsRedraw());
+
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 0U }, viewer.GetAddress());
+        Assert::AreEqual({ 1U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(3U));
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 0U }, viewer.GetAddress());
+        Assert::AreEqual({ 2U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(2U));
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(3U));
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 0U }, viewer.GetAddress());
+        Assert::AreEqual({ 3U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(2U));
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 0U }, viewer.GetAddress());
+        Assert::AreEqual({ 4U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(1U));
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(2U));
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 0U }, viewer.GetAddress());
+        Assert::AreEqual({ 5U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(1U));
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 0U }, viewer.GetAddress());
+        Assert::AreEqual({ 6U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(0U));
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(1U));
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 0U }, viewer.GetAddress());
+        Assert::AreEqual({ 7U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(0U));
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 4U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ COLOR_BLACK | COLOR_REDRAW }, viewer.GetColor(0U));
+        Assert::AreEqual({ COLOR_BLACK | COLOR_REDRAW }, viewer.GetColor(1U));
+        Assert::AreEqual({ COLOR_BLACK | COLOR_REDRAW }, viewer.GetColor(2U));
+        Assert::AreEqual({ COLOR_BLACK | COLOR_REDRAW }, viewer.GetColor(3U));
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(4U));
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(5U));
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(6U));
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(7U));
+        Assert::IsTrue(viewer.NeedsRedraw());
+
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 4U }, viewer.GetAddress());
+        Assert::AreEqual({ 1U }, viewer.GetSelectedNibble());
+
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 4U }, viewer.GetAddress());
+        Assert::AreEqual({ 2U }, viewer.GetSelectedNibble());
+
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 4U }, viewer.GetAddress());
+        Assert::AreEqual({ 3U }, viewer.GetSelectedNibble());
+
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 4U }, viewer.GetAddress());
+        Assert::AreEqual({ 4U }, viewer.GetSelectedNibble());
+
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 4U }, viewer.GetAddress());
+        Assert::AreEqual({ 5U }, viewer.GetSelectedNibble());
+
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 4U }, viewer.GetAddress());
+        Assert::AreEqual({ 6U }, viewer.GetSelectedNibble());
+
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 4U }, viewer.GetAddress());
+        Assert::AreEqual({ 7U }, viewer.GetSelectedNibble());
+
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 8U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+
+        Assert::AreEqual({ 0U }, viewer.GetFirstAddress());
+
+        // last visible word
+        viewer.SetAddress(124U);
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 124U }, viewer.GetAddress());
+        Assert::AreEqual({ 1U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ 0U }, viewer.GetFirstAddress());
+
+        viewer.AdvanceCursor();
+        viewer.AdvanceCursor();
+        viewer.AdvanceCursor();
+        viewer.AdvanceCursor();
+        viewer.AdvanceCursor();
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 124U }, viewer.GetAddress());
+        Assert::AreEqual({ 7U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ 0U }, viewer.GetFirstAddress());
+
+        // beyond visible range, will scroll one line
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 128U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ 16U }, viewer.GetFirstAddress());
+
+        // jump to last address - cannot advance past last nibble
+        viewer.SetAddress(252U);
+        Assert::AreEqual({ 252U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        viewer.AdvanceCursor();
+        viewer.AdvanceCursor();
+        viewer.AdvanceCursor();
+        viewer.AdvanceCursor();
+        viewer.AdvanceCursor();
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 252U }, viewer.GetAddress());
+        Assert::AreEqual({ 6U }, viewer.GetSelectedNibble());
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 252U }, viewer.GetAddress());
+        Assert::AreEqual({ 7U }, viewer.GetSelectedNibble());
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 252U }, viewer.GetAddress());
+        Assert::AreEqual({ 7U }, viewer.GetSelectedNibble());
+        Assert::IsFalse(viewer.NeedsRedraw());
+
+        // address not aligned - advance jumps to next aligned address
+        viewer.SetAddress(250U);
+        Assert::AreEqual({ 250U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 252U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+    }
+
+    TEST_METHOD(TestRetreatCursorThirtyTwoBit)
+    {
+        MemoryViewerViewModelHarness viewer;
+        viewer.InitializeMemory(256);
+        viewer.SetFirstAddress(128U);
+        viewer.SetSize(MemSize::ThirtyTwoBit);
+        viewer.SetAddress(132U);
+        viewer.MockRender();
+
+        Assert::AreEqual({ 132U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::IsFalse(viewer.NeedsRedraw());
+
+        viewer.RetreatCursor();
+        Assert::AreEqual({ 128U }, viewer.GetAddress());
+        Assert::AreEqual({ 7U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(128U));
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(129U));
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(130U));
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(131U));
+        Assert::AreEqual({ COLOR_BLACK | COLOR_REDRAW }, viewer.GetColor(132U));
+        Assert::AreEqual({ COLOR_BLACK | COLOR_REDRAW }, viewer.GetColor(133U));
+        Assert::AreEqual({ COLOR_BLACK | COLOR_REDRAW }, viewer.GetColor(134U));
+        Assert::AreEqual({ COLOR_BLACK | COLOR_REDRAW }, viewer.GetColor(135U));
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        viewer.RetreatCursor();
+        Assert::AreEqual({ 128U }, viewer.GetAddress());
+        Assert::AreEqual({ 6U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(128U));
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        viewer.RetreatCursor();
+        Assert::AreEqual({ 128U }, viewer.GetAddress());
+        Assert::AreEqual({ 5U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(128U));
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(129U));
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        viewer.RetreatCursor();
+        Assert::AreEqual({ 128U }, viewer.GetAddress());
+        Assert::AreEqual({ 4U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(129U));
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        viewer.RetreatCursor();
+        Assert::AreEqual({ 128U }, viewer.GetAddress());
+        Assert::AreEqual({ 3U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(129U));
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(130U));
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        viewer.RetreatCursor();
+        Assert::AreEqual({ 128U }, viewer.GetAddress());
+        Assert::AreEqual({ 2U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(130U));
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        viewer.RetreatCursor();
+        Assert::AreEqual({ 128U }, viewer.GetAddress());
+        Assert::AreEqual({ 1U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(130U));
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(131U));
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        viewer.RetreatCursor();
+        Assert::AreEqual({ 128U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(131U));
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+        Assert::AreEqual({ 128U }, viewer.GetFirstAddress());
+
+        // beyond visible range, will scroll one line
+        viewer.RetreatCursor();
+        Assert::AreEqual({ 124U }, viewer.GetAddress());
+        Assert::AreEqual({ 7U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ 112U }, viewer.GetFirstAddress());
+
+        // jump to first address - cannot retreat beyond first nibble
+        viewer.SetAddress(0U);
+        Assert::AreEqual({ 0U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        viewer.MockRender();
+
+        viewer.RetreatCursor();
+        Assert::AreEqual({ 0U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::IsFalse(viewer.NeedsRedraw());
+
+        // address not aligned - retreat jumps to aligned address
+        viewer.SetAddress(7U);
+        Assert::AreEqual({ 7U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+
+        viewer.RetreatCursor();
+        Assert::AreEqual({ 4U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+    }
+
+    TEST_METHOD(TestAdvanceCursorWordThirtyTwoBit)
+    {
+        MemoryViewerViewModelHarness viewer;
+        viewer.InitializeMemory(256);
+        viewer.SetSize(MemSize::ThirtyTwoBit);
+        viewer.MockRender();
+
+        Assert::AreEqual({ 0U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::IsFalse(viewer.NeedsRedraw());
+
+        viewer.AdvanceCursorWord();
+        Assert::AreEqual({ 4U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ COLOR_BLACK | COLOR_REDRAW }, viewer.GetColor(0U));
+        Assert::AreEqual({ COLOR_BLACK | COLOR_REDRAW }, viewer.GetColor(1U));
+        Assert::AreEqual({ COLOR_BLACK | COLOR_REDRAW }, viewer.GetColor(2U));
+        Assert::AreEqual({ COLOR_BLACK | COLOR_REDRAW }, viewer.GetColor(3U));
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(4U));
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(5U));
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(6U));
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(7U));
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        // mid-word jumps to start of next word
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 4U }, viewer.GetAddress());
+        Assert::AreEqual({ 1U }, viewer.GetSelectedNibble());
+
+        viewer.AdvanceCursorWord();
+        Assert::AreEqual({ 8U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+
+        viewer.SetAddress(10U);
+        viewer.AdvanceCursorWord();
+        Assert::AreEqual({ 12U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+
+        // beyond visible range, will scroll one line
+        viewer.SetAddress(124U);
+        viewer.AdvanceCursorWord();
+        Assert::AreEqual({ 128U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ 16U }, viewer.GetFirstAddress());
+
+        // jump to last address - cannot advance past last byte
+        viewer.SetAddress(252U);
+        Assert::AreEqual({ 252U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        viewer.AdvanceCursorWord();
+        Assert::AreEqual({ 252U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::IsFalse(viewer.NeedsRedraw());
+    }
+
+    TEST_METHOD(TestRetreatCursorWordThirtyTwoBit)
+    {
+        MemoryViewerViewModelHarness viewer;
+        viewer.InitializeMemory(256);
+        viewer.SetFirstAddress(128U);
+        viewer.SetSize(MemSize::ThirtyTwoBit);
+        viewer.SetAddress(132U);
+        viewer.MockRender();
+
+        Assert::AreEqual({ 132U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::IsFalse(viewer.NeedsRedraw());
+
+        viewer.RetreatCursorWord();
+        Assert::AreEqual({ 128U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(128U));
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(129U));
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(130U));
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(131U));
+        Assert::AreEqual({ COLOR_BLACK | COLOR_REDRAW }, viewer.GetColor(132U));
+        Assert::AreEqual({ COLOR_BLACK | COLOR_REDRAW }, viewer.GetColor(133U));
+        Assert::AreEqual({ COLOR_BLACK | COLOR_REDRAW }, viewer.GetColor(134U));
+        Assert::AreEqual({ COLOR_BLACK | COLOR_REDRAW }, viewer.GetColor(135U));
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        // mid-word jumps to start of current word
+        viewer.AdvanceCursor();
+        viewer.AdvanceCursor();
+        viewer.AdvanceCursor();
+        Assert::AreEqual({ 128U }, viewer.GetAddress());
+        Assert::AreEqual({ 3U }, viewer.GetSelectedNibble());
+        viewer.MockRender();
+
+        viewer.RetreatCursorWord();
+        Assert::AreEqual({ 128U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(131U));
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(130U));
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        viewer.SetAddress(131U);
+        viewer.RetreatCursorWord();
+        Assert::AreEqual({ 128U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+
+        // beyond visible range, will scroll one line
+        viewer.RetreatCursorWord();
+        Assert::AreEqual({ 124U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ 112U }, viewer.GetFirstAddress());
+
+        // jump to first address - cannot retreat beyond first nibble
+        viewer.SetAddress(0U);
+        Assert::AreEqual({ 0U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        viewer.MockRender();
+
+        viewer.RetreatCursorWord();
+        Assert::AreEqual({ 0U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::IsFalse(viewer.NeedsRedraw());
+    }
+
+    TEST_METHOD(TestOnCharSixteenBit)
+    {
+        MemoryViewerViewModelHarness viewer;
+        viewer.InitializeMemory(256);
+        viewer.SetSize(MemSize::SixteenBit);
+        viewer.MockRender();
+
+        Assert::AreEqual({ 0U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ 0U }, viewer.GetByte(0U));
+        Assert::IsFalse(viewer.NeedsRedraw());
+
+        // ignore if readonly
+        Assert::IsTrue(viewer.IsReadOnly());
+        Assert::IsFalse(viewer.OnChar('6'));
+
+        viewer.SetReadOnly(false);
+        Assert::IsFalse(viewer.IsReadOnly());
+
+        // '6' should be set as upper nibble of selected byte
+        Assert::IsTrue(viewer.OnChar('6'));
+        Assert::AreEqual({ 0U }, viewer.GetAddress());
+        Assert::AreEqual({ 1U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ 0x61U }, viewer.GetByte(1U));
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(1U));
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        // ignore invalid character
+        Assert::IsFalse(viewer.OnChar('G'));
+        Assert::AreEqual({ 0U }, viewer.GetAddress());
+        Assert::AreEqual({ 1U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ 0x61U }, viewer.GetByte(1U));
+        Assert::AreEqual({ COLOR_RED }, viewer.GetColor(1U));
+        Assert::IsFalse(viewer.NeedsRedraw());
+
+        // 'B' should be set as lower nibble of selected byte
+        viewer.OnChar('B');
+        Assert::AreEqual({ 0U }, viewer.GetAddress());
+        Assert::AreEqual({ 2U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ 0x6BU }, viewer.GetByte(1U));
+        Assert::AreEqual({ 0x00U }, viewer.GetByte(0U));
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(0U));
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(1U));
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        // 'F' should be set as upper nibble of next byte
+        viewer.OnChar('F');
+        Assert::AreEqual({ 0U }, viewer.GetAddress());
+        Assert::AreEqual({ 3U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ 0xF0U }, viewer.GetByte(0U));
+
+        // '2' should be set as lower nibble of selected byte
+        viewer.OnChar('2');
+        Assert::AreEqual({ 2U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ 0xF2U }, viewer.GetByte(0U));
+
+        // '3' should be set as upper nibble of next byte
+        viewer.OnChar('3');
+        Assert::AreEqual({ 2U }, viewer.GetAddress());
+        Assert::AreEqual({ 1U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ 0x33U }, viewer.GetByte(3U));
+    }
+
+    TEST_METHOD(TestOnCharThirtyTwoBit)
+    {
+        MemoryViewerViewModelHarness viewer;
+        viewer.InitializeMemory(256);
+        viewer.SetSize(MemSize::ThirtyTwoBit);
+        viewer.MockRender();
+
+        Assert::AreEqual({ 0U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ 0U }, viewer.GetByte(0U));
+        Assert::IsFalse(viewer.NeedsRedraw());
+
+        // ignore if readonly
+        Assert::IsTrue(viewer.IsReadOnly());
+        Assert::IsFalse(viewer.OnChar('6'));
+
+        viewer.SetReadOnly(false);
+        Assert::IsFalse(viewer.IsReadOnly());
+
+        // '6' should be set as upper nibble of selected byte
+        Assert::IsTrue(viewer.OnChar('6'));
+        Assert::AreEqual({ 0U }, viewer.GetAddress());
+        Assert::AreEqual({ 1U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ 0x63U }, viewer.GetByte(3U));
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(3U));
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        // ignore invalid character
+        Assert::IsFalse(viewer.OnChar('G'));
+        Assert::AreEqual({ 0U }, viewer.GetAddress());
+        Assert::AreEqual({ 1U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ 0x63U }, viewer.GetByte(3U));
+        Assert::AreEqual({ COLOR_RED }, viewer.GetColor(3U));
+        Assert::IsFalse(viewer.NeedsRedraw());
+
+        // 'B' should be set as lower nibble of selected byte
+        viewer.OnChar('B');
+        Assert::AreEqual({ 0U }, viewer.GetAddress());
+        Assert::AreEqual({ 2U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ 0x6BU }, viewer.GetByte(3U));
+        Assert::AreEqual({ COLOR_RED | COLOR_REDRAW }, viewer.GetColor(3U));
+        Assert::IsTrue(viewer.NeedsRedraw());
+        viewer.MockRender();
+
+        // 'F' should be set as upper nibble of next byte
+        viewer.OnChar('F');
+        Assert::AreEqual({ 0U }, viewer.GetAddress());
+        Assert::AreEqual({ 3U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ 0xF2U }, viewer.GetByte(2U));
+
+        viewer.OnChar('3');
+        viewer.OnChar('D');
+        viewer.OnChar('E');
+        viewer.OnChar('6');
+        viewer.OnChar('8');
+
+        Assert::AreEqual({ 4U }, viewer.GetAddress());
+        Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ 0xF3U }, viewer.GetByte(2U));
+        Assert::AreEqual({ 0xDEU }, viewer.GetByte(1U));
+        Assert::AreEqual({ 0x68U }, viewer.GetByte(0U));
+
+        viewer.OnChar('2');
+        Assert::AreEqual({ 4U }, viewer.GetAddress());
+        Assert::AreEqual({ 1U }, viewer.GetSelectedNibble());
+        Assert::AreEqual({ 0x27U }, viewer.GetByte(7U));
     }
 };
 

--- a/tests/ui/viewmodels/MemoryViewerViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/MemoryViewerViewModel_Tests.cpp
@@ -71,7 +71,7 @@ private:
             for (size_t i = 0; i < m_nTotalMemorySize; ++i)
                 m_pColor[i] &= 0x0F;
 
-            m_bNeedsRedraw = false;
+            m_nNeedsRedraw = 0;
         }
 
     private:

--- a/tests/ui/viewmodels/MemoryViewerViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/MemoryViewerViewModel_Tests.cpp
@@ -32,14 +32,14 @@ private:
         ra::data::mocks::MockGameContext mockGameContext;
         ra::ui::viewmodels::mocks::MockWindowManager mockWindowManager;
 
-        MemoryViewerViewModelHarness() : MemoryViewerViewModel()
+        GSL_SUPPRESS_F6 MemoryViewerViewModelHarness() : MemoryViewerViewModel()
         {
             InitializeNotifyTargets();
         }
 
-        int GetSelectedNibble() const { return m_nSelectedNibble; }
+        int GetSelectedNibble() const noexcept { return m_nSelectedNibble; }
 
-        size_t GetTotalMemorySize() const { return m_nTotalMemorySize; }
+        size_t GetTotalMemorySize() const noexcept { return m_nTotalMemorySize; }
 
         unsigned char GetByte(ra::ByteAddress nAddress) const
         {
@@ -51,8 +51,8 @@ private:
             return gsl::narrow_cast<unsigned char>(ra::itoe<TextColor>(m_pColor[nAddress - GetFirstAddress()]));
         }
 
-        bool IsReadOnly() const { return m_bReadOnly; }
-        void SetReadOnly(bool value) { m_bReadOnly = value;  }
+        bool IsReadOnly() const noexcept { return m_bReadOnly; }
+        void SetReadOnly(bool value) noexcept { m_bReadOnly = value;  }
 
         void InitializeMemory(size_t nSize)
         {
@@ -66,7 +66,7 @@ private:
             DoFrame(); // populates m_pMemory and m_pColor
         }
 
-        void MockRender()
+        void MockRender() noexcept
         {
             for (size_t i = 0; i < m_nTotalMemorySize; ++i)
                 m_pColor[i] &= 0x0F;


### PR DESCRIPTION
The old memory viewer would render every byte every frame, which was very demanding, particularly when the user had many bookmarks or code notes as every byte had to be looked up every render to determine which color to make it.

This replaces all of the rendering logic with state information. An offscreen bitmap is maintained along with the current "state" of the memory. When bookmarks or code notes are added/removed, the color state information is updated. When the memory changes, the numerical data is updated. When the watched address changes, both are updated. Then, if anything has updated, the image is redrawn offscreen, and any requests to render to the screen simply copy the offscreen bitmap to the screen.

With this solution, having the memory viewer open doesn't have any noticeable impact on the performance of the emulator.

Also implements #296
![image](https://user-images.githubusercontent.com/32680403/72213732-5188d880-34b1-11ea-8c0b-6f4c5bf86a68.png)

And adjusts the highlighting for 16- and 32-bit modes when the Watching address is not aligned to the view. Unaligned addresses can only be selected/entered via the Watching address field. Navigating the memory (and clicking within the memory) will always select aligned addresses.
![image](https://user-images.githubusercontent.com/32680403/72213739-741af180-34b1-11ea-8282-3fb8afa2c262.png)
![image](https://user-images.githubusercontent.com/32680403/72213742-7ed58680-34b1-11ea-8699-a29d66586a99.png)
