### PR TITLE
update bookmarks without triggering behaviors when toggling bits

### DIFF
--- a/src/ui/viewmodels/MemoryInspectorViewModel.cpp
+++ b/src/ui/viewmodels/MemoryInspectorViewModel.cpp
@@ -278,13 +278,18 @@ bool MemoryInspectorViewModel::PreviousNote()
 void MemoryInspectorViewModel::ToggleBit(int nBit)
 {
     const auto nAddress = GetCurrentAddress();
+
+    // push the updated value to the emulator
     const auto& pEmulatorContext = ra::services::ServiceLocator::Get<ra::data::EmulatorContext>();
     auto nValue = pEmulatorContext.ReadMemoryByte(nAddress);
     nValue ^= (1 << nBit);
     pEmulatorContext.WriteMemoryByte(nAddress, nValue);
-    
-    nValue = gsl::narrow_cast<uint8_t>(GetValue(CurrentAddressValueProperty));
-    nValue ^= (1 << nBit);
+
+    // if a bookmark exists for the modified address, update the current value
+    auto& pBookmarks = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::WindowManager>().MemoryBookmarks;
+    pBookmarks.OnEditMemory(nAddress);
+
+    // update the local value, which will cause the bits string to get updated
     SetValue(CurrentAddressValueProperty, nValue);
 }
 

--- a/src/ui/win32/MemoryInspectorDialog.cpp
+++ b/src/ui/win32/MemoryInspectorDialog.cpp
@@ -452,7 +452,10 @@ INT_PTR CALLBACK MemoryInspectorDialog::DialogProc(HWND hDlg, UINT uMsg, WPARAM 
                 {
                     const auto nBit = nChars >> 1;
                     if (nBit < 8)
+                    {
                         vmMemoryInspector->ToggleBit(nBit);
+                        m_bindViewer.Invalidate();
+                    }
                 }
             }
             break;

--- a/tests/ui/viewmodels/MemoryInspectorViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/MemoryInspectorViewModel_Tests.cpp
@@ -121,6 +121,34 @@ public:
         Assert::AreEqual(std::wstring(L"0 1 0 0 0 0 0 1"), inspector.GetCurrentAddressBits());
     }
 
+    TEST_METHOD(TestToggleBitWhileFrozen)
+    {
+        MemoryInspectorViewModelHarness inspector;
+        inspector.Viewer().SetAddress({ 3U });
+
+        inspector.mockWindowManager.MemoryBookmarks.AddBookmark(3, MemSize::EightBit);
+        auto* pNote = inspector.mockWindowManager.MemoryBookmarks.Bookmarks().GetItemAt(0);
+        Expects(pNote != nullptr);
+        Assert::AreEqual(3U, pNote->GetCurrentValue());
+        Assert::AreEqual((int)MemoryBookmarksViewModel::BookmarkBehavior::None, (int)pNote->GetBehavior());
+
+        Assert::AreEqual({ 0x03 }, inspector.memory.at(3));
+        Assert::AreEqual(std::wstring(L"0 0 0 0 0 0 1 1"), inspector.GetCurrentAddressBits());
+
+        inspector.ToggleBit(6);
+        Assert::AreEqual({ 0x43 }, inspector.memory.at(3));
+        Assert::AreEqual(std::wstring(L"0 1 0 0 0 0 1 1"), inspector.GetCurrentAddressBits());
+        Assert::AreEqual(0x43U, pNote->GetCurrentValue());
+
+        pNote->SetBehavior(MemoryBookmarksViewModel::BookmarkBehavior::Frozen);
+        Assert::AreEqual((int)MemoryBookmarksViewModel::BookmarkBehavior::Frozen, (int)pNote->GetBehavior());
+
+        inspector.ToggleBit(1);
+        Assert::AreEqual({ 0x41 }, inspector.memory.at(3));
+        Assert::AreEqual(std::wstring(L"0 1 0 0 0 0 0 1"), inspector.GetCurrentAddressBits());
+        Assert::AreEqual(0x41U, pNote->GetCurrentValue());
+    }
+
     TEST_METHOD(TestOpenNotesList)
     {
         MemoryInspectorViewModelHarness inspector;


### PR DESCRIPTION
Fixes #580 

Also prevent Pause on Change from triggering when clicking bitflags, and forces the memory view to update if toggling the bit while paused.