### PR TITLE
make code notes window modal; close on row double click

### DIFF
--- a/src/ui/viewmodels/MemoryInspectorViewModel.cpp
+++ b/src/ui/viewmodels/MemoryInspectorViewModel.cpp
@@ -224,7 +224,7 @@ void MemoryInspectorViewModel::DeleteCurrentAddressNote()
 void MemoryInspectorViewModel::OpenNotesList()
 {
     auto& pWindowManager = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::WindowManager>();
-    pWindowManager.CodeNotes.Show();
+    pWindowManager.CodeNotes.ShowModal(*this);
 }
 
 void MemoryInspectorViewModel::ToggleBit(int nBit)

--- a/src/ui/win32/CodeNotesDialog.cpp
+++ b/src/ui/win32/CodeNotesDialog.cpp
@@ -103,10 +103,10 @@ BOOL CodeNotesDialog::OnInitDialog()
     m_bindFilterValue.SetControl(*this, IDC_RA_FILTER_VALUE);
 
     auto* vmCodeNotes = dynamic_cast<CodeNotesViewModel*>(&m_vmWindow);
-    for (gsl::index nIndex = 0; nIndex < vmCodeNotes->Notes().Count(); ++nIndex)
+    for (gsl::index nIndex = 0; nIndex < gsl::narrow_cast<gsl::index>(vmCodeNotes->Notes().Count()); ++nIndex)
     {
         auto* pItem = vmCodeNotes->Notes().GetItemAt(nIndex);
-        if (pItem->IsSelected())
+        if (pItem && pItem->IsSelected())
         {
             m_bindNotes.EnsureVisible(nIndex);
             break;

--- a/src/ui/win32/CodeNotesDialog.cpp
+++ b/src/ui/win32/CodeNotesDialog.cpp
@@ -130,6 +130,7 @@ BOOL CodeNotesDialog::OnCommand(WORD nCommand)
             return TRUE;
         }
 
+        case IDOK: // this dialog doesn't have an OK button. if the user pressed Enter, apply the current filter
         case IDC_RA_APPLY_FILTER:
         {
             auto* vmCodeNotes = dynamic_cast<CodeNotesViewModel*>(&m_vmWindow);

--- a/src/ui/win32/CodeNotesDialog.cpp
+++ b/src/ui/win32/CodeNotesDialog.cpp
@@ -49,39 +49,10 @@ void CodeNotesDialog::Presenter::OnClosed() noexcept { m_pDialog.reset(); }
 
 // ------------------------------------
 
-class GridAddressRangeColumnBinding : public ra::ui::win32::bindings::GridTextColumnBinding
-{
-public:
-    GridAddressRangeColumnBinding(const StringModelProperty& pBoundProperty) noexcept
-        : GridTextColumnBinding(pBoundProperty)
-    {
-    }
-
-    bool HandleDoubleClick(const ra::ui::ViewModelCollectionBase& vmItems, gsl::index nIndex) override
-    {
-#ifndef RA_UTEST
-        const auto* pItems = dynamic_cast<const ra::ui::ViewModelCollection<CodeNotesViewModel::CodeNoteViewModel>*>(&vmItems);
-        if (pItems)
-        {
-            const auto* pItem = pItems->GetItemAt(nIndex);
-            if (pItem)
-            {
-                auto& pWindowManager = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::WindowManager>();
-                pWindowManager.MemoryInspector.SetCurrentAddress(pItem->nAddress);
-
-                auto& pDesktop = ra::services::ServiceLocator::Get<ra::ui::IDesktop>();
-                pDesktop.CloseWindow(pWindowManager.CodeNotes);
-            }
-        }
-#endif
-        return true;
-    }
-};
-
 CodeNotesDialog::CodeNotesDialog(CodeNotesViewModel& vmCodeNotes)
     : DialogBase(vmCodeNotes),
-      m_bindNotes(vmCodeNotes),
-      m_bindFilterValue(vmCodeNotes)
+    m_bindNotes(vmCodeNotes),
+    m_bindFilterValue(vmCodeNotes)
 {
     m_bindWindow.SetInitialPosition(RelativePosition::After, RelativePosition::Near, "Code Notes");
 
@@ -89,7 +60,7 @@ CodeNotesDialog::CodeNotesDialog(CodeNotesViewModel& vmCodeNotes)
 
     m_bindWindow.BindLabel(IDC_RA_RESULT_COUNT, CodeNotesViewModel::ResultCountProperty);
 
-    auto pAddressColumn = std::make_unique<GridAddressRangeColumnBinding>(
+    auto pAddressColumn = std::make_unique<ra::ui::win32::bindings::GridTextColumnBinding>(
         CodeNotesViewModel::CodeNoteViewModel::LabelProperty);
     pAddressColumn->SetHeader(L"Address");
     pAddressColumn->SetWidth(GridColumnBinding::WidthType::Pixels, 60);
@@ -104,6 +75,19 @@ CodeNotesDialog::CodeNotesDialog(CodeNotesViewModel& vmCodeNotes)
 
     m_bindNotes.BindItems(vmCodeNotes.Notes());
     m_bindNotes.BindIsSelected(CodeNotesViewModel::CodeNoteViewModel::IsSelectedProperty);
+    m_bindNotes.SetDoubleClickHandler([this](gsl::index nIndex)
+    {
+        const auto* vmCodeNotes = dynamic_cast<CodeNotesViewModel*>(&m_vmWindow);
+        const auto* pItem = vmCodeNotes->Notes().GetItemAt(nIndex);
+        if (pItem)
+        {
+            auto& pWindowManager = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::WindowManager>();
+            pWindowManager.MemoryInspector.SetCurrentAddress(pItem->nAddress);
+
+            auto& pDesktop = ra::services::ServiceLocator::Get<ra::ui::IDesktop>();
+            pDesktop.CloseWindow(pWindowManager.CodeNotes);
+        }
+    });
 
     using namespace ra::bitwise_ops;
     SetAnchor(IDC_RA_FILTER_VALUE, Anchor::Top | Anchor::Left | Anchor::Right);
@@ -118,8 +102,20 @@ BOOL CodeNotesDialog::OnInitDialog()
     m_bindNotes.SetControl(*this, IDC_RA_LBX_ADDRESSES);
     m_bindFilterValue.SetControl(*this, IDC_RA_FILTER_VALUE);
 
+    auto* vmCodeNotes = dynamic_cast<CodeNotesViewModel*>(&m_vmWindow);
+    for (gsl::index nIndex = 0; nIndex < vmCodeNotes->Notes().Count(); ++nIndex)
+    {
+        auto* pItem = vmCodeNotes->Notes().GetItemAt(nIndex);
+        if (pItem->IsSelected())
+        {
+            m_bindNotes.EnsureVisible(nIndex);
+            break;
+        }
+    }
+
     return DialogBase::OnInitDialog();
 }
+
 
 BOOL CodeNotesDialog::OnCommand(WORD nCommand)
 {

--- a/src/ui/win32/CodeNotesDialog.hh
+++ b/src/ui/win32/CodeNotesDialog.hh
@@ -39,7 +39,7 @@ public:
 protected:
     BOOL OnInitDialog() override;
     BOOL OnCommand(WORD nCommand) override;
-    
+
 private:
     ra::ui::win32::bindings::MultiLineGridBinding m_bindNotes;
     ra::ui::win32::bindings::TextBoxBinding m_bindFilterValue;

--- a/src/ui/win32/Desktop.cpp
+++ b/src/ui/win32/Desktop.cpp
@@ -85,7 +85,7 @@ void Desktop::CloseWindow(WindowViewModelBase& vmViewModel) const noexcept
 {
     const auto* const pBinding = ra::ui::win32::bindings::WindowBinding::GetBindingFor(vmViewModel);
     if (pBinding != nullptr)
-        ::DestroyWindow(pBinding->GetHWnd());
+        ::SendMessage(pBinding->GetHWnd(), WM_COMMAND, IDCANCEL, 0);
 }
 
 void Desktop::GetWorkArea(ra::ui::Position& oUpperLeftCorner, ra::ui::Size& oSize) const

--- a/src/ui/win32/bindings/GridBinding.cpp
+++ b/src/ui/win32/bindings/GridBinding.cpp
@@ -496,6 +496,11 @@ void GridBinding::BindRowColor(const IntModelProperty& pRowColorProperty) noexce
     m_pRowColorProperty = &pRowColorProperty;
 }
 
+void GridBinding::SetDoubleClickHandler(std::function<void(gsl::index)> pHandler)
+{
+    m_pDoubleClickHandler = pHandler;
+}
+
 void GridBinding::Virtualize(const IntModelProperty& pScrollOffsetProperty, const IntModelProperty& pScrollMaximumProperty,
     std::function<void(gsl::index, gsl::index, bool)> pUpdateSelectedItems)
 {
@@ -923,7 +928,8 @@ void GridBinding::OnNmDblClick(const NMITEMACTIVATE* pnmItemActivate)
             return;
     }
 
-    // TODO: row-level double-click handler
+    if (m_pDoubleClickHandler)
+        m_pDoubleClickHandler(gsl::narrow_cast<gsl::index>(pnmItemActivate->iItem));
 }
 
 GridColumnBinding::InPlaceEditorInfo* GridBinding::GetIPEInfo(HWND hwnd) noexcept

--- a/src/ui/win32/bindings/GridBinding.hh
+++ b/src/ui/win32/bindings/GridBinding.hh
@@ -36,6 +36,8 @@ public:
     void BindIsSelected(const BoolModelProperty& pIsSelectedProperty) noexcept;
     void BindRowColor(const IntModelProperty& pRowColorProperty) noexcept;
 
+    void SetDoubleClickHandler(std::function<void(gsl::index)> pHandler);
+
     GSL_SUPPRESS_CON3 virtual LRESULT OnLvnItemChanging(const LPNMLISTVIEW pnmListView);
     GSL_SUPPRESS_CON3 virtual void OnLvnItemChanged(const LPNMLISTVIEW pnmListView);
     GSL_SUPPRESS_CON3 void OnLvnOwnerDrawStateChanged(const LPNMLVODSTATECHANGE pnmStateChanged);
@@ -104,6 +106,8 @@ private:
     std::function<void(gsl::index, gsl::index, bool)> m_pUpdateSelectedItems = nullptr;
 
     HWND m_hInPlaceEditor = nullptr;
+
+    std::function<void(gsl::index)> m_pDoubleClickHandler = nullptr;
 
     gsl::index m_nSortIndex = -1;
 

--- a/src/ui/win32/bindings/MultiLineGridBinding.cpp
+++ b/src/ui/win32/bindings/MultiLineGridBinding.cpp
@@ -387,6 +387,15 @@ void MultiLineGridBinding::OnNmDblClick(const NMITEMACTIVATE* pnmItemActivate)
     GridBinding::OnNmDblClick(&nmItemActivate);
 }
 
+void MultiLineGridBinding::EnsureVisible(gsl::index nIndex)
+{
+    if (nIndex < m_vItemMetrics.size())
+    {
+        const auto nLine = m_vItemMetrics.at(nIndex).nFirstLine;
+        ListView_EnsureVisible(m_hWnd, nLine, FALSE);
+    }
+}
+
 } // namespace bindings
 } // namespace win32
 } // namespace ui

--- a/src/ui/win32/bindings/MultiLineGridBinding.cpp
+++ b/src/ui/win32/bindings/MultiLineGridBinding.cpp
@@ -389,7 +389,7 @@ void MultiLineGridBinding::OnNmDblClick(const NMITEMACTIVATE* pnmItemActivate)
 
 void MultiLineGridBinding::EnsureVisible(gsl::index nIndex)
 {
-    if (nIndex < m_vItemMetrics.size())
+    if (nIndex < gsl::narrow_cast<gsl::index>(m_vItemMetrics.size()))
     {
         const auto nLine = m_vItemMetrics.at(nIndex).nFirstLine;
         ListView_EnsureVisible(m_hWnd, nLine, FALSE);

--- a/src/ui/win32/bindings/MultiLineGridBinding.hh
+++ b/src/ui/win32/bindings/MultiLineGridBinding.hh
@@ -26,6 +26,8 @@ public:
     void OnNmClick(const NMITEMACTIVATE* pnmItemActivate) override;
     void OnNmDblClick(const NMITEMACTIVATE* pnmItemActivate) override;
 
+    void EnsureVisible(gsl::index nIndex);
+
 protected:
     void UpdateAllItems() override;
     void UpdateItems(gsl::index nColumn) override;


### PR DESCRIPTION
Changes the automatic close behavior from double clicking the address to double clicking anywhere in the row.

Also scrolls to the last selected item when reopening the window and changes the behavior of pressing Enter in the filter field to perform the filter instead of closing the dialog.