### PR TITLE
fix line padding on multibyte multiline note

### DIFF
--- a/src/ui/win32/CodeNotesDialog.cpp
+++ b/src/ui/win32/CodeNotesDialog.cpp
@@ -78,8 +78,7 @@ CodeNotesDialog::CodeNotesDialog(CodeNotesViewModel& vmCodeNotes)
     auto pAddressColumn = std::make_unique<ra::ui::win32::bindings::GridTextColumnBinding>(
         CodeNotesViewModel::CodeNoteViewModel::LabelProperty);
     pAddressColumn->SetHeader(L"Address");
-    pAddressColumn->SetWidth(GridColumnBinding::WidthType::Pixels, 60);
-    pAddressColumn->SetAlignment(ra::ui::RelativePosition::Far);
+    pAddressColumn->SetWidth(GridColumnBinding::WidthType::Pixels, 64);
     m_bindNotes.BindColumn(0, std::move(pAddressColumn));
 
     auto pDescriptionColumn = std::make_unique<ra::ui::win32::bindings::GridTextColumnBinding>(

--- a/src/ui/win32/bindings/MultiLineGridBinding.cpp
+++ b/src/ui/win32/bindings/MultiLineGridBinding.cpp
@@ -227,6 +227,7 @@ void MultiLineGridBinding::UpdateItems(gsl::index nColumn)
         const auto& pItemMetrics = m_vItemMetrics.at(i);
         if (pItemMetrics.nNumLines > 1)
         {
+            unsigned int nItemLine = 1;
             const auto pIter = pItemMetrics.mColumnLineOffsets.find(gsl::narrow_cast<int>(nColumn));
             if (pIter != pItemMetrics.mColumnLineOffsets.end())
             {
@@ -245,22 +246,22 @@ void MultiLineGridBinding::UpdateItems(gsl::index nColumn)
 
                     item.pszText = nIndex < sText.length() ? &sText.at(nIndex) : &sText.at(nIndex2);
                     item.iItem = gsl::narrow_cast<int>(++nLine);
+                    ++nItemLine;
 
                     nStop = nIndex;
                 }
             }
-            else
-            {
-                for (unsigned int nIndex = 1; nIndex < pItemMetrics.nNumLines; ++nIndex)
-                {
-                    if (nLine < nItems)
-                        ListView_SetItem(m_hWnd, &item);
-                    else
-                        ListView_InsertItem(m_hWnd, &item);
 
-                    sText.at(0) = '\0';
-                    item.iItem = gsl::narrow_cast<int>(++nLine);
-                }
+            for (unsigned int nIndex = nItemLine; nIndex < pItemMetrics.nNumLines; ++nIndex)
+            {
+                if (nLine < nItems)
+                    ListView_SetItem(m_hWnd, &item);
+                else
+                    ListView_InsertItem(m_hWnd, &item);
+
+                sText.at(0) = '\0';
+                item.pszText = sText.data();
+                item.iItem = gsl::narrow_cast<int>(++nLine);
             }
         }
 


### PR DESCRIPTION
A multibyte note was always allocated two lines, but when the note takes more than two lines, it would spill over into later notes.

![image](https://user-images.githubusercontent.com/32680403/82263048-522df180-991f-11ea-913a-580edaa4c48c.png)

The note at 0x000137 is:
```
- Objects -
<8-bit?> Enemy/object slots begin here? (this technically starts 5 bytes before this one)
Bit7 = Object slot is occupied
```
The "5 bytes" text makes the dialog think the note is 5 bytes long, so it tries to put "0x000137 - 0x00013B" as the address. The note itself takes four lines to display. 

The "Object ID" note is actually for address 0x000143.

I've fixed the logic so a note with a multibyte address still reserves enough lines to fully display the note. I've also widened the column slightly to fit a range's text when using 6-character addresses.