### PR TITLE
allow achievement to trigger when manually activated and presently true

### DIFF
--- a/src/RA_Dlg_Achievement.cpp
+++ b/src/RA_Dlg_Achievement.cpp
@@ -825,6 +825,13 @@ INT_PTR Dlg_Achievements::AchievementsProc(HWND hDlg, UINT nMsg, WPARAM wParam, 
                             {
                                 Cheevo.SetActive(true);
 
+                                // SetActive will only set the state to WAITING. We want it to be immediately active
+                                // (i.e. it should immediately trigger if all the conditions are true).
+                                auto& pRuntime = ra::services::ServiceLocator::GetMutable<ra::services::AchievementRuntime>();
+                                auto* pTrigger = pRuntime.GetAchievementTrigger(Cheevo.ID());
+                                if (pTrigger->state == RC_TRIGGER_STATE_WAITING)
+                                    pTrigger->state = RC_TRIGGER_STATE_ACTIVE;
+
                                 if (m_nActiveCategory == Achievement::Category::Core)
                                     OnEditData(nSel, Column::Achieved, "No");
                                 else
@@ -862,6 +869,7 @@ INT_PTR Dlg_Achievements::AchievementsProc(HWND hDlg, UINT nMsg, WPARAM wParam, 
                         const size_t nSel = ListView_GetNextItem(hList, -1, LVNI_SELECTED);
 
                         size_t nIndex = 0;
+                        auto& pRuntime = ra::services::ServiceLocator::GetMutable<ra::services::AchievementRuntime>();
                         const auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::GameContext>();
                         for (auto nAchievementID : m_vAchievementIDs)
                         {
@@ -869,6 +877,12 @@ INT_PTR Dlg_Achievements::AchievementsProc(HWND hDlg, UINT nMsg, WPARAM wParam, 
                             if (!Cheevo.Active())
                             {
                                 Cheevo.SetActive(true);
+
+                                // SetActive will only set the state to WAITING. We want it to be immediately active
+                                // (i.e. it should immediately trigger if all the conditions are true).
+                                auto* pTrigger = pRuntime.GetAchievementTrigger(Cheevo.ID());
+                                if (pTrigger->state == RC_TRIGGER_STATE_WAITING)
+                                    pTrigger->state = RC_TRIGGER_STATE_ACTIVE;
 
                                 if (m_nActiveCategory == Achievement::Category::Core)
                                     OnEditData(nIndex, Column::Achieved, "No");


### PR DESCRIPTION
Because of the "must be false before it can be true" logic we use to prevent false triggers when starting a game, manually activating an achievement may not cause the achievement to trigger if it's true when activated. This forces the achievement to skip over the "must be false before it can be true logic" when manually activated (by button on achievements list or checkbox on achievement editor).