### PR TITLE
truncate tooltip for condition address to 20 lines

### DIFF
--- a/src/RA_Dlg_AchEditor.cpp
+++ b/src/RA_Dlg_AchEditor.cpp
@@ -1947,7 +1947,34 @@ void Dlg_AchievementEditor::GetListViewTooltip()
 
     const auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::GameContext>();
     const auto* pNote = pGameContext.FindCodeNote(nAddr);
-    m_sTooltip = NativeStr(ra::StringPrintf(L"%s\r\n%s", ra::ByteAddressToString(nAddr), pNote ? *pNote : L""));
+    if (!pNote)
+    {
+        m_sTooltip = NativeStr(ra::StringPrintf(L"%s\r\n", ra::ByteAddressToString(nAddr)));
+    }
+    else
+    {
+        size_t nLines = 0;
+        size_t nIndex = 0;
+        do
+        {
+            nIndex = pNote->find('\n', nIndex);
+            if (nIndex == std::string::npos)
+                break;
+
+            ++nIndex;
+            ++nLines;
+        } while (nLines < 20);
+
+        if (nIndex != std::string::npos && pNote->find('\n', nIndex) != std::string::npos)
+        {
+            std::wstring sSubString(*pNote, 0, nIndex);
+            m_sTooltip = NativeStr(ra::StringPrintf(L"%s\r\n%s...", ra::ByteAddressToString(nAddr), sSubString));
+        }
+        else
+        {
+            m_sTooltip = NativeStr(ra::StringPrintf(L"%s\r\n%s", ra::ByteAddressToString(nAddr), *pNote));
+        }
+    }
 }
 
 GSL_SUPPRESS_CON4


### PR DESCRIPTION
prevents weird flashing behavior when tooltip height exceeds screen height by truncating the code note to 20 lines before inserting it into the tooltip