### PR TITLE
disable compatibility mode when loading a new game

### DIFF
--- a/src/RA_Dlg_Memory.cpp
+++ b/src/RA_Dlg_Memory.cpp
@@ -1280,6 +1280,7 @@ void Dlg_Memory::OnLoad_NewRom()
 
     if (pGameContext.GameId() == 0)
     {
+        SetWindowText(g_MemoryDialog.m_hWnd, TEXT("Memory Inspector [no game loaded]"));
         SetDlgItemText(g_MemoryDialog.m_hWnd, IDC_RA_WATCHING, TEXT(""));
 
         EnableWindow(GetDlgItem(g_MemoryDialog.m_hWnd, IDC_RA_ADDNOTE), FALSE);
@@ -1293,12 +1294,16 @@ void Dlg_Memory::OnLoad_NewRom()
 
         if (pGameContext.GetMode() == ra::data::GameContext::Mode::CompatibilityTest)
         {
+            SetWindowText(g_MemoryDialog.m_hWnd, TEXT("Memory Inspector [compatibility mode]"));
+
             EnableWindow(GetDlgItem(g_MemoryDialog.m_hWnd, IDC_RA_ADDNOTE), FALSE);
             EnableWindow(GetDlgItem(g_MemoryDialog.m_hWnd, IDC_RA_MEMSAVENOTE), FALSE);
             EnableWindow(GetDlgItem(g_MemoryDialog.m_hWnd, IDC_RA_REMNOTE), FALSE);
         }
         else
         {
+            SetWindowText(g_MemoryDialog.m_hWnd, TEXT("Memory Inspector"));
+
             EnableWindow(GetDlgItem(g_MemoryDialog.m_hWnd, IDC_RA_ADDNOTE), TRUE);
             EnableWindow(GetDlgItem(g_MemoryDialog.m_hWnd, IDC_RA_MEMSAVENOTE), TRUE);
             EnableWindow(GetDlgItem(g_MemoryDialog.m_hWnd, IDC_RA_REMNOTE), TRUE);

--- a/src/services/GameIdentifier.cpp
+++ b/src/services/GameIdentifier.cpp
@@ -61,6 +61,7 @@ unsigned int GameIdentifier::IdentifyHash(const std::string& sMD5)
     }
 
     unsigned int nGameId = 0U;
+    m_nPendingMode = ra::data::GameContext::Mode::Normal;
 
     ra::api::ResolveHash::Request request;
     request.Hash = sMD5;

--- a/tests/services/GameIdentifier_Tests.cpp
+++ b/tests/services/GameIdentifier_Tests.cpp
@@ -423,6 +423,35 @@ public:
         Assert::IsTrue(identifier.mockConfiguration.IsFeatureEnabled(ra::services::Feature::Hardcore));
     }
 
+    TEST_METHOD(TestActivateGameResetCompatibility)
+    {
+        GameIdentifierHarness identifier;
+        identifier.MockCompatibilityTest(23U);
+        identifier.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, true);
+        identifier.mockUserContext.Initialize("User", "ApiToken");
+
+        Assert::AreEqual(23U, identifier.IdentifyGame(&ROM.at(0), ROM.size()));
+        identifier.ActivateGame(23U);
+
+        Assert::AreEqual(23U, identifier.mockGameContext.GameId());
+        Assert::AreEqual(ROM_HASH, identifier.mockGameContext.GameHash());
+        Assert::AreEqual(ra::data::GameContext::Mode::CompatibilityTest, identifier.mockGameContext.GetMode());
+        Assert::AreEqual(23U, identifier.mockSessionTracker.CurrentSessionGameId());
+        Assert::IsNull(identifier.mockOverlayManager.GetMessage(1U));
+        Assert::IsTrue(identifier.mockGameContext.WasLoaded());
+
+        identifier.MockResolveHashResponse(22U);
+        Assert::AreEqual(22U, identifier.IdentifyHash(ROM_HASH));
+        identifier.ActivateGame(22U);
+
+        Assert::AreEqual(22U, identifier.mockGameContext.GameId());
+        Assert::AreEqual(ROM_HASH, identifier.mockGameContext.GameHash());
+        Assert::AreEqual(ra::data::GameContext::Mode::Normal, identifier.mockGameContext.GetMode());
+        Assert::AreEqual(22U, identifier.mockSessionTracker.CurrentSessionGameId());
+        Assert::IsNull(identifier.mockOverlayManager.GetMessage(1U));
+        Assert::IsTrue(identifier.mockGameContext.WasLoaded());
+    }
+
     TEST_METHOD(TestIdentifyAndActivateGameHardcore)
     {
         GameIdentifierHarness identifier;


### PR DESCRIPTION
Fixes an issue where compatibility mode would remain engaged when loading a normal game after loading a game in compatibility mode.

Also modifies the memory inspector dialog title to indicate when in compatibility testing mode, or when no game is loaded to help the user understand why certain parts of the editor are readonly.