### PR TITLE
Add OrNext flag and BitCount size

### DIFF
--- a/src/RA_Achievement.cpp
+++ b/src/RA_Achievement.cpp
@@ -237,6 +237,8 @@ static constexpr MemSize GetCompVariableSize(char nOperandSize) noexcept
             return MemSize::TwentyFourBit;
         case RC_MEMSIZE_32_BITS:
             return MemSize::ThirtyTwoBit;
+        case RC_MEMSIZE_8_BITS_BITCOUNT:
+            return MemSize::BitCount;
         default:
             ASSERT(!"Unsupported operand size");
             return MemSize::EightBit;
@@ -341,6 +343,9 @@ static void MakeConditionGroup(ConditionSet& vConditions, rc_condset_t* pCondSet
                 break;
             case RC_CONDITION_AND_NEXT:
                 cond.SetConditionType(Condition::Type::AndNext);
+                break;
+            case RC_CONDITION_OR_NEXT:
+                cond.SetConditionType(Condition::Type::OrNext);
                 break;
             case RC_CONDITION_MEASURED:
                 cond.SetConditionType(Condition::Type::Measured);

--- a/src/RA_Achievement.cpp
+++ b/src/RA_Achievement.cpp
@@ -295,23 +295,23 @@ static void MakeConditionGroup(ConditionSet& vConditions, rc_condset_t* pCondSet
             default:
                 ASSERT(!"Unsupported operator");
                 _FALLTHROUGH;
-            case RC_CONDITION_NONE:
-            case RC_CONDITION_EQ:
+            case RC_OPERATOR_NONE:
+            case RC_OPERATOR_EQ:
                 cond.SetCompareType(ComparisonType::Equals);
                 break;
-            case RC_CONDITION_NE:
+            case RC_OPERATOR_NE:
                 cond.SetCompareType(ComparisonType::NotEqualTo);
                 break;
-            case RC_CONDITION_LT:
+            case RC_OPERATOR_LT:
                 cond.SetCompareType(ComparisonType::LessThan);
                 break;
-            case RC_CONDITION_LE:
+            case RC_OPERATOR_LE:
                 cond.SetCompareType(ComparisonType::LessThanOrEqual);
                 break;
-            case RC_CONDITION_GT:
+            case RC_OPERATOR_GT:
                 cond.SetCompareType(ComparisonType::GreaterThan);
                 break;
-            case RC_CONDITION_GE:
+            case RC_OPERATOR_GE:
                 cond.SetCompareType(ComparisonType::GreaterThanOrEqual);
                 break;
         }

--- a/src/RA_Achievement.h
+++ b/src/RA_Achievement.h
@@ -97,6 +97,7 @@ public:
     void SetBadgeImage(const std::string& sFilename);
 
     Condition& GetCondition(size_t nCondGroup, size_t i) { return m_vConditions.GetGroup(nCondGroup).GetAt(i); }
+    const Condition& GetCondition(size_t nCondGroup, size_t i) const { return m_vConditions.GetGroup(nCondGroup).GetAt(i); }
     unsigned int GetConditionHitCount(size_t nCondGroup, size_t i) const;
     void SetConditionHitCount(size_t nCondGroup, size_t i, unsigned int nCurrentHits) const;
 

--- a/src/RA_Condition.cpp
+++ b/src/RA_Condition.cpp
@@ -6,6 +6,7 @@ _NODISCARD static _CONSTANT_FN ComparisonSizeToPrefix(_In_ MemSize nSize) noexce
 {
     switch (nSize)
     {
+        case MemSize::BitCount:     return "C";
         case MemSize::Bit_0:        return "M";
         case MemSize::Bit_1:        return "N";
         case MemSize::Bit_2:        return "O";
@@ -59,6 +60,9 @@ void Condition::SerializeAppend(std::string& buffer) const
             break;
         case Type::AndNext:
             buffer.append("N:");
+            break;
+        case Type::OrNext:
+            buffer.append("O:");
             break;
         case Type::Measured:
             buffer.append("M:");

--- a/src/RA_Condition.h
+++ b/src/RA_Condition.h
@@ -5,9 +5,10 @@
 #include "data\Types.hh"
 #include "ra_utility.h"
 
-inline constexpr std::array<const LPCTSTR, 14> MEMSIZE_STR{
+inline constexpr std::array<const LPCTSTR, 15> MEMSIZE_STR{
     _T("Bit0"), _T("Bit1"),   _T("Bit2"),   _T("Bit3"),  _T("Bit4"),   _T("Bit5"),   _T("Bit6"),
-    _T("Bit7"), _T("Lower4"), _T("Upper4"), _T("8-bit"), _T("16-bit"), _T("24-bit"), _T("32-bit")};
+    _T("Bit7"), _T("Lower4"), _T("Upper4"), _T("8-bit"), _T("16-bit"), _T("24-bit"), _T("32-bit"),
+    _T("BitCount")};
 
 enum class ComparisonType
 {
@@ -84,12 +85,13 @@ public:
         SubSource,
         AddHits,
         AndNext,
+        OrNext,
         Measured,
         AddAddress
     };
 
-    inline static constexpr std::array<LPCTSTR, 9> TYPE_STR{
-        _T(""), _T("Pause If"), _T("Reset If"), _T("Add Source"), _T("Sub Source"), _T("Add Hits"), _T("And Next"), _T("Measured"), _T("Add Address")};
+    inline static constexpr std::array<LPCTSTR, 10> TYPE_STR{
+        _T(""), _T("Pause If"), _T("Reset If"), _T("Add Source"), _T("Sub Source"), _T("Add Hits"), _T("And Next"), _T("Or Next"), _T("Measured"), _T("Add Address")};
 
     void SerializeAppend(std::string& buffer) const;
 

--- a/src/RA_Dlg_AchEditor.cpp
+++ b/src/RA_Dlg_AchEditor.cpp
@@ -24,7 +24,7 @@
 
 inline constexpr std::array<const char*, 10> COLUMN_TITLE{"ID",  "Flag", "Type", "Size",    "Memory",
                                                           "Cmp", "Type", "Size", "Mem/Val", "Hits"};
-inline constexpr std::array<int, 10> COLUMN_WIDTH{30, 75, 42, 50, 72, 35, 42, 50, 72, 84};
+inline constexpr std::array<int, 10> COLUMN_WIDTH{30, 75, 42, 54, 72, 35, 42, 54, 72, 84};
 static_assert(COLUMN_TITLE.size() == COLUMN_WIDTH.size());
 
 enum class CondSubItems : std::size_t

--- a/src/RA_Dlg_Achievement.cpp
+++ b/src/RA_Dlg_Achievement.cpp
@@ -310,7 +310,7 @@ _Success_(return ) _NODISCARD BOOL
             return FALSE;
         }
 
-#if RA_INTEGRATION_VERSION_MINOR < 77
+#if RA_INTEGRATION_VERSION_MINOR < 78
         if (!ra::services::ServiceLocator::Get<ra::services::IConfiguration>().IsCustomHost())
         {
             for (size_t nGroup = 0; nGroup < Ach.NumConditionGroups(); ++nGroup)
@@ -319,22 +319,16 @@ _Success_(return ) _NODISCARD BOOL
                 {
                     const auto& pCondition = Ach.GetCondition(nGroup, nCondition);
 
-                    if (pCondition.GetConditionType() == Condition::Type::Measured)
+                    if (pCondition.GetConditionType() == Condition::Type::OrNext)
                     {
-                        ra::ui::viewmodels::MessageBoxViewModel::ShowErrorMessage(L"Achievement contains pre-release logic.", L"* Measured");
+                        ra::ui::viewmodels::MessageBoxViewModel::ShowErrorMessage(L"Achievement contains pre-release logic.", L"* OrNext");
                         return FALSE;
                     }
 
-                    if (pCondition.GetConditionType() == Condition::Type::AddAddress)
+                    if (pCondition.CompSource().GetSize() == MemSize::BitCount ||
+                        pCondition.CompTarget().GetSize() == MemSize::BitCount)
                     {
-                        ra::ui::viewmodels::MessageBoxViewModel::ShowErrorMessage(L"Achievement contains pre-release logic.", L"* AddAddress");
-                        return FALSE;
-                    }
-
-                    if (pCondition.CompSource().GetSize() == MemSize::TwentyFourBit ||
-                        pCondition.CompTarget().GetSize() == MemSize::TwentyFourBit)
-                    {
-                        ra::ui::viewmodels::MessageBoxViewModel::ShowErrorMessage(L"Achievement contains pre-release logic.", L"* 24-bit memory size");
+                        ra::ui::viewmodels::MessageBoxViewModel::ShowErrorMessage(L"Achievement contains pre-release logic.", L"* BitCount memory size");
                         return FALSE;
                     }
                 }

--- a/src/data/GameContext.cpp
+++ b/src/data/GameContext.cpp
@@ -332,7 +332,7 @@ void GameContext::MergeLocalAchievements()
             // unquoted trigger requires special parsing because flags also use colons
             const char* pTrigger = pTokenizer.GetPointer(pTokenizer.CurrentPosition());
             const char* pScan = pTrigger;
-            while (*pScan && (*pScan != ':' || strchr("ABCMNOPRabcmnopr", pScan[-1]) != nullptr))
+            while (*pScan && (*pScan != ':' || strchr("ABCMNOPRTabcmnoprt", pScan[-1]) != nullptr))
                 pScan++;
 
             sTrigger.assign(pTrigger, pScan - pTrigger);

--- a/src/data/GameContext.cpp
+++ b/src/data/GameContext.cpp
@@ -332,7 +332,7 @@ void GameContext::MergeLocalAchievements()
             // unquoted trigger requires special parsing because flags also use colons
             const char* pTrigger = pTokenizer.GetPointer(pTokenizer.CurrentPosition());
             const char* pScan = pTrigger;
-            while (*pScan && (*pScan != ':' || strchr("ABCNPRabcnpr", pScan[-1]) != nullptr))
+            while (*pScan && (*pScan != ':' || strchr("ABCMNOPRabcmnopr", pScan[-1]) != nullptr))
                 pScan++;
 
             sTrigger.assign(pTrigger, pScan - pTrigger);

--- a/src/data/Types.hh
+++ b/src/data/Types.hh
@@ -17,7 +17,8 @@ enum class MemSize : uint8_t
     EightBit,
     SixteenBit,
     TwentyFourBit,
-    ThirtyTwoBit
+    ThirtyTwoBit,
+    BitCount
 };
 
 namespace ra {


### PR DESCRIPTION
`OrNext` allows multiple conditions to be chained in sequence. If any of the conditions is true, the `ResetIf`/`PauseIf`/`HitCount` of the final condition will be invoked. This mimics the behavior of `AndNext` but handles OR logic. (#462)

Interaction between `AndNext` and `OrNext` is sequential. If you have:
```
        AndNext A=1
        OrNext  B=1
        AndNext C=1
        OrNext  D=1
        AndNext E=1
ResetIf OrNext  F=1
```
The logic would be:
`reset if (((((A = 1 || B = 1) && C = 1) || D = 1) && E = 1) || F = 1)`

-----
`BitCount` is a new size. It appears in the size dropdown along with `8-bit`, `Bit6`, `Lower4`, etc.

The `BitCount` size reads the 8-bits at the specified address and returns the number of bits that are non-zero. For example, the value 0x13 has three bits set, so the `BitCount` of an address containing 0x13 would be 3. 

The primary use case for this is for measuring collect-a-thon achievements. If each collected item is represented by a single bit, you can add together `BitCount`s on each byte to get the number of items collected. This is possible using the individual `BitX` flags, but replaces 8 conditions with a single one.