### PR TITLE
ensure bookmarks window is open when adding bookmarks

### DIFF
--- a/src/ui/viewmodels/CodeNotesViewModel.cpp
+++ b/src/ui/viewmodels/CodeNotesViewModel.cpp
@@ -192,6 +192,9 @@ void CodeNotesViewModel::OnCodeNoteChanged(ra::ByteAddress nAddress, const std::
 void CodeNotesViewModel::BookmarkSelected() const
 {
     auto& vmBookmarks = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::WindowManager>().MemoryBookmarks;
+    if (!vmBookmarks.IsVisible())
+        vmBookmarks.Show();
+
     vmBookmarks.Bookmarks().BeginUpdate();
 
     int nCount = 0;

--- a/src/ui/viewmodels/MemorySearchViewModel.cpp
+++ b/src/ui/viewmodels/MemorySearchViewModel.cpp
@@ -896,6 +896,9 @@ void MemorySearchViewModel::BookmarkSelected()
     }
 
     auto& vmBookmarks = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::WindowManager>().MemoryBookmarks;
+    if (!vmBookmarks.IsVisible())
+        vmBookmarks.Show();
+
     vmBookmarks.Bookmarks().BeginUpdate();
 
     int nCount = 0;


### PR DESCRIPTION
From code notes dialog and search results. Was already happening from code notes section of memory inspector.