### PR TITLE
add runtime performance counters

### DIFF
--- a/src/Exports.cpp
+++ b/src/Exports.cpp
@@ -412,7 +412,7 @@ static void UpdateUIForFrameChange()
     auto& pWindowManager = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::WindowManager>();
     pWindowManager.MemoryBookmarks.DoFrame();
 
-    TALLY_PERFORMANCE(PerformanceCheckpoint::MemoryDialogInvalidate);
+    TALLY_PERFORMANCE(PerformanceCheckpoint::MemoryInspectorDoFrame);
     pWindowManager.MemoryInspector.DoFrame();
 }
 

--- a/src/RA_Integration.vcxproj
+++ b/src/RA_Integration.vcxproj
@@ -116,6 +116,7 @@
     <ClCompile Include="services\impl\WindowsFileSystem.cpp" />
     <ClCompile Include="services\impl\WindowsHttpRequester.cpp" />
     <ClCompile Include="services\Initialization.cpp" />
+    <ClCompile Include="services\PerformanceCounter.cpp" />
     <ClCompile Include="services\SearchResults.cpp" />
     <ClCompile Include="ui\drawing\gdi\GDIBitmapSurface.cpp" />
     <ClCompile Include="ui\drawing\gdi\GDISurface.cpp" />
@@ -259,6 +260,7 @@
     <ClInclude Include="services\impl\WindowsHttpRequester.hh" />
     <ClInclude Include="services\Initialization.hh" />
     <ClInclude Include="services\IThreadPool.hh" />
+    <ClInclude Include="services\PerformanceCounter.hh" />
     <ClInclude Include="services\ServiceLocator.hh" />
     <ClInclude Include="services\SearchResults.h" />
     <ClInclude Include="services\TextReader.hh" />

--- a/src/RA_Integration.vcxproj.filters
+++ b/src/RA_Integration.vcxproj.filters
@@ -315,6 +315,9 @@
     <ClCompile Include="ui\win32\bindings\ControlBinding.cpp">
       <Filter>UI\Win32\Bindings</Filter>
     </ClCompile>
+    <ClCompile Include="services\PerformanceCounter.cpp">
+      <Filter>Services</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="RA_Achievement.h">
@@ -799,6 +802,9 @@
     </ClInclude>
     <ClInclude Include="ui\win32\bindings\MemoryViewerControlBinding.hh">
       <Filter>UI\Win32\Bindings</Filter>
+    </ClInclude>
+    <ClInclude Include="services\PerformanceCounter.hh">
+      <Filter>Services</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/services/Initialization.cpp
+++ b/src/services/Initialization.cpp
@@ -10,6 +10,7 @@
 
 #include "services\AchievementRuntime.hh"
 #include "services\GameIdentifier.hh"
+#include "services\PerformanceCounter.hh"
 #include "services\ServiceLocator.hh"
 #include "services\impl\Clock.hh"
 #include "services\impl\FileLocalStorage.hh"
@@ -118,6 +119,11 @@ void Initialization::RegisterServices(EmulatorID nEmulatorId)
 
     auto pHttpRequester = std::make_unique<ra::services::impl::WindowsHttpRequester>();
     ra::services::ServiceLocator::Provide<ra::services::IHttpRequester>(std::move(pHttpRequester));
+
+#ifdef PERFORMANCE_COUNTERS
+    auto pPerformanceCounter = std::make_unique<ra::services::PerformanceCounter>();
+    ra::services::ServiceLocator::Provide<ra::services::PerformanceCounter>(std::move(pPerformanceCounter));
+#endif
 
     auto pUserContext = std::make_unique<ra::data::UserContext>();
     ra::services::ServiceLocator::Provide<ra::data::UserContext>(std::move(pUserContext));

--- a/src/services/PerformanceCounter.cpp
+++ b/src/services/PerformanceCounter.cpp
@@ -1,0 +1,113 @@
+#include "PerformanceCounter.hh"
+
+#ifdef PERFORMANCE_COUNTERS
+
+#include "RA_Log.h"
+
+#include "IClock.hh"
+
+namespace ra {
+namespace services {
+
+static std::string GetLabel(PerformanceCheckpoint nCheckpoint)
+{
+    std::string sCheckpoint;
+
+    switch (nCheckpoint)
+    {
+        case PerformanceCheckpoint::RuntimeProcess: sCheckpoint = "Runtime"; break;
+        case PerformanceCheckpoint::RuntimeEvents: sCheckpoint = "Events"; break;
+        case PerformanceCheckpoint::OverlayManagerAdvanceFrame: sCheckpoint = "Overlay"; break;
+        case PerformanceCheckpoint::MemoryBookmarksDoFrame: sCheckpoint = "Bookmarks"; break;
+        case PerformanceCheckpoint::MemoryDialogInvalidate: sCheckpoint = "Inspector"; break;
+        default: sCheckpoint = std::to_string(ra::etoi(nCheckpoint)); break;
+    }
+
+    return sCheckpoint;
+}
+
+void PerformanceCounter::Tally(PerformanceCheckpoint nCheckpoint)
+{
+    const auto& pClock = ra::services::ServiceLocator::Get<ra::services::IClock>();
+    m_vMeasurements.emplace_back(nCheckpoint, pClock.UpTime());
+}
+
+void PerformanceCounter::Stop()
+{
+    Tally(PerformanceCheckpoint::NUM_CHECKPOINTS);
+
+    int nLapTime = 0;
+    Lap& pLap = m_vLaps.at(m_nNextLap);
+    for (gsl::index nIndex = 1; nIndex < gsl::narrow_cast<gsl::index>(m_vMeasurements.size()); ++nIndex)
+    {
+        const auto& pMeasurement = m_vMeasurements.at(nIndex - 1);
+        const auto nElapsed = m_vMeasurements.at(nIndex).tWhen - pMeasurement.tWhen;
+        const auto nElapsedMicroseconds = gsl::narrow_cast<int>(std::chrono::duration_cast<std::chrono::microseconds>(nElapsed).count());
+
+        const auto nCheckpointIndex = ra::etoi(pMeasurement.nCheckpoint);
+        const auto nPreviousMicroseconds = pLap.at(nCheckpointIndex);
+        m_nRollingTotals.at(nCheckpointIndex) += nElapsedMicroseconds - nPreviousMicroseconds;
+        pLap.at(nCheckpointIndex) = nElapsedMicroseconds;
+
+        m_nLapTotal += nElapsedMicroseconds - nPreviousMicroseconds;
+        nLapTime += nElapsedMicroseconds;
+    }
+
+    m_vMeasurements.clear();
+
+    if (++m_nNextLap == NUM_LAPS)
+        m_nNextLap = 0;
+
+    if (++m_nTotalLaps > NUM_LAPS)
+    {
+        const auto nLapAverage = m_nLapTotal / NUM_LAPS;
+
+        if (m_nTotalLaps % NUM_LAPS == 0) 
+        {
+            RA_LOG("Lap averages: total: %d.%03d", nLapAverage / 1000, nLapAverage % 1000);
+            for (gsl::index i = 0; i < ra::etoi(PerformanceCheckpoint::NUM_CHECKPOINTS); ++i)
+            {
+                const auto nCheckpointTime = pLap.at(i);
+                if (nCheckpointTime != 0)
+                {
+                    const auto nCheckpointAverage = m_nRollingTotals.at(i) / NUM_LAPS;
+                    RA_LOG(" %s: %d.%03d", GetLabel(ra::itoe<PerformanceCheckpoint>(i)), nCheckpointAverage / 1000, nCheckpointAverage % 1000);
+                }
+            }
+        }
+        else if (nLapTime > 100) // ignore everything under 100us
+        {
+            if (nLapTime > 2000) // to achieve 60 fps, emulator has to render ever 16ms, we don't want to use more than 2ms of that.
+            {
+                RA_LOG("Outstanding lap: %d.%03d (avg: %d.%03d)", nLapTime / 1000, nLapTime % 1000, nLapAverage / 1000, nLapAverage % 1000);
+
+                for (gsl::index i = 0; i < ra::etoi(PerformanceCheckpoint::NUM_CHECKPOINTS); ++i)
+                {
+                    const auto nCheckpointTime = pLap.at(i);
+                    if (nCheckpointTime != 0)
+                        DumpCheckpoint(ra::itoe<PerformanceCheckpoint>(i), nCheckpointTime);
+                }
+            }
+            else
+            {
+                for (gsl::index i = 1; i < ra::etoi(PerformanceCheckpoint::NUM_CHECKPOINTS); ++i)
+                {
+                    const auto nCheckpointTime = pLap.at(i);
+                    if (nCheckpointTime > 75 && nCheckpointTime > m_nRollingTotals.at(i) * 2)
+                        DumpCheckpoint(ra::itoe<PerformanceCheckpoint>(i), nCheckpointTime);
+                }
+            }
+        }
+    }
+}
+
+void PerformanceCounter::DumpCheckpoint(PerformanceCheckpoint nCheckpoint, int nCheckpointTime)
+{
+    const auto nCheckpointAverage = m_nRollingTotals.at(ra::etoi(nCheckpoint)) / NUM_LAPS;
+    RA_LOG(" %s: %d.%03d (avg: %d.%03d)", GetLabel(nCheckpoint), nCheckpointTime / 1000, nCheckpointTime % 1000, nCheckpointAverage / 1000, nCheckpointAverage % 1000);
+}
+
+} // namespace services
+} // namespace ra
+
+#endif // PERFORMANCE_COUNTERS

--- a/src/services/PerformanceCounter.cpp
+++ b/src/services/PerformanceCounter.cpp
@@ -19,7 +19,7 @@ static std::string GetLabel(PerformanceCheckpoint nCheckpoint)
         case PerformanceCheckpoint::RuntimeEvents: sCheckpoint = "Events"; break;
         case PerformanceCheckpoint::OverlayManagerAdvanceFrame: sCheckpoint = "Overlay"; break;
         case PerformanceCheckpoint::MemoryBookmarksDoFrame: sCheckpoint = "Bookmarks"; break;
-        case PerformanceCheckpoint::MemoryDialogInvalidate: sCheckpoint = "Inspector"; break;
+        case PerformanceCheckpoint::MemoryInspectorDoFrame: sCheckpoint = "Inspector"; break;
         default: sCheckpoint = std::to_string(ra::etoi(nCheckpoint)); break;
     }
 

--- a/src/services/PerformanceCounter.hh
+++ b/src/services/PerformanceCounter.hh
@@ -1,0 +1,75 @@
+#ifndef RA_SERVICES_PERFORMANCECOUNTER_H
+#define RA_SERVICES_PERFORMANCECOUNTER_H
+#pragma once
+
+#ifndef RA_UTEST
+#define PERFORMANCE_COUNTERS
+#endif
+
+enum class PerformanceCheckpoint
+{
+    RuntimeProcess = 0,
+    RuntimeEvents,
+    OverlayManagerAdvanceFrame,
+    MemoryBookmarksDoFrame,
+    MemoryDialogInvalidate,
+
+    NUM_CHECKPOINTS
+};
+
+#ifdef PERFORMANCE_COUNTERS
+
+#include "services/ServiceLocator.hh"
+
+namespace ra {
+namespace services {
+
+class PerformanceCounter
+{
+public:
+    void Tally(PerformanceCheckpoint nCheckpoint);
+
+    void Stop();
+
+private:
+    void DumpCheckpoint(PerformanceCheckpoint nCheckpoint, int nCheckpointTime);
+
+    struct Measurement
+    {
+        Measurement(PerformanceCheckpoint nCheckpoint, std::chrono::steady_clock::time_point tWhen)
+        {
+            this->nCheckpoint = nCheckpoint;
+            this->tWhen = tWhen;
+        }
+
+        PerformanceCheckpoint nCheckpoint;
+        std::chrono::steady_clock::time_point tWhen;
+    };
+
+    std::vector<Measurement> m_vMeasurements;
+
+    size_t m_nTotalLaps = 0;
+    
+    using Lap = std::array<int, static_cast<size_t>(PerformanceCheckpoint::NUM_CHECKPOINTS)>;
+    Lap m_nRollingTotals;
+    int m_nLapTotal;
+
+    static constexpr size_t NUM_LAPS = 3600; // once per minute, log overall averages
+    std::array<Lap, NUM_LAPS> m_vLaps;
+    gsl::index m_nNextLap = 0;
+};
+
+} // namespace services
+} // namespace ra
+
+#define TALLY_PERFORMANCE(checkpoint) ra::services::ServiceLocator::GetMutable<ra::services::PerformanceCounter>().Tally(checkpoint)
+#define CHECK_PERFORMANCE() ra::services::ServiceLocator::GetMutable<ra::services::PerformanceCounter>().Stop()
+
+#else // PERFORMANCE_COUNTERS
+
+#define TALLY_PERFORMANCE(checkpoint) 
+#define CHECK_PERFORMANCE()
+
+#endif // PERFORMANCE_COUNTERS
+
+#endif !RA_SERVICES_PERFORMANCECOUNTER_H

--- a/src/services/PerformanceCounter.hh
+++ b/src/services/PerformanceCounter.hh
@@ -12,7 +12,7 @@ enum class PerformanceCheckpoint
     RuntimeEvents,
     OverlayManagerAdvanceFrame,
     MemoryBookmarksDoFrame,
-    MemoryDialogInvalidate,
+    MemoryInspectorDoFrame,
 
     NUM_CHECKPOINTS
 };

--- a/src/services/PerformanceCounter.hh
+++ b/src/services/PerformanceCounter.hh
@@ -3,7 +3,7 @@
 #pragma once
 
 #ifndef RA_UTEST
-#define PERFORMANCE_COUNTERS
+//#define PERFORMANCE_COUNTERS
 #endif
 
 enum class PerformanceCheckpoint


### PR DESCRIPTION
When enabled, writes a log message every 60 seconds detailing average time spent in `RA_DoAchievementsFrame`. 

For the emulator to run at 60 frames per second, each frame has to be processed in less than 16ms. Our goal is to never use more than 2ms of that.

I've retrofitted this logic into an 0.77 DLL, and you can see that with all the windows open (memory inspector, memory bookmarks, rich presence monitor, achievement list, achievement editor), the average is very close to that 2ms limit:
```
Lap averages: total: 1.524
 Runtime: 0.005
 Bookmarks: 0.009
 Inspector: 1.509
```
As an average has some variance, there are several frames that do exceed the 2ms limit. For most emulated systems, that has negligible impact, but more demanding systems like PSX and NDS do sometimes experience slowdown with the memory inspector open.

These numbers are also largely dependent on the host machine and whatever secondary processes are running. My machine is apparently significantly more powerful than many of the machines other devs use, so every bit of time we can shed is important. 

Performing the same test (as closely as possible) with the new DLL yields much better results:
```
Lap averages: total: 0.175
 Runtime: 0.006
 Bookmarks: 0.005
 Inspector: 0.163
```
The new DLL spends almost 90% less time in `RA_DoAchievementsFrame`.

I originally added this code to prove that the new dialog was faster, but I was surprised by how much faster it appears to be.

This logging (and the associated tracking) is disabled by default. To enable, uncomment the `#define PERFORMANCE_COUNTERS` line in `PerformanceCounter.hh`.