### PR TITLE
update all references to leaderboard scores to use signed ints

### DIFF
--- a/src/RA_Leaderboard.cpp
+++ b/src/RA_Leaderboard.cpp
@@ -60,7 +60,7 @@ void RA_Leaderboard::SetActive(bool bActive) noexcept
     }
 }
 
-std::string RA_Leaderboard::FormatScore(unsigned int nValue) const
+std::string RA_Leaderboard::FormatScore(int nValue) const
 {
     char buffer[32];
     rc_format_value(buffer, sizeof(buffer), nValue, m_nFormat);

--- a/src/RA_Leaderboard.h
+++ b/src/RA_Leaderboard.h
@@ -25,7 +25,7 @@ public:
     const std::string& Description() const noexcept { return m_sDescription; }
     void SetDescription(const std::string& sValue) { m_sDescription = sValue; }
 
-    std::string FormatScore(unsigned int nValue) const;
+    std::string FormatScore(int nValue) const;
 
     struct Entry
     {

--- a/src/api/SubmitLeaderboardEntry.hh
+++ b/src/api/SubmitLeaderboardEntry.hh
@@ -14,8 +14,8 @@ public:
 
     struct Response : ApiResponseBase
     {
-        unsigned int Score{ 0U };
-        unsigned int BestScore{ 0U };
+        int Score{ 0U };
+        int BestScore{ 0U };
         unsigned int NewRank{ 0U };
         unsigned int NumEntries{ 0U };
 
@@ -23,7 +23,7 @@ public:
         {
             unsigned int Rank{ 0U };
             std::string User;
-            unsigned int Score{ 0U };
+            int Score{ 0U };
         };
 
         std::vector<Entry> TopEntries;
@@ -32,7 +32,7 @@ public:
     struct Request : ApiRequestBase
     {
         unsigned int LeaderboardId{ 0U };
-        unsigned int Score{ 0U };
+        int Score{ 0U };
         std::string GameHash;
 
         using Callback = std::function<void(const Response& response)>;

--- a/src/api/impl/ConnectedServer.cpp
+++ b/src/api/impl/ConnectedServer.cpp
@@ -204,6 +204,27 @@ static void GetRequiredJsonField(_Out_ unsigned int& nValue, _In_ const rapidjso
     }
 }
 
+static void GetRequiredJsonField(_Out_ int& nValue, _In_ const rapidjson::Value& pDocument,
+    _In_ const char* const sField, _Inout_ ApiResponseBase& response)
+{
+    if (!pDocument.HasMember(sField))
+    {
+        nValue = 0;
+
+        response.Result = ApiResult::Error;
+        if (response.ErrorMessage.empty())
+            response.ErrorMessage = ra::StringPrintf("%s not found in response", sField);
+    }
+    else
+    {
+        auto& pField = pDocument[sField];
+        if (pField.IsInt())
+            nValue = pField.GetInt();
+        else
+            nValue = 0;
+    }
+}
+
 static void GetOptionalJsonField(_Out_ unsigned int& nValue, _In_ const rapidjson::Value& pDocument,
                                  _In_ const char* sField, _In_ unsigned int nDefaultValue = 0)
 {

--- a/src/data/GameContext.cpp
+++ b/src/data/GameContext.cpp
@@ -982,7 +982,7 @@ void GameContext::ActivateLeaderboards()
     }
 }
 
-void GameContext::SubmitLeaderboardEntry(ra::LeaderboardID nLeaderboardId, unsigned int nScore) const
+void GameContext::SubmitLeaderboardEntry(ra::LeaderboardID nLeaderboardId, int nScore) const
 {
     const auto* pLeaderboard = FindLeaderboard(nLeaderboardId);
     if (pLeaderboard == nullptr)

--- a/src/data/GameContext.hh
+++ b/src/data/GameContext.hh
@@ -157,7 +157,7 @@ public:
     /// <summary>
     /// Submit a new score for the specified leaderboard.
     /// </summary>
-    void SubmitLeaderboardEntry(ra::LeaderboardID nLeaderboardId, unsigned int nScore) const;
+    void SubmitLeaderboardEntry(ra::LeaderboardID nLeaderboardId, int nScore) const;
 
     /// <summary>
     /// Updates the set of unlocked achievements from the server.

--- a/tests/data/GameContext_Tests.cpp
+++ b/tests/data/GameContext_Tests.cpp
@@ -1664,7 +1664,7 @@ public:
             (const ra::api::SubmitLeaderboardEntry::Request& request, ra::api::SubmitLeaderboardEntry::Response& response)
         {
             Assert::AreEqual(1U, request.LeaderboardId);
-            Assert::AreEqual(1234U, request.Score);
+            Assert::AreEqual(1234, request.Score);
             Assert::AreEqual(std::string("hash"), request.GameHash);
             nNewScore = request.Score;
 
@@ -1886,7 +1886,7 @@ public:
         (const ra::api::SubmitLeaderboardEntry::Request & request, ra::api::SubmitLeaderboardEntry::Response & response)
         {
             Assert::AreEqual(1U, request.LeaderboardId);
-            Assert::AreEqual(1234U, request.Score);
+            Assert::AreEqual(1234, request.Score);
             Assert::AreEqual(std::string("hash"), request.GameHash);
             nNewScore = request.Score;
 


### PR DESCRIPTION
rcheevos was updated to support signed leaderboard values in 0.77, but there was apparently still an implicit cast to a non-signed value when the entry was submitted to the server. This audits all references to leaderboard scores and makes sure they're all signed.