### PR TITLE
add Initial Value filter type

### DIFF
--- a/src/services/SearchResults.h
+++ b/src/services/SearchResults.h
@@ -22,6 +22,7 @@ enum class SearchFilterType
     LastKnownValue,
     LastKnownValuePlus,
     LastKnownValueMinus,
+    InitialValue,
 };
 
 namespace impl {
@@ -108,7 +109,7 @@ public:
     void Initialize(ra::ByteAddress nAddress, size_t nBytes, SearchType nType);
 
     /// <summary>
-    /// Initializes a result set by comparing against the another result set.
+    /// Initializes a result set by comparing against another result set.
     /// </summary>
     /// <param name="srSource">The result set to filter.</param>
     /// <param name="nCompareType">Type of comparison to apply.</param>
@@ -116,6 +117,17 @@ public:
     /// <param name="nFilterValue">Parameter for filter being applied.</param>
     void Initialize(_In_ const SearchResults& srSource, _In_ ComparisonType nCompareType,
         _In_ SearchFilterType nFilterType, _In_ unsigned int nFilterValue);
+
+    /// <summary>
+    /// Initializes a result set by comparing against another result set using the address filter from a third set.
+    /// </summary>
+    /// <param name="srSource">The result set to filter.</param>
+    /// <param name="srAddresses">The result set specifying which addresses to examine.</param>
+    /// <param name="nCompareType">Type of comparison to apply.</param>
+    /// <param name="nFilterType">Type of filter to apply.</param>
+    /// <param name="nFilterValue">Parameter for filter being applied.</param>
+    void Initialize(_In_ const SearchResults& srSource, _In_ const SearchResults& srAddresses,
+        _In_ ComparisonType nCompareType, _In_ SearchFilterType nFilterType, _In_ unsigned int nFilterValue);
 
     /// <summary>
     /// Gets the number of matching addresses.

--- a/tests/ui/viewmodels/MemorySearchViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/MemorySearchViewModel_Tests.cpp
@@ -150,7 +150,7 @@ public:
         Assert::AreEqual(std::wstring(L"!="), search.ComparisonTypes().GetItemAt(5)->GetLabel());
         Assert::AreEqual(ComparisonType::Equals, search.GetComparisonType());
 
-        Assert::AreEqual({ 4U }, search.ValueTypes().Count());
+        Assert::AreEqual({ 5U }, search.ValueTypes().Count());
         Assert::AreEqual((int)ra::services::SearchFilterType::Constant, search.ValueTypes().GetItemAt(0)->GetId());
         Assert::AreEqual(std::wstring(L"Constant"), search.ValueTypes().GetItemAt(0)->GetLabel());
         Assert::AreEqual((int)ra::services::SearchFilterType::LastKnownValue, search.ValueTypes().GetItemAt(1)->GetId());
@@ -159,6 +159,8 @@ public:
         Assert::AreEqual(std::wstring(L"Last Value Plus"), search.ValueTypes().GetItemAt(2)->GetLabel());
         Assert::AreEqual((int)ra::services::SearchFilterType::LastKnownValueMinus, search.ValueTypes().GetItemAt(3)->GetId());
         Assert::AreEqual(std::wstring(L"Last Value Minus"), search.ValueTypes().GetItemAt(3)->GetLabel());
+        Assert::AreEqual((int)ra::services::SearchFilterType::InitialValue, search.ValueTypes().GetItemAt(4)->GetId());
+        Assert::AreEqual(std::wstring(L"Initial Value"), search.ValueTypes().GetItemAt(4)->GetLabel());
 
         Assert::AreEqual(ra::services::SearchFilterType::LastKnownValue, search.GetValueType());
 
@@ -357,11 +359,10 @@ public:
         Assert::AreEqual({ 1U }, search.Results().Count());
         AssertRow(search, 0, 12U, L"0x000c", L"0x09", L"0x0c");
 
-        // if results don't change and filter doesn't change, don't generate a new page
         search.memory.at(12) = 7;
         search.ApplyFilter();
         Assert::AreEqual({ 0 }, search.GetScrollOffset());
-        Assert::AreEqual(std::wstring(L"1/1"), search.GetSelectedPage());
+        Assert::AreEqual(std::wstring(L"2/2"), search.GetSelectedPage());
         Assert::AreEqual({ 1U }, search.GetResultCount());
         Assert::AreEqual(std::wstring(L"1"), search.GetResultCountText());
         Assert::AreEqual(MemSize::EightBit, search.ResultMemSize());
@@ -369,8 +370,7 @@ public:
 
         Assert::AreEqual({ 1U }, search.Results().Count());
 
-        // NOTE: current value is still old value. it will be updated by DoFrame, and normally memory would only be updated by DoFrame as well
-        AssertRow(search, 0, 12U, L"0x000c", L"0x09", L"0x0c");
+        AssertRow(search, 0, 12U, L"0x000c", L"0x07", L"0x09");
     }
 
     TEST_METHOD(TestApplyFilterEightBitLastKnownNoChange)
@@ -452,6 +452,44 @@ public:
 
         Assert::AreEqual({ 1U }, search.Results().Count());
         AssertRow(search, 0, 12U, L"0x000c", L"0x0a", L"0x0c");
+    }
+
+    TEST_METHOD(TestApplyFilterEightBitCompareToInitialValue)
+    {
+        MemorySearchViewModelHarness search;
+        search.InitializeMemory();
+        search.BeginNewSearch();
+
+        search.SetComparisonType(ComparisonType::GreaterThan);
+        search.SetValueType(ra::services::SearchFilterType::InitialValue);
+        Assert::IsFalse(search.CanEditFilterValue());
+
+        search.memory.at(10) = 20;
+        search.memory.at(20) = 30;
+        search.ApplyFilter();
+        Assert::AreEqual({ 0 }, search.GetScrollOffset());
+        Assert::AreEqual(std::wstring(L"1/1"), search.GetSelectedPage());
+        Assert::AreEqual({ 2U }, search.GetResultCount());
+        Assert::AreEqual(std::wstring(L"2"), search.GetResultCountText());
+        Assert::AreEqual(MemSize::EightBit, search.ResultMemSize());
+        Assert::AreEqual(std::wstring(L"> Initial"), search.GetFilterSummary());
+
+        Assert::AreEqual({ 2U }, search.Results().Count());
+        AssertRow(search, 0, 10U, L"0x000a", L"0x14", L"0x0a");
+        AssertRow(search, 1, 20U, L"0x0014", L"0x1e", L"0x14");
+
+        // 15 is still greater than initial value (10), but less than current value (20).
+        search.memory.at(10) = 15;
+        search.ApplyFilter();
+        Assert::AreEqual({ 2U }, search.Results().Count());
+        AssertRow(search, 0, 10U, L"0x000a", L"0x0f", L"0x0a");
+        AssertRow(search, 1, 20U, L"0x0014", L"0x1e", L"0x14");
+
+        // 5 is less than initial value and should be filtered out.
+        search.memory.at(10) = 5;
+        search.ApplyFilter();
+        Assert::AreEqual({ 1U }, search.Results().Count());
+        AssertRow(search, 0, 20U, L"0x0014", L"0x1e", L"0x14");
     }
 
     TEST_METHOD(TestDoFrameEightBit)


### PR DESCRIPTION
implements #175 

Behaves similar to Last Value, but instead of comparing against the value captured by the last filtering, it compares against the value captured when starting a "new search".