### PR TITLE
ensure updated item tallies at least one line

### DIFF
--- a/src/ui/win32/bindings/MultiLineGridBinding.cpp
+++ b/src/ui/win32/bindings/MultiLineGridBinding.cpp
@@ -92,7 +92,7 @@ void MultiLineGridBinding::OnViewModelStringValueChanged(gsl::index nIndex, cons
                 pColumnLineBreaks.swap(vLineBreaks);
             }
 
-            pItemMetrics.nNumLines = 0;
+            pItemMetrics.nNumLines = 1;
             for (const auto& pPair : pItemMetrics.mColumnLineOffsets)
             {
                 if (pPair.second.size() + 1 > pItemMetrics.nNumLines)


### PR DESCRIPTION
fixes an issue where performing a filter in the code notes dialog, then resetting it would cause double-clicking on items to go to the wrong item.