### PR TITLE
add text search capability to Memory Inspector

### DIFF
--- a/src/data/Types.hh
+++ b/src/data/Types.hh
@@ -18,7 +18,8 @@ enum class MemSize : uint8_t
     SixteenBit,
     TwentyFourBit,
     ThirtyTwoBit,
-    BitCount
+    BitCount,
+    Text
 };
 
 namespace ra {

--- a/src/services/SearchResults.cpp
+++ b/src/services/SearchResults.cpp
@@ -180,7 +180,7 @@ protected:
         return srResults.m_vBlocks.front().GetAddress();
     }
 
-    static const std::vector<impl::MemBlock>& GetBlocks(const SearchResults& srResults)
+    static const std::vector<impl::MemBlock>& GetBlocks(const SearchResults& srResults) noexcept
     {
         return srResults.m_vBlocks;
     }
@@ -555,6 +555,9 @@ public:
     virtual bool CompareMemory(const unsigned char* pLeft,
         const unsigned char* pRight, size_t nCount, ComparisonType nCompareType) const
     {
+        Expects(pLeft != nullptr);
+        Expects(pRight != nullptr);
+
         do
         {
             // not exact match, compare the current character normally

--- a/src/services/SearchResults.h
+++ b/src/services/SearchResults.h
@@ -15,6 +15,7 @@ enum class SearchType
     ThirtyTwoBit,
     SixteenBitAligned,
     ThirtyTwoBitAligned,
+    AsciiText,
 };
 
 enum class SearchFilterType
@@ -132,6 +133,27 @@ public:
         _In_ ComparisonType nCompareType, _In_ SearchFilterType nFilterType, _In_ unsigned int nFilterValue);
 
     /// <summary>
+    /// Initializes a result set by comparing against another result set.
+    /// </summary>
+    /// <param name="srSource">The result set to filter.</param>
+    /// <param name="nCompareType">Type of comparison to apply.</param>
+    /// <param name="nFilterType">Type of filter to apply.</param>
+    /// <param name="sFilterValue">Parameter for filter being applied.</param>
+    void Initialize(_In_ const SearchResults& srSource, _In_ ComparisonType nCompareType,
+        _In_ SearchFilterType nFilterType, _In_ const std::wstring& sFilterValue);
+
+    /// <summary>
+    /// Initializes a result set by comparing against another result set using the address filter from a third set.
+    /// </summary>
+    /// <param name="srSource">The result set to filter.</param>
+    /// <param name="srAddresses">The result set specifying which addresses to examine.</param>
+    /// <param name="nCompareType">Type of comparison to apply.</param>
+    /// <param name="nFilterType">Type of filter to apply.</param>
+    /// <param name="sFilterValue">Parameter for filter being applied.</param>
+    void Initialize(_In_ const SearchResults& srSource, _In_ const SearchResults& srAddresses,
+        _In_ ComparisonType nCompareType, _In_ SearchFilterType nFilterType, _In_ const std::wstring& sFilterValue);
+
+    /// <summary>
     /// Gets the number of matching addresses.
     /// </summary>
     size_t MatchingAddressCount() const noexcept;
@@ -178,6 +200,11 @@ public:
     unsigned int GetFilterValue() const noexcept { return m_nFilterValue; }
 
     /// <summary>
+    /// Gets the filter parameter that was applied to generate this search result.
+    /// </summary>
+    const std::wstring& GetFilterString() const noexcept { return m_sFilterValue; }
+
+    /// <summary>
     /// Gets the filter comparison that was applied to generate this search result.
     /// </summary>
     ComparisonType GetFilterComparison() const noexcept { return m_nCompareType; }
@@ -203,6 +230,8 @@ public:
     void ExcludeMatchingAddress(gsl::index nIndex);
 
 private:
+    void MergeSearchResults(const SearchResults& srMemory, const SearchResults& srAddresses);
+
     std::vector<impl::MemBlock> m_vBlocks;
     SearchType m_nType = SearchType::EightBit;
 
@@ -213,6 +242,7 @@ private:
     ComparisonType m_nCompareType = ComparisonType::Equals;
     SearchFilterType m_nFilterType = SearchFilterType::None;
     unsigned int m_nFilterValue = 0U;
+    std::wstring m_sFilterValue;
 };
 
 } // namespace services

--- a/src/services/SearchResults.h
+++ b/src/services/SearchResults.h
@@ -165,6 +165,7 @@ public:
         MemSize nSize{};
 
         bool Compare(unsigned int nPreviousValue, ComparisonType nCompareType) const noexcept;
+        bool Compare(const std::wstring& sPreviousValue, ComparisonType nCompareType) const noexcept;
     };
 
     /// <summary>
@@ -178,6 +179,11 @@ public:
     /// Gets the value at the specified address.
     /// </summary>
     bool GetValue(ra::ByteAddress nAddress, MemSize nSize, _Out_ unsigned int& nValue) const noexcept;
+
+    /// <summary>
+    /// Gets the raw bytes at the specified address.
+    /// </summary>
+    bool GetBytes(ra::ByteAddress nAddress, unsigned char* pBuffer, size_t nCount) const noexcept;
 
     /// <summary>
     /// Gets the type of search performed.

--- a/src/ui/viewmodels/MemorySearchViewModel.cpp
+++ b/src/ui/viewmodels/MemorySearchViewModel.cpp
@@ -838,8 +838,8 @@ void MemorySearchViewModel::UpdateResult(SearchResultViewModel& pRow, ra::servic
             pEmulatorContext.ReadMemory(pResult.nAddress, &pBuffer.at(0), pBuffer.size());
 
             std::string sText;
-            for (size_t i = 0; i < pBuffer.size() && pBuffer[i]; ++i)
-                sText.push_back(static_cast<char>(pBuffer[i]));
+            for (size_t i = 0; i < pBuffer.size() && pBuffer.at(i); ++i)
+                sText.push_back(static_cast<char>(pBuffer.at(i)));
 
             pRow.SetCurrentValue(ra::Widen(sText));
 
@@ -847,8 +847,8 @@ void MemorySearchViewModel::UpdateResult(SearchResultViewModel& pRow, ra::servic
             {
                 pCompareResults.GetBytes(pResult.nAddress, &pBuffer.at(0), pBuffer.size());
                 sText.clear();
-                for (size_t i = 0; i < pBuffer.size() && pBuffer[i]; ++i)
-                    sText.push_back(static_cast<char>(pBuffer[i]));
+                for (size_t i = 0; i < pBuffer.size() && pBuffer.at(i); ++i)
+                    sText.push_back(static_cast<char>(pBuffer.at(i)));
 
                 pRow.SetPreviousValue(ra::Widen(sText));
             }

--- a/src/ui/viewmodels/MemorySearchViewModel.cpp
+++ b/src/ui/viewmodels/MemorySearchViewModel.cpp
@@ -97,6 +97,7 @@ MemorySearchViewModel::MemorySearchViewModel()
     m_vSearchTypes.Add(ra::etoi(ra::services::SearchType::ThirtyTwoBit), L"32-bit");
     m_vSearchTypes.Add(ra::etoi(ra::services::SearchType::SixteenBitAligned), L"16-bit (aligned)");
     m_vSearchTypes.Add(ra::etoi(ra::services::SearchType::ThirtyTwoBitAligned), L"32-bit (aligned)");
+    m_vSearchTypes.Add(ra::etoi(ra::services::SearchType::AsciiText), L"ASCII Text");
 
     m_vComparisonTypes.Add(ra::etoi(ComparisonType::Equals), L"=");
     m_vComparisonTypes.Add(ra::etoi(ComparisonType::LessThan), L"<");

--- a/src/ui/viewmodels/MemorySearchViewModel.hh
+++ b/src/ui/viewmodels/MemorySearchViewModel.hh
@@ -465,6 +465,9 @@ private:
     bool ParseFilterRange(_Out_ ra::ByteAddress& nStart, _Out_ ra::ByteAddress& nEnd);
     void ApplyContinuousFilter();
     void UpdateResults();
+    void UpdateResult(SearchResultViewModel& pRow, ra::services::SearchResults::Result& pResult, 
+        const ra::data::EmulatorContext& pEmulatorContext, bool bCapturePrevious);
+
     void AddNewPage();
     void ChangePage(size_t nNewPage);
 
@@ -496,8 +499,8 @@ private:
     std::set<unsigned int> m_vSelectedAddresses;
 
     static bool TestFilter(const ra::services::SearchResults::Result& pResult, const SearchResult& pCurrentResults, unsigned int nPreviousValue) noexcept;
-    void ApplyFilter(SearchResult& pResult, const SearchResult& pPreviousResult, 
-        ComparisonType nComparisonType, ra::services::SearchFilterType nValueType, unsigned int nValue);
+    void ApplyFilter(SearchResult& pResult, const SearchResult& pPreviousResult,
+        ComparisonType nComparisonType, ra::services::SearchFilterType nValueType, unsigned int nValue, const std::wstring& sValue);
 };
 
 } // namespace viewmodels

--- a/src/ui/win32/MemoryInspectorDialog.cpp
+++ b/src/ui/win32/MemoryInspectorDialog.cpp
@@ -97,6 +97,7 @@ void MemoryInspectorDialog::SearchResultsGridBinding::OnViewModelIntValueChanged
             default:
             case MemSize::SixteenBit:   nWidth = nCharWidth * (4 + 2) + nPadding * 2; break;
             case MemSize::ThirtyTwoBit: nWidth = nCharWidth * (8 + 2) + nPadding * 2; break;
+            case MemSize::Text:         nWidth = nCharWidth * (16 + 2) + nPadding * 2; break;
         }
 
         m_vColumns.at(1)->SetWidth(GridColumnBinding::WidthType::Pixels, nWidth);

--- a/tests/RA_UnitTestHelpers.h
+++ b/tests/RA_UnitTestHelpers.h
@@ -50,7 +50,16 @@ std::wstring ToString<__int64>(const __int64& t)
 template<>
 std::wstring ToString<MemSize>(const MemSize& t)
 {
-    return MEMSIZE_STR.at(ra::etoi(t));
+    switch (t)
+    {
+        case MemSize::Text:
+            return L"Text";
+        default:
+            if (ra::etoi(t) < MEMSIZE_STR.size())
+                return MEMSIZE_STR.at(ra::etoi(t));
+            return std::to_wstring(ra::etoi(t));
+    }
+
 }
 
 template<>

--- a/tests/services/SearchResults_Tests.cpp
+++ b/tests/services/SearchResults_Tests.cpp
@@ -1076,12 +1076,12 @@ public:
         SearchResults::Result result;
         Assert::IsTrue(results.GetMatchingAddress(0U, result));
         Assert::AreEqual(0U, result.nAddress);
-        Assert::AreEqual(MemSize::EightBit, result.nSize);
+        Assert::AreEqual(MemSize::Text, result.nSize);
         Assert::AreEqual({ 'S' }, result.nValue);
 
         Assert::IsTrue(results.GetMatchingAddress(35U, result));
         Assert::AreEqual(35U, result.nAddress);
-        Assert::AreEqual(MemSize::EightBit, result.nSize);
+        Assert::AreEqual(MemSize::Text, result.nSize);
         Assert::AreEqual({ '.' }, result.nValue);
     }
 

--- a/tests/ui/viewmodels/MemorySearchViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/MemorySearchViewModel_Tests.cpp
@@ -131,7 +131,7 @@ public:
         Assert::AreEqual(std::wstring(L""), search.GetFilterRange());
         Assert::AreEqual(std::wstring(L""), search.GetFilterValue());
 
-        Assert::AreEqual({ 6U }, search.SearchTypes().Count());
+        Assert::AreEqual({ 7U }, search.SearchTypes().Count());
         Assert::AreEqual((int)ra::services::SearchType::FourBit, search.SearchTypes().GetItemAt(0)->GetId());
         Assert::AreEqual(std::wstring(L"4-bit"), search.SearchTypes().GetItemAt(0)->GetLabel());
         Assert::AreEqual((int)ra::services::SearchType::EightBit, search.SearchTypes().GetItemAt(1)->GetId());
@@ -144,6 +144,8 @@ public:
         Assert::AreEqual(std::wstring(L"16-bit (aligned)"), search.SearchTypes().GetItemAt(4)->GetLabel());
         Assert::AreEqual((int)ra::services::SearchType::ThirtyTwoBitAligned, search.SearchTypes().GetItemAt(5)->GetId());
         Assert::AreEqual(std::wstring(L"32-bit (aligned)"), search.SearchTypes().GetItemAt(5)->GetLabel());
+        Assert::AreEqual((int)ra::services::SearchType::AsciiText, search.SearchTypes().GetItemAt(6)->GetId());
+        Assert::AreEqual(std::wstring(L"ASCII Text"), search.SearchTypes().GetItemAt(6)->GetLabel());
         Assert::AreEqual(ra::services::SearchType::EightBit, search.GetSearchType());
 
         Assert::AreEqual({ 6U }, search.ComparisonTypes().Count());


### PR DESCRIPTION
There's a few situations where it would be nice to locate text in the memory. As we move to newer systems, they pretty much all use ASCII (8-bit) or Unicode (16-bit) character sets. This adds the ability to search for ASCII strings. Unicode strings will be added in a future PR, as will ASCII and Unicode formats for bookmarks.

![image](https://user-images.githubusercontent.com/32680403/94349094-93858a80-fffe-11ea-9359-e74d71015d1a.png)
