### PR TITLE
use rcheevos for managing runtime state

### DIFF
--- a/src/RA_Achievement.cpp
+++ b/src/RA_Achievement.cpp
@@ -244,8 +244,8 @@ static constexpr MemSize GetCompVariableSize(char nOperandSize) noexcept
             return MemSize::TwentyFourBit;
         case RC_MEMSIZE_32_BITS:
             return MemSize::ThirtyTwoBit;
-        case RC_MEMSIZE_8_BITS_BITCOUNT:
-            return MemSize::BitCount;
+//        case RC_MEMSIZE_BITCOUNT:
+//            return MemSize::BitCount;
         default:
             ASSERT(!"Unsupported operand size");
             return MemSize::EightBit;

--- a/src/api/impl/ConnectedServer.cpp
+++ b/src/api/impl/ConnectedServer.cpp
@@ -306,7 +306,7 @@ static bool DoUpload(const std::string& sHost, const char* restrict sApiName, co
     {
         const auto nLength = sPostData.length();
         sPostData.resize(gsl::narrow_cast<size_t>(nFileSize + nLength));
-        pFile->GetBytes(&sPostData.at(nLength), gsl::narrow_cast<size_t>(nFileSize));
+        pFile->GetBytes(reinterpret_cast<uint8_t*>(&sPostData.at(nLength)), gsl::narrow_cast<size_t>(nFileSize));
     }
 
     sPostData.append("\r\n");

--- a/src/api/impl/ConnectedServer.cpp
+++ b/src/api/impl/ConnectedServer.cpp
@@ -306,7 +306,9 @@ static bool DoUpload(const std::string& sHost, const char* restrict sApiName, co
     {
         const auto nLength = sPostData.length();
         sPostData.resize(gsl::narrow_cast<size_t>(nFileSize + nLength));
-        pFile->GetBytes(reinterpret_cast<uint8_t*>(&sPostData.at(nLength)), gsl::narrow_cast<size_t>(nFileSize));
+        uint8_t* pBytes;
+        GSL_SUPPRESS_TYPE1 pBytes = reinterpret_cast<uint8_t*>(&sPostData.at(nLength));
+        pFile->GetBytes(pBytes, gsl::narrow_cast<size_t>(nFileSize));
     }
 
     sPostData.append("\r\n");

--- a/src/rcheevos.vcxproj
+++ b/src/rcheevos.vcxproj
@@ -175,10 +175,12 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="..\rcheevos\include\rcheevos.h" />
+    <ClInclude Include="..\rcheevos\src\rcheevos\compat.h" />
     <ClInclude Include="..\rcheevos\src\rcheevos\internal.h" />
     <ClInclude Include="..\rcheevos\src\rhash\md5.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="..\rcheevos\src\rcheevos\compat.c" />
     <ClCompile Include="..\rcheevos\src\rcheevos\memref.c" />
     <ClCompile Include="..\rcheevos\src\rcheevos\richpresence.c" />
     <ClCompile Include="..\lua\lapi.c" />
@@ -205,12 +207,11 @@
     <ClCompile Include="..\rcheevos\src\rcheevos\alloc.c" />
     <ClCompile Include="..\rcheevos\src\rcheevos\condition.c" />
     <ClCompile Include="..\rcheevos\src\rcheevos\condset.c" />
-    <ClCompile Include="..\rcheevos\src\rcheevos\expression.c" />
     <ClCompile Include="..\rcheevos\src\rcheevos\format.c" />
     <ClCompile Include="..\rcheevos\src\rcheevos\lboard.c" />
     <ClCompile Include="..\rcheevos\src\rcheevos\operand.c" />
     <ClCompile Include="..\rcheevos\src\rcheevos\runtime.c" />
-    <ClCompile Include="..\rcheevos\src\rcheevos\term.c" />
+    <ClCompile Include="..\rcheevos\src\rcheevos\runtime_progress.c" />
     <ClCompile Include="..\rcheevos\src\rcheevos\trigger.c" />
     <ClCompile Include="..\rcheevos\src\rcheevos\value.c" />
     <ClCompile Include="..\rcheevos\src\rhash\md5.c" />

--- a/src/rcheevos.vcxproj.filters
+++ b/src/rcheevos.vcxproj.filters
@@ -76,16 +76,10 @@
     <ClCompile Include="..\rcheevos\src\rcheevos\condset.c">
       <Filter>rcheevos</Filter>
     </ClCompile>
-    <ClCompile Include="..\rcheevos\src\rcheevos\expression.c">
-      <Filter>rcheevos</Filter>
-    </ClCompile>
     <ClCompile Include="..\rcheevos\src\rcheevos\format.c">
       <Filter>rcheevos</Filter>
     </ClCompile>
     <ClCompile Include="..\rcheevos\src\rcheevos\operand.c">
-      <Filter>rcheevos</Filter>
-    </ClCompile>
-    <ClCompile Include="..\rcheevos\src\rcheevos\term.c">
       <Filter>rcheevos</Filter>
     </ClCompile>
     <ClCompile Include="..\rcheevos\src\rcheevos\trigger.c">
@@ -106,6 +100,12 @@
     <ClCompile Include="..\rcheevos\src\rhash\md5.c">
       <Filter>md5</Filter>
     </ClCompile>
+    <ClCompile Include="..\rcheevos\src\rcheevos\runtime_progress.c">
+      <Filter>rcheevos</Filter>
+    </ClCompile>
+    <ClCompile Include="..\rcheevos\src\rcheevos\compat.c">
+      <Filter>rcheevos</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\rcheevos\include\rcheevos.h">
@@ -116,6 +116,9 @@
     </ClInclude>
     <ClInclude Include="..\rcheevos\src\rhash\md5.h">
       <Filter>md5</Filter>
+    </ClInclude>
+    <ClInclude Include="..\rcheevos\src\rcheevos\compat.h">
+      <Filter>rcheevos</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/services/TextReader.hh
+++ b/src/services/TextReader.hh
@@ -34,12 +34,22 @@ public:
     /// <param name="pBuffer">The buffer to read into.</param>
     /// <param name="nBytes">The number of bytes to read.</param>
     /// <returns>The number of bytes copied to the buffer.</returns>
-    virtual size_t GetBytes(_Inout_ char pBuffer[], _In_ size_t nBytes) = 0;
+    virtual size_t GetBytes(_Inout_ uint8_t pBuffer[], _In_ size_t nBytes) = 0;
 
     /// <summary>
     /// Gets the current read offset within the input.
     /// </summary>
     virtual std::streampos GetPosition() const = 0;
+
+    /// <summary>
+    /// Sets the current read offset within the input.
+    /// </summary>
+    virtual void SetPosition(std::streampos nNewPosition) = 0;
+
+    /// <summary>
+    /// Gets the size of the input.
+    /// </summary>
+    virtual size_t GetSize() const = 0;
 
 protected:
     TextReader() noexcept = default;

--- a/src/services/impl/FileTextReader.hh
+++ b/src/services/impl/FileTextReader.hh
@@ -41,7 +41,9 @@ public:
     size_t GetBytes(_Inout_ uint8_t pBuffer[], _In_ size_t nBytes) override
     {
         const auto nPos = GetPosition();
-        m_iStream.read(reinterpret_cast<char*>(pBuffer), nBytes);
+        char* pCharBuffer;
+        GSL_SUPPRESS_TYPE1 pCharBuffer = reinterpret_cast<char*>(pBuffer);
+        m_iStream.read(pCharBuffer, nBytes);
         return gsl::narrow_cast<size_t>(GetPosition() - nPos);
     }
 

--- a/src/services/impl/FileTextReader.hh
+++ b/src/services/impl/FileTextReader.hh
@@ -38,10 +38,10 @@ public:
         return true;
     }
 
-    size_t GetBytes(_Inout_ char pBuffer[], _In_ size_t nBytes) override
+    size_t GetBytes(_Inout_ uint8_t pBuffer[], _In_ size_t nBytes) override
     {
         const auto nPos = GetPosition();
-        m_iStream.read(pBuffer, nBytes);
+        m_iStream.read(reinterpret_cast<char*>(pBuffer), nBytes);
         return gsl::narrow_cast<size_t>(GetPosition() - nPos);
     }
 
@@ -58,6 +58,21 @@ public:
         }
 
         return m_iStream.tellg();
+    }
+
+    void SetPosition(std::streampos nNewPosition) override
+    {
+        Expects(nNewPosition >= 0);
+        m_iStream.seekg(nNewPosition);
+    }
+
+    size_t GetSize() const override
+    {
+        const auto nPos = GetPosition();
+        m_iStream.seekg(0, m_iStream.end);
+        const auto nSize = gsl::narrow_cast<size_t>(m_iStream.tellg());
+        m_iStream.seekg(nPos, m_iStream.beg);
+        return nSize;
     }
 
     std::ifstream& GetFStream() noexcept { return m_iStream; }

--- a/src/services/impl/StringTextReader.hh
+++ b/src/services/impl/StringTextReader.hh
@@ -41,7 +41,9 @@ public:
     size_t GetBytes(_Inout_ uint8_t pBuffer[], _In_ size_t nBytes) override
     {
         const auto nPos = GetPosition();
-        m_iStream.read(reinterpret_cast<char*>(pBuffer), nBytes);
+        char* pCharBuffer;
+        GSL_SUPPRESS_TYPE1 pCharBuffer = reinterpret_cast<char*>(pBuffer);
+        m_iStream.read(pCharBuffer, nBytes);
         return gsl::narrow_cast<size_t>(GetPosition() - nPos);
     }
 

--- a/src/services/impl/StringTextReader.hh
+++ b/src/services/impl/StringTextReader.hh
@@ -38,10 +38,10 @@ public:
         return true;
     }
 
-    size_t GetBytes(_Inout_ char pBuffer[], _In_ size_t nBytes) override
+    size_t GetBytes(_Inout_ uint8_t pBuffer[], _In_ size_t nBytes) override
     {
         const auto nPos = GetPosition();
-        m_iStream.read(pBuffer, nBytes);
+        m_iStream.read(reinterpret_cast<char*>(pBuffer), nBytes);
         return gsl::narrow_cast<size_t>(GetPosition() - nPos);
     }
 
@@ -58,6 +58,21 @@ public:
         }
 
         return m_iStream.tellg();
+    }
+
+    void SetPosition(std::streampos nNewPosition) override
+    {
+        Expects(nNewPosition >= 0);
+        m_iStream.seekg(nNewPosition);
+    }
+
+    size_t GetSize() const override
+    {
+        const auto nPos = GetPosition();
+        m_iStream.seekg(0, m_iStream.end);
+        const auto nSize = gsl::narrow_cast<size_t>(m_iStream.tellg());
+        m_iStream.seekg(nPos, m_iStream.beg);
+        return nSize;
     }
 
     std::string GetString() { return m_iStream.str(); }

--- a/tests/services/AchievementRuntime_Tests.cpp
+++ b/tests/services/AchievementRuntime_Tests.cpp
@@ -439,10 +439,10 @@ public:
         auto pMemRef = runtime.GetMemRefs(); // 0xH1234
         pMemRef->value = 0x02;
         pMemRef->previous = 0x03;
-        pMemRef->prior = 0x04;
+        pMemRef->prior = 0x03;
         pMemRef = pMemRef->next; // 0xX1234
         pMemRef->value = 0x020000;
-        pMemRef->previous = 0x030000;
+        pMemRef->previous = 0x020000;
         pMemRef->prior = 0x040000;
 
         runtime.SaveProgress("test.sav");
@@ -468,10 +468,10 @@ public:
         pMemRef = runtime.GetMemRefs();
         Assert::AreEqual(0x02U, pMemRef->value);
         Assert::AreEqual(0x03U, pMemRef->previous);
-        Assert::AreEqual(0x04U, pMemRef->prior);
+        Assert::AreEqual(0x03U, pMemRef->prior);
         pMemRef = pMemRef->next;
         Assert::AreEqual(0x020000U, pMemRef->value);
-        Assert::AreEqual(0x030000U, pMemRef->previous);
+        Assert::AreEqual(0x020000U, pMemRef->previous);
         Assert::AreEqual(0x040000U, pMemRef->prior);
     }
 
@@ -516,10 +516,10 @@ public:
         auto pMemRef = runtime.GetMemRefs(); // 0xH1234
         pMemRef->value = 0x02;
         pMemRef->previous = 0x03;
-        pMemRef->prior = 0x04;
+        pMemRef->prior = 0x03;
         pMemRef = pMemRef->next; // 0xX1234
         pMemRef->value = 0x020000;
-        pMemRef->previous = 0x030000;
+        pMemRef->previous = 0x020000;
         pMemRef->prior = 0x040000;
 
         runtime.SaveProgress("test.sav");
@@ -545,10 +545,10 @@ public:
         pMemRef = runtime.GetMemRefs();
         Assert::AreEqual(0x02U, pMemRef->value);
         Assert::AreEqual(0x03U, pMemRef->previous);
-        Assert::AreEqual(0x04U, pMemRef->prior);
+        Assert::AreEqual(0x03U, pMemRef->prior);
         pMemRef = pMemRef->next;
         Assert::AreEqual(0x020000U, pMemRef->value);
-        Assert::AreEqual(0x030000U, pMemRef->previous);
+        Assert::AreEqual(0x020000U, pMemRef->previous);
         Assert::AreEqual(0x040000U, pMemRef->prior);
     }
 


### PR DESCRIPTION
RAP file contents are now binary and managed by rcheevos. The logic was recently moved into rcheevos for possible future support in RetroArch. This modifies the DLL to use the common code.