### PR TITLE
ensure notes are updated when dialog isn't visible

### DIFF
--- a/src/ui/viewmodels/CodeNotesViewModel.cpp
+++ b/src/ui/viewmodels/CodeNotesViewModel.cpp
@@ -35,14 +35,14 @@ void CodeNotesViewModel::OnViewModelBoolValueChanged(const BoolModelProperty::Ch
         auto& pGameContext = ra::services::ServiceLocator::GetMutable<ra::data::GameContext>();
         if (args.tNewValue)
         {
+            // don't subscribe until the first time the dialog is shown, but we have to keep
+            // the subscription while its closed to make sure the notes stay up-to-date
+            // call Remove before Add to ensure we're only subscribed once.
+            pGameContext.RemoveNotifyTarget(*this);
             pGameContext.AddNotifyTarget(*this);
 
             if (m_nGameId != pGameContext.GameId())
                 OnActiveGameChanged();
-        }
-        else
-        {
-            pGameContext.RemoveNotifyTarget(*this);
         }
     }
 }

--- a/tests/ui/viewmodels/CodeNotesViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/CodeNotesViewModel_Tests.cpp
@@ -310,6 +310,34 @@ public:
         AssertRow(notes, 2, 0x0030, L"0x0030", L"Item 1 Quantity");
     }
 
+    TEST_METHOD(TestUpdateNoteDialogNotVisible)
+    {
+        CodeNotesViewModelHarness notes;
+        notes.PopulateNotes();
+        Assert::AreEqual({ 0U }, notes.Notes().Count());
+
+        // update before dialog is visible will be picked up when first made visible
+        notes.mockGameContext.SetCodeNote(0x0030, L"Item 1b");
+        Assert::AreEqual({ 0U }, notes.Notes().Count());
+
+        notes.SetIsVisible(true);
+        Assert::AreEqual({ 14U }, notes.Notes().Count());
+
+        notes.SetFilterValue(L"em");
+        notes.ApplyFilter();
+        Assert::AreEqual({ 6U }, notes.Notes().Count());
+        Assert::AreEqual(std::wstring(L"6/14"), notes.GetResultCount());
+        AssertRow(notes, 1, 0x0030, L"0x0030", L"Item 1b");
+
+        notes.SetIsVisible(false);
+
+        // change should be picked up even if not visible
+        notes.mockGameContext.SetCodeNote(0x0030, L"Item 1s");
+        Assert::AreEqual({ 6U }, notes.Notes().Count());
+        Assert::AreEqual(std::wstring(L"6/14"), notes.GetResultCount());
+        AssertRow(notes, 1, 0x0030, L"0x0030", L"Item 1s");
+    }
+
     TEST_METHOD(TestRemoveNoteUnfiltered)
     {
         CodeNotesViewModelHarness notes;


### PR DESCRIPTION
more prominent with changes made in #536. now it's impossible to modify notes without closing the dialog.