### PR TITLE
prevent attempt to fetch image '0'

### DIFF
--- a/src/RA_Achievement.cpp
+++ b/src/RA_Achievement.cpp
@@ -527,6 +527,9 @@ void Achievement::SetBadgeImage(const std::string& sBadgeURI)
         m_sBadgeImageURI.assign(sBadgeURI.c_str(), sBadgeURI.length() - 5);
     else
         m_sBadgeImageURI = sBadgeURI;
+
+    if (m_sBadgeImageURI.length() < 5)
+        m_sBadgeImageURI.insert(0, 5 - m_sBadgeImageURI.length(), '0');
 }
 
 size_t Achievement::AddCondition(size_t nConditionGroup, const Condition& rNewCond)


### PR DESCRIPTION
Minor optimization to avoid any attempt to download image `0.png` and `.png` - the actual image is `00000.png`. 

This will also pad any other badge names shorter than expected, though I haven't encountered any cases where that is occurring.