### PR TITLE
have rich presence monitor watch for game and visibility changes

### DIFF
--- a/src/RA_Core.cpp
+++ b/src/RA_Core.cpp
@@ -536,8 +536,6 @@ API void CCONV _RA_InvokeDialog(LPARAM nID)
 
             auto& pWindowManager = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::WindowManager>();
             pWindowManager.RichPresenceMonitor.Show();
-            pWindowManager.RichPresenceMonitor.StartMonitoring();
-
             break;
         }
 

--- a/src/services/GameIdentifier.cpp
+++ b/src/services/GameIdentifier.cpp
@@ -201,10 +201,6 @@ void GameIdentifier::ActivateGame(unsigned int nGameId)
 #ifndef RA_UTEST
     g_AchievementsDialog.OnLoad_NewRom(nGameId);
     g_AchievementEditorDialog.OnLoad_NewRom();
-
-    // TODO: have RichPresenceMonitor watch GameContext.ActiveGameChanged
-    auto& pWindowManager = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::WindowManager>();
-    pWindowManager.RichPresenceMonitor.UpdateDisplayString();
 #endif
 }
 

--- a/src/services/Initialization.cpp
+++ b/src/services/Initialization.cpp
@@ -164,9 +164,15 @@ void Initialization::RegisterServices(EmulatorID nEmulatorId)
     auto pServer = std::make_unique<ra::api::impl::DisconnectedServer>(pConfiguration->GetHostUrl());
     ra::services::ServiceLocator::Provide<ra::api::IServer>(std::move(pServer));
 
+    InitializeNotifyTargets();
+}
 
+void Initialization::InitializeNotifyTargets()
+{
     ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().InitializeNotifyTargets();
-    ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::WindowManager>().MemoryInspector.InitializeNotifyTargets();
+    auto& pWindowManager = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::WindowManager>();
+    pWindowManager.MemoryInspector.InitializeNotifyTargets();
+    pWindowManager.RichPresenceMonitor.InitializeNotifyTargets();
 }
 
 void Initialization::Shutdown()

--- a/src/services/Initialization.hh
+++ b/src/services/Initialization.hh
@@ -15,6 +15,9 @@ public:
     static void RegisterServices(EmulatorID nEmulatorId);
 
     static void Shutdown();
+
+private:
+    static void InitializeNotifyTargets();
 };
 
 } // namespace services

--- a/src/ui/viewmodels/RichPresenceMonitorViewModel.cpp
+++ b/src/ui/viewmodels/RichPresenceMonitorViewModel.cpp
@@ -17,6 +17,14 @@ const StringModelProperty RichPresenceMonitorViewModel::DisplayStringProperty("R
 RichPresenceMonitorViewModel::RichPresenceMonitorViewModel() noexcept
 {
     SetWindowTitle(L"Rich Presence Monitor");
+
+    AddNotifyTarget(*this);
+}
+
+void RichPresenceMonitorViewModel::InitializeNotifyTargets()
+{
+    auto& pGameContext = ra::services::ServiceLocator::GetMutable<ra::data::GameContext>();
+    pGameContext.AddNotifyTarget(*this);
 }
 
 static time_t GetRichPresenceModified()
@@ -136,6 +144,28 @@ void RichPresenceMonitorViewModel::UpdateDisplayString()
         {
             m_nState = MonitorState::Active;
             ScheduleUpdateDisplayString();
+        }
+    }
+}
+
+void RichPresenceMonitorViewModel::OnActiveGameChanged()
+{
+    if (IsVisible())
+        UpdateDisplayString();
+}
+
+void RichPresenceMonitorViewModel::OnViewModelBoolValueChanged(const BoolModelProperty::ChangeArgs& args)
+{
+    if (args.Property == IsVisibleProperty)
+    {
+        if (args.tNewValue)
+        {
+            UpdateDisplayString();
+            StartMonitoring();
+        }
+        else
+        {
+            StopMonitoring();
         }
     }
 }

--- a/src/ui/viewmodels/RichPresenceMonitorViewModel.hh
+++ b/src/ui/viewmodels/RichPresenceMonitorViewModel.hh
@@ -4,14 +4,20 @@
 
 #include "ui/WindowViewModelBase.hh"
 
+#include "data/GameContext.hh"
+
 namespace ra {
 namespace ui {
 namespace viewmodels {
 
-class RichPresenceMonitorViewModel : public WindowViewModelBase
+class RichPresenceMonitorViewModel : public WindowViewModelBase, 
+    protected ViewModelBase::NotifyTarget,
+    protected ra::data::GameContext::NotifyTarget
 {
 public:
     GSL_SUPPRESS_F6 RichPresenceMonitorViewModel() noexcept;
+
+    void InitializeNotifyTargets();
 
     /// <summary>
     /// The <see cref="ModelProperty" /> for the message.
@@ -23,6 +29,17 @@ public:
     /// </summary>
     const std::wstring& GetDisplayString() const { return GetValue(DisplayStringProperty); }
 
+protected:
+    /// <summary>
+    /// Refreshes the display string.
+    /// </summary>
+    void UpdateDisplayString();
+
+    /// <summary>
+    /// Sets the message to display.
+    /// </summary>
+    void SetDisplayString(const std::wstring& sValue) { SetValue(DisplayStringProperty, sValue); }
+
     /// <summary>
     /// Starts periodically updating the display string.
     /// </summary>
@@ -33,16 +50,11 @@ public:
     /// </summary>
     void StopMonitoring() noexcept;
 
-    /// <summary>
-    /// Refreshes the display string.
-    /// </summary>
-    void UpdateDisplayString();
+    // ViewModelBase::NotifyTarget
+    void OnViewModelBoolValueChanged(const BoolModelProperty::ChangeArgs& args) override;
 
-protected:
-    /// <summary>
-    /// Sets the message to display.
-    /// </summary>
-    void SetDisplayString(const std::wstring& sValue) { SetValue(DisplayStringProperty, sValue); }
+    // GameContext::NotifyTarget
+    void OnActiveGameChanged() override;
 
 private:
     void ScheduleUpdateDisplayString();

--- a/src/ui/win32/RichPresenceDialog.cpp
+++ b/src/ui/win32/RichPresenceDialog.cpp
@@ -58,22 +58,6 @@ BOOL RichPresenceDialog::OnInitDialog()
     return DialogBase::OnInitDialog();
 }
 
-void RichPresenceDialog::OnShown()
-{
-    auto& vmRichPresence = dynamic_cast<ra::ui::viewmodels::RichPresenceMonitorViewModel&>(m_vmWindow);
-    vmRichPresence.StartMonitoring();
-
-    DialogBase::OnShown();
-}
-
-void RichPresenceDialog::OnDestroy()
-{
-    auto& vmRichPresence = dynamic_cast<ra::ui::viewmodels::RichPresenceMonitorViewModel&>(m_vmWindow);
-    vmRichPresence.StopMonitoring();
-
-    DialogBase::OnDestroy();
-}
-
 } // namespace win32
 } // namespace ui
 } // namespace ra

--- a/src/ui/win32/RichPresenceDialog.hh
+++ b/src/ui/win32/RichPresenceDialog.hh
@@ -33,8 +33,6 @@ public:
 
 protected:
     BOOL OnInitDialog() override;
-    void OnShown() override;
-    void OnDestroy() override;
 
 private:
     HFONT m_hFont = nullptr;

--- a/tests/ui/viewmodels/RichPresenceMonitorViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/RichPresenceMonitorViewModel_Tests.cpp
@@ -24,168 +24,169 @@ namespace tests {
 
 TEST_CLASS(RichPresenceMonitorViewModel_Tests)
 {
+    class RichPresenceMonitorViewModelHarness : public RichPresenceMonitorViewModel
+    {
+    public:
+        RichPresenceMonitorViewModelHarness()
+        {
+            InitializeNotifyTargets();
+        }
+
+        ra::data::mocks::MockGameContext mockGameContext;
+        ra::services::mocks::MockLocalStorage mockLocalStorage;
+        ra::services::mocks::MockThreadPool mockThreadPool;
+
+        void UpdateDisplayString() { RichPresenceMonitorViewModel::UpdateDisplayString(); }
+    };
+
     TEST_METHOD(TestInitialization)
     {
-        RichPresenceMonitorViewModel vmRichPresence;
+        RichPresenceMonitorViewModelHarness vmRichPresence;
         Assert::AreEqual(std::wstring(L"Rich Presence Monitor"), vmRichPresence.GetWindowTitle());
         Assert::AreEqual(std::wstring(L"No Rich Presence defined."), vmRichPresence.GetDisplayString());
     }
 
     TEST_METHOD(TestUpdateDisplayString)
     {
-        MockGameContext mockGameContext;
-        MockThreadPool mockThreadPool;
-        RichPresenceMonitorViewModel vmRichPresence;
+        RichPresenceMonitorViewModelHarness vmRichPresence;
 
         vmRichPresence.UpdateDisplayString();
         Assert::AreEqual(std::wstring(L"No game loaded."), vmRichPresence.GetDisplayString());
-        Assert::AreEqual({ 0U }, mockThreadPool.PendingTasks());
+        Assert::AreEqual({ 0U }, vmRichPresence.mockThreadPool.PendingTasks());
 
-        mockGameContext.SetGameId(1);
+        vmRichPresence.mockGameContext.SetGameId(1);
         vmRichPresence.UpdateDisplayString();
         Assert::AreEqual(std::wstring(L"No Rich Presence defined."), vmRichPresence.GetDisplayString());
-        Assert::AreEqual({ 0U }, mockThreadPool.PendingTasks());
+        Assert::AreEqual({ 0U }, vmRichPresence.mockThreadPool.PendingTasks());
 
-        mockGameContext.SetRichPresenceDisplayString(L"Hello, world!");
+        vmRichPresence.mockGameContext.SetRichPresenceDisplayString(L"Hello, world!");
         vmRichPresence.UpdateDisplayString();
         Assert::AreEqual(std::wstring(L"Hello, world!"), vmRichPresence.GetDisplayString());
-        Assert::AreEqual({ 0U }, mockThreadPool.PendingTasks());
+        Assert::AreEqual({ 0U }, vmRichPresence.mockThreadPool.PendingTasks());
     }
 
     TEST_METHOD(TestStartMonitoringNoGame)
     {
-        MockGameContext mockGameContext;
-        MockThreadPool mockThreadPool;
-        MockLocalStorage mockLocalStorage;
-        RichPresenceMonitorViewModel vmRichPresence;
+        RichPresenceMonitorViewModelHarness vmRichPresence;
 
         // with no game loaded, message should be static and no callback registered
-        vmRichPresence.StartMonitoring();
+        vmRichPresence.SetIsVisible(true);
         Assert::AreEqual(std::wstring(L"No game loaded."), vmRichPresence.GetDisplayString());
-        Assert::AreEqual({ 0U }, mockThreadPool.PendingTasks());
+        Assert::AreEqual({ 0U }, vmRichPresence.mockThreadPool.PendingTasks());
     }
 
     TEST_METHOD(TestStartMonitoringNoRichPresence)
     {
-        MockGameContext mockGameContext;
-        MockThreadPool mockThreadPool;
-        MockLocalStorage mockLocalStorage;
-        RichPresenceMonitorViewModel vmRichPresence;
+        RichPresenceMonitorViewModelHarness vmRichPresence;
 
         // with no rich presence, message should be static and no callback registered
-        mockGameContext.SetGameId(1);
-        vmRichPresence.StartMonitoring();
+        vmRichPresence.mockGameContext.SetGameId(1);
+        vmRichPresence.SetIsVisible(true);
         Assert::AreEqual(std::wstring(L"No Rich Presence defined."), vmRichPresence.GetDisplayString());
-        Assert::AreEqual({ 0U }, mockThreadPool.PendingTasks());
+        Assert::AreEqual({ 0U }, vmRichPresence.mockThreadPool.PendingTasks());
     }
 
     TEST_METHOD(TestStartMonitoring)
     {
-        MockGameContext mockGameContext;
-        MockThreadPool mockThreadPool;
-        MockLocalStorage mockLocalStorage;
-        RichPresenceMonitorViewModel vmRichPresence;
+        RichPresenceMonitorViewModelHarness vmRichPresence;
 
-        mockGameContext.SetGameId(1);
-        mockGameContext.SetRichPresenceDisplayString(L"Initial Value");
-        vmRichPresence.StartMonitoring();
+        vmRichPresence.mockGameContext.SetGameId(1);
+        vmRichPresence.mockGameContext.SetRichPresenceDisplayString(L"Initial Value");
+        vmRichPresence.SetIsVisible(true);
         Assert::AreEqual(std::wstring(L"Initial Value"), vmRichPresence.GetDisplayString());
-        Assert::AreEqual({ 1U }, mockThreadPool.PendingTasks());
+        Assert::AreEqual({ 1U }, vmRichPresence.mockThreadPool.PendingTasks());
 
         // display text shouldn't update until callback fires
-        mockGameContext.SetRichPresenceDisplayString(L"Hello, world!");
+        vmRichPresence.mockGameContext.SetRichPresenceDisplayString(L"Hello, world!");
         Assert::AreEqual(std::wstring(L"Initial Value"), vmRichPresence.GetDisplayString());
-        Assert::AreEqual({ 1U }, mockThreadPool.PendingTasks());
+        Assert::AreEqual({ 1U }, vmRichPresence.mockThreadPool.PendingTasks());
 
         // callback fires, and schedules itself to be called again
-        mockThreadPool.AdvanceTime(std::chrono::seconds(1));
+        vmRichPresence.mockThreadPool.AdvanceTime(std::chrono::seconds(1));
         Assert::AreEqual(std::wstring(L"Hello, world!"), vmRichPresence.GetDisplayString());
-        Assert::AreEqual({ 1U }, mockThreadPool.PendingTasks());
+        Assert::AreEqual({ 1U }, vmRichPresence.mockThreadPool.PendingTasks());
 
-        mockGameContext.SetRichPresenceDisplayString(L"Hello, world 2!");
-        mockThreadPool.AdvanceTime(std::chrono::seconds(1));
+        vmRichPresence.mockGameContext.SetRichPresenceDisplayString(L"Hello, world 2!");
+        vmRichPresence.mockThreadPool.AdvanceTime(std::chrono::seconds(1));
         Assert::AreEqual(std::wstring(L"Hello, world 2!"), vmRichPresence.GetDisplayString());
-        Assert::AreEqual({ 1U }, mockThreadPool.PendingTasks());
+        Assert::AreEqual({ 1U }, vmRichPresence.mockThreadPool.PendingTasks());
     }
 
     TEST_METHOD(TestStopMonitoring)
     {
-        MockGameContext mockGameContext;
-        MockThreadPool mockThreadPool;
-        MockLocalStorage mockLocalStorage;
-        RichPresenceMonitorViewModel vmRichPresence;
+        RichPresenceMonitorViewModelHarness vmRichPresence;
 
-        mockGameContext.SetGameId(1);
-        mockGameContext.SetRichPresenceDisplayString(L"Hello, world!");
-        vmRichPresence.StartMonitoring();
+        vmRichPresence.mockGameContext.SetGameId(1);
+        vmRichPresence.mockGameContext.SetRichPresenceDisplayString(L"Hello, world!");
+        vmRichPresence.SetIsVisible(true);
         Assert::AreEqual(std::wstring(L"Hello, world!"), vmRichPresence.GetDisplayString());
-        Assert::AreEqual({ 1U }, mockThreadPool.PendingTasks());
+        Assert::AreEqual({ 1U }, vmRichPresence.mockThreadPool.PendingTasks());
 
         // when monitoring stops, updated message should be ignored. callback will still be
         // called once, but won't reschedule itself
-        vmRichPresence.StopMonitoring();
-        Assert::AreEqual({ 1U }, mockThreadPool.PendingTasks());
+        vmRichPresence.SetIsVisible(false);
+        Assert::AreEqual({ 1U }, vmRichPresence.mockThreadPool.PendingTasks());
 
-        mockGameContext.SetRichPresenceDisplayString(L"Hello, world 2!");
-        mockThreadPool.AdvanceTime(std::chrono::seconds(1));
+        vmRichPresence.mockGameContext.SetRichPresenceDisplayString(L"Hello, world 2!");
+        vmRichPresence.mockThreadPool.AdvanceTime(std::chrono::seconds(1));
         Assert::AreEqual(std::wstring(L"Hello, world!"), vmRichPresence.GetDisplayString());
-        Assert::AreEqual({ 0U }, mockThreadPool.PendingTasks());
+        Assert::AreEqual({ 0U }, vmRichPresence.mockThreadPool.PendingTasks());
+
+        // when monitoring restarts, updated message should be immediately displayed and
+        // callback will be scheduled
+        vmRichPresence.SetIsVisible(true);
+        Assert::AreEqual(std::wstring(L"Hello, world 2!"), vmRichPresence.GetDisplayString());
+        Assert::AreEqual({ 1U }, vmRichPresence.mockThreadPool.PendingTasks());
     }
 
     TEST_METHOD(TestMonitoringStartsWhenGameLoaded)
     {
-        MockGameContext mockGameContext;
-        MockThreadPool mockThreadPool;
-        MockLocalStorage mockLocalStorage;
-        RichPresenceMonitorViewModel vmRichPresence;
+        RichPresenceMonitorViewModelHarness vmRichPresence;
 
         // with no game loaded, message should be static and no callback registered
-        vmRichPresence.StartMonitoring();
+        vmRichPresence.SetIsVisible(true);
         Assert::AreEqual(std::wstring(L"No game loaded."), vmRichPresence.GetDisplayString());
-        Assert::AreEqual({ 0U }, mockThreadPool.PendingTasks());
+        Assert::AreEqual({ 0U }, vmRichPresence.mockThreadPool.PendingTasks());
 
         // without a callback, display string is not automatically updated
-        mockGameContext.SetGameId(1);
-        mockGameContext.SetRichPresenceDisplayString(L"Hello, world!");
-        mockThreadPool.AdvanceTime(std::chrono::seconds(1));
+        vmRichPresence.mockGameContext.SetGameId(1);
+        vmRichPresence.mockGameContext.SetRichPresenceDisplayString(L"Hello, world!");
+        vmRichPresence.mockThreadPool.AdvanceTime(std::chrono::seconds(1));
         Assert::AreEqual(std::wstring(L"No game loaded."), vmRichPresence.GetDisplayString());
-        Assert::AreEqual({ 0U }, mockThreadPool.PendingTasks());
+        Assert::AreEqual({ 0U }, vmRichPresence.mockThreadPool.PendingTasks());
 
         // explicit Update causes callback to be scheduled
-        vmRichPresence.UpdateDisplayString();
+        vmRichPresence.mockGameContext.NotifyActiveGameChanged();
         Assert::AreEqual(std::wstring(L"Hello, world!"), vmRichPresence.GetDisplayString());
-        Assert::AreEqual({ 1U }, mockThreadPool.PendingTasks());
+        Assert::AreEqual({ 1U }, vmRichPresence.mockThreadPool.PendingTasks());
 
         // now callback will be called regularly
-        mockGameContext.SetRichPresenceDisplayString(L"Hello, world 2!");
-        mockThreadPool.AdvanceTime(std::chrono::seconds(1));
+        vmRichPresence.mockGameContext.SetRichPresenceDisplayString(L"Hello, world 2!");
+        vmRichPresence.mockThreadPool.AdvanceTime(std::chrono::seconds(1));
         Assert::AreEqual(std::wstring(L"Hello, world 2!"), vmRichPresence.GetDisplayString());
-        Assert::AreEqual({ 1U }, mockThreadPool.PendingTasks());
+        Assert::AreEqual({ 1U }, vmRichPresence.mockThreadPool.PendingTasks());
     }
 
     TEST_METHOD(TestMonitoringStopsWhenGameUnloaded)
     {
-        MockGameContext mockGameContext;
-        MockThreadPool mockThreadPool;
-        MockLocalStorage mockLocalStorage;
-        RichPresenceMonitorViewModel vmRichPresence;
+        RichPresenceMonitorViewModelHarness vmRichPresence;
 
-        mockGameContext.SetGameId(1);
-        mockGameContext.SetRichPresenceDisplayString(L"Initial Value");
-        vmRichPresence.StartMonitoring();
+        vmRichPresence.mockGameContext.SetGameId(1);
+        vmRichPresence.mockGameContext.SetRichPresenceDisplayString(L"Initial Value");
+        vmRichPresence.SetIsVisible(true);
         Assert::AreEqual(std::wstring(L"Initial Value"), vmRichPresence.GetDisplayString());
-        Assert::AreEqual({ 1U }, mockThreadPool.PendingTasks());
+        Assert::AreEqual({ 1U }, vmRichPresence.mockThreadPool.PendingTasks());
 
-        mockGameContext.SetRichPresenceDisplayString(L"Hello, world!");
-        mockThreadPool.AdvanceTime(std::chrono::seconds(1));
+        vmRichPresence.mockGameContext.SetRichPresenceDisplayString(L"Hello, world!");
+        vmRichPresence.mockThreadPool.AdvanceTime(std::chrono::seconds(1));
         Assert::AreEqual(std::wstring(L"Hello, world!"), vmRichPresence.GetDisplayString());
-        Assert::AreEqual({ 1U }, mockThreadPool.PendingTasks());
+        Assert::AreEqual({ 1U }, vmRichPresence.mockThreadPool.PendingTasks());
 
         // game is unloaded - default text should be displayed and callback unscheduled
-        mockGameContext.SetGameId(0);
-        mockThreadPool.AdvanceTime(std::chrono::seconds(1));
+        vmRichPresence.mockGameContext.SetGameId(0);
+        vmRichPresence.mockThreadPool.AdvanceTime(std::chrono::seconds(1));
         Assert::AreEqual(std::wstring(L"No game loaded."), vmRichPresence.GetDisplayString());
-        Assert::AreEqual({ 0U }, mockThreadPool.PendingTasks());
+        Assert::AreEqual({ 0U }, vmRichPresence.mockThreadPool.PendingTasks());
     }
 };
 


### PR DESCRIPTION
eliminates some hard-coded calls to refresh the rich presence monitor with an event-driven mechanism.