### PR TITLE
don't send custom rich presence to server

### DIFF
--- a/src/Exports.cpp
+++ b/src/Exports.cpp
@@ -303,7 +303,7 @@ static void ProcessAchievements()
                 if (!pAchievement)
                     break;
 
-                if (pGameContext.HasRichPresence())
+                if (pGameContext.HasRichPresence() && !pGameContext.IsRichPresenceFromFile())
                     pAchievement->SetUnlockRichPresence(pGameContext.GetRichPresenceDisplayString());
 
 #ifndef RA_UTEST

--- a/src/data/GameContext.cpp
+++ b/src/data/GameContext.cpp
@@ -102,8 +102,16 @@ void GameContext::LoadGame(unsigned int nGameId, Mode nMode)
     m_sGameImage = response.ImageIcon;
 
     // rich presence
-    LoadRichPresenceScript(response.RichPresence);
-    m_sServerRichPresenceMD5 = RAGenerateMD5(response.RichPresence);
+    {
+        // normalize for MD5 calulation (unix line endings, must end with a line ending)
+        std::string sRichPresence = response.RichPresence;
+        sRichPresence.erase(std::remove(sRichPresence.begin(), sRichPresence.end(), '\r'), sRichPresence.end());
+        if (!sRichPresence.empty() && sRichPresence.back() != '\n')
+            sRichPresence.push_back('\n');
+
+        LoadRichPresenceScript(sRichPresence);
+        m_sServerRichPresenceMD5 = RAGenerateMD5(sRichPresence);
+    }
 
     if (!response.RichPresence.empty())
     {
@@ -1055,7 +1063,6 @@ void GameContext::ReloadRichPresenceScript()
             sRichPresence.append(sLine);
             sRichPresence.append("\n");
         }
-        sRichPresence.resize(pRich->GetPosition()); // remove trailing newline if not present in file
     }
 
     const auto sFileRichPresenceMD5 = RAGenerateMD5(sRichPresence);

--- a/src/data/GameContext.cpp
+++ b/src/data/GameContext.cpp
@@ -5,6 +5,7 @@
 #include "RA_Defs.h"
 #include "RA_Dlg_Achievement.h"
 #include "RA_Log.h"
+#include "RA_md5factory.h"
 #include "RA_StringUtils.h"
 
 #include "api\AwardAchievement.hh"
@@ -56,6 +57,7 @@ void GameContext::LoadGame(unsigned int nGameId, Mode nMode)
 
     m_nMode = nMode;
     m_sGameTitle.clear();
+    m_bRichPresenceFromFile = false;
     m_mCodeNotes.clear();
     m_nNextLocalId = GameContext::FirstLocalId;
 
@@ -100,10 +102,11 @@ void GameContext::LoadGame(unsigned int nGameId, Mode nMode)
     m_sGameImage = response.ImageIcon;
 
     // rich presence
+    LoadRichPresenceScript(response.RichPresence);
+    m_sServerRichPresenceMD5 = RAGenerateMD5(response.RichPresence);
+
     if (!response.RichPresence.empty())
     {
-        LoadRichPresenceScript(response.RichPresence);
-
         // TODO: this file is written so devs can modify the rich presence without having to restart
         // the game. if the user doesn't have dev permission, there's no reason to write it.
         auto& pLocalStorage = ra::services::ServiceLocator::GetMutable<ra::services::ILocalStorage>();
@@ -1040,18 +1043,23 @@ std::wstring GameContext::GetRichPresenceDisplayString() const
 
 void GameContext::ReloadRichPresenceScript()
 {
-    const auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::GameContext>();
     auto& pLocalStorage = ra::services::ServiceLocator::GetMutable<ra::services::ILocalStorage>();
-    auto pRich = pLocalStorage.ReadText(ra::services::StorageItemType::RichPresence, std::to_wstring(pGameContext.GameId()));
-    if (pRich == nullptr)
-        return;
+    auto pRich = pLocalStorage.ReadText(ra::services::StorageItemType::RichPresence, std::to_wstring(GameId()));
 
-    std::string sRichPresence, sLine;
-    while (pRich->GetLine(sLine))
+    std::string sRichPresence;
+    if (pRich != nullptr)
     {
-        sRichPresence.append(sLine);
-        sRichPresence.append("\n");
+        std::string sLine;
+        while (pRich->GetLine(sLine))
+        {
+            sRichPresence.append(sLine);
+            sRichPresence.append("\n");
+        }
+        sRichPresence.resize(pRich->GetPosition()); // remove trailing newline if not present in file
     }
+
+    const auto sFileRichPresenceMD5 = RAGenerateMD5(sRichPresence);
+    m_bRichPresenceFromFile = (sFileRichPresenceMD5 != m_sServerRichPresenceMD5);
 
     LoadRichPresenceScript(sRichPresence);
 }

--- a/src/data/GameContext.hh
+++ b/src/data/GameContext.hh
@@ -170,6 +170,11 @@ public:
     virtual bool HasRichPresence() const;
     
     /// <summary>
+    /// Gets whether or not the loaded game has a rich presence script.
+    /// </summary>
+    bool IsRichPresenceFromFile() const noexcept { return m_bRichPresenceFromFile; }
+
+    /// <summary>
     /// Gets the current rich presence display string.
     /// </summary>
     virtual std::wstring GetRichPresenceDisplayString() const;
@@ -323,6 +328,8 @@ protected:
     std::string m_sGameHash;
     std::string m_sGameImage;
     Mode m_nMode{};
+    std::string m_sServerRichPresenceMD5;
+    bool m_bRichPresenceFromFile = false;
 
     ra::AchievementID m_nNextLocalId = 0;
     static const ra::AchievementID FirstLocalId = 111000001;

--- a/src/data/SessionTracker.cpp
+++ b/src/data/SessionTracker.cpp
@@ -269,15 +269,12 @@ std::wstring SessionTracker::GetCurrentActivity() const
         return L"Fixing Achievements";
     }
 
-    if (pGameContext.HasRichPresence())
+    if (pGameContext.HasRichPresence() && !pGameContext.IsRichPresenceFromFile())
     {
         const auto sRPResponse = pGameContext.GetRichPresenceDisplayString();
         if (!sRPResponse.empty())
             return sRPResponse;
     }
-
-    if (HasCoreAchievements(pGameContext))
-        return L"Earning Achievements";
 
     return L"Playing " + pGameContext.GameTitle();
 }

--- a/src/services/AchievementRuntime.cpp
+++ b/src/services/AchievementRuntime.cpp
@@ -160,11 +160,22 @@ void AchievementRuntime::ActivateRichPresence(const std::string& sScript)
 {
     EnsureInitialized();
 
-    const auto nResult = rc_runtime_activate_richpresence(&m_pRuntime, sScript.c_str(), nullptr, 0);
-    if (nResult != RC_OK)
+    if (sScript.empty())
     {
-        const std::string sErrorRP = ra::StringPrintf("Parse error %d\n", nResult);
-        m_pRuntime.richpresence_display_buffer = _strdup(sErrorRP.c_str());
+        if (m_pRuntime.richpresence_display_buffer != nullptr)
+        {
+            free(m_pRuntime.richpresence_display_buffer);
+            m_pRuntime.richpresence_display_buffer = nullptr;
+        }
+    }
+    else
+    {
+        const auto nResult = rc_runtime_activate_richpresence(&m_pRuntime, sScript.c_str(), nullptr, 0);
+        if (nResult != RC_OK)
+        {
+            const std::string sErrorRP = ra::StringPrintf("Parse error %d\n", nResult);
+            m_pRuntime.richpresence_display_buffer = _strdup(sErrorRP.c_str());
+        }
     }
 }
 

--- a/tests/data/GameContext_Tests.cpp
+++ b/tests/data/GameContext_Tests.cpp
@@ -59,6 +59,8 @@ public:
 
         void SetGameId(unsigned int nGameId) noexcept { m_nGameId = nGameId; }
 
+        void SetRichPresenceFromFile(bool bValue) noexcept { m_bRichPresenceFromFile = bValue; }
+
         Achievement& MockAchievement()
         {
             auto& pAch = NewAchievement(Achievement::Category::Core);
@@ -238,6 +240,25 @@ public:
         Assert::IsTrue(game.HasRichPresence());
         Assert::AreEqual(std::string("Display:\nHello, World"),
             game.mockStorage.GetStoredData(ra::services::StorageItemType::RichPresence, L"1"));
+        Assert::IsFalse(game.IsRichPresenceFromFile());
+    }
+
+    TEST_METHOD(TestLoadGameResetsRichPresenceFromFile)
+    {
+        GameContextHarness game;
+        game.mockServer.HandleRequest<ra::api::FetchGameData>([](const ra::api::FetchGameData::Request&, ra::api::FetchGameData::Response& response)
+        {
+            response.RichPresence = "Display:\nHello, World";
+            return true;
+        });
+
+        game.SetRichPresenceFromFile(true);
+        game.LoadGame(1U);
+
+        Assert::IsTrue(game.HasRichPresence());
+        Assert::AreEqual(std::string("Display:\nHello, World"),
+            game.mockStorage.GetStoredData(ra::services::StorageItemType::RichPresence, L"1"));
+        Assert::IsFalse(game.IsRichPresenceFromFile());
     }
 
     TEST_METHOD(TestLoadGameAchievements)
@@ -716,6 +737,53 @@ public:
         game.mockThreadPool.ExecuteNextTask(); // FetchUserUnlocks and FetchCodeNotes are async
         game.mockThreadPool.ExecuteNextTask();
         Assert::IsTrue(game.runtime.IsPaused());
+    }
+
+    TEST_METHOD(TestReloadRichPresenceScriptNoFile)
+    {
+        GameContextHarness game;
+        game.mockServer.HandleRequest<ra::api::FetchGameData>([](const ra::api::FetchGameData::Request&, ra::api::FetchGameData::Response& response)
+        {
+            response.RichPresence = "Display:\nHello, World";
+            return true;
+        });
+
+        game.LoadGame(1U);
+
+        /* load game will write the server RP to storage */
+        game.ReloadRichPresenceScript();
+
+        Assert::IsTrue(game.HasRichPresence());
+        Assert::AreEqual(std::wstring(L"Hello, World"), game.GetRichPresenceDisplayString());
+        Assert::IsFalse(game.IsRichPresenceFromFile());
+
+        /* replace written server RP with empty file */
+        game.mockStorage.DeleteStoredData(ra::services::StorageItemType::RichPresence, L"1");
+        game.ReloadRichPresenceScript();
+
+        Assert::IsFalse(game.HasRichPresence());
+        Assert::AreEqual(std::wstring(L"No Rich Presence defined."), game.GetRichPresenceDisplayString());
+        Assert::IsTrue(game.IsRichPresenceFromFile());
+    }
+
+    TEST_METHOD(TestReloadRichPresenceScript)
+    {
+        GameContextHarness game;
+        game.mockServer.HandleRequest<ra::api::FetchGameData>([](const ra::api::FetchGameData::Request&, ra::api::FetchGameData::Response& response)
+        {
+            response.RichPresence = "Display:\nHello, World";
+            return true;
+        });
+
+        game.LoadGame(1U);
+
+        /* load game will write the server RP to storage, so overwrite it now */
+        game.mockStorage.MockStoredData(ra::services::StorageItemType::RichPresence, L"1", "Display:\nFrom File");
+        game.ReloadRichPresenceScript();
+
+        Assert::IsTrue(game.HasRichPresence());
+        Assert::AreEqual(std::wstring(L"From File"), game.GetRichPresenceDisplayString());
+        Assert::IsTrue(game.IsRichPresenceFromFile());
     }
 
     TEST_METHOD(TestAwardAchievementNonExistant)

--- a/tests/data/GameContext_Tests.cpp
+++ b/tests/data/GameContext_Tests.cpp
@@ -766,6 +766,33 @@ public:
         Assert::IsTrue(game.IsRichPresenceFromFile());
     }
 
+    TEST_METHOD(TestReloadRichPresenceScriptWindowsLineEndings)
+    {
+        GameContextHarness game;
+        game.mockServer.HandleRequest<ra::api::FetchGameData>([](const ra::api::FetchGameData::Request&, ra::api::FetchGameData::Response& response)
+        {
+            response.RichPresence = "Display:\r\nHello, World\r\n";
+            return true;
+        });
+
+        game.LoadGame(1U);
+
+        /* load game will write the server RP to storage */
+        game.ReloadRichPresenceScript();
+
+        Assert::IsTrue(game.HasRichPresence());
+        Assert::AreEqual(std::wstring(L"Hello, World"), game.GetRichPresenceDisplayString());
+        Assert::IsFalse(game.IsRichPresenceFromFile());
+
+        /* replace written server RP with a different file */
+        game.mockStorage.MockStoredData(ra::services::StorageItemType::RichPresence, L"1", "Display:\r\nFrom File\r\n");
+        game.ReloadRichPresenceScript();
+
+        Assert::IsTrue(game.HasRichPresence());
+        Assert::AreEqual(std::wstring(L"From File"), game.GetRichPresenceDisplayString());
+        Assert::IsTrue(game.IsRichPresenceFromFile());
+    }
+
     TEST_METHOD(TestReloadRichPresenceScript)
     {
         GameContextHarness game;

--- a/tests/data/SessionTracker_Tests.cpp
+++ b/tests/data/SessionTracker_Tests.cpp
@@ -352,6 +352,15 @@ public:
         Assert::AreEqual(std::wstring(L"Level 10"), tracker.GetActivity());
     }
 
+    TEST_METHOD(TestCurrentActivityRichPresenceFromFile)
+    {
+        SessionTrackerHarness tracker;
+        tracker.mockGameContext.SetGameTitle(L"GameTitle");
+        tracker.mockGameContext.SetRichPresenceDisplayString(L"Level 10");
+        tracker.mockGameContext.SetRichPresenceFromFile(true);
+        Assert::AreEqual(std::wstring(L"Playing GameTitle"), tracker.GetActivity());
+    }
+
     TEST_METHOD(TestCurrentActivityRichPresenceCompatibilityMode)
     {
         SessionTrackerHarness tracker;

--- a/tests/data/SessionTracker_Tests.cpp
+++ b/tests/data/SessionTracker_Tests.cpp
@@ -331,18 +331,11 @@ public:
         Assert::AreEqual(std::string(""), tracker.GetStoredData());
     }
 
-    TEST_METHOD(TestCurrentActivityNoAchievements)
+    TEST_METHOD(TestCurrentActivityNoRichPresence)
     {
         SessionTrackerHarness tracker;
         tracker.mockGameContext.SetGameTitle(L"GameTitle");
         Assert::AreEqual(std::wstring(L"Playing GameTitle"), tracker.GetActivity());
-    }
-
-    TEST_METHOD(TestCurrentActivityNoRichPresence)
-    {
-        SessionTrackerHarness tracker;
-        tracker.mockGameContext.NewAchievement(Achievement::Category::Core);
-        Assert::AreEqual(std::wstring(L"Earning Achievements"), tracker.GetActivity());
     }
 
     TEST_METHOD(TestCurrentActivityRichPresence)

--- a/tests/mocks/MockGameContext.hh
+++ b/tests/mocks/MockGameContext.hh
@@ -46,6 +46,8 @@ public:
     /// </summary>
     void SetRichPresenceDisplayString(std::wstring sValue) { m_sRichPresenceDisplayString = sValue; }
 
+    void SetRichPresenceFromFile(bool bValue) noexcept { m_bRichPresenceFromFile = bValue; }
+
     RA_Leaderboard& NewLeaderboard(ra::LeaderboardID nLeaderboardId)
     {
         return *m_vLeaderboards.emplace_back(std::make_unique<RA_Leaderboard>(nLeaderboardId));

--- a/tests/mocks/MockLocalStorage.hh
+++ b/tests/mocks/MockLocalStorage.hh
@@ -37,6 +37,13 @@ public:
         return sEmpty;
     }
 
+    void DeleteStoredData(ra::services::StorageItemType nType, const std::wstring& sKey)
+    {
+        auto pMap = m_mStoredData.find(nType);
+        if (pMap != m_mStoredData.end())
+            pMap->second.erase(sKey);
+    }
+
     std::chrono::system_clock::time_point GetLastModified(_UNUSED StorageItemType nType,
                                                           _UNUSED const std::wstring& sKey) noexcept override
     {

--- a/tests/services/AchievementRuntime_Tests.cpp
+++ b/tests/services/AchievementRuntime_Tests.cpp
@@ -813,6 +813,24 @@ public:
         runtime.Process(changes);
         Assert::AreEqual(std::wstring(L"13 11"), runtime.GetRichPresenceDisplayString());
     }
+
+    TEST_METHOD(TestActivateRichPresenceChange)
+    {
+        std::array<unsigned char, 5> memory{ 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        std::vector<ra::services::AchievementRuntime::Change> changes;
+
+        AchievementRuntimeHarness runtime;
+        runtime.mockEmulatorContext.MockMemory(memory);
+
+        runtime.ActivateRichPresence("Display:\nHello, World\n");
+        Assert::AreEqual(std::wstring(L"Hello, World"), runtime.GetRichPresenceDisplayString());
+
+        runtime.ActivateRichPresence("Display:\nNew String\n");
+        Assert::AreEqual(std::wstring(L"New String"), runtime.GetRichPresenceDisplayString());
+
+        runtime.ActivateRichPresence("");
+        Assert::AreEqual(std::wstring(L"No Rich Presence defined."), runtime.GetRichPresenceDisplayString());
+    }
 };
 
 } // namespace tests


### PR DESCRIPTION
The ability to edit the local XXX-Rich.txt file is meant for developing the rich presence. Until finished and uploaded to the server, there's minimal benefit to broadcasting the test state. Instead, "Playing [gamename]" will be sent. The test script evaluation will still be visible in the Rich Presence Monitor.

Also eliminates the "Earning Achievements" message that was shown if a game had achievements but no rich presence. In that case, "Playing [gamename]" will also be shown. RetroArch doesn't handle this behavior with the new rich presence feature. When that fact was brought up in the staff channel, there was a general consensus to remove it from the DLL rather than add it to RetroArch.