### PR TITLE
allow virtual index calculations when backing data is being updated

### DIFF
--- a/src/ui/win32/bindings/GridBinding.cpp
+++ b/src/ui/win32/bindings/GridBinding.cpp
@@ -790,7 +790,7 @@ int GridBinding::GetVisibleItemIndex(int iItem)
 
     // make sure there's backing data
     const auto nItems = gsl::narrow_cast<int>(m_vmItems->Count());
-    if (nItems == 0 || m_vmItems->IsUpdating())
+    if (nItems == 0)
         return -1;
 
     // adjust for scroll offset


### PR DESCRIPTION
Fixes an issue in RAProject64 where selecting a search result would jump to address 0.

RAProject64's emulator runs on a different thread than the Windows messaging loop. The problem is caused when the UI thread was trying to update the selected state of an item while the "emulator thread" is updating the memory values in the results list.

