### PR TITLE
include error message when reporting parse error

### DIFF
--- a/src/RA_Achievement.cpp
+++ b/src/RA_Achievement.cpp
@@ -178,7 +178,7 @@ void Achievement::RebuildTrigger()
 
             ra::ui::viewmodels::MessageBoxViewModel::ShowWarningMessage(
                 ra::StringPrintf(L"Unable to rebuild achievement: %s", Title()),
-                ra::StringPrintf(L"Parse error %d", nResult));
+                ra::StringPrintf(L"Parse error %d\n%s", nResult, rc_error_str(nResult)));
         }
 
         m_pTrigger = pRuntime.GetAchievementTrigger(ID());
@@ -408,7 +408,7 @@ void Achievement::GenerateConditions()
 
                 ra::ui::viewmodels::MessageBoxViewModel::ShowWarningMessage(
                     ra::StringPrintf(L"Unable to activate achievement: %s", Title()),
-                    ra::StringPrintf(L"Parse error %d", nSize));
+                    ra::StringPrintf(L"Parse error %d\n%s", nSize, rc_error_str(nSize)));
 
                 return;
             }
@@ -515,7 +515,7 @@ void Achievement::SetActive(BOOL bActive) noexcept
 
                     ra::ui::viewmodels::MessageBoxViewModel::ShowWarningMessage(
                         ra::StringPrintf(L"Unable to activate achievement: %s", Title()),
-                        ra::StringPrintf(L"Parse error %d", nResult));
+                        ra::StringPrintf(L"Parse error %d\n%s", nResult, rc_error_str(nResult)));
                 }
             }
         }

--- a/src/RA_Leaderboard.cpp
+++ b/src/RA_Leaderboard.cpp
@@ -53,7 +53,7 @@ void RA_Leaderboard::SetActive(bool bActive) noexcept
 
                     ra::ui::viewmodels::MessageBoxViewModel::ShowWarningMessage(
                         ra::StringPrintf(L"Unable to activate leaderboard: %s", Title()),
-                        ra::StringPrintf(L"Parse error %d", nResult));
+                        ra::StringPrintf(L"Parse error %d\n%s", nResult, rc_error_str(nResult)));
                 }
             }
         }

--- a/src/services/AchievementRuntime.cpp
+++ b/src/services/AchievementRuntime.cpp
@@ -173,7 +173,7 @@ void AchievementRuntime::ActivateRichPresence(const std::string& sScript)
         const auto nResult = rc_runtime_activate_richpresence(&m_pRuntime, sScript.c_str(), nullptr, 0);
         if (nResult != RC_OK)
         {
-            const std::string sErrorRP = ra::StringPrintf("Parse error %d\n", nResult);
+            const std::string sErrorRP = ra::StringPrintf("Parse error %d: %s\n", nResult, rc_error_str(nResult));
             m_pRuntime.richpresence_display_buffer = _strdup(sErrorRP.c_str());
         }
     }

--- a/tests/ui/viewmodels/RichPresenceMonitorViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/RichPresenceMonitorViewModel_Tests.cpp
@@ -27,16 +27,16 @@ TEST_CLASS(RichPresenceMonitorViewModel_Tests)
     class RichPresenceMonitorViewModelHarness : public RichPresenceMonitorViewModel
     {
     public:
-        RichPresenceMonitorViewModelHarness()
+        RichPresenceMonitorViewModelHarness() noexcept
         {
-            InitializeNotifyTargets();
+            GSL_SUPPRESS_F6 InitializeNotifyTargets();
         }
 
         ra::data::mocks::MockGameContext mockGameContext;
         ra::services::mocks::MockLocalStorage mockLocalStorage;
         ra::services::mocks::MockThreadPool mockThreadPool;
 
-        void UpdateDisplayString() { RichPresenceMonitorViewModel::UpdateDisplayString(); }
+        GSL_SUPPRESS_C128 void UpdateDisplayString() { RichPresenceMonitorViewModel::UpdateDisplayString(); }
     };
 
     TEST_METHOD(TestInitialization)


### PR DESCRIPTION
expands the cases where a Parse Error X is displayed to include a simple string elaborating what the code means.

![image](https://user-images.githubusercontent.com/32680403/79668240-786f3e80-8173-11ea-9a2d-6a5e1025bef5.png)
