### PR TITLE
replace subscriptions to self with OnValueChanged override for property change notifications

### DIFF
--- a/src/ui/viewmodels/CodeNotesViewModel.cpp
+++ b/src/ui/viewmodels/CodeNotesViewModel.cpp
@@ -24,11 +24,9 @@ const BoolModelProperty CodeNotesViewModel::CodeNoteViewModel::IsSelectedPropert
 CodeNotesViewModel::CodeNotesViewModel() noexcept
 {
     SetWindowTitle(L"Code Notes");
-
-    AddNotifyTarget(*this);
 }
 
-void CodeNotesViewModel::OnViewModelBoolValueChanged(const BoolModelProperty::ChangeArgs& args)
+void CodeNotesViewModel::OnValueChanged(const BoolModelProperty::ChangeArgs& args)
 {
     if (args.Property == IsVisibleProperty)
     {
@@ -45,6 +43,8 @@ void CodeNotesViewModel::OnViewModelBoolValueChanged(const BoolModelProperty::Ch
                 OnActiveGameChanged();
         }
     }
+
+    WindowViewModelBase::OnValueChanged(args);
 }
 
 void CodeNotesViewModel::OnActiveGameChanged()

--- a/src/ui/viewmodels/CodeNotesViewModel.hh
+++ b/src/ui/viewmodels/CodeNotesViewModel.hh
@@ -13,7 +13,6 @@ namespace ui {
 namespace viewmodels {
 
 class CodeNotesViewModel : public WindowViewModelBase,
-    protected ViewModelBase::NotifyTarget,
     protected ra::data::GameContext::NotifyTarget
 {
 public:
@@ -139,8 +138,7 @@ public:
     void BookmarkSelected() const;
 
 protected:
-    // ViewModelBase::NotifyTarget
-    void OnViewModelBoolValueChanged(const BoolModelProperty::ChangeArgs& args) override;
+    void OnValueChanged(const BoolModelProperty::ChangeArgs& args) override;
 
     // ra::data::GameContext::NotifyTarget
     void OnActiveGameChanged() override;

--- a/src/ui/viewmodels/MemoryBookmarksViewModel.cpp
+++ b/src/ui/viewmodels/MemoryBookmarksViewModel.cpp
@@ -45,11 +45,10 @@ MemoryBookmarksViewModel::MemoryBookmarksViewModel() noexcept
     m_vBehaviors.Add(ra::etoi(BookmarkBehavior::Frozen), L"Frozen");
     m_vBehaviors.Add(ra::etoi(BookmarkBehavior::PauseOnChange), L"Pause");
 
-    AddNotifyTarget(*this);
     m_vBookmarks.AddNotifyTarget(*this);
 }
 
-void MemoryBookmarksViewModel::OnViewModelBoolValueChanged(const BoolModelProperty::ChangeArgs& args)
+void MemoryBookmarksViewModel::OnValueChanged(const BoolModelProperty::ChangeArgs& args)
 {
     if (args.Property == IsVisibleProperty)
     {
@@ -64,6 +63,8 @@ void MemoryBookmarksViewModel::OnViewModelBoolValueChanged(const BoolModelProper
             pGameContext.RemoveNotifyTarget(*this);
         }
     }
+
+    WindowViewModelBase::OnValueChanged(args);
 }
 
 GSL_SUPPRESS_F6

--- a/src/ui/viewmodels/MemoryBookmarksViewModel.hh
+++ b/src/ui/viewmodels/MemoryBookmarksViewModel.hh
@@ -18,7 +18,6 @@ namespace viewmodels {
 
 class MemoryBookmarksViewModel : public WindowViewModelBase,
     protected ra::data::GameContext::NotifyTarget,
-    protected ViewModelBase::NotifyTarget,
     protected ViewModelCollectionBase::NotifyTarget
 {
 public:
@@ -293,8 +292,7 @@ protected:
     void LoadBookmarks(ra::services::TextReader& sBookmarksFile);
     void SaveBookmarks(ra::services::TextWriter& sBookmarksFile) const;
 
-    // ViewModelBase::NotifyTarget
-    void OnViewModelBoolValueChanged(const BoolModelProperty::ChangeArgs& args) override;
+    void OnValueChanged(const BoolModelProperty::ChangeArgs& args) override;
 
     // ViewModelCollectionBase::NotifyTarget
     void OnViewModelIntValueChanged(gsl::index nIndex, const IntModelProperty::ChangeArgs& args) override;

--- a/src/ui/viewmodels/MemoryInspectorViewModel.hh
+++ b/src/ui/viewmodels/MemoryInspectorViewModel.hh
@@ -111,9 +111,11 @@ public:
     void ToggleBit(int nBit);
 
 protected:
+    void OnValueChanged(const IntModelProperty::ChangeArgs& args) override;
+    void OnValueChanged(const StringModelProperty::ChangeArgs& args) override;
+
     // ViewModelBase::NotifyTarget
     void OnViewModelIntValueChanged(const IntModelProperty::ChangeArgs& args) override;
-    void OnViewModelStringValueChanged(const StringModelProperty::ChangeArgs& args) override;
 
     // GameContext::NotifyTarget
     void OnActiveGameChanged() override;
@@ -125,6 +127,7 @@ private:
 
     MemorySearchViewModel m_pSearch;
     MemoryViewerViewModel m_pViewer;
+    bool m_bTyping = false;
 };
 
 } // namespace viewmodels

--- a/src/ui/viewmodels/MemorySearchViewModel.hh
+++ b/src/ui/viewmodels/MemorySearchViewModel.hh
@@ -17,7 +17,6 @@ namespace ui {
 namespace viewmodels {
 
 class MemorySearchViewModel : public ViewModelBase,
-    protected ViewModelBase::NotifyTarget,
     protected ViewModelCollectionBase::NotifyTarget,
     protected data::EmulatorContext::NotifyTarget,
     protected data::GameContext::NotifyTarget
@@ -447,10 +446,9 @@ public:
     void BookmarkSelected();
 
 protected:
-    // ViewModelBase::NotifyTarget
-    void OnViewModelBoolValueChanged(const BoolModelProperty::ChangeArgs& args) override;
-    void OnViewModelIntValueChanged(const IntModelProperty::ChangeArgs& args) override;
-    void OnViewModelStringValueChanged(const StringModelProperty::ChangeArgs& args) override;
+    void OnValueChanged(const BoolModelProperty::ChangeArgs& args) override;
+    void OnValueChanged(const IntModelProperty::ChangeArgs& args) override;
+    void OnValueChanged(const StringModelProperty::ChangeArgs& args) override;
 
     // ViewModelCollectionBase::NotifyTarget
     void OnViewModelBoolValueChanged(gsl::index nIndex, const BoolModelProperty::ChangeArgs& args) override;
@@ -482,6 +480,8 @@ private:
     bool m_bIsContinuousFiltering = false;
     std::chrono::steady_clock::time_point m_tLastContinuousFilter;
     bool m_bNeedsRedraw = false;
+    bool m_bScrolling = false;
+    bool m_bSelectingFilter = false;
 
     struct SearchResult
     {

--- a/src/ui/viewmodels/MemoryViewerViewModel.cpp
+++ b/src/ui/viewmodels/MemoryViewerViewModel.cpp
@@ -95,8 +95,6 @@ MemoryViewerViewModel::MemoryViewerViewModel()
     memset(m_pColor, STALE_COLOR, MaxLines * 16);
 
     m_pColor[0] = HIGHLIGHTED_COLOR;
-
-    AddNotifyTarget(*this);
 }
 
 void MemoryViewerViewModel::InitializeNotifyTargets()
@@ -255,7 +253,7 @@ void MemoryViewerViewModel::SetFirstAddress(ra::ByteAddress value)
     SetValue(FirstAddressProperty, nSignedValue);
 }
 
-void MemoryViewerViewModel::OnViewModelIntValueChanged(const IntModelProperty::ChangeArgs& args)
+void MemoryViewerViewModel::OnValueChanged(const IntModelProperty::ChangeArgs& args)
 {
     if (args.Property == AddressProperty)
     {
@@ -313,6 +311,8 @@ void MemoryViewerViewModel::OnViewModelIntValueChanged(const IntModelProperty::C
         m_pSurface.reset();
         m_nNeedsRedraw = REDRAW_ALL;
     }
+
+    ViewModelBase::OnValueChanged(args);
 }
 
 void MemoryViewerViewModel::AdvanceCursor()

--- a/src/ui/viewmodels/MemoryViewerViewModel.hh
+++ b/src/ui/viewmodels/MemoryViewerViewModel.hh
@@ -17,7 +17,6 @@ namespace ui {
 namespace viewmodels {
 
 class MemoryViewerViewModel : public ViewModelBase,
-                              protected ViewModelBase::NotifyTarget,
                               protected ra::data::GameContext::NotifyTarget,
                               protected ra::data::EmulatorContext::NotifyTarget
 {
@@ -173,7 +172,7 @@ public:
     void RetreatCursorPage();
 
 protected:
-    void OnViewModelIntValueChanged(const IntModelProperty::ChangeArgs& args) override;
+    void OnValueChanged(const IntModelProperty::ChangeArgs& args) override;
 
     // GameContext::NotifyTarget
     void OnActiveGameChanged() override;

--- a/src/ui/viewmodels/OverlaySettingsViewModel.cpp
+++ b/src/ui/viewmodels/OverlaySettingsViewModel.cpp
@@ -22,8 +22,6 @@ const StringModelProperty OverlaySettingsViewModel::ScreenshotLocationProperty("
 OverlaySettingsViewModel::OverlaySettingsViewModel() noexcept
 {
     SetWindowTitle(L"Overlay Settings");
-
-    AddNotifyTarget(*this);
 }
 
 void OverlaySettingsViewModel::Initialize()
@@ -63,7 +61,7 @@ void OverlaySettingsViewModel::Commit()
     pConfiguration.Save();
 }
 
-void OverlaySettingsViewModel::OnViewModelBoolValueChanged(const BoolModelProperty::ChangeArgs& args)
+void OverlaySettingsViewModel::OnValueChanged(const BoolModelProperty::ChangeArgs& args)
 {
     if (args.Property == DisplayAchievementTriggerProperty && !args.tNewValue)
         SetScreenshotAchievementTrigger(false);
@@ -73,6 +71,8 @@ void OverlaySettingsViewModel::OnViewModelBoolValueChanged(const BoolModelProper
         SetScreenshotMastery(false);
     else if (args.Property == ScreenshotMasteryProperty && args.tNewValue)
         SetDisplayMastery(true);
+
+    WindowViewModelBase::OnValueChanged(args);
 }
 
 void OverlaySettingsViewModel::BrowseLocation()

--- a/src/ui/viewmodels/OverlaySettingsViewModel.hh
+++ b/src/ui/viewmodels/OverlaySettingsViewModel.hh
@@ -8,7 +8,7 @@ namespace ra {
 namespace ui {
 namespace viewmodels {
 
-class OverlaySettingsViewModel : public WindowViewModelBase, ViewModelBase::NotifyTarget
+class OverlaySettingsViewModel : public WindowViewModelBase
 {
 public:
     GSL_SUPPRESS_F6 OverlaySettingsViewModel() noexcept;
@@ -164,7 +164,7 @@ public:
     void BrowseLocation();
 
 protected:
-    void OnViewModelBoolValueChanged(const BoolModelProperty::ChangeArgs& args) override;
+    void OnValueChanged(const BoolModelProperty::ChangeArgs& args) override;
 };
 
 } // namespace viewmodels

--- a/src/ui/viewmodels/RichPresenceMonitorViewModel.cpp
+++ b/src/ui/viewmodels/RichPresenceMonitorViewModel.cpp
@@ -17,8 +17,6 @@ const StringModelProperty RichPresenceMonitorViewModel::DisplayStringProperty("R
 RichPresenceMonitorViewModel::RichPresenceMonitorViewModel() noexcept
 {
     SetWindowTitle(L"Rich Presence Monitor");
-
-    AddNotifyTarget(*this);
 }
 
 void RichPresenceMonitorViewModel::InitializeNotifyTargets()
@@ -154,7 +152,7 @@ void RichPresenceMonitorViewModel::OnActiveGameChanged()
         UpdateDisplayString();
 }
 
-void RichPresenceMonitorViewModel::OnViewModelBoolValueChanged(const BoolModelProperty::ChangeArgs& args)
+void RichPresenceMonitorViewModel::OnValueChanged(const BoolModelProperty::ChangeArgs& args)
 {
     if (args.Property == IsVisibleProperty)
     {
@@ -168,6 +166,8 @@ void RichPresenceMonitorViewModel::OnViewModelBoolValueChanged(const BoolModelPr
             StopMonitoring();
         }
     }
+
+    WindowViewModelBase::OnValueChanged(args);
 }
 
 } // namespace viewmodels

--- a/src/ui/viewmodels/RichPresenceMonitorViewModel.hh
+++ b/src/ui/viewmodels/RichPresenceMonitorViewModel.hh
@@ -11,7 +11,6 @@ namespace ui {
 namespace viewmodels {
 
 class RichPresenceMonitorViewModel : public WindowViewModelBase, 
-    protected ViewModelBase::NotifyTarget,
     protected ra::data::GameContext::NotifyTarget
 {
 public:
@@ -50,8 +49,7 @@ protected:
     /// </summary>
     void StopMonitoring() noexcept;
 
-    // ViewModelBase::NotifyTarget
-    void OnViewModelBoolValueChanged(const BoolModelProperty::ChangeArgs& args) override;
+    void OnValueChanged(const BoolModelProperty::ChangeArgs& args) override;
 
     // GameContext::NotifyTarget
     void OnActiveGameChanged() override;

--- a/src/ui/viewmodels/UnknownGameViewModel.cpp
+++ b/src/ui/viewmodels/UnknownGameViewModel.cpp
@@ -25,8 +25,6 @@ const BoolModelProperty UnknownGameViewModel::TestModeProperty("UnknownGameViewM
 UnknownGameViewModel::UnknownGameViewModel() noexcept
 {
     SetWindowTitle(L"Unknown Title");
-
-    AddNotifyTarget(*this); // so we can synchronize NewGameName and SelectedGameId in one direction only
 }
 
 void UnknownGameViewModel::InitializeGameTitles()
@@ -132,25 +130,29 @@ bool UnknownGameViewModel::BeginTest()
     return true;
 }
 
-void UnknownGameViewModel::OnViewModelStringValueChanged(const StringModelProperty::ChangeArgs& args)
+void UnknownGameViewModel::OnValueChanged(const StringModelProperty::ChangeArgs& args)
 {
-    if (args.Property == NewGameNameProperty)
+    if (args.Property == NewGameNameProperty && !m_bSelectingGame)
     {
         // user is entering a custom name, make sure <New Game> is selected
         SetSelectedGameId(0);
     }
+
+    WindowViewModelBase::OnValueChanged(args);
 }
 
-void UnknownGameViewModel::OnViewModelIntValueChanged(const IntModelProperty::ChangeArgs& args)
+void UnknownGameViewModel::OnValueChanged(const IntModelProperty::ChangeArgs& args)
 {
     if (args.Property == SelectedGameIdProperty && args.tNewValue != 0)
     {
         // copy the selected game name into the new game name field
         // disable the notifications so we don't reset the selection to <New Game>
-        RemoveNotifyTarget(*this);
+        m_bSelectingGame = true;
         SetNewGameName(m_vGameTitles.GetLabelForId(args.tNewValue));
-        AddNotifyTarget(*this);
+        m_bSelectingGame = false;
     }
+
+    WindowViewModelBase::OnValueChanged(args);
 }
 
 void UnknownGameViewModel::CopyChecksumToClipboard() const

--- a/src/ui/viewmodels/UnknownGameViewModel.hh
+++ b/src/ui/viewmodels/UnknownGameViewModel.hh
@@ -12,7 +12,7 @@ namespace ra {
 namespace ui {
 namespace viewmodels {
 
-class UnknownGameViewModel : public WindowViewModelBase, protected ViewModelBase::NotifyTarget, protected ra::data::AsyncObject
+class UnknownGameViewModel : public WindowViewModelBase, protected ra::data::AsyncObject
 {
 public:
     GSL_SUPPRESS_F6 UnknownGameViewModel() noexcept;
@@ -150,10 +150,11 @@ public:
     bool BeginTest();
 
 protected:
-    void OnViewModelStringValueChanged(const StringModelProperty::ChangeArgs& args) override;
-    void OnViewModelIntValueChanged(const IntModelProperty::ChangeArgs& args) override;
+    void OnValueChanged(const StringModelProperty::ChangeArgs& args) override;
+    void OnValueChanged(const IntModelProperty::ChangeArgs& args) override;
 
     LookupItemViewModelCollection m_vGameTitles;
+    bool m_bSelectingGame = false;
 };
 
 } // namespace viewmodels

--- a/tests/ui/TransactionalViewModelBase_Tests.cpp
+++ b/tests/ui/TransactionalViewModelBase_Tests.cpp
@@ -62,7 +62,7 @@ TEST_CLASS(TransactionalViewModelBase_Tests)
 
         void AssertBoolChanged(const BoolModelProperty& pProperty, bool bOldValue, bool bNewValue)
         {
-            for(const auto& args : m_vChangedBools)
+            for (const auto& args : m_vChangedBools)
             {
                 if (args.Property == pProperty)
                 {
@@ -74,7 +74,7 @@ TEST_CLASS(TransactionalViewModelBase_Tests)
 
             Assert::Fail(L"Property did not change");
         }
-        
+
         void AssertNotChanged(const BoolModelProperty& pProperty)
         {
             for (const auto& args : m_vChangedBools)
@@ -91,7 +91,7 @@ TEST_CLASS(TransactionalViewModelBase_Tests)
 
         void AssertStringChanged(const StringModelProperty& pProperty, const std::wstring& sOldValue, const std::wstring& sNewValue)
         {
-            for(const auto& args : m_vChangedStrings)
+            for (const auto& args : m_vChangedStrings)
             {
                 if (args.Property == pProperty)
                 {
@@ -120,7 +120,7 @@ TEST_CLASS(TransactionalViewModelBase_Tests)
 
         void AssertIntChanged(const IntModelProperty& pProperty, int nOldValue, int nNewValue)
         {
-            for(const auto& args : m_vChangedInts)
+            for (const auto& args : m_vChangedInts)
             {
                 if (args.Property == pProperty)
                 {


### PR DESCRIPTION
#588 added a virtual method to the `ViewModelBase` class for handling property changes via a virtual function instead of having to subscribe to the class's notification event. This gives the subclass control to make changes before or after notifying other subscribers. The trade-off is that booleans have to be added (instead of temporarily unsubscribing) when a property changing should be ignored because the class is modifying a related property.