### PR TITLE
allow theming of MemoryViewer

### DIFF
--- a/data/editor_theme-dark.json
+++ b/data/editor_theme-dark.json
@@ -1,0 +1,18 @@
+{
+  "MemoryViewer": {
+    "Font": "Consolas",
+    "FontSize": 17,
+    "Colors": {
+      "Background": "#121212",
+      "Separator": "#303030",
+      "Cursor": "#606080",
+      "Normal": "#C0C0C0",
+      "Selected": "#E0E0E0",
+      "HasNote": "#4040E0",
+      "HasBookmark": "#40A040",
+      "Frozen": "#E0C040",
+      "Header": "#606060",
+      "HeaderSelected": "#C0B0B0"
+    }
+  }
+}

--- a/data/editor_theme-dark.json
+++ b/data/editor_theme-dark.json
@@ -8,7 +8,7 @@
       "Cursor": "#606080",
       "Normal": "#C0C0C0",
       "Selected": "#E0E0E0",
-      "HasNote": "#4040E0",
+      "HasNote": "#6060E0",
       "HasBookmark": "#40A040",
       "Frozen": "#E0C040",
       "Header": "#606060",

--- a/data/editor_theme.json
+++ b/data/editor_theme.json
@@ -1,0 +1,18 @@
+{
+  "MemoryViewer": {
+    "Font": "Consolas",
+    "FontSize": 17,
+    "Colors": {
+      "Background": "#FFFFFF",
+      "Separator": "#C0C0C0",
+      "Cursor": "#C0C0C0",
+      "Normal": "#000000",
+      "Selected": "#FF0000",
+      "HasNote": "#0000FF",
+      "HasBookmark": "#00A000",
+      "Frozen": "#FFC800",
+      "Header": "#808080",
+      "HeaderSelected": "#FF8080"
+    }
+  }
+}

--- a/src/RA_Integration.vcxproj
+++ b/src/RA_Integration.vcxproj
@@ -122,7 +122,7 @@
     <ClCompile Include="ui\drawing\gdi\GDISurface.cpp" />
     <ClCompile Include="ui\drawing\gdi\ImageRepository.cpp" />
     <ClCompile Include="ui\ModelProperty.cpp" />
-    <ClCompile Include="ui\OverlayTheme.cpp" />
+    <ClCompile Include="ui\Theme.cpp" />
     <ClCompile Include="ui\ViewModelBase.cpp" />
     <ClCompile Include="ui\ViewModelCollection.cpp" />
     <ClCompile Include="ui\viewmodels\BrokenAchievementsViewModel.cpp" />
@@ -271,6 +271,7 @@
     <ClInclude Include="ui\drawing\gdi\ImageRepository.hh" />
     <ClInclude Include="ui\drawing\gdi\ResourceRepository.hh" />
     <ClInclude Include="ui\drawing\ISurface.hh" />
+    <ClInclude Include="ui\EditorTheme.hh" />
     <ClInclude Include="ui\IDesktop.hh" />
     <ClInclude Include="ui\ImageReference.hh" />
     <ClInclude Include="ui\ModelProperty.hh" />

--- a/src/RA_Integration.vcxproj.filters
+++ b/src/RA_Integration.vcxproj.filters
@@ -222,9 +222,6 @@
     <ClCompile Include="ui\viewmodels\PopupViewModelBase.cpp">
       <Filter>UI\ViewModels</Filter>
     </ClCompile>
-    <ClCompile Include="ui\OverlayTheme.cpp">
-      <Filter>UI</Filter>
-    </ClCompile>
     <ClCompile Include="services\GameIdentifier.cpp">
       <Filter>Services</Filter>
     </ClCompile>
@@ -317,6 +314,9 @@
     </ClCompile>
     <ClCompile Include="services\PerformanceCounter.cpp">
       <Filter>Services</Filter>
+    </ClCompile>
+    <ClCompile Include="ui\Theme.cpp">
+      <Filter>UI</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -805,6 +805,9 @@
     </ClInclude>
     <ClInclude Include="services\PerformanceCounter.hh">
       <Filter>Services</Filter>
+    </ClInclude>
+    <ClInclude Include="ui\EditorTheme.hh">
+      <Filter>UI</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/services/Initialization.cpp
+++ b/src/services/Initialization.cpp
@@ -22,6 +22,7 @@
 #include "services\impl\WindowsFileSystem.hh"
 #include "services\impl\WindowsHttpRequester.hh"
 
+#include "ui\EditorTheme.hh"
 #include "ui\OverlayTheme.hh"
 #include "ui\WindowViewModelBase.hh"
 #include "ui\drawing\gdi\GDIBitmapSurface.hh"
@@ -152,6 +153,10 @@ void Initialization::RegisterServices(EmulatorID nEmulatorId)
     auto pOverlayTheme = std::make_unique<ra::ui::OverlayTheme>();
     pOverlayTheme->LoadFromFile();
     ra::services::ServiceLocator::Provide<ra::ui::OverlayTheme>(std::move(pOverlayTheme));
+
+    auto pEditorTheme = std::make_unique<ra::ui::EditorTheme>();
+    pEditorTheme->LoadFromFile();
+    ra::services::ServiceLocator::Provide<ra::ui::EditorTheme>(std::move(pEditorTheme));
 
     auto pWindowManager = std::make_unique<ra::ui::viewmodels::WindowManager>();
     ra::services::ServiceLocator::Provide<ra::ui::viewmodels::WindowManager>(std::move(pWindowManager));

--- a/src/ui/EditorTheme.hh
+++ b/src/ui/EditorTheme.hh
@@ -1,0 +1,61 @@
+#ifndef RA_UI_EDITOR_THEME_H
+#define RA_UI_EDITOR_THEME_H
+#pragma once
+
+#include "ra_fwd.h"
+
+#include "ui/Types.hh"
+
+namespace ra {
+namespace ui {
+
+class EditorTheme
+{
+public:
+    GSL_SUPPRESS_F6 EditorTheme() = default;
+    virtual ~EditorTheme() noexcept = default;
+    EditorTheme(const EditorTheme&) noexcept = delete;
+    EditorTheme& operator=(const EditorTheme&) noexcept = delete;
+    EditorTheme(EditorTheme&&) noexcept = delete;
+    EditorTheme& operator=(EditorTheme&&) noexcept = delete;
+
+    // ===== memory viewer =====
+
+    const std::string& FontMemoryViewer() const noexcept { return m_sFontMemoryViewer; }
+    int FontSizeMemoryViewer() const noexcept { return m_nFontSizeMemoryViewer; }
+
+    Color ColorBackground() const noexcept { return m_colorBackground; }
+    Color ColorSeparator() const noexcept { return m_colorSeparator; }
+    Color ColorCursor() const noexcept { return m_colorCursor; }
+    Color ColorNormal() const noexcept { return m_colorNormal; }
+    Color ColorSelected() const noexcept { return m_colorSelected; }
+    Color ColorHasNote() const noexcept { return m_colorHasNote; }
+    Color ColorHasBookmark() const noexcept { return m_colorHasBookmark; }
+    Color ColorFrozen() const noexcept { return m_colorFrozen; }
+    Color ColorHeader() const noexcept { return m_colorHeader; }
+    Color ColorHeaderSelected() const noexcept { return m_colorHeaderSelected; }
+
+    // ===== methods =====
+
+    void LoadFromFile();
+
+private:
+    std::string m_sFontMemoryViewer = "Consolas";
+    int m_nFontSizeMemoryViewer = 17;
+
+    Color m_colorBackground{ 255, 255, 255, 255 };
+    Color m_colorSeparator{ 255, 192, 192, 192 };
+    Color m_colorCursor{ 255, 192, 192, 192 };
+    Color m_colorNormal{ 255, 0, 0, 0 };
+    Color m_colorSelected{ 255, 255, 0, 0 };
+    Color m_colorHasNote{ 255, 0, 0, 255 };
+    Color m_colorHasBookmark{ 255, 0, 160, 0 };
+    Color m_colorFrozen{ 255, 255, 200, 0 };
+    Color m_colorHeader{ 255, 128, 128, 128 };
+    Color m_colorHeaderSelected{ 255, 255, 96, 96 };
+};
+
+} // namespace ui
+} // namespace ra
+
+#endif RA_UI_EDITOR_THEME_H

--- a/src/ui/Theme.cpp
+++ b/src/ui/Theme.cpp
@@ -1,3 +1,4 @@
+#include "EditorTheme.hh"
 #include "OverlayTheme.hh"
 
 #include "RA_Json.h"
@@ -140,6 +141,53 @@ void OverlayTheme::LoadFromFile()
     }
 
     ReadBool(m_bTransparent, document, "Transparent");
+}
+
+void EditorTheme::LoadFromFile()
+{
+    const auto& pFileSystem = ra::services::ServiceLocator::Get<ra::services::IFileSystem>();
+    std::wstring sFullPath = pFileSystem.BaseDirectory() + L"Overlay\\editor_theme.json";
+    if (pFileSystem.GetFileSize(sFullPath) == -1)
+        return;
+
+    auto pFile = pFileSystem.OpenTextFile(sFullPath);
+    if (!pFile)
+        return;
+
+    rapidjson::Document document;
+    if (!LoadDocument(document, *pFile))
+    {
+        RA_LOG_ERR("Unable to read Overlay\\editor_theme.json: %s (%zu)",
+            GetParseError_En(document.GetParseError()), document.GetErrorOffset());
+        return;
+    }
+
+    if (document.HasMember("MemoryViewer"))
+    {
+        const rapidjson::Value& memoryViewer = document["MemoryViewer"];
+
+        if (memoryViewer.HasMember("Font"))
+            m_sFontMemoryViewer = memoryViewer["Font"].GetString();
+
+        if (memoryViewer.HasMember("FontSize"))
+            ReadSize(m_nFontSizeMemoryViewer, memoryViewer, "FontSize");
+
+        if (memoryViewer.HasMember("Colors"))
+        {
+            const rapidjson::Value& colors = memoryViewer["Colors"];
+
+            ReadColor(m_colorBackground, colors, "Background");
+            ReadColor(m_colorSeparator, colors, "Separator");
+            ReadColor(m_colorCursor, colors, "Cursor");
+            ReadColor(m_colorNormal, colors, "Normal");
+            ReadColor(m_colorSelected, colors, "Selected");
+            ReadColor(m_colorHasNote, colors, "HasNote");
+            ReadColor(m_colorHasBookmark, colors, "HasBookmark");
+            ReadColor(m_colorFrozen, colors, "Frozen");
+            ReadColor(m_colorHeader, colors, "Header");
+            ReadColor(m_colorHeaderSelected, colors, "HeaderSelected");
+        }
+    }
 }
 
 } // namespace ui

--- a/src/ui/viewmodels/MemoryViewerViewModel.hh
+++ b/src/ui/viewmodels/MemoryViewerViewModel.hh
@@ -69,12 +69,12 @@ public:
 
     enum class TextColor
     {
-        Black = 0,  // default
-        Red,        // selected
-        RedOnBlack, // selected and highlighted
-        Blue,       // has notes
-        Green,      // has bookmark
-        Yellow,     // has frozen bookmark
+        Default = 0,     // default
+        Selected,        // selected
+        Cursor,          // selected and highlighted
+        HasNote,         // has notes
+        HasBookmark,     // has bookmark
+        Frozen,          // has frozen bookmark
 
         NumColors
     };

--- a/src/ui/win32/bindings/MemoryViewerControlBinding.cpp
+++ b/src/ui/win32/bindings/MemoryViewerControlBinding.cpp
@@ -3,6 +3,7 @@
 #include "ra_fwd.h"
 #include "ra_utility.h"
 
+#include "ui/EditorTheme.hh"
 #include "ui/drawing/gdi/GDISurface.hh"
 
 namespace ra {
@@ -296,28 +297,36 @@ void MemoryViewerControlBinding::RenderMemViewer()
     GetClientRect(m_hWnd, &rcClient);
 
     const auto& pRenderImage = m_pViewModel.GetRenderImage();
+    const auto& pEditorTheme = ra::services::ServiceLocator::Get<ra::ui::EditorTheme>();
+    HBRUSH hBackground = CreateSolidBrush(RGB(pEditorTheme.ColorBackground().Channel.R, pEditorTheme.ColorBackground().Channel.G, pEditorTheme.ColorBackground().Channel.B));
 
-    HBRUSH hBackground = GetStockBrush(WHITE_BRUSH);
-    RECT rcFill{ rcClient.left + 1, rcClient.top + 1, rcClient.left + MEMVIEW_MARGIN, rcClient.bottom - 2 };
+    // left margin
+    RECT rcFill{ rcClient.left, rcClient.top, rcClient.left + MEMVIEW_MARGIN, rcClient.bottom - 1 };
     FillRect(hDC, &rcFill, hBackground);
 
+    // right margin
     rcFill.left = rcClient.left + MEMVIEW_MARGIN + pRenderImage.GetWidth();
-    rcFill.right = rcClient.right - 2;
+    rcFill.right = rcClient.right - 1;
     FillRect(hDC, &rcFill, hBackground);
 
-    rcFill.left = rcClient.left + 1;
+    // top margin
+    rcFill.left = rcClient.left;
     rcFill.bottom = rcClient.top + MEMVIEW_MARGIN;
     FillRect(hDC, &rcFill, hBackground);
 
+    // bottom margin
     rcFill.top = rcClient.top + MEMVIEW_MARGIN + pRenderImage.GetHeight();
-    rcFill.bottom = rcClient.bottom - 2;
+    rcFill.bottom = rcClient.bottom - 1;
     FillRect(hDC, &rcFill, hBackground);
 
-    DrawEdge(hDC, &rcClient, EDGE_ETCHED, BF_RECT);
+    // frame
+    FrameRect(hDC, &rcClient, GetSysColorBrush(COLOR_3DSHADOW));
 
+    // content
     ra::ui::drawing::gdi::GDISurface pSurface(hDC, rcClient);
     pSurface.DrawSurface(MEMVIEW_MARGIN, MEMVIEW_MARGIN, pRenderImage);
 
+    DeleteObject(hBackground);
     EndPaint(m_hWnd, &ps);
 }
 

--- a/tests/RA_Integration.Tests.vcxproj
+++ b/tests/RA_Integration.Tests.vcxproj
@@ -290,7 +290,7 @@
     <ClCompile Include="..\src\services\impl\FileLocalStorage.cpp" />
     <ClCompile Include="..\src\services\impl\JsonFileConfiguration.cpp" />
     <ClCompile Include="..\src\services\SearchResults.cpp" />
-    <ClCompile Include="..\src\ui\OverlayTheme.cpp" />
+    <ClCompile Include="..\src\ui\Theme.cpp" />
     <ClCompile Include="..\src\ui\ViewModelCollection.cpp" />
     <ClCompile Include="..\src\ui\viewmodels\BrokenAchievementsViewModel.cpp" />
     <ClCompile Include="..\src\ui\viewmodels\CodeNotesViewModel.cpp" />

--- a/tests/RA_Integration.Tests.vcxproj.filters
+++ b/tests/RA_Integration.Tests.vcxproj.filters
@@ -243,9 +243,6 @@
     <ClCompile Include="ui\OverlayTheme_Tests.cpp">
       <Filter>Tests\UI</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\ui\OverlayTheme.cpp">
-      <Filter>Code</Filter>
-    </ClCompile>
     <ClCompile Include="services\GameIdentifier_Tests.cpp">
       <Filter>Tests\Services</Filter>
     </ClCompile>
@@ -331,6 +328,9 @@
       <Filter>Tests\UI\ViewModels</Filter>
     </ClCompile>
     <ClCompile Include="..\src\ui\viewmodels\MemoryInspectorViewModel.cpp">
+      <Filter>Code</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\ui\Theme.cpp">
       <Filter>Code</Filter>
     </ClCompile>
   </ItemGroup>

--- a/tests/ui/viewmodels/MemoryViewerViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/MemoryViewerViewModel_Tests.cpp
@@ -18,8 +18,8 @@ namespace ui {
 namespace viewmodels {
 namespace tests {
 
-constexpr unsigned char COLOR_RED = gsl::narrow_cast<unsigned char>(ra::etoi(MemoryViewerViewModel::TextColor::Red));
-constexpr unsigned char COLOR_BLACK = gsl::narrow_cast<unsigned char>(ra::etoi(MemoryViewerViewModel::TextColor::Black));
+constexpr unsigned char COLOR_RED = gsl::narrow_cast<unsigned char>(ra::etoi(MemoryViewerViewModel::TextColor::Selected));
+constexpr unsigned char COLOR_BLACK = gsl::narrow_cast<unsigned char>(ra::etoi(MemoryViewerViewModel::TextColor::Default));
 constexpr unsigned char COLOR_REDRAW = 0x80;
 
 TEST_CLASS(MemoryViewerViewModel_Tests)


### PR DESCRIPTION
Addresses feedback that some of the colors are too similar - especially the selected column in the header. Allows user to specify their own colors via a JSON file (similar to the overlay customization). The file is name `editor_theme.json` and placed in the `overlay` folder. I wanted to keep this separate from the overlay theme as the overlay "packages" would overwrite any customizations, but I didn't really have any better place to put the file.

As an example (and proof-of-concept), there's dark theme JSON in the repository.
![image](https://user-images.githubusercontent.com/32680403/80920516-9de07880-8d2d-11ea-8fca-d147afe156da.png)
