### PR TITLE
refresh UI when lines are added/removed to code note while dialog is open

### DIFF
--- a/src/ui/win32/bindings/MultiLineGridBinding.cpp
+++ b/src/ui/win32/bindings/MultiLineGridBinding.cpp
@@ -57,7 +57,7 @@ void MultiLineGridBinding::OnViewModelAdded(gsl::index nIndex)
     }
 
     if (!m_vmItems->IsUpdating())
-        UpdateLineOffsets();
+        OnEndViewModelCollectionUpdate();
 }
 
 void MultiLineGridBinding::OnViewModelRemoved(gsl::index nIndex)
@@ -65,10 +65,7 @@ void MultiLineGridBinding::OnViewModelRemoved(gsl::index nIndex)
     m_vItemMetrics.erase(m_vItemMetrics.begin() + nIndex);
 
     if (!m_vmItems->IsUpdating())
-    {
-        UpdateLineOffsets();
-        GridBinding::UpdateAllItems();
-    }
+        OnEndViewModelCollectionUpdate();
 }
 
 void MultiLineGridBinding::OnViewModelStringValueChanged(gsl::index nIndex, const StringModelProperty::ChangeArgs& args)
@@ -98,10 +95,12 @@ void MultiLineGridBinding::OnViewModelStringValueChanged(gsl::index nIndex, cons
             pItemMetrics.nNumLines = 0;
             for (const auto& pPair : pItemMetrics.mColumnLineOffsets)
             {
-                if (pPair.second.size() > pItemMetrics.nNumLines)
-                    pItemMetrics.nNumLines = gsl::narrow_cast<unsigned int>(pPair.second.size());
+                if (pPair.second.size() + 1 > pItemMetrics.nNumLines)
+                    pItemMetrics.nNumLines = gsl::narrow_cast<unsigned int>(pPair.second.size()) + 1;
             }
-            ++pItemMetrics.nNumLines;
+
+            if (!m_vmItems->IsUpdating())
+                OnEndViewModelCollectionUpdate();
         }
     }
 }


### PR DESCRIPTION
When adding or removing lines within a code note, the changes were not being reflected in the code notes dialog.

This could lead to a situation where attempting to select a code note from the dialog went into an infinite loop as it tried to identify the address associated with the multi-line note.