### PR TITLE
fix index out of range error if highlighted address includes byte immediately preceding first visible address

### DIFF
--- a/src/RA_Dlg_GameLibrary.cpp
+++ b/src/RA_Dlg_GameLibrary.cpp
@@ -231,13 +231,16 @@ void Dlg_GameLibrary::AddTitle(const std::string& sTitle, const std::string& sFi
     item.iItem = ListView_InsertItem(hList, &item);
 
     item.iSubItem = 1;
-    ListView_SetItemText(hList, item.iItem, 1, NativeStr(sTitle).data());
+    auto sNativeStr = NativeStr(sTitle);
+    ListView_SetItemText(hList, item.iItem, 1, sNativeStr.data());
 
     item.iSubItem = 2;
-    ListView_SetItemText(hList, item.iItem, 2, NativeStr(m_ProgressLibrary[nGameID]).data());
+    sNativeStr = NativeStr(m_ProgressLibrary[nGameID]);
+    ListView_SetItemText(hList, item.iItem, 2, sNativeStr.data());
 
     item.iSubItem = 3;
-    ListView_SetItemText(hList, item.iItem, 3, NativeStr(sFilename).data());
+    sNativeStr = NativeStr(sFilename);
+    ListView_SetItemText(hList, item.iItem, 3, sNativeStr.data());
 
     // NB: Perfect forwarding seems to cause an access violation here, so it's using an rvalue instead
     m_vGameEntries.emplace_back(GameEntry(sTitle, sFilename, nGameID));

--- a/src/api/impl/OfflineServer.cpp
+++ b/src/api/impl/OfflineServer.cpp
@@ -20,7 +20,7 @@ Login::Response OfflineServer::Login(const Login::Request& request)
     return std::move(response);
 }
 
-Logout::Response OfflineServer::Logout(const Logout::Request&)
+Logout::Response OfflineServer::Logout(const Logout::Request&) noexcept
 {
     Logout::Response response;
     response.Result = ApiResult::Success;

--- a/src/api/impl/OfflineServer.hh
+++ b/src/api/impl/OfflineServer.hh
@@ -12,7 +12,7 @@ public:
     const char* Name() const noexcept override { return "offline client"; }
 
     Login::Response Login(const Login::Request& request) override;
-    Logout::Response Logout(const Logout::Request&) override;
+    Logout::Response Logout(const Logout::Request&) noexcept override;
 
     FetchGameData::Response FetchGameData(const FetchGameData::Request& request) override;
     FetchCodeNotes::Response FetchCodeNotes(const FetchCodeNotes::Request& request) override;

--- a/src/data/EmulatorContext.cpp
+++ b/src/data/EmulatorContext.cpp
@@ -530,13 +530,14 @@ void EmulatorContext::ReadMemory(ra::ByteAddress nAddress, uint8_t pBuffer[], si
 
         switch (nToRead) // partial Duff's device to read remaining bytes
         {
-            case 7: *pBuffer++ = pBlock.read(nAddress++);
-            case 6: *pBuffer++ = pBlock.read(nAddress++);
-            case 5: *pBuffer++ = pBlock.read(nAddress++);
-            case 4: *pBuffer++ = pBlock.read(nAddress++);
-            case 3: *pBuffer++ = pBlock.read(nAddress++);
-            case 2: *pBuffer++ = pBlock.read(nAddress++);
-            case 1: *pBuffer++ = pBlock.read(nAddress++);
+            case 7: *pBuffer++ = pBlock.read(nAddress++); _FALLTHROUGH;
+            case 6: *pBuffer++ = pBlock.read(nAddress++); _FALLTHROUGH;
+            case 5: *pBuffer++ = pBlock.read(nAddress++); _FALLTHROUGH;
+            case 4: *pBuffer++ = pBlock.read(nAddress++); _FALLTHROUGH;
+            case 3: *pBuffer++ = pBlock.read(nAddress++); _FALLTHROUGH;
+            case 2: *pBuffer++ = pBlock.read(nAddress++); _FALLTHROUGH;
+            case 1: *pBuffer++ = pBlock.read(nAddress++); _FALLTHROUGH;
+            default: break;
         }
 
         if (nCount == 0)

--- a/src/ui/viewmodels/MemoryViewerViewModel.cpp
+++ b/src/ui/viewmodels/MemoryViewerViewModel.cpp
@@ -180,7 +180,7 @@ void MemoryViewerViewModel::UpdateHighlight(ra::ByteAddress nAddress, int nNewLe
         return;
 
     const auto nFirstAddress = GetFirstAddress();
-    if (nAddress < nFirstAddress && nAddress + nNewLength < nFirstAddress && nAddress + nOldLength < nFirstAddress)
+    if (nAddress < nFirstAddress && nAddress + nNewLength <= nFirstAddress && nAddress + nOldLength <= nFirstAddress)
         return;
 
     const auto nVisibleLines = GetNumVisibleLines();
@@ -192,7 +192,9 @@ void MemoryViewerViewModel::UpdateHighlight(ra::ByteAddress nAddress, int nNewLe
 
     for (int i = 0; i < nNewLength; ++i)
     {
-        m_pColor[nAddress - nFirstAddress] = HIGHLIGHTED_COLOR;
+        if (nAddress >= nFirstAddress)
+            m_pColor[nAddress - nFirstAddress] = HIGHLIGHTED_COLOR;
+
         if (++nAddress == nMaxAddress)
             return;
     }
@@ -204,7 +206,9 @@ void MemoryViewerViewModel::UpdateHighlight(ra::ByteAddress nAddress, int nNewLe
 
         while (nOldLength > nNewLength)
         {
-            m_pColor[nAddress - nFirstAddress] = STALE_COLOR | gsl::narrow_cast<uint8_t>(ra::etoi(GetColor(nAddress, pBookmarksViewModel, pGameContext)));
+            if (nAddress >= nFirstAddress)
+                m_pColor[nAddress - nFirstAddress] = STALE_COLOR | gsl::narrow_cast<uint8_t>(ra::etoi(GetColor(nAddress, pBookmarksViewModel, pGameContext)));
+
             if (++nAddress == nMaxAddress)
                 return;
 

--- a/src/ui/win32/DialogBase.cpp
+++ b/src/ui/win32/DialogBase.cpp
@@ -346,6 +346,8 @@ INT_PTR CALLBACK DialogBase::DialogProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPA
                     return 0;
                 }
             }
+
+            return 0;
         }
 
         case WM_MOVE:
@@ -385,6 +387,8 @@ INT_PTR CALLBACK DialogBase::DialogProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPA
                 if (!m_qActions.empty())
                     PostMessage(m_hWnd, WM_QUEUED_ACTION, NULL, NULL);
             }
+
+            return 0;
         }
 
         default:

--- a/tests/mocks/MockConfiguration.hh
+++ b/tests/mocks/MockConfiguration.hh
@@ -44,7 +44,7 @@ public:
     const std::wstring& GetScreenshotDirectory() const noexcept override { return m_sScreenshotDirectory; }
     void SetScreenshotDirectory(const std::wstring& sValue) override { m_sScreenshotDirectory = sValue; }
 
-    ra::ui::Position GetWindowPosition([[maybe_unused]] const std::string& /*sPositionKey*/) const override
+    ra::ui::Position GetWindowPosition([[maybe_unused]] const std::string& /*sPositionKey*/) const noexcept override
     {
         assert(!"Not implemented");
         return ra::ui::Position();

--- a/tests/mocks/MockFileSystem.hh
+++ b/tests/mocks/MockFileSystem.hh
@@ -116,7 +116,7 @@ public:
         m_mFileModifiedTimes.insert_or_assign(sPath, tLastModified);
     }
 
-    bool DeleteFile(const std::wstring& sPath) const override
+    bool DeleteFile(const std::wstring& sPath) const noexcept override
     {
         m_mFileSizes.erase(sPath);
         m_mFileModifiedTimes.erase(sPath);

--- a/tests/mocks/MockThreadPool.hh
+++ b/tests/mocks/MockThreadPool.hh
@@ -55,7 +55,7 @@ public:
     /// <summary>
     /// Gets the delay until the next task would be executed.
     /// </summary>
-    std::chrono::milliseconds NextTaskDelay() const
+    std::chrono::milliseconds NextTaskDelay() const noexcept
     {
         if (!m_vTasks.empty())
             return std::chrono::milliseconds(0);
@@ -69,7 +69,7 @@ public:
     /// <summary>
     /// Gets the number of outstanding asynchronous tasks are queued
     /// </summary>
-    size_t PendingTasks() const { return m_vTasks.size() + m_vDelayedTasks.size(); }
+    size_t PendingTasks() const noexcept { return m_vTasks.size() + m_vDelayedTasks.size(); }
 
     /// <summary>
     /// Executes the next outstanding task.

--- a/tests/ui/viewmodels/MemoryViewerViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/MemoryViewerViewModel_Tests.cpp
@@ -1705,6 +1705,47 @@ public:
         Assert::AreEqual({ 2U }, viewer.GetAddress());
         Assert::AreEqual({ 0U }, viewer.GetSelectedNibble());
     }
+
+    TEST_METHOD(TestScrollCursorOffscreen)
+    {
+        MemoryViewerViewModelHarness viewer;
+        viewer.InitializeMemory(256); // 16 rows of 16 bytes
+
+        viewer.SetFirstAddress(0x40U);
+
+        // set cursor to last character of second line
+        viewer.SetAddress(0x5FU);
+
+        // simulates scroll wheel down - advance two lines
+        viewer.SetFirstAddress(0x60U);
+
+        // selected address is offscreen, but should not have changed
+        // this also validates an edge case that was causing an index out of range exception
+        Assert::AreEqual({ 0x5FU }, viewer.GetAddress());
+
+        // reset and try again in 16-bit mode
+        viewer.SetFirstAddress(0x40U);
+        viewer.SetSize(MemSize::SixteenBit);
+        viewer.SetFirstAddress(0x60U);
+        Assert::AreEqual({ 0x5FU }, viewer.GetAddress());
+
+        viewer.SetFirstAddress(0x40U);
+        viewer.SetAddress(0x5EU);
+        viewer.SetFirstAddress(0x60U);
+        Assert::AreEqual({ 0x5EU }, viewer.GetAddress());
+
+        // reset and try again in 32-bit mode
+        viewer.SetFirstAddress(0x40U);
+        viewer.SetAddress(0x5FU);
+        viewer.SetSize(MemSize::ThirtyTwoBit);
+        viewer.SetFirstAddress(0x60U);
+        Assert::AreEqual({ 0x5FU }, viewer.GetAddress());
+
+        viewer.SetFirstAddress(0x40U);
+        viewer.SetAddress(0x5CU);
+        viewer.SetFirstAddress(0x60U);
+        Assert::AreEqual({ 0x5CU }, viewer.GetAddress());
+    }
 };
 
 } // namespace tests


### PR DESCRIPTION
Fixes a crash that occurs when using the scroll wheel to scan memory. 

![image](https://user-images.githubusercontent.com/32680403/89605622-3bff4580-d82b-11ea-8e59-60cdaa3686c7.png)

In this case, the selected address if $1BFDF, and the first visible address is $1BFC0. When I use the scroll wheel to advance the memory, the first visible address becomes $1BFE0, which is one byte after the highlighted address. When attempting to highlight the address, the logic is off by one, so it tries to update memory that is not valid, causing the application to crash.

Similar behavior was also seen in 16 and 32-bit modes when the highlighted address was was partially before the first address and partially after.