### PR TITLE
ignore achievements that aren't flagged as Core or Unofficial

### DIFF
--- a/src/data/GameContext.cpp
+++ b/src/data/GameContext.cpp
@@ -130,7 +130,12 @@ void GameContext::LoadGame(unsigned int nGameId, Mode nMode)
     unsigned int nTotalCoreAchievementPoints = 0;
     for (const auto& pAchievementData : response.Achievements)
     {
-        auto& pAchievement = NewAchievement(ra::itoe<Achievement::Category>(pAchievementData.CategoryId));
+        // if the server has provided an unexpected category (usually 0), ignore it.
+        const auto nCategory = ra::itoe<Achievement::Category>(pAchievementData.CategoryId);
+        if (nCategory != Achievement::Category::Core && nCategory != Achievement::Category::Unofficial)
+            continue;
+
+        auto& pAchievement = NewAchievement(nCategory);
         pAchievement.SetID(pAchievementData.Id);
         CopyAchievementData(pAchievement, pAchievementData);
 


### PR DESCRIPTION
Several achievements across various titles are being returned with Flags of 0. 
```
{
  "ID":35,
  "MemAddr":"0xfe20>=40",
  "Title":"40 Rings",
  "Description":"40 Rings Desc",
  "Points":0,
  "Author":"Scott",
  "Modified":1351890591,
  "Created":1351814592,
  "BadgeName":"00083",
  "Flags":0
}
```
This causes them to appear in Local and confuse developers.

As these achievements don't appear when viewing the game page or when viewing the page for Unofficial achievements for the game, I've updated the client to treat them the same way. Anything coming from the server with an unrecognized Flags value will be ignored.