### PR TITLE
make code notes dialog non-modal

### DIFF
--- a/src/ui/viewmodels/MemoryInspectorViewModel.cpp
+++ b/src/ui/viewmodels/MemoryInspectorViewModel.cpp
@@ -224,7 +224,7 @@ void MemoryInspectorViewModel::DeleteCurrentAddressNote()
 void MemoryInspectorViewModel::OpenNotesList()
 {
     auto& pWindowManager = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::WindowManager>();
-    pWindowManager.CodeNotes.ShowModal(*this);
+    pWindowManager.CodeNotes.Show();
 }
 
 bool MemoryInspectorViewModel::NextNote()

--- a/src/ui/win32/CodeNotesDialog.cpp
+++ b/src/ui/win32/CodeNotesDialog.cpp
@@ -57,6 +57,21 @@ CodeNotesDialog::CodeNotesDialog(CodeNotesViewModel& vmCodeNotes)
     m_bindWindow.SetInitialPosition(RelativePosition::After, RelativePosition::Near, "Code Notes");
 
     m_bindFilterValue.BindText(CodeNotesViewModel::FilterValueProperty);
+    m_bindFilterValue.BindKey(VK_RETURN, [this]()
+    {
+        m_bindFilterValue.UpdateSourceText();
+
+        auto* vmCodeNotes = dynamic_cast<CodeNotesViewModel*>(&m_vmWindow);
+        vmCodeNotes->ApplyFilter();
+        return true;
+    });
+    m_bindFilterValue.BindKey(VK_ESCAPE, [this]()
+    {
+        auto* vmCodeNotes = dynamic_cast<CodeNotesViewModel*>(&m_vmWindow);
+        vmCodeNotes->SetFilterValue(L"");
+        vmCodeNotes->ResetFilter();
+        return true;
+    });
 
     m_bindWindow.BindLabel(IDC_RA_RESULT_COUNT, CodeNotesViewModel::ResultCountProperty);
 
@@ -83,9 +98,6 @@ CodeNotesDialog::CodeNotesDialog(CodeNotesViewModel& vmCodeNotes)
         {
             auto& pWindowManager = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::WindowManager>();
             pWindowManager.MemoryInspector.SetCurrentAddress(pItem->nAddress);
-
-            auto& pDesktop = ra::services::ServiceLocator::Get<ra::ui::IDesktop>();
-            pDesktop.CloseWindow(pWindowManager.CodeNotes);
         }
     });
 

--- a/src/ui/win32/bindings/MultiLineGridBinding.cpp
+++ b/src/ui/win32/bindings/MultiLineGridBinding.cpp
@@ -65,7 +65,10 @@ void MultiLineGridBinding::OnViewModelRemoved(gsl::index nIndex)
     m_vItemMetrics.erase(m_vItemMetrics.begin() + nIndex);
 
     if (!m_vmItems->IsUpdating())
+    {
         UpdateLineOffsets();
+        GridBinding::UpdateAllItems();
+    }
 }
 
 void MultiLineGridBinding::OnViewModelStringValueChanged(gsl::index nIndex, const StringModelProperty::ChangeArgs& args)

--- a/src/ui/win32/bindings/TextBoxBinding.hh
+++ b/src/ui/win32/bindings/TextBoxBinding.hh
@@ -60,6 +60,18 @@ public:
         m_mKeyHandlers.insert_or_assign(nKey, pHandler);
     }
 
+    void UpdateSourceText()
+    {
+        const int nLength = GetWindowTextLengthW(m_hWnd);
+
+        std::wstring sBuffer;
+        sBuffer.resize(gsl::narrow_cast<size_t>(nLength) + 1);
+        GetWindowTextW(m_hWnd, sBuffer.data(), gsl::narrow_cast<int>(sBuffer.capacity()));
+        sBuffer.resize(nLength);
+
+        SetValue(*m_pTextBoundProperty, sBuffer);
+    }
+
 protected:
     void OnViewModelStringValueChanged(const StringModelProperty::ChangeArgs& args) override
     {
@@ -87,18 +99,6 @@ protected:
     }
 
 private:
-    void UpdateSourceText()
-    {
-        const int nLength = GetWindowTextLengthW(m_hWnd);
-
-        std::wstring sBuffer;
-        sBuffer.resize(gsl::narrow_cast<size_t>(nLength) + 1);
-        GetWindowTextW(m_hWnd, sBuffer.data(), gsl::narrow_cast<int>(sBuffer.capacity()));
-        sBuffer.resize(nLength);
-
-        SetValue(*m_pTextBoundProperty, sBuffer);
-    }
-
     void UpdateBoundText()
     {
         if (m_hWnd && m_pTextBoundProperty)


### PR DESCRIPTION
Allows the code notes window to stay open while using the emulator or other tool windows. Double-clicking on a row still goes to the associated address, but no longer closes the window. The window must be closed by the X.