### PR TITLE
add 32-bit search functionality

### DIFF
--- a/src/RA_Core.cpp
+++ b/src/RA_Core.cpp
@@ -51,6 +51,7 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD dwReason, _UNUSED LPVOID)
             break;
 
         case DLL_PROCESS_DETACH:
+            _RA_Shutdown();
             IsolationAwareCleanup();
             break;
     }

--- a/src/services/SearchResults.cpp
+++ b/src/services/SearchResults.cpp
@@ -111,6 +111,9 @@ public:
 
         if (srResults.m_vMatchingAddresses.empty())
         {
+            if (srResults.m_vBlocks.empty())
+                return false;
+
             result.nAddress = GetFirstAddress(srResults) + gsl::narrow_cast<ra::ByteAddress>(nIndex);
         }
         else

--- a/src/services/SearchResults.cpp
+++ b/src/services/SearchResults.cpp
@@ -13,60 +13,9 @@
 namespace ra {
 namespace services {
 
-_CONSTANT_VAR MAX_BLOCK_SIZE = 256U * 1024; // 256K
+namespace impl {
 
-_NODISCARD inline static constexpr auto Padding(_In_ MemSize size) noexcept
-{
-    switch (size)
-    {
-        case MemSize::ThirtyTwoBit:
-            return 3U;
-        case MemSize::SixteenBit:
-            return 1U;
-        default:
-            return 0U;
-    }
-}
-
-void SearchResults::Initialize(ra::ByteAddress nAddress, size_t nBytes, MemSize nSize)
-{
-    if (nSize == MemSize::Nibble_Upper)
-        nSize = MemSize::Nibble_Lower;
-
-    m_nSize = nSize;
-    m_bUnfiltered = true;
-
-    const auto& pEmulatorContext = ra::services::ServiceLocator::Get<ra::data::EmulatorContext>();
-    if (nBytes + nAddress > pEmulatorContext.TotalMemorySize())
-        nBytes = pEmulatorContext.TotalMemorySize() - nAddress;
-
-    const unsigned int nPadding = Padding(nSize);
-    if (nPadding >= nBytes)
-        nBytes = 0;
-    else if (nBytes > nPadding)
-        nBytes -= nPadding;
-
-    while (nBytes > 0)
-    {
-        const auto nBlockSize = gsl::narrow_cast<unsigned int>((nBytes > MAX_BLOCK_SIZE) ? MAX_BLOCK_SIZE : nBytes);
-        auto& block = AddBlock(nAddress, nBlockSize + nPadding);
-        pEmulatorContext.ReadMemory(block.GetAddress(), block.GetBytes(), gsl::narrow_cast<size_t>(block.GetSize()));
-
-        nAddress += nBlockSize;
-        nBytes -= nBlockSize;
-    }
-}
-
-SearchResults::MemBlock& SearchResults::AddBlock(ra::ByteAddress nAddress, unsigned int nSize)
-{
-    m_vBlocks.emplace_back(nAddress, nSize);
-    return m_vBlocks.back();
-}
-
-_Success_(return)
-_NODISCARD _CONSTANT_FN CompareValues(_In_ unsigned int nLeft,
-                                      _In_ unsigned int nRight,
-                                      _In_ ComparisonType nCompareType) noexcept
+_NODISCARD static constexpr bool CompareValues(_In_ unsigned int nLeft, _In_ unsigned int nRight, _In_ ComparisonType nCompareType) noexcept
 {
     switch (nCompareType)
     {
@@ -87,73 +36,345 @@ _NODISCARD _CONSTANT_FN CompareValues(_In_ unsigned int nLeft,
     }
 }
 
+class SearchImpl
+{
+public:
+    // Gets the number of bytes after an address that are required to hold the data at the address
+    virtual unsigned int GetPadding() const { return 0U; }
+
+    // Gets the size of values handled by this implementation
+    virtual MemSize GetMemSize() const { return MemSize::EightBit; }
+
+    // Determines if the specified address exists in the collection of addresses.
+    virtual bool ContainsAddress(const std::vector<ra::ByteAddress>& vAddresses, ra::ByteAddress nAddress) const
+    {
+        return std::binary_search(vAddresses.begin(), vAddresses.end(), nAddress);
+    }
+
+    // populates a vector of addresses that match the specified filter when applied to a previous search result
+    void ApplyFilter(SearchResults& srNew, const SearchResults& srPrevious,
+        ComparisonType nCompareType, SearchFilterType nFilterType, unsigned int nFilterValue) const
+    {
+        unsigned int nLargestBlock = 0U;
+        for (auto& block : srPrevious.m_vBlocks)
+        {
+            if (block.GetSize() > nLargestBlock)
+                nLargestBlock = block.GetSize();
+        }
+
+        std::vector<unsigned char> vMemory(nLargestBlock);
+        std::vector<ra::ByteAddress> vMatches;
+        const auto& pEmulatorContext = ra::services::ServiceLocator::Get<ra::data::EmulatorContext>();
+
+        for (auto& block : srPrevious.m_vBlocks)
+        {
+            pEmulatorContext.ReadMemory(block.GetAddress(), vMemory.data(), block.GetSize());
+
+            const auto nStop = block.GetSize() - GetPadding();
+
+            switch (nFilterType)
+            {
+                default:
+                case SearchFilterType::Constant:
+                    for (unsigned int i = 0; i < nStop; ++i)
+                    {
+                        const unsigned int nValue1 = BuildValue(&vMemory.at(i));
+                        const unsigned int nAddress = block.GetAddress() + i;
+                        ApplyFilter(vMatches, srPrevious, nAddress, nFilterType, nValue1, nFilterValue, nCompareType);
+                    }
+                    break;
+
+                case SearchFilterType::LastKnownValue:
+                    for (unsigned int i = 0; i < nStop; ++i)
+                    {
+                        const unsigned int nValue1 = BuildValue(&vMemory.at(i));
+                        const unsigned int nValue2 = BuildValue(block.GetBytes() + i);
+                        const unsigned int nAddress = block.GetAddress() + i;
+                        ApplyFilter(vMatches, srPrevious, nAddress, nFilterType, nValue1, nValue2, nCompareType);
+                    }
+                    break;
+            }
+
+            if (!vMatches.empty())
+            {
+                AddBlock(srNew, vMatches, vMemory, block.GetAddress());
+                srNew.m_vMatchingAddresses.insert(srNew.m_vMatchingAddresses.end(), vMatches.begin(), vMatches.end());
+                vMatches.clear();
+            }
+        }
+    }
+
+    // gets the nIndex'th search result
+    virtual bool GetMatchingAddress(const SearchResults& srResults, gsl::index nIndex, _Out_ SearchResults::Result& result) const
+    {
+        result.nSize = GetMemSize();
+
+        if (srResults.m_vMatchingAddresses.empty())
+        {
+            result.nAddress = GetFirstAddress(srResults) + gsl::narrow_cast<ra::ByteAddress>(nIndex);
+        }
+        else
+        {
+            if (ra::to_unsigned(nIndex) >= srResults.m_vMatchingAddresses.size())
+                return false;
+
+            result.nAddress = srResults.m_vMatchingAddresses.at(nIndex);
+        }
+
+        return GetValue(srResults, result);
+    }
+
+    // gets the value associated with the address and size in the search result structure
+    bool GetValue(const SearchResults& srResults, SearchResults::Result& result) const
+    {
+        for (const auto& block : srResults.m_vBlocks)
+        {
+            if (GetValue(block, result))
+                return true;
+        }
+
+        result.nValue = 0;
+        return false;
+    }
+
+protected:
+    static const std::vector<ra::ByteAddress>& GetMatchingAddresses(const SearchResults& srResults)
+    {
+        return srResults.m_vMatchingAddresses;
+    }
+
+    static ra::ByteAddress GetFirstAddress(const SearchResults& srResults)
+    {
+        return srResults.m_vBlocks.front().GetAddress();
+    }
+
+    virtual bool GetValue(const impl::MemBlock& block, SearchResults::Result& result) const
+    {
+        if (result.nAddress < block.GetAddress())
+            return false;
+
+        unsigned int nOffset = result.nAddress - block.GetAddress();
+        if (nOffset >= block.GetSize() - GetPadding())
+            return false;
+
+        result.nValue = BuildValue(block.GetBytes() + nOffset);
+        return true;
+    }
+
+    virtual unsigned int BuildValue(const unsigned char* ptr) const
+    {
+        return ptr[0];
+    }
+
+    virtual void ApplyFilter(std::vector<ra::ByteAddress>& vMatches, const SearchResults& srPrevious,
+        ra::ByteAddress nAddress, _UNUSED SearchFilterType nFilterType, unsigned int nValue1, unsigned int nValue2, ComparisonType nCompareType) const
+    {
+        if (CompareValues(nValue1, nValue2, nCompareType))
+            AddMatch(vMatches, srPrevious, nAddress);
+    }
+
+    static void AddMatch(std::vector<ra::ByteAddress>& vMatches, const SearchResults& srPrevious, ra::ByteAddress nAddress)
+    {
+        if (srPrevious.m_nFilterType == SearchFilterType::None ||
+            std::binary_search(srPrevious.m_vMatchingAddresses.begin(), srPrevious.m_vMatchingAddresses.end(), nAddress))
+        {
+            vMatches.push_back(nAddress);
+        }
+    }
+
+    static impl::MemBlock& AddBlock(SearchResults& srNew, ra::ByteAddress nAddress, unsigned int nSize)
+    {
+        return srNew.m_vBlocks.emplace_back(nAddress, nSize);
+    }
+
+    virtual void AddBlock(SearchResults& srNew, std::vector<ra::ByteAddress>& vMatches,
+        std::vector<unsigned char>& vMemory, ra::ByteAddress nFirstMemoryAddress) const
+    {
+        const unsigned int nBlockSize = vMatches.back() - vMatches.front() + GetPadding() + 1;
+        MemBlock& block = AddBlock(srNew, vMatches.front(), nBlockSize);
+        memcpy((void*)block.GetBytes(), &vMemory.at(vMatches.front() - nFirstMemoryAddress), nBlockSize);
+    }
+};
+
+class FourBitSearchImpl : public SearchImpl
+{
+    MemSize GetMemSize() const override { return MemSize::Nibble_Lower; }
+
+    bool ContainsAddress(const std::vector<ra::ByteAddress>& vAddresses, ra::ByteAddress nAddress) const override
+    {
+        nAddress <<= 1;
+        const auto iter = std::lower_bound(vAddresses.begin(), vAddresses.end(), nAddress);
+        if (iter == vAddresses.end())
+            return false;
+
+        return (*iter == nAddress || *iter == (nAddress | 1));
+    }
+
+    void ApplyFilter(std::vector<ra::ByteAddress>& vMatches, const SearchResults& srPrevious,
+        ra::ByteAddress nAddress, SearchFilterType nFilterType, unsigned int nValue1, unsigned int nValue2, ComparisonType nCompareType) const override
+    {
+        const unsigned int nValue1a = (nValue1 & 0x0F);
+        const unsigned int nValue1b = ((nValue1 >> 4) & 0x0F);
+
+        switch (nFilterType)
+        {
+            case SearchFilterType::LastKnownValue:
+                if (CompareValues(nValue1a, nValue2 & 0x0F, nCompareType))
+                    AddMatch(vMatches, srPrevious, nAddress << 1);
+                if (CompareValues(nValue1b, ((nValue2 >> 4) & 0x0F), nCompareType))
+                    AddMatch(vMatches, srPrevious, (nAddress << 1) | 1);
+                break;
+
+            default:
+                if (CompareValues(nValue1a, nValue2, nCompareType))
+                    AddMatch(vMatches, srPrevious, nAddress << 1);
+                if (CompareValues(nValue1b, nValue2, nCompareType))
+                    AddMatch(vMatches, srPrevious, (nAddress << 1) | 1);
+                break;
+        }
+    }
+
+    bool GetMatchingAddress(const SearchResults& srResults, gsl::index nIndex, _Out_ SearchResults::Result& result) const override
+    {
+        result.nSize = GetMemSize();
+
+        const auto& vMatchingAddresses = GetMatchingAddresses(srResults);
+        if (vMatchingAddresses.empty())
+        {
+            result.nAddress = (GetFirstAddress(srResults) << 1) + gsl::narrow_cast<ra::ByteAddress>(nIndex);
+        }
+        else
+        {
+            if (ra::to_unsigned(nIndex) >= vMatchingAddresses.size())
+                return false;
+
+            result.nAddress = vMatchingAddresses.at(nIndex);
+        }
+
+        if (result.nAddress & 0x01)
+            result.nSize = MemSize::Nibble_Upper;
+
+        result.nAddress >>= 1;
+        return SearchImpl::GetValue(srResults, result);
+    }
+
+protected:
+    void AddBlock(SearchResults& srNew, std::vector<ra::ByteAddress>& vMatches,
+        std::vector<unsigned char>& vMemory, ra::ByteAddress nFirstMemoryAddress) const override
+    {
+        const ra::ByteAddress nFirstAddress = (vMatches.front() >> 1);
+        const unsigned int nBlockSize = (vMatches.back() >> 1) - nFirstAddress + 1;
+        MemBlock& block = SearchImpl::AddBlock(srNew, nFirstAddress, nBlockSize);
+        memcpy((void*)block.GetBytes(), &vMemory.at(nFirstAddress - nFirstMemoryAddress), nBlockSize);
+    }
+
+    bool GetValue(const impl::MemBlock& block, SearchResults::Result& result) const override
+    {
+        if (!SearchImpl::GetValue(block, result))
+            return false;
+
+        if (result.nSize == MemSize::Nibble_Lower)
+            result.nValue &= 0x0F;
+        else
+            result.nValue = (result.nValue >> 4) & 0x0F;
+
+        return true;
+    }
+};
+
+class EightBitSearchImpl : public SearchImpl
+{
+
+};
+
+class SixteenBitSearchImpl : public SearchImpl
+{
+public:
+    MemSize GetMemSize() const override { return MemSize::SixteenBit; }
+
+    unsigned int GetPadding() const override { return 1U; }
+
+    unsigned int BuildValue(const unsigned char* ptr) const override
+    {
+        return (ptr[1] << 8) | ptr[0];
+    }
+};
+
+class ThirtyTwoBitSearchImpl : public SearchImpl
+{
+public:
+    MemSize GetMemSize() const override { return MemSize::ThirtyTwoBit; }
+
+    unsigned int GetPadding() const override { return 3U; }
+
+    unsigned int BuildValue(const unsigned char* ptr) const override
+    {
+        return (ptr[3] << 24) | (ptr[2] << 16) | (ptr[1] << 8) | ptr[0];
+    }
+};
+
+static FourBitSearchImpl s_pFourBitSearchImpl;
+static EightBitSearchImpl s_pEightBitSearchImpl;
+static SixteenBitSearchImpl s_pSixteenBitSearchImpl;
+static ThirtyTwoBitSearchImpl s_pThirtyTwoBitSearchImpl;
+
+} // namespace impl
+
+_CONSTANT_VAR MAX_BLOCK_SIZE = 256U * 1024; // 256K
+
+void SearchResults::Initialize(ra::ByteAddress nAddress, size_t nBytes, SearchType nType)
+{
+    m_nType = nType;
+
+    const auto& pEmulatorContext = ra::services::ServiceLocator::Get<ra::data::EmulatorContext>();
+    if (nBytes + nAddress > pEmulatorContext.TotalMemorySize())
+        nBytes = pEmulatorContext.TotalMemorySize() - nAddress;
+
+    switch (nType)
+    {
+        case SearchType::FourBit:
+            m_pImpl = &ra::services::impl::s_pFourBitSearchImpl;
+            break;
+        default:
+        case SearchType::EightBit:
+            m_pImpl = &ra::services::impl::s_pEightBitSearchImpl;
+            break;
+        case SearchType::SixteenBit:
+            m_pImpl = &ra::services::impl::s_pSixteenBitSearchImpl;
+            break;
+        case SearchType::ThirtyTwoBit:
+            m_pImpl = &ra::services::impl::s_pThirtyTwoBitSearchImpl;
+            break;
+    }
+
+    const unsigned int nPadding = m_pImpl->GetPadding();
+    if (nPadding >= nBytes)
+        nBytes = 0;
+    else if (nBytes > nPadding)
+        nBytes -= nPadding;
+
+    while (nBytes > 0)
+    {
+        const auto nBlockSize = gsl::narrow_cast<unsigned int>((nBytes > MAX_BLOCK_SIZE) ? MAX_BLOCK_SIZE : nBytes);
+        auto& block = m_vBlocks.emplace_back(nAddress, nBlockSize + nPadding);
+        pEmulatorContext.ReadMemory(block.GetAddress(), block.GetBytes(), gsl::narrow_cast<size_t>(block.GetSize()));
+
+        nAddress += nBlockSize;
+        nBytes -= nBlockSize;
+    }
+}
+
 bool SearchResults::Result::Compare(unsigned int nPreviousValue, ComparisonType nCompareType) const noexcept
 {
-    return CompareValues(nValue, nPreviousValue, nCompareType);
-}
-
-_NODISCARD _CONSTANT_FN ComparisonString(_In_ ComparisonType nCompareType) noexcept
-{
-    switch (nCompareType)
-    {
-        case ComparisonType::Equals:
-            return "EQUAL";
-        case ComparisonType::LessThan:
-            return "LESS THAN";
-        case ComparisonType::LessThanOrEqual:
-            return "LESS THAN/EQUAL";
-        case ComparisonType::GreaterThan:
-            return "GREATER THAN";
-        case ComparisonType::GreaterThanOrEqual:
-            return "GREATER THAN/EQUAL";
-        case ComparisonType::NotEqualTo:
-            return "NOT EQUAL";
-        default:
-            return "?";
-    }
-}
-
-_Success_(return)
-_NODISCARD inline static constexpr auto BuildValue(_In_ const unsigned char* const restrict pBuffer,
-                                                   _In_ gsl::index nOffset, _In_ MemSize nSize) noexcept
-{
-    Expects(pBuffer != nullptr);
-    auto ret{ 0U };
-    switch (nSize)
-    {
-        case MemSize::EightBit:
-            ret = pBuffer[nOffset];
-            break;
-        case MemSize::SixteenBit:
-            ret = pBuffer[nOffset] | (pBuffer[nOffset + 1U] << 8U);
-            break;
-        case MemSize::ThirtyTwoBit:
-            ret = (pBuffer[nOffset] | (pBuffer[nOffset + 1] << 8U) |
-                (pBuffer[nOffset + 2] << 16U) | (pBuffer[nOffset + 3] << 24U));
-            break;
-        case MemSize::Nibble_Upper:
-            ret = pBuffer[nOffset] >> 4U;
-            break;
-        case MemSize::Nibble_Lower:
-            ret = pBuffer[nOffset] & 0x0FU;
-    }
-
-    return ret;
+    return impl::CompareValues(nValue, nPreviousValue, nCompareType);
 }
 
 bool SearchResults::ContainsAddress(ra::ByteAddress nAddress) const
 {
-    if (!m_bUnfiltered)
-    {
-        if (m_nSize != MemSize::Nibble_Lower)
-            return std::binary_search(m_vMatchingAddresses.begin(), m_vMatchingAddresses.end(), nAddress);
+    if (m_nFilterType != SearchFilterType::None)
+        return m_pImpl->ContainsAddress(m_vMatchingAddresses, nAddress);
 
-        nAddress <<= 1;
-        const auto iter = std::lower_bound(m_vMatchingAddresses.begin(), m_vMatchingAddresses.end(), nAddress);
-        return (iter != m_vMatchingAddresses.end() && (*iter == nAddress || *iter == (nAddress | 1)));
-    }
-
-    const unsigned int nPadding = Padding(m_nSize);
+    const unsigned int nPadding = m_pImpl->GetPadding();
     for (const auto& block : m_vBlocks)
     {
         if (block.GetAddress() > nAddress)
@@ -165,367 +386,74 @@ bool SearchResults::ContainsAddress(ra::ByteAddress nAddress) const
     return false;
 }
 
-bool SearchResults::ContainsNibble(ra::ByteAddress nAddress) const
+void SearchResults::Initialize(const SearchResults& srSource, ComparisonType nCompareType,
+    SearchFilterType nFilterType, unsigned int nFilterValue)
 {
-    if (!m_bUnfiltered)
-        return std::binary_search(m_vMatchingAddresses.begin(), m_vMatchingAddresses.end(), nAddress);
+    m_nType = srSource.m_nType;
+    m_pImpl = srSource.m_pImpl;
+    m_nCompareType = nCompareType;
+    m_nFilterType = nFilterType;
+    m_nFilterValue = nFilterValue;
 
-    // an unfiltered collection implicitly contains both nibbles of an address
-    return ContainsAddress(nAddress >> 1);
-}
-
-void SearchResults::AddMatches(ra::ByteAddress nAddressBase, const unsigned char* restrict pMemory, const std::vector<ra::ByteAddress>& vMatches)
-{
-    const unsigned int nBlockSize = vMatches.back() - vMatches.front() + Padding(m_nSize) + 1;
-    MemBlock& block = AddBlock(nAddressBase + vMatches.front(), nBlockSize);
-    memcpy(block.GetBytes(), pMemory + vMatches.front(), nBlockSize);
-
-    for (auto nMatch : vMatches)
-        m_vMatchingAddresses.push_back(nAddressBase + nMatch);
-}
-
-void SearchResults::ProcessBlocks(const SearchResults& srSource, std::function<bool(gsl::index nIndex, const unsigned char* restrict pMemory, const unsigned char* restrict pPrev)> testIndexFunction)
-{
-    std::vector<unsigned int> vMatches;
-    std::vector<unsigned char> vMemory;
-    const unsigned int nPadding = Padding(m_nSize);
-    const auto& pEmulatorContext = ra::services::ServiceLocator::Get<ra::data::EmulatorContext>();
-
-    for (auto& block : srSource.m_vBlocks)
-    {
-        if (block.GetSize() > vMemory.capacity())
-            vMemory.reserve(block.GetSize());
-
-        unsigned char* pMemory = vMemory.data();
-        const unsigned char* pPrev = block.GetBytes();
-
-        pEmulatorContext.ReadMemory(block.GetAddress(), pMemory, block.GetSize());
-
-        for (unsigned int i = 0; i < block.GetSize() - nPadding; ++i)
-        {
-            if (!testIndexFunction(i, pMemory, pPrev))
-                continue;
-
-            const unsigned int nAddress = block.GetAddress() + i;
-            if (!srSource.ContainsAddress(nAddress))
-                continue;
-
-            if (!vMatches.empty() && (i - vMatches.back()) > 16)
-            {
-                AddMatches(block.GetAddress(), pMemory, vMatches);
-                vMatches.clear();
-            }
-
-            vMatches.push_back(i);
-        }
-
-        if (!vMatches.empty())
-        {
-            AddMatches(block.GetAddress(), pMemory, vMatches);
-            vMatches.clear();
-        }
-    }
-}
-
-void SearchResults::AddMatchesNibbles(ra::ByteAddress nAddressBase, const unsigned char* restrict pMemory, const std::vector<ra::ByteAddress>& vMatches)
-{
-    const unsigned int nBlockSize = (vMatches.back() >> 1) - (vMatches.front() >> 1) + Padding(m_nSize) + 1;
-    auto& block = AddBlock((nAddressBase + vMatches.front()) >> 1, nBlockSize);
-    memcpy(block.GetBytes(), pMemory + (vMatches.front() >> 1), nBlockSize);
-
-    for (auto nMatch : vMatches)
-        m_vMatchingAddresses.push_back(nAddressBase + nMatch);
-}
-
-void SearchResults::ProcessBlocksNibbles(const SearchResults& srSource, unsigned int nTestValue, ComparisonType nCompareType)
-{
-    std::vector<unsigned int> vMatches;
-    std::vector<unsigned char> vMemory;
-    const unsigned int nPadding = Padding(m_nSize);
-    const auto& pEmulatorContext = ra::services::ServiceLocator::Get<ra::data::EmulatorContext>();
-
-    for (auto& block : srSource.m_vBlocks)
-    {
-        if (block.GetSize() > vMemory.size())
-            vMemory.resize(block.GetSize());
-
-        pEmulatorContext.ReadMemory(block.GetAddress(), vMemory.data(), block.GetSize());
-
-        for (unsigned int i = 0; i < block.GetSize() - nPadding; ++i)
-        {
-            const unsigned int nValue1 = vMemory.at(i);
-            unsigned int nValue2 = (nTestValue > 15) ? (block.GetByte(i) & 0x0F) : nTestValue;
-
-            if (CompareValues(nValue1 & 0x0F, nValue2, nCompareType))
-            {
-                const unsigned int nAddress = (block.GetAddress() + i) << 1;
-                if (srSource.ContainsNibble(nAddress))
-                {
-                    if (!vMatches.empty() && (i - (vMatches.back() >> 1)) > 16)
-                    {
-                        AddMatchesNibbles(block.GetAddress() << 1, vMemory.data(), vMatches);
-                        vMatches.clear();
-                    }
-
-                    vMatches.push_back(i << 1);
-                }
-            }
-
-            if (nTestValue > 15)
-                nValue2 = block.GetByte(i) >> 4;
-
-            if (CompareValues(nValue1 >> 4, nValue2, nCompareType))
-            {
-                const unsigned int nAddress = ((block.GetAddress() + i) << 1) | 1;
-                if (srSource.ContainsNibble(nAddress))
-                {
-                    if (!vMatches.empty() && (i - (vMatches.back() >> 1)) > 16)
-                    {
-                        AddMatchesNibbles(block.GetAddress() << 1, vMemory.data(), vMatches);
-                        vMatches.clear();
-                    }
-
-                    vMatches.push_back((i << 1) | 1);
-                }
-            }
-        }
-
-        if (!vMatches.empty())
-        {
-            AddMatchesNibbles(block.GetAddress() << 1, vMemory.data(), vMatches);
-            vMatches.clear();
-        }
-    }
-}
-
-
-void SearchResults::Initialize(const SearchResults& srSource, ComparisonType nCompareType, unsigned int nTestValue)
-{
-    m_nSize = srSource.m_nSize;
-
-    switch (m_nSize)
-    {
-        case MemSize::Nibble_Lower:
-            ProcessBlocksNibbles(srSource, nTestValue & 0x0F, nCompareType);
-            break;
-
-        case MemSize::EightBit:
-            ProcessBlocks(srSource,
-                          [nTestValue, nCompareType](gsl::index nIndex, const unsigned char* restrict pMemory,
-                                                     [[maybe_unused]] const unsigned char* restrict)
-            {
-                Expects(pMemory != nullptr);
-                return CompareValues(pMemory[nIndex], nTestValue, nCompareType);
-            });
-            break;
-
-        case MemSize::SixteenBit:
-            ProcessBlocks(srSource, [nTestValue, nCompareType](gsl::index nIndex, const unsigned char* restrict pMemory, [[maybe_unused]] const unsigned char* restrict)
-            {
-                Expects(pMemory != nullptr);
-                const unsigned int nValue = pMemory[nIndex] | (pMemory[nIndex + 1] << 8);
-                return CompareValues(nValue, nTestValue, nCompareType);
-            });
-            break;
-
-        case MemSize::ThirtyTwoBit:
-            ProcessBlocks(srSource, [nTestValue, nCompareType](gsl::index nIndex, const unsigned char* restrict pMemory, [[maybe_unused]] const unsigned char* restrict)
-            {
-                Expects(pMemory != nullptr);
-                const unsigned int nValue = pMemory[nIndex] | (pMemory[nIndex + 1] << 8) |
-                    (pMemory[nIndex + 2] << 16) | (pMemory[nIndex + 3] << 24);
-                return CompareValues(nValue, nTestValue, nCompareType);
-            });
-            break;
-    }
-}
-
-_Use_decl_annotations_
-void SearchResults::Initialize(const SearchResults& srSource, ComparisonType nCompareType)
-{
-    m_nSize = srSource.m_nSize;
-
-    if (m_nSize == MemSize::EightBit)
-    {
-        // efficient comparisons for 8-bit
-        switch (nCompareType)
-        {
-            case ComparisonType::Equals:
-                ProcessBlocks(srSource, [](gsl::index nIndex, const unsigned char* restrict pMemory, const unsigned char* restrict pPrev)
-                {
-                    Expects((pMemory != nullptr) && (pPrev != nullptr));
-                    return pMemory[nIndex] == pPrev[nIndex];
-                });
-                break;
-
-            case ComparisonType::NotEqualTo:
-                ProcessBlocks(srSource, [](gsl::index nIndex, const unsigned char* restrict pMemory, const unsigned char* restrict pPrev)
-                {
-                    Expects((pMemory != nullptr) && (pPrev != nullptr));
-                    return pMemory[nIndex] != pPrev[nIndex];
-                });
-                break;
-
-            default:
-                ProcessBlocks(srSource, [nCompareType](gsl::index nIndex, const unsigned char* restrict pMemory, const unsigned char* restrict pPrev)
-                {
-                    Expects((pMemory != nullptr) && (pPrev != nullptr));
-                    return CompareValues(pMemory[nIndex], pPrev[nIndex], nCompareType);
-                });
-                break;
-        }
-    }
-    else if (m_nSize == MemSize::Nibble_Lower)
-    {
-        // special logic for nibbles
-        ProcessBlocksNibbles(srSource, 0xFFFF, nCompareType);
-    }
-    else
-    {
-        // generic handling for 16-bit and 32-bit
-        ProcessBlocks(srSource, [nCompareType, nSize = m_nSize](gsl::index nIndex, const unsigned char* restrict pMemory, const unsigned char* restrict pPrev)
-        {
-            Expects((pMemory != nullptr) && (pPrev != nullptr));
-            const auto nValue = BuildValue(pMemory, nIndex, nSize);
-            const auto nPrevValue = BuildValue(pPrev, nIndex, nSize);
-            return CompareValues(nValue, nPrevValue, nCompareType);
-        });
-    }
+    m_pImpl->ApplyFilter(*this, srSource, nCompareType, nFilterType, nFilterValue);
 }
 
 size_t SearchResults::MatchingAddressCount() const noexcept
 {
-    if (!m_bUnfiltered)
+    if (m_nFilterType != SearchFilterType::None)
         return m_vMatchingAddresses.size();
 
-    const unsigned int nPadding = Padding(m_nSize);
+    if (m_pImpl == nullptr)
+        return 0;
+
+    const unsigned int nPadding = m_pImpl->GetPadding();
     size_t nCount = 0;
     for (auto& block : m_vBlocks)
         nCount += gsl::narrow_cast<size_t>(block.GetSize()) - nPadding;
 
-    if (m_nSize == MemSize::Nibble_Lower)
+    if (m_nType == SearchType::FourBit)
         nCount *= 2;
 
     return nCount;
 }
 
-void SearchResults::IterateMatchingAddresses(std::function<void(ra::ByteAddress)> pHandler) const
-{
-    if (!m_bUnfiltered)
-    {
-        for (const auto nAddress : m_vMatchingAddresses)
-            pHandler(nAddress);
-    }
-    else if (m_nSize == MemSize::Nibble_Lower)
-    {
-        for (auto& block : m_vBlocks)
-        {
-            auto nAddress = block.GetAddress() << 1;
-            for (unsigned int i = 0; i < block.GetSize(); ++i)
-            {
-                pHandler(nAddress++); // low nibble
-                pHandler(nAddress++); // high nibble
-            }
-        }
-    }
-    else
-    {
-        const unsigned int nPadding = Padding(m_nSize);
-        for (auto& block : m_vBlocks)
-        {
-            auto nAddress = block.GetAddress();
-            for (unsigned int i = 0; i < block.GetSize() - nPadding; ++i)
-                pHandler(nAddress++);
-        }
-    }
-}
-
 void SearchResults::ExcludeAddress(ra::ByteAddress nAddress)
 {
-    if (!m_bUnfiltered)
+    if (m_nFilterType != SearchFilterType::None)
         m_vMatchingAddresses.erase(std::remove(m_vMatchingAddresses.begin(), m_vMatchingAddresses.end(), nAddress), m_vMatchingAddresses.end());
 }
 
 void SearchResults::ExcludeMatchingAddress(gsl::index nIndex)
 {
-    if (!m_bUnfiltered)
+    if (m_nFilterType != SearchFilterType::None)
         m_vMatchingAddresses.erase(m_vMatchingAddresses.begin() + nIndex);
 }
 
 bool SearchResults::GetMatchingAddress(gsl::index nIndex, _Out_ SearchResults::Result& result) const
 {
-    result.nSize = m_nSize;
-
-    if (m_vBlocks.empty())
+    if (m_pImpl == nullptr)
         return false;
 
-    unsigned int nPadding = 0;
-    if (m_bUnfiltered)
-    {
-        if (m_nSize == MemSize::Nibble_Lower)
-        {
-            result.nAddress = m_vBlocks.front().GetAddress() + gsl::narrow_cast<ra::ByteAddress>(nIndex >> 1);
-            if (nIndex & 1)
-                result.nSize = MemSize::Nibble_Upper;
-        }
-        else
-        {
-            result.nAddress = m_vBlocks.front().GetAddress() + gsl::narrow_cast<ra::ByteAddress>(nIndex);
-        }
-
-        // in unfiltered mode, blocks are padded so we don't have to cross blocks to read multi-byte values
-        nPadding = Padding(m_nSize);
-    }
-    else
-    {
-        if (ra::to_unsigned(nIndex) >= m_vMatchingAddresses.size())
-            return false;
-
-        result.nAddress = m_vMatchingAddresses.at(nIndex);
-
-        if (m_nSize == MemSize::Nibble_Lower)
-        {
-            if (result.nAddress & 1)
-                result.nSize = MemSize::Nibble_Upper;
-
-            result.nAddress >>= 1;
-        }
-    }
-
-    return GetValue(result.nAddress, result.nSize, result.nValue);
+    return m_pImpl->GetMatchingAddress(*this, nIndex, result);
 }
 
 bool SearchResults::GetValue(ra::ByteAddress nAddress, MemSize nSize, _Out_ unsigned int& nValue) const
 {
-    if (m_vBlocks.empty())
+    if (m_pImpl == nullptr)
     {
-        nValue = 0;
+        nValue = 0U;
         return false;
     }
 
-    size_t nBlockIndex = 0;
-    gsl::not_null<const MemBlock*> block{gsl::make_not_null(&m_vBlocks.at(nBlockIndex))};
+    Result result{ nAddress, 0, nSize };
+    const auto ret = m_pImpl->GetValue(*this, result);
+    nValue = result.nValue;
+    return ret;
+}
 
-    const unsigned int nPadding = (m_bUnfiltered) ? Padding(m_nSize) : 0;
-    while (nAddress >= block->GetAddress() + block->GetSize() - nPadding)
-    {
-        if (++nBlockIndex == m_vBlocks.size())
-        {
-            nValue = 0;
-            return false;
-        }
-
-        block = gsl::make_not_null(&m_vBlocks.at(nBlockIndex));
-    }
-
-    if (nAddress < block->GetAddress())
-    {
-        nValue = 0;
-        return false;
-    }
-
-    nValue = BuildValue(block->GetBytes(), nAddress - block->GetAddress(), nSize);
-    return true;
+MemSize SearchResults::GetSize() const noexcept
+{
+    return m_pImpl ? m_pImpl->GetMemSize() : MemSize::EightBit;
 }
 
 } // namespace services

--- a/src/ui/ViewModelCollection.hh
+++ b/src/ui/ViewModelCollection.hh
@@ -219,7 +219,7 @@ public:
     {
         for (const auto& pItem : m_vItems)
         {
-            if (pItem.ViewModel().GetValue(pProperty) == nValue)
+            if (pItem.HasViewModel() && pItem.ViewModel().GetValue(pProperty) == nValue)
                 return pItem.Index();
         }
 

--- a/src/ui/viewmodels/MemorySearchViewModel.cpp
+++ b/src/ui/viewmodels/MemorySearchViewModel.cpp
@@ -24,9 +24,9 @@ constexpr int MEMORY_RANGE_CUSTOM = 3;
 
 const IntModelProperty MemorySearchViewModel::PredefinedFilterRangeProperty("MemorySearchViewModel", "PredefinedFilterRange", MEMORY_RANGE_ALL);
 const StringModelProperty MemorySearchViewModel::FilterRangeProperty("MemorySearchViewModel", "FilterRange", L"");
-const IntModelProperty MemorySearchViewModel::SearchTypeProperty("MemorySearchViewModel", "SearchType", ra::etoi(MemorySearchViewModel::SearchType::EightBit));
+const IntModelProperty MemorySearchViewModel::SearchTypeProperty("MemorySearchViewModel", "SearchType", ra::etoi(ra::services::SearchType::EightBit));
 const IntModelProperty MemorySearchViewModel::ComparisonTypeProperty("MemorySearchViewModel", "ComparisonType", ra::etoi(ComparisonType::Equals));
-const IntModelProperty MemorySearchViewModel::ValueTypeProperty("MemorySearchViewModel", "ValueType", ra::etoi(MemorySearchViewModel::ValueType::LastKnownValue));
+const IntModelProperty MemorySearchViewModel::ValueTypeProperty("MemorySearchViewModel", "ValueType", ra::etoi(ra::services::SearchFilterType::LastKnownValue));
 const StringModelProperty MemorySearchViewModel::FilterValueProperty("MemorySearchViewModel", "FilterValue", L"");
 const StringModelProperty MemorySearchViewModel::FilterSummaryProperty("MemorySearchViewModel", "FilterSummary", L"");
 const IntModelProperty MemorySearchViewModel::ResultCountProperty("MemorySearchViewModel", "ResultCount", 0);
@@ -87,9 +87,9 @@ MemorySearchViewModel::MemorySearchViewModel()
     m_vPredefinedFilterRanges.Add(MEMORY_RANGE_ALL, L"All");
     m_vPredefinedFilterRanges.Add(MEMORY_RANGE_CUSTOM, L"Custom");
 
-    m_vSearchTypes.Add(ra::etoi(SearchType::FourBit), L"4-bit");
-    m_vSearchTypes.Add(ra::etoi(SearchType::EightBit), L"8-bit");
-    m_vSearchTypes.Add(ra::etoi(SearchType::SixteenBit), L"16-bit");
+    m_vSearchTypes.Add(ra::etoi(ra::services::SearchType::FourBit), L"4-bit");
+    m_vSearchTypes.Add(ra::etoi(ra::services::SearchType::EightBit), L"8-bit");
+    m_vSearchTypes.Add(ra::etoi(ra::services::SearchType::SixteenBit), L"16-bit");
 
     m_vComparisonTypes.Add(ra::etoi(ComparisonType::Equals), L"=");
     m_vComparisonTypes.Add(ra::etoi(ComparisonType::LessThan), L"<");
@@ -98,8 +98,8 @@ MemorySearchViewModel::MemorySearchViewModel()
     m_vComparisonTypes.Add(ra::etoi(ComparisonType::GreaterThanOrEqual), L">=");
     m_vComparisonTypes.Add(ra::etoi(ComparisonType::NotEqualTo), L"!=");
 
-    m_vValueTypes.Add(ra::etoi(ValueType::Constant), L"Constant");
-    m_vValueTypes.Add(ra::etoi(ValueType::LastKnownValue), L"Last Known Value");
+    m_vValueTypes.Add(ra::etoi(ra::services::SearchFilterType::Constant), L"Constant");
+    m_vValueTypes.Add(ra::etoi(ra::services::SearchFilterType::LastKnownValue), L"Last Known Value");
 
     AddNotifyTarget(*this);
     m_vResults.AddNotifyTarget(*this);
@@ -303,16 +303,16 @@ void MemorySearchViewModel::OnFilterRangeChanged()
     SetPredefinedFilterRange(MEMORY_RANGE_CUSTOM);
 }
 
-static constexpr MemSize SearchTypeToMemSize(MemorySearchViewModel::SearchType nSearchType) 
+static constexpr MemSize SearchTypeToMemSize(ra::services::SearchType nSearchType) 
 {
     switch (nSearchType)
     {
-        case MemorySearchViewModel::SearchType::FourBit:
+        case ra::services::SearchType::FourBit:
             return MemSize::Nibble_Lower;
         default:
-        case MemorySearchViewModel::SearchType::EightBit:
+        case ra::services::SearchType::EightBit:
             return MemSize::EightBit;
-        case MemorySearchViewModel::SearchType::SixteenBit:
+        case ra::services::SearchType::SixteenBit:
             return MemSize::SixteenBit;
     }
 }
@@ -480,18 +480,13 @@ void MemorySearchViewModel::BeginNewSearch()
         return;
     }
 
-    const MemSize nMemSize = SearchTypeToMemSize(GetSearchType());
-
     m_vSelectedAddresses.clear();
 
     m_vSearchResults.clear();
     SearchResult& pResult = m_vSearchResults.emplace_back();
     m_nSelectedSearchResult = 0;
 
-    pResult.nCompareType = GetComparisonType();
-    pResult.nValueType = GetValueType();
-    pResult.nValue = 0;
-    pResult.pResults.Initialize(nStart, gsl::narrow<size_t>(nEnd) - nStart + 1, nMemSize);
+    pResult.pResults.Initialize(nStart, gsl::narrow<size_t>(nEnd) - nStart + 1, GetSearchType());
     pResult.sSummary = ra::StringPrintf(L"New %s Search", SearchTypes().GetLabelForId(ra::etoi(GetSearchType())));
 
     m_vResults.BeginUpdate();
@@ -526,7 +521,7 @@ void MemorySearchViewModel::ApplyFilter()
         return;
 
     unsigned int nValue = 0U;
-    if (GetValueType() == ValueType::Constant)
+    if (GetValueType() == ra::services::SearchFilterType::Constant)
     {
         const auto& sValue = GetFilterValue();
         const wchar_t* pStart = sValue.c_str();
@@ -551,28 +546,21 @@ void MemorySearchViewModel::ApplyFilter()
 
     SearchResult const& pPreviousResult = *(m_vSearchResults.end() - 2);
     SearchResult& pResult = m_vSearchResults.back();
-
-    pResult.nCompareType = GetComparisonType();
-    pResult.nValueType = GetValueType();
-    pResult.nValue = nValue;
-
-    if (pResult.nValueType == ValueType::LastKnownValue)
-        pResult.pResults.Initialize(pPreviousResult.pResults, pResult.nCompareType);
-    else
-        pResult.pResults.Initialize(pPreviousResult.pResults, pResult.nCompareType, nValue);
+    pResult.pResults.Initialize(pPreviousResult.pResults, GetComparisonType(), GetValueType(), nValue);
 
     const auto nMatches = pResult.pResults.MatchingAddressCount();
     if (nMatches == pPreviousResult.pResults.MatchingAddressCount())
     {
         // same number of matches. if the same filter was applied, don't double up on the search history.
         // unless this is the first filter, then display it anyway.
-        if (pResult.nCompareType == pPreviousResult.nCompareType &&
-            pResult.nValueType == pPreviousResult.nValueType &&
-            pResult.nValue == pPreviousResult.nValue &&
+        if (pResult.pResults.GetFilterComparison() == pPreviousResult.pResults.GetFilterComparison() &&
+            pResult.pResults.GetFilterType() == pPreviousResult.pResults.GetFilterType() &&
+            pResult.pResults.GetFilterValue() == pPreviousResult.pResults.GetFilterValue() &&
             m_vSearchResults.size() > 2)
         {
             // comparing against last known value with not equals may result in different highlights, keep it.
-            if (pResult.nValueType == ValueType::LastKnownValue || pResult.nCompareType == ComparisonType::Equals)
+            if (pResult.pResults.GetFilterType() == ra::services::SearchFilterType::LastKnownValue ||
+                pResult.pResults.GetFilterComparison() == ComparisonType::Equals)
             {
                 m_vSearchResults.pop_back();
                 --m_nSelectedSearchResult;
@@ -593,11 +581,11 @@ void MemorySearchViewModel::ApplyFilter()
     builder.Append(L" ");
     switch (GetValueType())
     {
-        case ValueType::Constant:
+        case ra::services::SearchFilterType::Constant:
             builder.Append(GetFilterValue());
             break;
 
-        case ValueType::LastKnownValue:
+        case ra::services::SearchFilterType::LastKnownValue:
             builder.Append(L"Last Known Value");
             break;
     }
@@ -718,13 +706,13 @@ void MemorySearchViewModel::UpdateResults()
 
 bool MemorySearchViewModel::TestFilter(const ra::services::SearchResults::Result& pResult, const SearchResult& pCurrentResults, unsigned int nPreviousValue) noexcept
 {
-    switch (pCurrentResults.nValueType)
+    switch (pCurrentResults.pResults.GetFilterType())
     {
-        case ValueType::Constant:
-            return pResult.Compare(pCurrentResults.nValue, pCurrentResults.nCompareType);
+        case ra::services::SearchFilterType::Constant:
+            return pResult.Compare(pCurrentResults.pResults.GetFilterValue(), pCurrentResults.pResults.GetFilterComparison());
 
-        case ValueType::LastKnownValue:
-            return pResult.Compare(nPreviousValue, pCurrentResults.nCompareType);
+        case ra::services::SearchFilterType::LastKnownValue:
+            return pResult.Compare(nPreviousValue, pCurrentResults.pResults.GetFilterComparison());
 
         default:
             return false;
@@ -736,7 +724,7 @@ void MemorySearchViewModel::OnViewModelBoolValueChanged(const BoolModelProperty:
     if (args.Property == CanFilterProperty)
     {
         if (args.tNewValue)
-            SetValue(CanEditFilterValueProperty, GetValueType() == ValueType::Constant);
+            SetValue(CanEditFilterValueProperty, GetValueType() == ra::services::SearchFilterType::Constant);
         else
             SetValue(CanEditFilterValueProperty, false);
     }
@@ -762,7 +750,7 @@ void MemorySearchViewModel::OnViewModelIntValueChanged(const IntModelProperty::C
     }
     else if (args.Property == ValueTypeProperty)
     {
-        SetValue(CanEditFilterValueProperty, GetValueType() == ValueType::Constant && GetValue(CanFilterProperty));
+        SetValue(CanEditFilterValueProperty, GetValueType() == ra::services::SearchFilterType::Constant && GetValue(CanFilterProperty));
     }
     else if (args.Property == PredefinedFilterRangeProperty)
     {

--- a/src/ui/viewmodels/MemorySearchViewModel.hh
+++ b/src/ui/viewmodels/MemorySearchViewModel.hh
@@ -118,13 +118,6 @@ public:
     /// </summary>
     void SetFilterRange(const std::wstring& sValue) { SetValue(FilterRangeProperty, sValue); }
 
-    enum class SearchType
-    {
-        FourBit,
-        EightBit,
-        SixteenBit,
-    };
-
     /// <summary>
     /// Gets the list of selectable search types.
     /// </summary>
@@ -141,12 +134,12 @@ public:
     /// <summary>
     /// Gets the selected search type.
     /// </summary>
-    SearchType GetSearchType() const { return ra::itoe<SearchType>(GetValue(SearchTypeProperty)); }
+    ra::services::SearchType GetSearchType() const { return ra::itoe<ra::services::SearchType>(GetValue(SearchTypeProperty)); }
 
     /// <summary>
     /// Sets the selected search type.
     /// </summary>
-    void SetSearchType(SearchType value) { SetValue(SearchTypeProperty, ra::etoi(value)); }
+    void SetSearchType(ra::services::SearchType value) { SetValue(SearchTypeProperty, ra::etoi(value)); }
 
     /// <summary>
     /// Gets the list of selectable comparison types.
@@ -171,12 +164,6 @@ public:
     /// </summary>
     void SetComparisonType(ComparisonType value) { SetValue(ComparisonTypeProperty, ra::etoi(value)); }
 
-    enum class ValueType
-    {
-        Constant,
-        LastKnownValue,
-    };
-
     /// <summary>
     /// Gets the list of selectable value types.
     /// </summary>
@@ -193,12 +180,12 @@ public:
     /// <summary>
     /// Gets the selected value type.
     /// </summary>
-    ValueType GetValueType() const { return ra::itoe<ValueType>(GetValue(ValueTypeProperty)); }
+    ra::services::SearchFilterType GetValueType() const { return ra::itoe<ra::services::SearchFilterType>(GetValue(ValueTypeProperty)); }
 
     /// <summary>
     /// Sets the selected value type.
     /// </summary>
-    void SetValueType(ValueType value) { SetValue(ValueTypeProperty, ra::etoi(value)); }
+    void SetValueType(ra::services::SearchFilterType value) { SetValue(ValueTypeProperty, ra::etoi(value)); }
 
     /// <summary>
     /// The <see cref="ModelProperty" /> for the filter value.
@@ -485,9 +472,6 @@ private:
         std::set<unsigned int> vModifiedAddresses;
 
         std::wstring sSummary;
-        ValueType nValueType = ValueType::Constant;
-        ComparisonType nCompareType = ComparisonType::Equals;
-        unsigned int nValue = 0U;
     };
 
     size_t m_nSelectedSearchResult = 0U;

--- a/src/ui/viewmodels/MemorySearchViewModel.hh
+++ b/src/ui/viewmodels/MemorySearchViewModel.hh
@@ -338,9 +338,14 @@ public:
     }
 
     /// <summary>
+    /// The <see cref="ModelProperty" /> for the memory size of result items.
+    /// </summary>
+    static const IntModelProperty ResultMemSizeProperty;
+
+    /// <summary>
     /// Gets the memory size of the items in <see cref="Results"/>.
     /// </summary>
-    MemSize ResultMemSize() const;
+    MemSize ResultMemSize() const { return ra::itoe<MemSize>(GetValue(ResultMemSizeProperty)); }
 
     /// <summary>
     /// The <see cref="ModelProperty" /> for the number of results found.

--- a/src/ui/win32/MemoryInspectorDialog.cpp
+++ b/src/ui/win32/MemoryInspectorDialog.cpp
@@ -76,6 +76,30 @@ void MemoryInspectorDialog::SearchResultsGridBinding::OnLvnItemChanged(const LPN
     }
 }
 
+void MemoryInspectorDialog::SearchResultsGridBinding::OnViewModelIntValueChanged(const IntModelProperty::ChangeArgs& args)
+{
+    if (args.Property == MemorySearchViewModel::ResultMemSizeProperty)
+    {
+        int nWidth;
+        const auto& vmMemory = GetViewModel<MemorySearchViewModel>();
+        constexpr int nCharWidth = 6;
+        constexpr int nPadding = 6;
+        switch (vmMemory.ResultMemSize())
+        {
+            case MemSize::Nibble_Lower: nWidth = nCharWidth * (1 + 2) + nPadding * 2; break;
+            case MemSize::EightBit:     nWidth = nCharWidth * (2 + 2) + nPadding * 2; break;
+            default:
+            case MemSize::SixteenBit:   nWidth = nCharWidth * (4 + 2) + nPadding * 2; break;
+            case MemSize::ThirtyTwoBit: nWidth = nCharWidth * (8 + 2) + nPadding * 2; break;
+        }
+
+        m_vColumns.at(1)->SetWidth(GridColumnBinding::WidthType::Pixels, nWidth);
+        UpdateLayout();
+    }
+
+    GridBinding::OnViewModelIntValueChanged(args);
+}
+
 
 MemoryInspectorDialog::MemoryInspectorDialog(MemoryInspectorViewModel& vmMemoryInspector)
     : DialogBase(vmMemoryInspector),

--- a/src/ui/win32/MemoryInspectorDialog.hh
+++ b/src/ui/win32/MemoryInspectorDialog.hh
@@ -65,6 +65,8 @@ private:
 
         void OnLvnItemChanged(const LPNMLISTVIEW pnmListView) override;
 
+        void OnViewModelIntValueChanged(const IntModelProperty::ChangeArgs& args) override;
+
     protected:
         void Invalidate() override;
     };

--- a/tests/services/SearchResults_Tests.cpp
+++ b/tests/services/SearchResults_Tests.cpp
@@ -497,6 +497,31 @@ public:
         Assert::AreEqual(0xAB55U, result.nValue);
     }
 
+    TEST_METHOD(TestInitializeFromResultsThirtyTwoBitNotEqualPrevious)
+    {
+        std::array<unsigned char, 5> memory{0x00, 0x12, 0x34, 0xAB, 0x56};
+        ra::data::mocks::MockEmulatorContext mockEmulatorContext;
+        mockEmulatorContext.MockMemory(memory);
+
+        SearchResults results1;
+        results1.Initialize(0U, 5U, ra::services::SearchType::ThirtyTwoBit);
+        Assert::AreEqual({ 2U }, results1.MatchingAddressCount());
+
+        memory.at(4) = 0x55;
+        SearchResults results;
+        results.Initialize(results1, ComparisonType::NotEqualTo, ra::services::SearchFilterType::LastKnownValue, 0U);
+
+        Assert::AreEqual({ 1U }, results.MatchingAddressCount());
+        Assert::IsFalse(results.ContainsAddress(0U));
+        Assert::IsTrue(results.ContainsAddress(1U));
+
+        SearchResults::Result result;
+        Assert::IsTrue(results.GetMatchingAddress(0U, result));
+        Assert::AreEqual(1U, result.nAddress);
+        Assert::AreEqual(MemSize::ThirtyTwoBit, result.nSize);
+        Assert::AreEqual(0x55AB3412U, result.nValue);
+    }
+
     TEST_METHOD(TestInitializeFromResultsFourBitNotEqualsPrevious)
     {
         std::array<unsigned char, 5> memory{0x00, 0x12, 0x34, 0xAB, 0x56};

--- a/tests/services/SearchResults_Tests.cpp
+++ b/tests/services/SearchResults_Tests.cpp
@@ -31,7 +31,7 @@ public:
         mockEmulatorContext.MockMemory(memory);
 
         SearchResults results;
-        results.Initialize(1U, 3U, MemSize::EightBit);
+        results.Initialize(1U, 3U, ra::services::SearchType::EightBit);
 
         Assert::AreEqual({ 3U }, results.MatchingAddressCount());
 
@@ -65,7 +65,7 @@ public:
         mockEmulatorContext.MockMemory(memory);
 
         SearchResults results;
-        results.Initialize(1U, 3U, MemSize::SixteenBit);
+        results.Initialize(1U, 3U, ra::services::SearchType::SixteenBit);
 
         Assert::AreEqual({ 2U }, results.MatchingAddressCount());
 
@@ -93,7 +93,7 @@ public:
         mockEmulatorContext.MockMemory(memory);
 
         SearchResults results;
-        results.Initialize(1U, 4U, MemSize::ThirtyTwoBit);
+        results.Initialize(1U, 4U, ra::services::SearchType::ThirtyTwoBit);
 
         Assert::AreEqual({ 1U }, results.MatchingAddressCount());
 
@@ -108,56 +108,6 @@ public:
         Assert::AreEqual(0x56AB3412U, result.nValue);
     }
 
-    TEST_METHOD(TestInitializeFromMemoryUpperNibble)
-    {
-        std::array<unsigned char, 5> memory{0x00, 0x12, 0x34, 0xAB, 0x56};
-        ra::data::mocks::MockEmulatorContext mockEmulatorContext;
-        mockEmulatorContext.MockMemory(memory);
-
-        SearchResults results;
-        results.Initialize(1U, 3U, MemSize::Nibble_Upper);
-
-        Assert::AreEqual({ 6U }, results.MatchingAddressCount());
-
-        Assert::IsFalse(results.ContainsAddress(0U));
-        Assert::IsTrue(results.ContainsAddress(1U));
-        Assert::IsTrue(results.ContainsAddress(2U));
-        Assert::IsTrue(results.ContainsAddress(3U));
-        Assert::IsFalse(results.ContainsAddress(4U));
-
-        // lower nibble always returned first
-        SearchResults::Result result;
-        Assert::IsTrue(results.GetMatchingAddress(0U, result));
-        Assert::AreEqual(1U, result.nAddress);
-        Assert::AreEqual(MemSize::Nibble_Lower, result.nSize);
-        Assert::AreEqual(0x2U, result.nValue);
-
-        Assert::IsTrue(results.GetMatchingAddress(1U, result));
-        Assert::AreEqual(1U, result.nAddress);
-        Assert::AreEqual(MemSize::Nibble_Upper, result.nSize);
-        Assert::AreEqual(0x1U, result.nValue);
-
-        Assert::IsTrue(results.GetMatchingAddress(2U, result));
-        Assert::AreEqual(2U, result.nAddress);
-        Assert::AreEqual(MemSize::Nibble_Lower, result.nSize);
-        Assert::AreEqual(0x4U, result.nValue);
-
-        Assert::IsTrue(results.GetMatchingAddress(3U, result));
-        Assert::AreEqual(2U, result.nAddress);
-        Assert::AreEqual(MemSize::Nibble_Upper, result.nSize);
-        Assert::AreEqual(0x3U, result.nValue);
-
-        Assert::IsTrue(results.GetMatchingAddress(4U, result));
-        Assert::AreEqual(3U, result.nAddress);
-        Assert::AreEqual(MemSize::Nibble_Lower, result.nSize);
-        Assert::AreEqual(0xBU, result.nValue);
-
-        Assert::IsTrue(results.GetMatchingAddress(5U, result));
-        Assert::AreEqual(3U, result.nAddress);
-        Assert::AreEqual(MemSize::Nibble_Upper, result.nSize);
-        Assert::AreEqual(0xAU, result.nValue);
-    }
-
     TEST_METHOD(TestInitializeFromMemoryLowerNibble)
     {
         std::array<unsigned char, 5> memory{0x00, 0x12, 0x34, 0xAB, 0x56};
@@ -165,7 +115,7 @@ public:
         mockEmulatorContext.MockMemory(memory);
 
         SearchResults results;
-        results.Initialize(1U, 3U, MemSize::Nibble_Lower); // should behave identical to Nibble_Upper
+        results.Initialize(1U, 3U, ra::services::SearchType::FourBit);
 
         Assert::AreEqual({ 6U }, results.MatchingAddressCount());
 
@@ -215,7 +165,7 @@ public:
         mockEmulatorContext.MockMemory(memory);
 
         SearchResults results;
-        results.Initialize(1U, 8U, MemSize::SixteenBit);
+        results.Initialize(1U, 8U, ra::services::SearchType::SixteenBit);
 
         Assert::AreEqual({ 3U }, results.MatchingAddressCount());
 
@@ -249,11 +199,11 @@ public:
         mockEmulatorContext.MockMemory(memory);
 
         SearchResults results1;
-        results1.Initialize(1U, 3U, MemSize::EightBit);
+        results1.Initialize(1U, 3U, ra::services::SearchType::EightBit);
         Assert::AreEqual({ 3U }, results1.MatchingAddressCount());
 
         SearchResults results;
-        results.Initialize(results1, ComparisonType::Equals, 0xABU);
+        results.Initialize(results1, ComparisonType::Equals, ra::services::SearchFilterType::Constant, 0xABU);
 
         Assert::AreEqual({ 1U }, results.MatchingAddressCount());
         Assert::IsFalse(results.ContainsAddress(0U));
@@ -276,11 +226,11 @@ public:
         mockEmulatorContext.MockMemory(memory);
 
         SearchResults results1;
-        results1.Initialize(1U, 3U, MemSize::EightBit);
+        results1.Initialize(1U, 3U, ra::services::SearchType::EightBit);
         Assert::AreEqual({ 3U }, results1.MatchingAddressCount());
 
         SearchResults results;
-        results.Initialize(results1, ComparisonType::NotEqualTo, 0xABU);
+        results.Initialize(results1, ComparisonType::NotEqualTo, ra::services::SearchFilterType::Constant, 0xABU);
 
         Assert::AreEqual({ 2U }, results.MatchingAddressCount());
         Assert::IsFalse(results.ContainsAddress(0U));
@@ -308,11 +258,11 @@ public:
         mockEmulatorContext.MockMemory(memory);
 
         SearchResults results1;
-        results1.Initialize(1U, 3U, MemSize::EightBit);
+        results1.Initialize(1U, 3U, ra::services::SearchType::EightBit);
         Assert::AreEqual({ 3U }, results1.MatchingAddressCount());
 
         SearchResults results;
-        results.Initialize(results1, ComparisonType::NotEqualTo, 0x34U);
+        results.Initialize(results1, ComparisonType::NotEqualTo, ra::services::SearchFilterType::Constant, 0x34U);
 
         Assert::AreEqual({ 2U }, results.MatchingAddressCount());
         Assert::IsFalse(results.ContainsAddress(0U));
@@ -340,11 +290,11 @@ public:
         mockEmulatorContext.MockMemory(memory);
 
         SearchResults results1;
-        results1.Initialize(1U, 3U, MemSize::EightBit);
+        results1.Initialize(1U, 3U, ra::services::SearchType::EightBit);
         Assert::AreEqual({ 3U }, results1.MatchingAddressCount());
 
         SearchResults results;
-        results.Initialize(results1, ComparisonType::GreaterThan, 0x34U);
+        results.Initialize(results1, ComparisonType::GreaterThan, ra::services::SearchFilterType::Constant, 0x34U);
 
         Assert::AreEqual({ 1U }, results.MatchingAddressCount());
         Assert::IsFalse(results.ContainsAddress(0U));
@@ -367,11 +317,11 @@ public:
         mockEmulatorContext.MockMemory(memory);
 
         SearchResults results1;
-        results1.Initialize(1U, 3U, MemSize::EightBit);
+        results1.Initialize(1U, 3U, ra::services::SearchType::EightBit);
         Assert::AreEqual({ 3U }, results1.MatchingAddressCount());
 
         SearchResults results;
-        results.Initialize(results1, ComparisonType::GreaterThanOrEqual, 0x34U);
+        results.Initialize(results1, ComparisonType::GreaterThanOrEqual, ra::services::SearchFilterType::Constant, 0x34U);
 
         Assert::AreEqual({ 2U }, results.MatchingAddressCount());
         Assert::IsFalse(results.ContainsAddress(0U));
@@ -399,11 +349,11 @@ public:
         mockEmulatorContext.MockMemory(memory);
 
         SearchResults results1;
-        results1.Initialize(1U, 3U, MemSize::EightBit);
+        results1.Initialize(1U, 3U, ra::services::SearchType::EightBit);
         Assert::AreEqual({ 3U }, results1.MatchingAddressCount());
 
         SearchResults results;
-        results.Initialize(results1, ComparisonType::LessThan, 0x34U);
+        results.Initialize(results1, ComparisonType::LessThan, ra::services::SearchFilterType::Constant, 0x34U);
 
         Assert::AreEqual({ 1U }, results.MatchingAddressCount());
         Assert::IsFalse(results.ContainsAddress(0U));
@@ -426,11 +376,11 @@ public:
         mockEmulatorContext.MockMemory(memory);
 
         SearchResults results1;
-        results1.Initialize(1U, 3U, MemSize::EightBit);
+        results1.Initialize(1U, 3U, ra::services::SearchType::EightBit);
         Assert::AreEqual({ 3U }, results1.MatchingAddressCount());
 
         SearchResults results;
-        results.Initialize(results1, ComparisonType::LessThanOrEqual, 0x34U);
+        results.Initialize(results1, ComparisonType::LessThanOrEqual, ra::services::SearchFilterType::Constant, 0x34U);
 
         Assert::AreEqual({ 2U }, results.MatchingAddressCount());
         Assert::IsFalse(results.ContainsAddress(0U));
@@ -458,14 +408,14 @@ public:
         mockEmulatorContext.MockMemory(memory);
 
         SearchResults results1;
-        results1.Initialize(1U, 3U, MemSize::EightBit);
+        results1.Initialize(1U, 3U, ra::services::SearchType::EightBit);
         Assert::AreEqual({ 3U }, results1.MatchingAddressCount());
 
         // swap bytes 1 and 3, match should be found at address 1, not address 3
         memory.at(1) = 0xAB;
         memory.at(3) = 0x12;
         SearchResults results;
-        results.Initialize(results1, ComparisonType::Equals, 0xABU);
+        results.Initialize(results1, ComparisonType::Equals, ra::services::SearchFilterType::Constant, 0xABU);
 
         Assert::AreEqual({ 1U }, results.MatchingAddressCount());
         Assert::IsFalse(results.ContainsAddress(0U));
@@ -488,13 +438,13 @@ public:
         mockEmulatorContext.MockMemory(memory);
 
         SearchResults results1;
-        results1.Initialize(1U, 3U, MemSize::EightBit);
+        results1.Initialize(1U, 3U, ra::services::SearchType::EightBit);
         Assert::AreEqual({ 3U }, results1.MatchingAddressCount());
 
         memory.at(1) = 0x14;
         memory.at(2) = 0x55;
         SearchResults results;
-        results.Initialize(results1, ComparisonType::NotEqualTo);
+        results.Initialize(results1, ComparisonType::NotEqualTo, ra::services::SearchFilterType::LastKnownValue, 0U);
 
         Assert::AreEqual({ 2U }, results.MatchingAddressCount());
         Assert::IsFalse(results.ContainsAddress(0U));
@@ -522,12 +472,12 @@ public:
         mockEmulatorContext.MockMemory(memory);
 
         SearchResults results1;
-        results1.Initialize(1U, 4U, MemSize::SixteenBit);
+        results1.Initialize(1U, 4U, ra::services::SearchType::SixteenBit);
         Assert::AreEqual({ 3U }, results1.MatchingAddressCount());
 
         memory.at(2) = 0x55;
         SearchResults results;
-        results.Initialize(results1, ComparisonType::NotEqualTo);
+        results.Initialize(results1, ComparisonType::NotEqualTo, ra::services::SearchFilterType::LastKnownValue, 0U);
 
         Assert::AreEqual({ 2U }, results.MatchingAddressCount());
         Assert::IsFalse(results.ContainsAddress(0U));
@@ -554,13 +504,13 @@ public:
         mockEmulatorContext.MockMemory(memory);
 
         SearchResults results1;
-        results1.Initialize(1U, 3U, MemSize::Nibble_Lower);
+        results1.Initialize(1U, 3U, ra::services::SearchType::FourBit);
         Assert::AreEqual({ 6U }, results1.MatchingAddressCount());
 
         memory.at(1) = 0x14;
         memory.at(2) = 0x55;
         SearchResults results;
-        results.Initialize(results1, ComparisonType::NotEqualTo);
+        results.Initialize(results1, ComparisonType::NotEqualTo, ra::services::SearchFilterType::LastKnownValue, 0U);
 
         Assert::AreEqual({ 3U }, results.MatchingAddressCount());
         Assert::IsFalse(results.ContainsAddress(0U));
@@ -593,11 +543,11 @@ public:
         mockEmulatorContext.MockMemory(memory);
 
         SearchResults results;
-        results.Initialize(1U, 3U, MemSize::Nibble_Lower);
+        results.Initialize(1U, 3U, ra::services::SearchType::FourBit);
         Assert::AreEqual({ 6U }, results.MatchingAddressCount());
 
         SearchResults filtered1;
-        filtered1.Initialize(results, ComparisonType::Equals, 1);
+        filtered1.Initialize(results, ComparisonType::Equals, ra::services::SearchFilterType::Constant, 1U);
         Assert::AreEqual({ 1U }, filtered1.MatchingAddressCount());
 
         SearchResults::Result result;
@@ -609,13 +559,13 @@ public:
         // Nibble_Upper no longer matches, but Nibble_Lower does. Neither should not be returned.
         memory.at(1) = 0x21;
         SearchResults filtered2;
-        filtered2.Initialize(filtered1, ComparisonType::Equals, 1);
+        filtered2.Initialize(filtered1, ComparisonType::Equals, ra::services::SearchFilterType::Constant, 1U);
         Assert::AreEqual({ 0U }, filtered2.MatchingAddressCount());
 
         // Both nibbles match, only previously matched one should be returned
         memory.at(1) = 0x11;
         SearchResults filtered3;
-        filtered3.Initialize(filtered1, ComparisonType::Equals, 1);
+        filtered3.Initialize(filtered1, ComparisonType::Equals, ra::services::SearchFilterType::Constant, 1U);
         Assert::AreEqual({ 1U }, filtered3.MatchingAddressCount());
 
         Assert::IsTrue(filtered3.GetMatchingAddress(0U, result));
@@ -631,7 +581,7 @@ public:
         mockEmulatorContext.MockMemory(memory);
 
         SearchResults results1;
-        results1.Initialize(1U, 3U, MemSize::EightBit);
+        results1.Initialize(1U, 3U, ra::services::SearchType::EightBit);
         Assert::AreEqual({ 3U }, results1.MatchingAddressCount());
 
         // exclude doesn't do anything to unfiltered results
@@ -641,7 +591,7 @@ public:
         memory.at(1) = 0x14;
         memory.at(2) = 0x55;
         SearchResults results;
-        results.Initialize(results1, ComparisonType::NotEqualTo);
+        results.Initialize(results1, ComparisonType::NotEqualTo, ra::services::SearchFilterType::LastKnownValue, 0U);
 
         Assert::AreEqual({ 2U }, results.MatchingAddressCount());
         Assert::IsFalse(results.ContainsAddress(0U));
@@ -672,7 +622,7 @@ public:
         mockEmulatorContext.MockMemory(memory);
 
         SearchResults results1;
-        results1.Initialize(1U, 3U, MemSize::EightBit);
+        results1.Initialize(1U, 3U, ra::services::SearchType::EightBit);
         Assert::AreEqual({ 3U }, results1.MatchingAddressCount());
 
         // exclude doesn't do anything to unfiltered results
@@ -682,7 +632,7 @@ public:
         memory.at(1) = 0x14;
         memory.at(2) = 0x55;
         SearchResults results;
-        results.Initialize(results1, ComparisonType::NotEqualTo);
+        results.Initialize(results1, ComparisonType::NotEqualTo, ra::services::SearchFilterType::LastKnownValue, 0U);
 
         Assert::AreEqual({ 2U }, results.MatchingAddressCount());
         Assert::IsFalse(results.ContainsAddress(0U));
@@ -715,7 +665,7 @@ public:
         mockEmulatorContext.MockMemory(memory.get(), BIG_BLOCK_SIZE);
 
         SearchResults results;
-        results.Initialize(0U, BIG_BLOCK_SIZE, MemSize::EightBit);
+        results.Initialize(0U, BIG_BLOCK_SIZE, ra::services::SearchType::EightBit);
 
         Assert::AreEqual({ BIG_BLOCK_SIZE }, results.MatchingAddressCount());
         Assert::IsTrue(results.ContainsAddress(0U));
@@ -752,7 +702,7 @@ public:
         mockEmulatorContext.MockMemory(memory.get(), BIG_BLOCK_SIZE);
 
         SearchResults results;
-        results.Initialize(0U, BIG_BLOCK_SIZE, MemSize::SixteenBit);
+        results.Initialize(0U, BIG_BLOCK_SIZE, ra::services::SearchType::SixteenBit);
 
         Assert::AreEqual({ BIG_BLOCK_SIZE - 1 }, results.MatchingAddressCount());
         Assert::IsTrue(results.ContainsAddress(0U));
@@ -787,7 +737,7 @@ public:
         mockEmulatorContext.MockMemory(memory);
 
         SearchResults results;
-        results.Initialize(0U, 0U, MemSize::SixteenBit);
+        results.Initialize(0U, 0U, ra::services::SearchType::SixteenBit);
 
         Assert::AreEqual({ 0U }, results.MatchingAddressCount());
     }
@@ -799,7 +749,7 @@ public:
         mockEmulatorContext.MockMemory(memory);
 
         SearchResults results1;
-        results1.Initialize(1U, 3U, MemSize::EightBit);
+        results1.Initialize(1U, 3U, ra::services::SearchType::EightBit);
         Assert::AreEqual({ 3U }, results1.MatchingAddressCount());
 
         // exclude doesn't do anything to unfiltered results
@@ -809,7 +759,7 @@ public:
         memory.at(1) = 0x14;
         memory.at(2) = 0x55;
         SearchResults results;
-        results.Initialize(results1, ComparisonType::NotEqualTo);
+        results.Initialize(results1, ComparisonType::NotEqualTo, ra::services::SearchFilterType::LastKnownValue, 0U);
 
         SearchResults results2(results);
 

--- a/tests/ui/viewmodels/MemorySearchViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/MemorySearchViewModel_Tests.cpp
@@ -17,16 +17,16 @@ namespace VisualStudio {
 namespace CppUnitTestFramework {
 
 template<>
-std::wstring ToString<ra::ui::viewmodels::MemorySearchViewModel::SearchType>(
-    const ra::ui::viewmodels::MemorySearchViewModel::SearchType& nSearchType)
+std::wstring ToString<ra::services::SearchType>(
+    const ra::services::SearchType& nSearchType)
 {
     switch (nSearchType)
     {
-        case ra::ui::viewmodels::MemorySearchViewModel::SearchType::FourBit:
+        case ra::services::SearchType::FourBit:
             return L"FourBit";
-        case ra::ui::viewmodels::MemorySearchViewModel::SearchType::EightBit:
+        case ra::services::SearchType::EightBit:
             return L"EightBit";
-        case ra::ui::viewmodels::MemorySearchViewModel::SearchType::SixteenBit:
+        case ra::services::SearchType::SixteenBit:
             return L"SixteenBit";
         default:
             return std::to_wstring(static_cast<int>(nSearchType));
@@ -34,14 +34,14 @@ std::wstring ToString<ra::ui::viewmodels::MemorySearchViewModel::SearchType>(
 }
 
 template<>
-std::wstring ToString<ra::ui::viewmodels::MemorySearchViewModel::ValueType>(
-    const ra::ui::viewmodels::MemorySearchViewModel::ValueType& nValueType)
+std::wstring ToString<ra::services::SearchFilterType>(
+    const ra::services::SearchFilterType& nValueType)
 {
     switch (nValueType)
     {
-        case ra::ui::viewmodels::MemorySearchViewModel::ValueType::Constant:
+        case ra::services::SearchFilterType::Constant:
             return L"Constant";
-        case ra::ui::viewmodels::MemorySearchViewModel::ValueType::LastKnownValue:
+        case ra::services::SearchFilterType::LastKnownValue:
             return L"LastKnownValue";
         default:
             return std::to_wstring(static_cast<int>(nValueType));
@@ -119,13 +119,13 @@ public:
         Assert::AreEqual(std::wstring(L""), search.GetFilterValue());
 
         Assert::AreEqual({ 3U }, search.SearchTypes().Count());
-        Assert::AreEqual((int)MemorySearchViewModel::SearchType::FourBit, search.SearchTypes().GetItemAt(0)->GetId());
+        Assert::AreEqual((int)ra::services::SearchType::FourBit, search.SearchTypes().GetItemAt(0)->GetId());
         Assert::AreEqual(std::wstring(L"4-bit"), search.SearchTypes().GetItemAt(0)->GetLabel());
-        Assert::AreEqual((int)MemorySearchViewModel::SearchType::EightBit, search.SearchTypes().GetItemAt(1)->GetId());
+        Assert::AreEqual((int)ra::services::SearchType::EightBit, search.SearchTypes().GetItemAt(1)->GetId());
         Assert::AreEqual(std::wstring(L"8-bit"), search.SearchTypes().GetItemAt(1)->GetLabel());
-        Assert::AreEqual((int)MemorySearchViewModel::SearchType::SixteenBit, search.SearchTypes().GetItemAt(2)->GetId());
+        Assert::AreEqual((int)ra::services::SearchType::SixteenBit, search.SearchTypes().GetItemAt(2)->GetId());
         Assert::AreEqual(std::wstring(L"16-bit"), search.SearchTypes().GetItemAt(2)->GetLabel());
-        Assert::AreEqual(MemorySearchViewModel::SearchType::EightBit, search.GetSearchType());
+        Assert::AreEqual(ra::services::SearchType::EightBit, search.GetSearchType());
 
         Assert::AreEqual({ 6U }, search.ComparisonTypes().Count());
         Assert::AreEqual((int)ComparisonType::Equals, search.ComparisonTypes().GetItemAt(0)->GetId());
@@ -143,11 +143,11 @@ public:
         Assert::AreEqual(ComparisonType::Equals, search.GetComparisonType());
 
         Assert::AreEqual({ 2U }, search.ValueTypes().Count());
-        Assert::AreEqual((int)MemorySearchViewModel::ValueType::Constant, search.ValueTypes().GetItemAt(0)->GetId());
+        Assert::AreEqual((int)ra::services::SearchFilterType::Constant, search.ValueTypes().GetItemAt(0)->GetId());
         Assert::AreEqual(std::wstring(L"Constant"), search.ValueTypes().GetItemAt(0)->GetLabel());
-        Assert::AreEqual((int)MemorySearchViewModel::ValueType::LastKnownValue, search.ValueTypes().GetItemAt(1)->GetId());
+        Assert::AreEqual((int)ra::services::SearchFilterType::LastKnownValue, search.ValueTypes().GetItemAt(1)->GetId());
         Assert::AreEqual(std::wstring(L"Last Known Value"), search.ValueTypes().GetItemAt(1)->GetLabel());
-        Assert::AreEqual(MemorySearchViewModel::ValueType::LastKnownValue, search.GetValueType());
+        Assert::AreEqual(ra::services::SearchFilterType::LastKnownValue, search.GetValueType());
 
         Assert::AreEqual({ 0 }, search.GetScrollOffset());
         Assert::AreEqual(std::wstring(L"0/0"), search.GetSelectedPage());
@@ -184,7 +184,7 @@ public:
     {
         MemorySearchViewModelHarness search;
         search.InitializeMemory();
-        search.SetSearchType(MemorySearchViewModel::SearchType::SixteenBit);
+        search.SetSearchType(ra::services::SearchType::SixteenBit);
         Assert::IsFalse(search.CanFilter());
 
         search.BeginNewSearch();
@@ -203,7 +203,7 @@ public:
     {
         MemorySearchViewModelHarness search;
         search.InitializeMemory();
-        search.SetSearchType(MemorySearchViewModel::SearchType::FourBit);
+        search.SetSearchType(ra::services::SearchType::FourBit);
         Assert::IsFalse(search.CanFilter());
 
         search.BeginNewSearch();
@@ -225,7 +225,7 @@ public:
         search.BeginNewSearch();
 
         search.SetComparisonType(ComparisonType::Equals);
-        search.SetValueType(MemorySearchViewModel::ValueType::Constant);
+        search.SetValueType(ra::services::SearchFilterType::Constant);
         search.SetFilterValue(L"12");
 
         search.ApplyFilter();
@@ -246,7 +246,7 @@ public:
         search.BeginNewSearch();
 
         search.SetComparisonType(ComparisonType::Equals);
-        search.SetValueType(MemorySearchViewModel::ValueType::Constant);
+        search.SetValueType(ra::services::SearchFilterType::Constant);
         search.SetFilterValue(L"0x0C");
 
         search.ApplyFilter();
@@ -267,7 +267,7 @@ public:
         search.BeginNewSearch();
 
         search.SetComparisonType(ComparisonType::Equals);
-        search.SetValueType(MemorySearchViewModel::ValueType::Constant);
+        search.SetValueType(ra::services::SearchFilterType::Constant);
         Assert::IsTrue(search.CanEditFilterValue());
         search.SetFilterValue(L"banana");
 
@@ -298,7 +298,7 @@ public:
         search.BeginNewSearch();
 
         search.SetComparisonType(ComparisonType::NotEqualTo);
-        search.SetValueType(MemorySearchViewModel::ValueType::LastKnownValue);
+        search.SetValueType(ra::services::SearchFilterType::LastKnownValue);
         Assert::IsFalse(search.CanEditFilterValue());
         search.memory.at(12) = 9;
 
@@ -336,7 +336,7 @@ public:
         search.BeginNewSearch();
 
         search.SetComparisonType(ComparisonType::NotEqualTo);
-        search.SetValueType(MemorySearchViewModel::ValueType::LastKnownValue);
+        search.SetValueType(ra::services::SearchFilterType::LastKnownValue);
         search.memory.at(12) = 9;
 
         search.ApplyFilter();
@@ -368,7 +368,7 @@ public:
         search.InitializeMemory();
         search.BeginNewSearch();
         search.SetComparisonType(ComparisonType::Equals);
-        search.SetValueType(MemorySearchViewModel::ValueType::LastKnownValue);
+        search.SetValueType(ra::services::SearchFilterType::LastKnownValue);
         search.ApplyFilter();
 
         search.memory.at(2) = 9;
@@ -389,10 +389,10 @@ public:
     {
         MemorySearchViewModelHarness search;
         search.InitializeMemory();
-        search.SetSearchType(MemorySearchViewModel::SearchType::SixteenBit);
+        search.SetSearchType(ra::services::SearchType::SixteenBit);
         search.BeginNewSearch();
         search.SetComparisonType(ComparisonType::Equals);
-        search.SetValueType(MemorySearchViewModel::ValueType::LastKnownValue);
+        search.SetValueType(ra::services::SearchFilterType::LastKnownValue);
         search.ApplyFilter();
 
         search.memory.at(2) = 9;
@@ -412,10 +412,10 @@ public:
     {
         MemorySearchViewModelHarness search;
         search.InitializeMemory();
-        search.SetSearchType(MemorySearchViewModel::SearchType::FourBit);
+        search.SetSearchType(ra::services::SearchType::FourBit);
         search.BeginNewSearch();
         search.SetComparisonType(ComparisonType::Equals);
-        search.SetValueType(MemorySearchViewModel::ValueType::LastKnownValue);
+        search.SetValueType(ra::services::SearchFilterType::LastKnownValue);
         search.ApplyFilter();
 
         search.memory.at(1) = 9;
@@ -438,7 +438,7 @@ public:
         search.BeginNewSearch();
 
         search.SetComparisonType(ComparisonType::LessThan);
-        search.SetValueType(MemorySearchViewModel::ValueType::Constant);
+        search.SetValueType(ra::services::SearchFilterType::Constant);
         search.SetFilterValue(L"8");
         Assert::IsFalse(search.CanGoToPreviousPage());
         Assert::IsFalse(search.CanGoToNextPage());
@@ -621,7 +621,7 @@ public:
         search.BeginNewSearch();
 
         search.SetComparisonType(ComparisonType::LessThan);
-        search.SetValueType(MemorySearchViewModel::ValueType::Constant);
+        search.SetValueType(ra::services::SearchFilterType::Constant);
         search.SetFilterValue(L"8");
         search.ApplyFilter();
         Assert::AreEqual({ 8U }, search.GetResultCount());
@@ -659,7 +659,7 @@ public:
         search.BeginNewSearch();
 
         search.SetComparisonType(ComparisonType::LessThan);
-        search.SetValueType(MemorySearchViewModel::ValueType::Constant);
+        search.SetValueType(ra::services::SearchFilterType::Constant);
         search.SetFilterValue(L"5");
 
         search.ApplyFilter();
@@ -695,7 +695,7 @@ public:
         search.BeginNewSearch();
 
         search.SetComparisonType(ComparisonType::LessThan);
-        search.SetValueType(MemorySearchViewModel::ValueType::Constant);
+        search.SetValueType(ra::services::SearchFilterType::Constant);
         search.SetFilterValue(L"5");
 
         search.ApplyFilter();
@@ -728,11 +728,11 @@ public:
     {
         MemorySearchViewModelHarness search;
         search.InitializeMemory();
-        search.SetSearchType(MemorySearchViewModel::SearchType::FourBit);
+        search.SetSearchType(ra::services::SearchType::FourBit);
         search.BeginNewSearch();
 
         search.SetComparisonType(ComparisonType::GreaterThan);
-        search.SetValueType(MemorySearchViewModel::ValueType::Constant);
+        search.SetValueType(ra::services::SearchFilterType::Constant);
         search.SetFilterValue(L"13");
 
         search.ApplyFilter();

--- a/tests/ui/viewmodels/MemorySearchViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/MemorySearchViewModel_Tests.cpp
@@ -28,6 +28,8 @@ std::wstring ToString<ra::services::SearchType>(
             return L"EightBit";
         case ra::services::SearchType::SixteenBit:
             return L"SixteenBit";
+        case ra::services::SearchType::ThirtyTwoBit:
+            return L"ThirtyTwoBit";
         default:
             return std::to_wstring(static_cast<int>(nSearchType));
     }
@@ -112,19 +114,21 @@ public:
         MemorySearchViewModelHarness search;
 
         Assert::AreEqual({ 0U }, search.Results().Count());
-        Assert::AreEqual(MemSize::EightBit, search.ResultMemSize());
+        Assert::AreEqual(MemSize::Bit_0, search.ResultMemSize());
         Assert::AreEqual({ 0U }, search.GetResultCount());
 
         Assert::AreEqual(std::wstring(L""), search.GetFilterRange());
         Assert::AreEqual(std::wstring(L""), search.GetFilterValue());
 
-        Assert::AreEqual({ 3U }, search.SearchTypes().Count());
+        Assert::AreEqual({ 4U }, search.SearchTypes().Count());
         Assert::AreEqual((int)ra::services::SearchType::FourBit, search.SearchTypes().GetItemAt(0)->GetId());
         Assert::AreEqual(std::wstring(L"4-bit"), search.SearchTypes().GetItemAt(0)->GetLabel());
         Assert::AreEqual((int)ra::services::SearchType::EightBit, search.SearchTypes().GetItemAt(1)->GetId());
         Assert::AreEqual(std::wstring(L"8-bit"), search.SearchTypes().GetItemAt(1)->GetLabel());
         Assert::AreEqual((int)ra::services::SearchType::SixteenBit, search.SearchTypes().GetItemAt(2)->GetId());
         Assert::AreEqual(std::wstring(L"16-bit"), search.SearchTypes().GetItemAt(2)->GetLabel());
+        Assert::AreEqual((int)ra::services::SearchType::ThirtyTwoBit, search.SearchTypes().GetItemAt(3)->GetId());
+        Assert::AreEqual(std::wstring(L"32-bit"), search.SearchTypes().GetItemAt(3)->GetLabel());
         Assert::AreEqual(ra::services::SearchType::EightBit, search.GetSearchType());
 
         Assert::AreEqual({ 6U }, search.ComparisonTypes().Count());


### PR DESCRIPTION
implements #477 

![image](https://user-images.githubusercontent.com/32680403/79178172-beb64d80-7dc1-11ea-9f5e-d18fa0f58762.png)

includes some refactoring in `SearchResults` to move search-specific functionality into subclasses rather than switch statements.