### PR TITLE
hide bits when not in 8-bit mode

### DIFF
--- a/src/ui/viewmodels/MemoryInspectorViewModel.cpp
+++ b/src/ui/viewmodels/MemoryInspectorViewModel.cpp
@@ -21,6 +21,7 @@ const StringModelProperty MemoryInspectorViewModel::CurrentAddressNoteProperty("
 const StringModelProperty MemoryInspectorViewModel::CurrentAddressBitsProperty("MemoryInspectorViewModel", "CurrentAddressBits", L"0 0 0 0 0 0 0 0");
 const IntModelProperty MemoryInspectorViewModel::CurrentAddressValueProperty("MemoryInspectorViewModel", "CurrentAddressValue", 0);
 const BoolModelProperty MemoryInspectorViewModel::CanModifyNotesProperty("MemoryInspectorViewModel", "CanModifyNotes", true);
+const BoolModelProperty MemoryInspectorViewModel::CurrentBitsVisibleProperty("MemoryInspectorViewModel", "CurrentBitsVisibleProperty", true);
 
 MemoryInspectorViewModel::MemoryInspectorViewModel()
 {
@@ -83,6 +84,8 @@ void MemoryInspectorViewModel::OnViewModelIntValueChanged(const IntModelProperty
 {
     if (args.Property == MemoryViewerViewModel::AddressProperty)
         SetValue(CurrentAddressProperty, args.tNewValue);
+    else if (args.Property == MemoryViewerViewModel::SizeProperty)
+        SetValue(CurrentBitsVisibleProperty, ra::itoe<MemSize>(args.tNewValue) == MemSize::EightBit);
 }
 
 void MemoryInspectorViewModel::OnValueChanged(const StringModelProperty::ChangeArgs& args)

--- a/src/ui/viewmodels/MemoryInspectorViewModel.hh
+++ b/src/ui/viewmodels/MemoryInspectorViewModel.hh
@@ -108,6 +108,11 @@ public:
     /// </summary>
     const std::wstring& GetCurrentAddressBits() const { return GetValue(CurrentAddressBitsProperty); }
 
+    /// <summary>
+    /// The <see cref="ModelProperty" /> for whether or not the CurrentBits should be visible.
+    /// </summary>
+    static const BoolModelProperty CurrentBitsVisibleProperty;
+
     void ToggleBit(int nBit);
 
 protected:

--- a/src/ui/win32/MemoryInspectorDialog.cpp
+++ b/src/ui/win32/MemoryInspectorDialog.cpp
@@ -225,6 +225,8 @@ MemoryInspectorDialog::MemoryInspectorDialog(MemoryInspectorViewModel& vmMemoryI
     m_bindViewer16Bit.BindCheck(MemoryViewerViewModel::SizeProperty, ra::etoi(MemSize::SixteenBit));
     m_bindViewer32Bit.BindCheck(MemoryViewerViewModel::SizeProperty, ra::etoi(MemSize::ThirtyTwoBit));
     m_bindWindow.BindLabel(IDC_RA_MEMBITS, MemoryInspectorViewModel::CurrentAddressBitsProperty);
+    m_bindWindow.BindVisible(IDC_RA_MEMBITS_TITLE, MemoryInspectorViewModel::CurrentBitsVisibleProperty);
+    m_bindWindow.BindVisible(IDC_RA_MEMBITS, MemoryInspectorViewModel::CurrentBitsVisibleProperty);
 
     // Resize behavior
     using namespace ra::bitwise_ops;

--- a/src/ui/win32/bindings/WindowBinding.hh
+++ b/src/ui/win32/bindings/WindowBinding.hh
@@ -103,6 +103,13 @@ public:
     void BindEnabled(int nDlgItemId, const BoolModelProperty& pSourceProperty);
 
     /// <summary>
+    /// Binds the a visibility of a control to a property of the viewmodel.
+    /// </summary>
+    /// <param name="nDlgItemId">The unique identifier of the control in the dialog.</param>
+    /// <param name="pSourceProperty">The property to bind to.</param>
+    void BindVisible(int nDlgItemId, const BoolModelProperty& pSourceProperty);
+
+    /// <summary>
     /// Called when the window's size changes.
     /// </summary>
     /// <param name="oSize">The new size.</param>
@@ -125,6 +132,7 @@ protected:
 private:
     std::unordered_map<int, int> m_mLabelBindings;
     std::unordered_map<int, std::set<int>> m_mEnabledBindings;
+    std::unordered_map<int, std::set<int>> m_mVisibilityBindings;
 
     class ChildBinding : public BindingBase
     {

--- a/tests/ui/viewmodels/MemoryInspectorViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/MemoryInspectorViewModel_Tests.cpp
@@ -58,6 +58,7 @@ private:
         MemoryInspectorViewModelHarness& operator=(MemoryInspectorViewModelHarness&&) noexcept = delete;
 
         bool CanModifyCodeNotes() const { return GetValue(CanModifyNotesProperty); }
+        bool CurrentBitsVisible() const { return GetValue(CurrentBitsVisibleProperty); }
     };
 
 
@@ -157,6 +158,23 @@ public:
         Assert::AreEqual({ 0x41 }, inspector.memory.at(3));
         Assert::AreEqual(std::wstring(L"0 1 0 0 0 0 0 1"), inspector.GetCurrentAddressBits());
         Assert::AreEqual(0x41U, pNote->GetCurrentValue());
+    }
+
+    TEST_METHOD(TestCurrentBitsVisible)
+    {
+        MemoryInspectorViewModelHarness inspector;
+        inspector.Viewer().SetAddress({ 3U });
+        Assert::AreEqual(MemSize::EightBit, inspector.Viewer().GetSize());
+        Assert::IsTrue(inspector.CurrentBitsVisible());
+
+        inspector.Viewer().SetSize(MemSize::SixteenBit);
+        Assert::IsFalse(inspector.CurrentBitsVisible());
+
+        inspector.Viewer().SetSize(MemSize::ThirtyTwoBit);
+        Assert::IsFalse(inspector.CurrentBitsVisible());
+
+        inspector.Viewer().SetSize(MemSize::EightBit);
+        Assert::IsTrue(inspector.CurrentBitsVisible());
     }
 
     TEST_METHOD(TestOpenNotesList)


### PR DESCRIPTION
When in 16-bit or 32-bit mode, the bits values for the current address were still being displayed, though they did not allow clicking to toggle the values. Prior to the 0.78 memory inspector dialog upgrade, the bits were hidden when in 16-bit or 32-bit. This restores that behavior.