### PR TITLE
add _RA_CaptureState and _RA_RestoreState

### DIFF
--- a/src/Exports.hh
+++ b/src/Exports.hh
@@ -68,6 +68,14 @@ extern "C" {
     // Immediately after saving a new state.
     API void CCONV _RA_OnSaveState(const char* sFileName);
 
+    // Captures the current RetroAchievements state data.
+    //  returns the number of bytes written to pBuffer. if larger than nBufferSize, the
+    //  caller should allocate a larger buffer and call again.
+    API int CCONV _RA_CaptureState(char* pBuffer, int nBufferSize);
+
+    // Restores the RetroAchievements state from captured state data.
+    API void CCONV _RA_RestoreState(const char* pBuffer);
+
     // Immediately after resetting the system.
     API void CCONV _RA_OnReset();
 

--- a/src/services/AchievementRuntime.cpp
+++ b/src/services/AchievementRuntime.cpp
@@ -689,7 +689,9 @@ bool AchievementRuntime::LoadProgressFromBuffer(const char* pBuffer)
     if (!pUserContext.IsLoggedIn())
         return false;
 
-    rc_runtime_deserialize_progress(&m_pRuntime, (unsigned char*)pBuffer, nullptr);
+    const unsigned char* pBytes;
+    GSL_SUPPRESS_TYPE1 pBytes = reinterpret_cast<const unsigned char*>(pBuffer);
+    rc_runtime_deserialize_progress(&m_pRuntime, pBytes, nullptr);
     return true;
 }
 

--- a/src/services/AchievementRuntime.cpp
+++ b/src/services/AchievementRuntime.cpp
@@ -616,7 +616,7 @@ bool AchievementRuntime::LoadProgressV2(ra::services::TextReader& pFile, std::se
     return true;
 }
 
-bool AchievementRuntime::LoadProgress(const char* sLoadStateFilename)
+bool AchievementRuntime::LoadProgressFromFile(const char* sLoadStateFilename)
 {
     if (!m_bInitialized)
         return true;
@@ -677,7 +677,23 @@ bool AchievementRuntime::LoadProgress(const char* sLoadStateFilename)
     return true;
 }
 
-void AchievementRuntime::SaveProgress(const char* sSaveStateFilename) const
+bool AchievementRuntime::LoadProgressFromBuffer(const char* pBuffer)
+{
+    if (!m_bInitialized)
+        return true;
+
+    // reset the runtime state, then apply state from file
+    rc_runtime_reset(&m_pRuntime);
+
+    const auto& pUserContext = ra::services::ServiceLocator::Get<ra::data::UserContext>();
+    if (!pUserContext.IsLoggedIn())
+        return false;
+
+    rc_runtime_deserialize_progress(&m_pRuntime, (unsigned char*)pBuffer, nullptr);
+    return true;
+}
+
+void AchievementRuntime::SaveProgressToFile(const char* sSaveStateFilename) const
 {
     if (sSaveStateFilename == nullptr)
         return;
@@ -699,6 +715,19 @@ void AchievementRuntime::SaveProgress(const char* sSaveStateFilename) const
     sSerialized.resize(nSize);
     rc_runtime_serialize_progress(sSerialized.data(), &m_pRuntime, nullptr);
     pFile->Write(sSerialized);
+}
+
+int AchievementRuntime::SaveProgressToBuffer(char* pBuffer, int nBufferSize) const
+{
+    const auto& pUserContext = ra::services::ServiceLocator::Get<ra::data::UserContext>();
+    if (!pUserContext.IsLoggedIn())
+        return 0;
+
+    const auto nSize = rc_runtime_progress_size(&m_pRuntime, nullptr);
+    if (nSize <= nBufferSize)
+        rc_runtime_serialize_progress(pBuffer, &m_pRuntime, nullptr);
+
+    return nSize;
 }
 
 } // namespace services

--- a/src/services/AchievementRuntime.hh
+++ b/src/services/AchievementRuntime.hh
@@ -151,13 +151,32 @@ public:
     /// </summary>
     /// <param name="sLoadStateFilename">The name of the save state file.</param>
     /// <returns><c>true</c> if the achievement HitCounts were modified, <c>false</c> if not.</returns>
-    bool LoadProgress(const char* sLoadStateFilename);
+    bool LoadProgressFromFile(const char* sLoadStateFilename);
+
+    /// <summary>
+    /// Loads HitCount data for active achievements from a buffer.
+    /// </summary>
+    /// <param name="pBuffer">The buffer to read from.</param>
+    /// <returns><c>true</c> if the achievement HitCounts were modified, <c>false</c> if not.</returns>
+    bool LoadProgressFromBuffer(const char* pBuffer);
 
     /// <summary>
     /// Writes HitCount data for active achievements to a save state file.
     /// </summary>
     /// <param name="sLoadStateFilename">The name of the save state file.</param>
-    void SaveProgress(const char* sSaveStateFilename) const;
+    void SaveProgressToFile(const char* sSaveStateFilename) const;
+
+    /// <summary>
+    /// Writes HitCount data for active achievements to a buffer.
+    /// </summary>
+    /// <param name="pBuffer">The buffer to write to.</param>
+    /// <param name="nBufferSize">The size of the buffer to write to.</param>
+    /// <returns>
+    /// The numberof bytes required to capture the HitCount data (may be larger than 
+    /// nBufferSize - in which case the caller should allocate the specified amount
+    /// and call again.
+    /// </returns>
+    int SaveProgressToBuffer(char* pBuffer, int nBufferSize) const;
 
     /// <summary>
     /// Gets whether achievement processing is temporarily suspended.

--- a/tests/RA_Interface_Tests.cpp
+++ b/tests/RA_Interface_Tests.cpp
@@ -90,6 +90,8 @@ public:
         Assert::IsNotNull((const void*)_RA_SetPaused);
         Assert::IsNotNull((const void*)_RA_OnLoadState);
         Assert::IsNotNull((const void*)_RA_OnSaveState);
+        Assert::IsNotNull((const void*)_RA_CaptureState);
+        Assert::IsNotNull((const void*)_RA_RestoreState);
         Assert::IsNotNull((const void*)_RA_OnReset);
         Assert::IsNotNull((const void*)_RA_DoAchievementsFrame);
         Assert::IsNotNull((const void*)_RA_SetConsoleID);
@@ -124,6 +126,8 @@ public:
         Assert::IsNull((const void*)_RA_SetPaused);
         Assert::IsNull((const void*)_RA_OnLoadState);
         Assert::IsNull((const void*)_RA_OnSaveState);
+        Assert::IsNull((const void*)_RA_CaptureState);
+        Assert::IsNull((const void*)_RA_RestoreState);
         Assert::IsNull((const void*)_RA_OnReset);
         Assert::IsNull((const void*)_RA_DoAchievementsFrame);
         Assert::IsNull((const void*)_RA_SetConsoleID);

--- a/tests/services/AchievementRuntime_Tests.cpp
+++ b/tests/services/AchievementRuntime_Tests.cpp
@@ -444,7 +444,7 @@ public:
         pAchievement5->SetConditionHitCount(0, 0, 2);
 
         std::string sBuffer;
-        int nSize = runtime.SaveProgressToBuffer(NULL, 0);
+        int nSize = runtime.SaveProgressToBuffer(nullptr, 0);
         sBuffer.resize(nSize);
         runtime.SaveProgressToBuffer(sBuffer.data(), nSize);
 
@@ -461,7 +461,7 @@ public:
         runtime.GetAchievementTrigger(3U)->state = RC_TRIGGER_STATE_ACTIVE;
         pAchievement3->SetConditionHitCount(0, 0, 1);
         pAchievement5->SetConditionHitCount(0, 0, 1);
-        nSize = runtime.SaveProgressToBuffer(sBuffer.data(), sBuffer.size());
+        nSize = runtime.SaveProgressToBuffer(sBuffer.data(), nSize);
         if (nSize > sBuffer.size())
         {
             sBuffer.resize(nSize);
@@ -479,7 +479,7 @@ public:
         // both active, save and restore should reset both
         runtime.GetAchievementTrigger(5U)->state = RC_TRIGGER_STATE_ACTIVE;
         pAchievement5->SetConditionHitCount(0, 0, 1);
-        nSize = runtime.SaveProgressToBuffer(sBuffer.data(), sBuffer.size());
+        nSize = runtime.SaveProgressToBuffer(sBuffer.data(), nSize);
         if (nSize > sBuffer.size())
         {
             sBuffer.resize(nSize);


### PR DESCRIPTION
Allows emulator to manage HitCount persistence (RAP files). Expected usage is to combine the RAP file with the save state file, but could potentially also be used for rewind functionality or similar behaviors.