### PR TITLE
force full repaint when total memory size changes

### DIFF
--- a/src/ui/viewmodels/MemoryViewerViewModel.cpp
+++ b/src/ui/viewmodels/MemoryViewerViewModel.cpp
@@ -543,7 +543,8 @@ void MemoryViewerViewModel::OnTotalMemorySizeChanged()
             SetFirstAddress(nMaxFirstAddress);
     }
 
-    m_nNeedsRedraw |= REDRAW_ADDRESSES | REDRAW_MEMORY;
+    m_pSurface.reset();
+    m_nNeedsRedraw = REDRAW_ALL;
 }
 
 void MemoryViewerViewModel::OnByteWritten(ra::ByteAddress nAddress, uint8_t nValue)


### PR DESCRIPTION
Fixes an issue where switching from a console with a lot of memory to a console with very little memory (i.e. Atari 2600) does not clear the viewer of addresses above the new limit.