### PR TITLE
sync result description with code note changes

### DIFF
--- a/src/ui/viewmodels/MemorySearchViewModel.cpp
+++ b/src/ui/viewmodels/MemorySearchViewModel.cpp
@@ -722,6 +722,7 @@ void MemorySearchViewModel::UpdateResults()
     const auto& vmBookmarks = ra::services::ServiceLocator::Get<ra::ui::viewmodels::WindowManager>().MemoryBookmarks;
     const auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::GameContext>();
     const auto& pConsoleContext = ra::services::ServiceLocator::Get<ra::data::ConsoleContext>();
+    const auto& pEmulatorContext = ra::services::ServiceLocator::Get<ra::data::EmulatorContext>();
 
     m_vResults.RemoveNotifyTarget(*this);
     m_vResults.BeginUpdate();
@@ -755,6 +756,8 @@ void MemorySearchViewModel::UpdateResults()
         }
 
         pRow->SetAddress(ra::Widen(sAddress));
+
+        pResult.nValue = pEmulatorContext.ReadMemory(pResult.nAddress, pResult.nSize);
         pRow->SetCurrentValue(ra::StringPrintf(sValueFormat, pResult.nValue));
 
         unsigned int nPreviousValue = 0;
@@ -806,9 +809,9 @@ void MemorySearchViewModel::UpdateResults()
     m_vResults.AddNotifyTarget(*this);
 }
 
-void MemorySearchViewModel::OnCodeNoteChanged(ra::ByteAddress nAddress, const std::wstring& sNote)
+void MemorySearchViewModel::OnCodeNoteChanged(ra::ByteAddress nAddress, const std::wstring&)
 {
-    for (gsl::index i = 0; i < m_vResults.Count(); ++i)
+    for (gsl::index i = 0; i < ra::to_signed(m_vResults.Count()); ++i)
     {
         auto* pRow = m_vResults.GetItemAt(i);
         if (pRow != nullptr && pRow->nAddress == nAddress)

--- a/src/ui/viewmodels/MemorySearchViewModel.cpp
+++ b/src/ui/viewmodels/MemorySearchViewModel.cpp
@@ -125,6 +125,9 @@ void MemorySearchViewModel::InitializeNotifyTargets()
     auto& pEmulatorContext = ra::services::ServiceLocator::GetMutable<ra::data::EmulatorContext>();
     pEmulatorContext.AddNotifyTarget(*this);
     OnTotalMemorySizeChanged();
+
+    auto& pGameContext = ra::services::ServiceLocator::GetMutable<ra::data::GameContext>();
+    pGameContext.AddNotifyTarget(*this);
 }
 
 void MemorySearchViewModel::OnTotalMemorySizeChanged()
@@ -801,6 +804,19 @@ void MemorySearchViewModel::UpdateResults()
 
     m_vResults.EndUpdate();
     m_vResults.AddNotifyTarget(*this);
+}
+
+void MemorySearchViewModel::OnCodeNoteChanged(ra::ByteAddress nAddress, const std::wstring& sNote)
+{
+    for (gsl::index i = 0; i < m_vResults.Count(); ++i)
+    {
+        auto* pRow = m_vResults.GetItemAt(i);
+        if (pRow != nullptr && pRow->nAddress == nAddress)
+        {
+            UpdateResults();
+            break;
+        }
+    }
 }
 
 bool MemorySearchViewModel::TestFilter(const ra::services::SearchResults::Result& pResult, const SearchResult& pCurrentResults, unsigned int nPreviousValue) noexcept

--- a/src/ui/viewmodels/MemorySearchViewModel.hh
+++ b/src/ui/viewmodels/MemorySearchViewModel.hh
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "data\EmulatorContext.hh"
+#include "data\GameContext.hh"
 #include "data\Types.hh"
 
 #include "services\SearchResults.h"
@@ -18,7 +19,8 @@ namespace viewmodels {
 class MemorySearchViewModel : public ViewModelBase,
     protected ViewModelBase::NotifyTarget,
     protected ViewModelCollectionBase::NotifyTarget,
-    protected data::EmulatorContext::NotifyTarget
+    protected data::EmulatorContext::NotifyTarget,
+    protected data::GameContext::NotifyTarget
 {
 public:
     GSL_SUPPRESS_F6 MemorySearchViewModel();
@@ -457,6 +459,9 @@ protected:
 
     // EmulatorContext::NotifyTarget
     void OnTotalMemorySizeChanged() override;
+
+    // GameContext::NotifyTarget
+    void OnCodeNoteChanged(ra::ByteAddress nAddress, const std::wstring& sNote) override;
 
 private:
     bool ParseFilterRange(_Out_ ra::ByteAddress& nStart, _Out_ ra::ByteAddress& nEnd);

--- a/src/ui/win32/bindings/GridBinding.cpp
+++ b/src/ui/win32/bindings/GridBinding.cpp
@@ -303,6 +303,8 @@ void GridBinding::OnViewModelIntValueChanged(gsl::index nIndex, const IntModelPr
             sText = NativeStr(pColumn.GetText(*m_vmItems, nIndex));
             item.pszText = sText.data();
             ListView_SetItem(m_hWnd, &item);
+
+            m_bForceRepaint = true;
         }
     }
 }
@@ -327,6 +329,8 @@ void GridBinding::OnViewModelBoolValueChanged(gsl::index nIndex, const BoolModel
             sText = NativeStr(pColumn.GetText(*m_vmItems, nIndex));
             item.pszText = sText.data();
             ListView_SetItem(m_hWnd, &item);
+
+            m_bForceRepaint = true;
         }
     }
 }
@@ -351,6 +355,8 @@ void GridBinding::OnViewModelStringValueChanged(gsl::index nIndex, const StringM
             sText = NativeStr(pColumn.GetText(*m_vmItems, nIndex));
             item.pszText = sText.data();
             ListView_SetItem(m_hWnd, &item);
+
+            m_bForceRepaint = true;
         }
     }
 }

--- a/tests/mocks/MockConsoleContext.hh
+++ b/tests/mocks/MockConsoleContext.hh
@@ -30,12 +30,13 @@ public:
 
     void ResetMemoryRegions() noexcept { m_vRegions.clear(); }
 
-    void AddMemoryRegion(ra::ByteAddress nStartAddress, ra::ByteAddress nEndAddress, AddressType nAddressType)
+    void AddMemoryRegion(ra::ByteAddress nStartAddress, ra::ByteAddress nEndAddress, AddressType nAddressType, const std::string& sDescription = "")
     { 
         auto& pRegion = m_vRegions.emplace_back();
         pRegion.StartAddress = nStartAddress;
         pRegion.EndAddress = nEndAddress;
         pRegion.Type = nAddressType;
+        pRegion.Description = sDescription;
     }
 
 private:

--- a/tests/ui/viewmodels/MemorySearchViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/MemorySearchViewModel_Tests.cpp
@@ -101,6 +101,8 @@ private:
         bool CanGoToNextPage() const { return GetValue(CanGoToNextPageProperty); }
         bool HasSelection() const { return GetValue(HasSelectionProperty); }
 
+        void SetScrollOffset(int nValue) { SetValue(ScrollOffsetProperty, nValue); }
+
         const std::wstring& ContinuousFilterLabel() const { return GetValue(ContinuousFilterLabelProperty); }
     };
 
@@ -1193,6 +1195,31 @@ public:
         Assert::IsFalse(search.CanFilter());
         Assert::IsFalse(search.CanContinuousFilter());
         Assert::AreEqual(std::wstring(L"Continuous Filter"), search.ContinuousFilterLabel());
+    }
+
+    TEST_METHOD(TestScrollDisplaysCurrentValue)
+    {
+        MemorySearchViewModelHarness search;
+        search.InitializeMemory();
+        search.BeginNewSearch();
+        search.SetComparisonType(ComparisonType::Equals);
+        search.SetValueType(ra::services::SearchFilterType::LastKnownValue);
+        search.ApplyFilter();
+
+        search.memory.at(2) = 9;
+        search.DoFrame();
+
+        Assert::IsTrue(search.Results().Count() > 3);
+        AssertRow(search, 0, 0U, L"0x0000", L"0x00", L"0x00");
+        AssertRow(search, 1, 1U, L"0x0001", L"0x01", L"0x01");
+        AssertRow(search, 2, 2U, L"0x0002", L"0x09", L"0x02");
+
+        search.SetScrollOffset(1U);
+
+        Assert::IsTrue(search.Results().Count() > 3);
+        AssertRow(search, 0, 1U, L"0x0001", L"0x01", L"0x01");
+        AssertRow(search, 1, 2U, L"0x0002", L"0x09", L"0x02");
+        AssertRow(search, 2, 3U, L"0x0003", L"0x03", L"0x03");
     }
 };
 

--- a/tests/ui/viewmodels/MemorySearchViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/MemorySearchViewModel_Tests.cpp
@@ -1197,6 +1197,41 @@ public:
         Assert::AreEqual(std::wstring(L"Continuous Filter"), search.ContinuousFilterLabel());
     }
 
+    TEST_METHOD(TestOnCodeNoteChanged)
+    {
+        MemorySearchViewModelHarness search;
+        search.InitializeMemory();
+        search.mockConsoleContext.AddMemoryRegion({ 0U }, { 0xFFU }, ra::data::ConsoleContext::AddressType::SystemRAM, "System RAM");
+        search.BeginNewSearch();
+
+        search.SetComparisonType(ComparisonType::Equals);
+        search.SetValueType(ra::services::SearchFilterType::Constant);
+        search.SetFilterValue(L"12");
+
+        search.ApplyFilter();
+
+        Assert::AreEqual({ 1U }, search.Results().Count());
+        auto* pRow = search.Results().GetItemAt(0);
+        Assert::IsNotNull(pRow);
+        Ensures(pRow != nullptr);
+
+        Assert::AreEqual({ 12U }, pRow->nAddress);
+        Assert::AreEqual(std::wstring(L"System RAM"), pRow->GetDescription());
+        Assert::IsFalse(pRow->bHasCodeNote);
+
+        search.mockGameContext.SetCodeNote({ 12U }, L"Note");
+        Assert::AreEqual(std::wstring(L"Note"), pRow->GetDescription());
+        Assert::IsTrue(pRow->bHasCodeNote);
+
+        search.mockGameContext.SetCodeNote({ 12U }, L"Note 2");
+        Assert::AreEqual(std::wstring(L"Note 2"), pRow->GetDescription());
+        Assert::IsTrue(pRow->bHasCodeNote);
+
+        search.mockGameContext.SetCodeNote({ 12U }, L"");
+        Assert::AreEqual(std::wstring(L"System RAM"), pRow->GetDescription());
+        Assert::IsFalse(pRow->bHasCodeNote);
+    }
+
     TEST_METHOD(TestScrollDisplaysCurrentValue)
     {
         MemorySearchViewModelHarness search;


### PR DESCRIPTION
when editing a code note associated to an address in the results window, the description will now update as well.

also fixes an issue where scrolling the results would temporarily cause the "current value" to revert to the value at the time of the last filter.