### PR TITLE
support for selecting/deselecting all items in grid control

### DIFF
--- a/src/ui/win32/DialogBase.cpp
+++ b/src/ui/win32/DialogBase.cpp
@@ -345,6 +345,23 @@ INT_PTR CALLBACK DialogBase::DialogProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPA
 
                     return 0;
                 }
+
+                case LVN_KEYDOWN:
+                {
+                    ra::ui::win32::bindings::GridBinding* pGridBinding;
+                    GSL_SUPPRESS_TYPE1 pGridBinding = dynamic_cast<ra::ui::win32::bindings::GridBinding*>(
+                        FindControlBinding(pnmHdr->hwndFrom));
+
+                    if (pGridBinding)
+                    {
+                        NMLVKEYDOWN* plvkd;
+                        GSL_SUPPRESS_TYPE1{ plvkd = reinterpret_cast<NMLVKEYDOWN*>(lParam); }
+                        Expects(plvkd != nullptr);
+                        pGridBinding->OnLvnKeyDown(plvkd);
+                    }
+
+                    return 0;
+                }
             }
 
             return 0;

--- a/src/ui/win32/bindings/GridBinding.cpp
+++ b/src/ui/win32/bindings/GridBinding.cpp
@@ -1036,6 +1036,37 @@ void GridBinding::OnNmDblClick(const NMITEMACTIVATE* pnmItemActivate)
         m_pDoubleClickHandler(gsl::narrow_cast<gsl::index>(pnmItemActivate->iItem));
 }
 
+void GridBinding::OnLvnKeyDown(const LPNMLVKEYDOWN pnmKeyDown) noexcept
+{
+    // only interested in Ctrl key events
+    const bool bControlHeld = (GetKeyState(VK_CONTROL) < 0);
+    if (!bControlHeld)
+        return;
+
+    // ignore Ctrl+Alt
+    const bool bAltHeld = (GetKeyState(VK_MENU) < 0);
+    if (bAltHeld)
+        return;
+
+    // ignore Ctrl+Shift
+    const bool bShiftHeld = (GetKeyState(VK_SHIFT) < 0);
+    if (bShiftHeld)
+        return;
+
+    switch (pnmKeyDown->wVKey)
+    {
+        case 'A': // Ctrl+A = select all
+            if ((GetWindowLong(m_hWnd, GWL_STYLE) & LVS_SINGLESEL) == 0)
+                ListView_SetItemState(m_hWnd, -1, LVIS_SELECTED, LVIS_SELECTED);
+            break;
+
+        case 'D': // Ctrl+D = deselect all
+            ListView_SetItemState(m_hWnd, -1, 0, LVIS_SELECTED);
+            break;
+    }
+
+}
+
 GridColumnBinding::InPlaceEditorInfo* GridBinding::GetIPEInfo(HWND hwnd) noexcept
 {
     GridColumnBinding::InPlaceEditorInfo* pInfo;

--- a/src/ui/win32/bindings/GridBinding.hh
+++ b/src/ui/win32/bindings/GridBinding.hh
@@ -42,6 +42,7 @@ public:
     GSL_SUPPRESS_CON3 virtual void OnLvnItemChanged(const LPNMLISTVIEW pnmListView);
     GSL_SUPPRESS_CON3 void OnLvnOwnerDrawStateChanged(const LPNMLVODSTATECHANGE pnmStateChanged);
     GSL_SUPPRESS_CON3 void OnLvnColumnClick(const LPNMLISTVIEW pnmListView);
+    GSL_SUPPRESS_CON3 void OnLvnKeyDown(const LPNMLVKEYDOWN pnmKeyDown) noexcept;
     void OnLvnGetDispInfo(NMLVDISPINFO& pnmDispInfo);
     virtual void OnNmClick(const NMITEMACTIVATE* pnmItemActivate);
     virtual void OnNmDblClick(const NMITEMACTIVATE* pnmItemActivate);


### PR DESCRIPTION
Adds the ability to select all items in the memory bookmarks dialog and search results list (as well as the in-development asset list and trigger conditions list) by pressing Ctrl+A when the list has focus. Also adds the ability to deselect all items by pressing Ctrl+D. 