### PR TITLE
add continuous filter

### DIFF
--- a/src/ui/viewmodels/MemorySearchViewModel.cpp
+++ b/src/ui/viewmodels/MemorySearchViewModel.cpp
@@ -38,6 +38,8 @@ const StringModelProperty MemorySearchViewModel::SelectedPageProperty("MemorySea
 const BoolModelProperty MemorySearchViewModel::CanBeginNewSearchProperty("MemorySearchViewModel", "CanBeginNewSearch", true);
 const BoolModelProperty MemorySearchViewModel::CanFilterProperty("MemorySearchViewModel", "CanFilter", true);
 const BoolModelProperty MemorySearchViewModel::CanEditFilterValueProperty("MemorySearchViewModel", "CanEditFilterValue", true);
+const BoolModelProperty MemorySearchViewModel::CanContinuousFilterProperty("MemorySearchViewModel", "CanContinuousFilter", true);
+const StringModelProperty MemorySearchViewModel::ContinuousFilterLabelProperty("MemorySearchViewModel", "ContinuousFilterLabel", L"Continuous Filter");
 const BoolModelProperty MemorySearchViewModel::CanGoToPreviousPageProperty("MemorySearchViewModel", "CanGoToPreviousPage", true);
 const BoolModelProperty MemorySearchViewModel::CanGoToNextPageProperty("MemorySearchViewModel", "CanGoToNextPage", false);
 const BoolModelProperty MemorySearchViewModel::HasSelectionProperty("MemorySearchViewModel", "HasSelection", false);
@@ -333,6 +335,12 @@ void MemorySearchViewModel::DoFrame()
     if (m_vSearchResults.size() < 2)
         return;
 
+    if (m_bIsContinuousFiltering)
+    {
+        ApplyContinuousFilter();
+        return;
+    }
+
     m_bNeedsRedraw = false;
     m_vResults.BeginUpdate();
 
@@ -468,6 +476,9 @@ void MemorySearchViewModel::BeginNewSearch()
         return;
     }
 
+    if (m_bIsContinuousFiltering)
+        ToggleContinuousFilter();
+
     m_vSelectedAddresses.clear();
 
     m_vSearchResults.clear();
@@ -588,6 +599,45 @@ void MemorySearchViewModel::ApplyFilter()
     ChangePage(m_nSelectedSearchResult);
 }
 
+void MemorySearchViewModel::ToggleContinuousFilter()
+{
+    if (m_bIsContinuousFiltering)
+    {
+        m_bIsContinuousFiltering = false;
+        SetValue(CanFilterProperty, GetResultCount() > 0);
+        SetValue(ContinuousFilterLabelProperty, ContinuousFilterLabelProperty.GetDefaultValue());
+    }
+    else
+    {
+        m_bIsContinuousFiltering = true;
+        SetValue(CanFilterProperty, false);
+        SetValue(ContinuousFilterLabelProperty, L"Stop Filtering");
+
+        ApplyFilter();
+    }
+}
+
+void MemorySearchViewModel::ApplyContinuousFilter()
+{
+    const SearchResult& pResult = m_vSearchResults.back();
+    SearchResult pNewResult;
+
+    // apply the current filter
+    pNewResult.pResults.Initialize(pResult.pResults, pResult.pResults.GetFilterComparison(),
+        pResult.pResults.GetFilterType(), pResult.pResults.GetFilterValue());
+    pNewResult.sSummary = pResult.sSummary;
+
+    // replace the last item with the new results
+    m_vSearchResults.erase(m_vSearchResults.end() - 1);
+    m_vSearchResults.push_back(pNewResult);
+
+    ChangePage(m_nSelectedSearchResult);
+
+    // if no results are remaining, stop filtering
+    if (m_vSearchResults.back().pResults.MatchingAddressCount() == 0)
+        ToggleContinuousFilter();
+}
+
 void MemorySearchViewModel::ChangePage(size_t nNewPage)
 {
     m_nSelectedSearchResult = nNewPage;
@@ -684,7 +734,7 @@ void MemorySearchViewModel::UpdateResults()
 
         pRow->SetSelected(m_vSelectedAddresses.find(pRow->nAddress) != m_vSelectedAddresses.end());
 
-        pRow->bMatchesFilter = TestFilter(pResult, pCurrentResults, nPreviousValue);
+        pRow->bMatchesFilter = !m_bIsContinuousFiltering || TestFilter(pResult, pCurrentResults, nPreviousValue);
         pRow->bHasBookmark = vmBookmarks.HasBookmark(pResult.nAddress);
         pRow->bHasBeenModified = (pCurrentResults.vModifiedAddresses.find(pRow->nAddress) != pCurrentResults.vModifiedAddresses.end());
         pRow->UpdateRowColor();
@@ -744,9 +794,15 @@ void MemorySearchViewModel::OnViewModelBoolValueChanged(const BoolModelProperty:
     else if (args.Property == CanBeginNewSearchProperty)
     {
         if (args.tNewValue)
+        {
             SetValue(CanFilterProperty, GetResultCount() > 0);
+            SetValue(CanContinuousFilterProperty, GetResultCount() > 0);
+        }
         else
+        {
             SetValue(CanFilterProperty, false);
+            SetValue(CanContinuousFilterProperty, false);
+        }
     }
 }
 
@@ -759,7 +815,8 @@ void MemorySearchViewModel::OnViewModelIntValueChanged(const IntModelProperty::C
     else if (args.Property == ResultCountProperty)
     {
         SetValue(ResultCountTextProperty, std::to_wstring(args.tNewValue));
-        SetValue(CanFilterProperty, args.tNewValue > 0);
+        SetValue(CanFilterProperty, !m_bIsContinuousFiltering && (args.tNewValue > 0));
+        SetValue(CanContinuousFilterProperty, args.tNewValue > 0);
     }
     else if (args.Property == ValueTypeProperty)
     {
@@ -813,7 +870,12 @@ void MemorySearchViewModel::PreviousPage()
 {
     // at least two pages (initialization and first filter) must be avaiable to go back to
     if (m_nSelectedSearchResult > 1)
+    {
+        if (m_bIsContinuousFiltering)
+            ToggleContinuousFilter();
+
         ChangePage(m_nSelectedSearchResult - 1);
+    }
 }
 
 void MemorySearchViewModel::SelectRange(gsl::index nFrom, gsl::index nTo, bool bValue)

--- a/src/ui/viewmodels/MemorySearchViewModel.hh
+++ b/src/ui/viewmodels/MemorySearchViewModel.hh
@@ -475,6 +475,7 @@ private:
 
     ViewModelCollection<SearchResultViewModel> m_vResults;
     bool m_bIsContinuousFiltering = false;
+    int m_nOversizedContinuousFilterFrames = 0;
     bool m_bNeedsRedraw = false;
 
     struct SearchResult

--- a/src/ui/viewmodels/MemorySearchViewModel.hh
+++ b/src/ui/viewmodels/MemorySearchViewModel.hh
@@ -429,6 +429,10 @@ public:
     static const BoolModelProperty CanFilterProperty;
     static const BoolModelProperty CanEditFilterValueProperty;
 
+    void ToggleContinuousFilter();
+    static const BoolModelProperty CanContinuousFilterProperty;
+    static const StringModelProperty ContinuousFilterLabelProperty;
+
     /// <summary>
     /// Excludes the currently selected items from the search results.
     /// </summary>
@@ -456,6 +460,7 @@ protected:
 
 private:
     bool ParseFilterRange(_Out_ ra::ByteAddress& nStart, _Out_ ra::ByteAddress& nEnd);
+    void ApplyContinuousFilter();
     void UpdateResults();
     void AddNewPage();
     void ChangePage(size_t nNewPage);
@@ -469,6 +474,7 @@ private:
     LookupItemViewModelCollection m_vValueTypes;
 
     ViewModelCollection<SearchResultViewModel> m_vResults;
+    bool m_bIsContinuousFiltering = false;
     bool m_bNeedsRedraw = false;
 
     struct SearchResult

--- a/src/ui/viewmodels/MemorySearchViewModel.hh
+++ b/src/ui/viewmodels/MemorySearchViewModel.hh
@@ -475,7 +475,7 @@ private:
 
     ViewModelCollection<SearchResultViewModel> m_vResults;
     bool m_bIsContinuousFiltering = false;
-    int m_nOversizedContinuousFilterFrames = 0;
+    std::chrono::steady_clock::time_point m_tLastContinuousFilter;
     bool m_bNeedsRedraw = false;
 
     struct SearchResult

--- a/src/ui/win32/MemoryInspectorDialog.cpp
+++ b/src/ui/win32/MemoryInspectorDialog.cpp
@@ -145,7 +145,8 @@ MemoryInspectorDialog::MemoryInspectorDialog(MemoryInspectorViewModel& vmMemoryI
     m_bindWindow.BindEnabled(IDC_RA_SPECIAL_FILTER, MemorySearchViewModel::CanFilterProperty);
     m_bindWindow.BindEnabled(IDC_RA_FILTER_VALUE, MemorySearchViewModel::CanEditFilterValueProperty);
     m_bindWindow.BindEnabled(IDC_RA_APPLY_FILTER, MemorySearchViewModel::CanFilterProperty);
-    m_bindWindow.BindEnabled(IDC_RA_CONTINUOUS_FILTER, MemorySearchViewModel::CanFilterProperty);
+    m_bindWindow.BindEnabled(IDC_RA_CONTINUOUS_FILTER, MemorySearchViewModel::CanContinuousFilterProperty);
+    m_bindWindow.BindLabel(IDC_RA_CONTINUOUS_FILTER, MemorySearchViewModel::ContinuousFilterLabelProperty);
 
     // Results
     m_bindWindow.BindLabel(IDC_RA_RESULT_COUNT, MemorySearchViewModel::ResultCountTextProperty);
@@ -286,8 +287,6 @@ BOOL MemoryInspectorDialog::OnInitDialog()
     SetWindowFont(GetDlgItem(GetHWND(), IDC_RA_MEMBITS), GetStockObject(SYSTEM_FIXED_FONT), TRUE);
     SetWindowFont(GetDlgItem(GetHWND(), IDC_RA_MEMBITS_TITLE), GetStockObject(SYSTEM_FIXED_FONT), TRUE);
 
-    ShowWindow(GetDlgItem(GetHWND(), IDC_RA_CONTINUOUS_FILTER), SW_HIDE);
-
     return DialogBase::OnInitDialog();
 }
 
@@ -309,6 +308,15 @@ BOOL MemoryInspectorDialog::OnCommand(WORD nCommand)
             auto* vmMemoryInspector = dynamic_cast<MemoryInspectorViewModel*>(&m_vmWindow);
             if (vmMemoryInspector)
                 vmMemoryInspector->Search().ApplyFilter();
+
+            return TRUE;
+        }
+
+        case IDC_RA_CONTINUOUS_FILTER:
+        {
+            auto* vmMemoryInspector = dynamic_cast<MemoryInspectorViewModel*>(&m_vmWindow);
+            if (vmMemoryInspector)
+                vmMemoryInspector->Search().ToggleContinuousFilter();
 
             return TRUE;
         }

--- a/src/ui/win32/bindings/WindowBinding.cpp
+++ b/src/ui/win32/bindings/WindowBinding.cpp
@@ -256,15 +256,20 @@ void WindowBinding::OnViewModelBoolValueChanged(const BoolModelProperty::ChangeA
     const auto pEnabledIter = m_mEnabledBindings.find(args.Property.GetKey());
     if (pEnabledIter != m_mEnabledBindings.end())
     {
+        bool bRepaint = false;
+
         for (const auto nDlgItemId : pEnabledIter->second)
         {
             auto hControl = GetDlgItem(m_hWnd, nDlgItemId);
             if (hControl)
             {
                 EnableWindow(hControl, args.tNewValue ? TRUE : FALSE);
-                ControlBinding::ForceRepaint(hControl);
+                bRepaint = true;
             }
         }
+
+        if (bRepaint)
+            ControlBinding::ForceRepaint(m_hWnd);
     }
 }
 

--- a/tests/ui/viewmodels/MemorySearchViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/MemorySearchViewModel_Tests.cpp
@@ -3,6 +3,7 @@
 #include "ui\viewmodels\MemorySearchViewModel.hh"
 
 #include "tests\RA_UnitTestHelpers.h"
+#include "tests\mocks\MockClock.hh"
 #include "tests\mocks\MockConfiguration.hh"
 #include "tests\mocks\MockConsoleContext.hh"
 #include "tests\mocks\MockDesktop.hh"
@@ -77,6 +78,7 @@ private:
         ra::data::mocks::MockConsoleContext mockConsoleContext;
         ra::data::mocks::MockEmulatorContext mockEmulatorContext;
         ra::data::mocks::MockGameContext mockGameContext;
+        ra::services::mocks::MockClock mockClock;
         ra::services::mocks::MockConfiguration mockConfiguration;
         ra::ui::mocks::MockDesktop mockDesktop;
         ra::ui::viewmodels::mocks::MockWindowManager mockWindowManager;


### PR DESCRIPTION
Implements #107

Press once to start filtering, press again to stop filtering. While filtering, the current filter will automatically be applied every frame. 

The continuous filter results are applied to the same record in the search history. For Last Value comparisons, the filter _will_ look at the value from the previous frame, but after the next frame that data is no longer available. Going back one step in the history (<< button) will go back to the state before starting the continuous filter.

Note: this has significant overhead when there are more than a couple thousand results. To account for this, if the number of results does not drop to a reasonable level within 60 frames, it will automatically be stopped and the user will be warned to try again with fewer results.