### PR TITLE
use custom GSL contract handler to log and report exceptions

### DIFF
--- a/src/RA_Core.cpp
+++ b/src/RA_Core.cpp
@@ -59,6 +59,62 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD dwReason, _UNUSED LPVOID)
     return TRUE;
 }
 
+static inline constexpr const char* __gsl_filename(const char* const str)
+{
+    if (str == nullptr)
+        return str;
+
+    if (str[0] == 's' && str[1] == 'r' && str[2] == 'c' && str[3] == '\\')
+        return str;
+
+    const char* scan = str;
+    if (scan == nullptr)
+        return str;
+
+    while (*scan != '\\')
+    {
+        if (!*scan)
+            return str;
+        scan++;
+    }
+
+    return __gsl_filename(scan + 1);
+}
+
+#ifdef NDEBUG
+void __gsl_contract_handler(const char* const file, unsigned int line)
+{
+    static char buffer[128];
+    snprintf(buffer, sizeof(buffer), "Assertion failure at %s: %d", __gsl_filename(file), line);
+
+    if (ra::services::ServiceLocator::Exists<ra::services::ILogger>())
+    {
+        RA_LOG_ERR(buffer);
+    }
+
+    if (ra::services::ServiceLocator::Exists<ra::ui::IDesktop>())
+    {
+        const auto sBuffer = ra::Widen(buffer);
+        ra::ui::viewmodels::MessageBoxViewModel::ShowErrorMessage(L"Unexpected error", sBuffer);
+    }
+
+    gsl::details::throw_exception(gsl::fail_fast(buffer));
+}
+#else
+void __gsl_contract_handler(const char* const file, unsigned int line, const char* const error)
+{
+    const char* const filename = __gsl_filename(file);
+    const auto sError = ra::StringPrintf("Assertion failure at %s: %d: %s", filename, line, error);
+
+    if (ra::services::ServiceLocator::Exists<ra::services::ILogger>())
+    {
+        RA_LOG_ERR("%s", sError.c_str());
+    }
+
+    _wassert(ra::Widen(error).c_str(), ra::Widen(filename).c_str(), line);
+}
+#endif
+
 API void CCONV _RA_UpdateHWnd(HWND hMainHWND)
 {
     if (hMainHWND != g_RAMainWnd)

--- a/src/pch.h
+++ b/src/pch.h
@@ -69,6 +69,21 @@
 /* gsl stuff */
 #define GSL_THROW_ON_CONTRACT_VIOLATION
 #include <gsl\gsl>
+
+// the default GSL Expects() macro throws an exception, which we don't try to catch anywhere.
+// replace it with our custom handler, which will log and report the error before throwing it.
+#ifndef RA_UTEST
+ #ifdef NDEBUG
+  extern void __gsl_contract_handler(const char* const file, unsigned int line);
+  #undef Expects
+  #define Expects(cond) (GSL_LIKELY(cond) ? static_cast<void>(0) : __gsl_contract_handler(__FILE__, __LINE__))
+ #else
+  extern void __gsl_contract_handler(const char* const file, unsigned int line, const char* const error);
+  #undef Expects
+  #define Expects(cond) (GSL_LIKELY(cond) ? static_cast<void>(0) : __gsl_contract_handler(__FILE__, __LINE__, GSL_STRINGIFY(cond)))
+ #endif
+#endif
+
 #pragma warning(pop)
 
 #if RA_UTEST

--- a/src/ui/ModelProperty.cpp
+++ b/src/ui/ModelProperty.cpp
@@ -36,10 +36,12 @@ const ModelPropertyBase* ModelPropertyBase::GetPropertyForKey(int nKey)
 {
     ModelPropertyBase search(nKey);
     auto iter = std::lower_bound(s_vProperties.begin(), s_vProperties.end(), &search,
-                                 [](const ModelPropertyBase* restrict left,
-                                    const ModelPropertyBase* restrict right)
+        [](const ModelPropertyBase* restrict left, const ModelPropertyBase* restrict right)
     {
-        Expects((left != nullptr) && (right != nullptr));
+        if (left == nullptr)
+            return (right != nullptr);
+        if (right == nullptr)
+            return false;
         return left->GetKey() < right->GetKey();
     });
 


### PR DESCRIPTION
There are several places in the code where we've added assertions to pacify the compiler complaining about something that could go wrong. These assertions are us telling the compiler not to worry about that because we don't think it should ever happen. However, in the rare case where it does happen, a generic "Debug Error!" dialog is shown and the application crashes.

![image](https://user-images.githubusercontent.com/32680403/89317910-4824b080-d63b-11ea-8c52-f12634f4f7c3.png)

The "Debug Error!" dialog is just reporting an unhandled exception that was thrown by the assertion. This PR expands on the assertion code to display an alternate (or additional) dialog indicating which check failed.

For release builds, the following dialog will be shown before throwing the exception (i.e. the Debug Error! dialog will still appear after this dialog):

![image](https://user-images.githubusercontent.com/32680403/89318006-730f0480-d63b-11ea-81c3-f9a41b7d2d35.png)

For debug builds. the standard assertion dialog will be shown and the exception will not be thrown. Without throwing the exception, the program may attempt to continue running, but will likely encounter a different error (like null reference) that the assertion was guarding against. 

![image](https://user-images.githubusercontent.com/32680403/89318218-b9646380-d63b-11ea-94e0-ce1994ee3de9.png)

In both cases, the file and line number associated with the problem are reported, which provides useful information for debugging the issue, although as stated above, the situations associated with this behavior are explicitly unexpected, so knowing which assertion failed won't likely be enough to resolve the problem.
