### PR TITLE
prefer server response over http response

### DIFF
--- a/src/api/impl/ConnectedServer.cpp
+++ b/src/api/impl/ConnectedServer.cpp
@@ -40,22 +40,17 @@ _NODISCARD static bool GetJson([[maybe_unused]] _In_ const char* sApiName,
                                _In_ const ra::services::Http::Response& httpResponse,
                                _Inout_ ApiResponseBase& pResponse, _Out_ rapidjson::Document& pDocument)
 {
-    /*this function can throw std::bad_alloc (from the strings allocator) but very low chance*/
-    if (HandleHttpError(httpResponse, pResponse))
-    {
-        pDocument.SetArray();
-
-        RA_LOG_ERR("-- %s: %s", sApiName, pResponse.ErrorMessage.c_str());
-        return false;
-    }
-
     if (httpResponse.Content().empty())
     {
         pDocument.SetArray();
 
-        RA_LOG_ERR("-- %s: Empty JSON response", sApiName);
-        pResponse.Result = ApiResult::Failed;
-        pResponse.ErrorMessage = "Empty JSON response";
+        if (!HandleHttpError(httpResponse, pResponse))
+        {
+            pResponse.ErrorMessage = "Empty JSON response";
+            pResponse.Result = ApiResult::Failed;
+        }
+
+        RA_LOG_ERR("-- %s: %s", sApiName, pResponse.ErrorMessage.c_str());
         return false;
     }
 
@@ -64,6 +59,12 @@ _NODISCARD static bool GetJson([[maybe_unused]] _In_ const char* sApiName,
     pDocument.Parse(httpResponse.Content());
     if (pDocument.HasParseError())
     {
+        if (HandleHttpError(httpResponse, pResponse))
+        {
+            RA_LOG_ERR("-- %s: %s", sApiName, pResponse.ErrorMessage.c_str());
+            return false;
+        }
+
         RA_LOG_ERR("-- %s: JSON Parse Error encountered!", sApiName);
 
         pResponse.Result = ApiResult::Error;
@@ -111,6 +112,12 @@ _NODISCARD static bool GetJson([[maybe_unused]] _In_ const char* sApiName,
     {
         pResponse.Result = ApiResult::Failed;
         RA_LOG_ERR("-- %s Error: Success=false", sApiName);
+        return false;
+    }
+
+    if (HandleHttpError(httpResponse, pResponse))
+    {
+        RA_LOG_ERR("-- %s: %s", sApiName, pResponse.ErrorMessage.c_str());
         return false;
     }
 

--- a/src/services/Http.hh
+++ b/src/services/Http.hh
@@ -13,6 +13,8 @@ public:
     enum class StatusCode
     {
         OK = 200,
+        Unauthorized = 401,
+        Forbidden = 403,
         NotFound = 404,
     };
 


### PR DESCRIPTION
Now that the server returns an HTTP error code of 401 on invalid login, the error message was being ignored and a generic "HTTP error 401" message was being displayed. This inverts the logic so the error message returned by the server will be given preference.