### PR TITLE
don't throw exception if recursive GetVisibleItemIndex changes ScrollOffset

### DIFF
--- a/src/ui/win32/bindings/GridBinding.hh
+++ b/src/ui/win32/bindings/GridBinding.hh
@@ -96,7 +96,7 @@ private:
     bool m_bShowGridLines = false;
     bool m_bHasScrollbar = false;
     bool m_bForceRepaint = false;
-    bool m_bAdjustingScrollOffset = false;
+    int m_nAdjustingScrollOffset = 0;
 
     size_t m_nColumnsCreated = 0;
     bool m_bHasColoredColumns = false;


### PR DESCRIPTION
Fixes an issue where selecting an item near the top of the results list would throw an exception if a number of items were selected near the bottom of the list.