### PR TITLE
highlight recently earned achievements in overlay

### DIFF
--- a/src/ui/viewmodels/AssetListViewModel.cpp
+++ b/src/ui/viewmodels/AssetListViewModel.cpp
@@ -126,6 +126,28 @@ void AssetListViewModel::OnViewModelIntValueChanged(gsl::index nIndex, const Int
             }
         }
     }
+    else if (args.Property == AssetViewModelBase::IDProperty)
+    {
+        auto* pAsset = m_vAssets.GetItemAt(nIndex);
+        if (pAsset != nullptr)
+        {
+            gsl::index nFilteredIndex = -1;
+            const auto nType = pAsset->GetType();
+
+            for (gsl::index nScanIndex = 0; nScanIndex < gsl::narrow_cast<gsl::index>(m_vFilteredAssets.Count()); ++nScanIndex)
+            {
+                auto* pItem = m_vFilteredAssets.GetItemAt(nScanIndex);
+                if (pItem != nullptr && pItem->GetId() == args.tOldValue && pItem->GetType() == nType)
+                {
+                    nFilteredIndex = nScanIndex;
+                    break;
+                }
+            }
+
+            if (nFilteredIndex != -1)
+                m_vFilteredAssets.SetItemValue(nFilteredIndex, AssetSummaryViewModel::IdProperty, args.tNewValue);
+        }
+    }
 }
 
 void AssetListViewModel::OnViewModelAdded(_UNUSED gsl::index nIndex)

--- a/src/ui/viewmodels/OverlayAchievementsPageViewModel.cpp
+++ b/src/ui/viewmodels/OverlayAchievementsPageViewModel.cpp
@@ -27,6 +27,8 @@ const StringModelProperty OverlayAchievementsPageViewModel::AchievementViewModel
 
 OverlayListPageViewModel::ItemViewModel& OverlayAchievementsPageViewModel::GetNextItem(size_t* nIndex)
 {
+    Expects(nIndex != nullptr);
+
     ItemViewModel* pvmAchievement = m_vItems.GetItemAt((*nIndex)++);
     if (pvmAchievement == nullptr)
     {
@@ -93,12 +95,14 @@ static void SetAchievement(OverlayListPageViewModel::ItemViewModel& vmItem, cons
 
 static bool AppearsInFilter(const ra::ui::viewmodels::AchievementViewModel* vmAchievement)
 {
+    Expects(vmAchievement != nullptr);
+
     const auto nId = ra::to_signed(vmAchievement->GetID());
     const auto& vFilteredAssets = ra::services::ServiceLocator::Get<ra::ui::viewmodels::WindowManager>().AssetList.FilteredAssets();
     for (gsl::index nIndex = 0; nIndex < ra::to_signed(vFilteredAssets.Count()); ++nIndex)
     {
         const auto* pAsset = vFilteredAssets.GetItemAt(nIndex);
-        if (pAsset->GetId() == nId && pAsset->GetType() == AssetType::Achievement)
+        if (pAsset && pAsset->GetId() == nId && pAsset->GetType() == AssetType::Achievement)
             return true;
     }
 

--- a/src/ui/viewmodels/OverlayAchievementsPageViewModel.cpp
+++ b/src/ui/viewmodels/OverlayAchievementsPageViewModel.cpp
@@ -9,8 +9,11 @@
 #include "data\UserContext.hh"
 
 #include "services\AchievementRuntime.hh"
+#include "services\IClock.hh"
 
 #include "ui\OverlayTheme.hh"
+
+#include "ui\viewmodels\WindowManager.hh"
 
 namespace ra {
 namespace ui {
@@ -21,6 +24,76 @@ const StringModelProperty OverlayAchievementsPageViewModel::UnlockedAchievements
 const StringModelProperty OverlayAchievementsPageViewModel::AchievementViewModel::CreatedDateProperty("AchievementViewModel", "CreatedDate", L"");
 const StringModelProperty OverlayAchievementsPageViewModel::AchievementViewModel::ModifiedDateProperty("AchievementViewModel", "ModifiedDate", L"");
 const StringModelProperty OverlayAchievementsPageViewModel::AchievementViewModel::WonByProperty("AchievementViewModel", "WonBy", L"");
+
+OverlayListPageViewModel::ItemViewModel& OverlayAchievementsPageViewModel::GetNextItem(size_t* nIndex)
+{
+    ItemViewModel* pvmAchievement = m_vItems.GetItemAt((*nIndex)++);
+    if (pvmAchievement == nullptr)
+    {
+        pvmAchievement = &m_vItems.Add();
+        Ensures(pvmAchievement != nullptr);
+    }
+
+    return *pvmAchievement;
+}
+
+static void SetHeader(OverlayListPageViewModel::ItemViewModel& vmItem, const std::wstring& sHeader)
+{
+    vmItem.SetId(0);
+    vmItem.SetLabel(sHeader);
+    vmItem.SetDetail(L"");
+    vmItem.SetDisabled(false);
+    vmItem.Image.ChangeReference(ra::ui::ImageType::None, "");
+    vmItem.SetProgressValue(0U);
+    vmItem.SetProgressMaximum(0U);
+}
+
+static void SetAchievement(OverlayListPageViewModel::ItemViewModel& vmItem, const ra::ui::viewmodels::AchievementViewModel& vmAchievement)
+{
+    vmItem.SetId(vmAchievement.GetID());
+    vmItem.SetLabel(ra::StringPrintf(L"%s (%s points)", vmAchievement.GetName(), vmAchievement.GetPoints()));
+    vmItem.SetDetail(vmAchievement.GetDescription());
+
+    if (vmAchievement.IsActive())
+    {
+        vmItem.Image.ChangeReference(ra::ui::ImageType::Badge, ra::Narrow(vmAchievement.GetBadge()) + "_lock");
+        vmItem.SetDisabled(true);
+
+        const auto& pRuntime = ra::services::ServiceLocator::Get<ra::services::AchievementRuntime>();
+        const auto* pTrigger = pRuntime.GetAchievementTrigger(vmAchievement.GetID());
+        if (pTrigger != nullptr)
+        {
+            vmItem.SetProgressMaximum(pTrigger->measured_target);
+            vmItem.SetProgressValue(pTrigger->measured_value);
+        }
+        else
+        {
+            vmItem.SetProgressMaximum(0);
+            vmItem.SetProgressValue(0);
+        }
+    }
+    else
+    {
+        vmItem.Image.ChangeReference(ra::ui::ImageType::Badge, ra::Narrow(vmAchievement.GetBadge()));
+        vmItem.SetDisabled(false);
+        vmItem.SetProgressValue(0U);
+        vmItem.SetProgressMaximum(0U);
+    }
+}
+
+static bool AppearsInFilter(const ra::ui::viewmodels::AchievementViewModel* vmAchievement)
+{
+    const auto nId = ra::to_signed(vmAchievement->GetID());
+    const auto& vFilteredAssets = ra::services::ServiceLocator::Get<ra::ui::viewmodels::WindowManager>().AssetList.FilteredAssets();
+    for (gsl::index nIndex = 0; nIndex < ra::to_signed(vFilteredAssets.Count()); ++nIndex)
+    {
+        const auto* pAsset = vFilteredAssets.GetItemAt(nIndex);
+        if (pAsset->GetId() == nId && pAsset->GetType() == AssetType::Achievement)
+            return true;
+    }
+
+    return false;
+}
 
 void OverlayAchievementsPageViewModel::Refresh()
 {
@@ -33,72 +106,203 @@ void OverlayAchievementsPageViewModel::Refresh()
     SetListTitle(pGameContext.GameTitle());
 
     // achievement list
+    std::vector<const ra::ui::viewmodels::AchievementViewModel*> vRecentAchievements;
+    std::vector<const ra::ui::viewmodels::AchievementViewModel*> vAlmostThereAchievements;
+    std::vector<const ra::ui::viewmodels::AchievementViewModel*> vUnofficialAchievements;
+    std::vector<const ra::ui::viewmodels::AchievementViewModel*> vLocalAchievements;
+    std::vector<const ra::ui::viewmodels::AchievementViewModel*> vLockedCoreAchievements;
+    std::vector<const ra::ui::viewmodels::AchievementViewModel*> vUnlockedCoreAchievements;
+
+    const auto& pRuntime = ra::services::ServiceLocator::Get<ra::services::AchievementRuntime>();
+    const auto tNow = ra::services::ServiceLocator::Get<ra::services::IClock>().Now();
+
+    const auto& vmAssetList = ra::services::ServiceLocator::Get<ra::ui::viewmodels::WindowManager>().AssetList;
+    for (gsl::index nIndex = 0; nIndex < ra::to_signed(vmAssetList.Assets().Count()); ++nIndex)
+    {
+        const auto* pAsset = vmAssetList.Assets().GetItemAt(nIndex);
+        if (!pAsset || pAsset->GetType() != AssetType::Achievement)
+            continue;
+
+        const auto* vmAchievement = dynamic_cast<const ra::ui::viewmodels::AchievementViewModel*>(pAsset);
+        switch (vmAchievement->GetState())
+        {
+            case AssetState::Inactive:
+                break;
+
+            case AssetState::Triggered:
+            {
+                const auto tUnlock = vmAchievement->GetUnlockTime();
+                const auto tElapsed = tNow - tUnlock;
+                if (tElapsed < std::chrono::minutes(10))
+                {
+                    gsl::index nInsert = 0;
+                    while (nInsert < ra::to_signed(vRecentAchievements.size()) && vRecentAchievements.at(nInsert)->GetUnlockTime() > tUnlock)
+                        nInsert++;
+                    vRecentAchievements.insert(vRecentAchievements.begin() + nInsert, vmAchievement);
+                    continue;
+                }
+                break;
+            }
+
+            default:
+            {
+                const auto* pTrigger = pRuntime.GetAchievementTrigger(vmAchievement->GetID());
+                if (pTrigger != nullptr && pTrigger->measured_target > 0)
+                {
+                    const auto nProgress = pTrigger->measured_value * 100 / pTrigger->measured_target;
+                    if (nProgress >= 80)
+                    {
+                        vAlmostThereAchievements.push_back(vmAchievement);
+                        continue;
+                    }
+                }
+                break;
+            }
+        }
+
+        switch (vmAchievement->GetCategory())
+        {
+            case AssetCategory::Local:
+                if (AppearsInFilter(vmAchievement))
+                    vLocalAchievements.push_back(vmAchievement);
+                break;
+
+            case AssetCategory::Unofficial:
+                if (AppearsInFilter(vmAchievement))
+                    vUnofficialAchievements.push_back(vmAchievement);
+                break;
+
+            default:
+                if (vmAchievement->IsActive())
+                    vLockedCoreAchievements.push_back(vmAchievement);
+                else
+                    vUnlockedCoreAchievements.push_back(vmAchievement);
+                break;
+        }
+    }
+
     unsigned int nMaxPts = 0;
     unsigned int nUserPts = 0;
     unsigned int nUserCompleted = 0;
+    size_t nIndex = 0;
     size_t nNumberOfAchievements = 0;
     size_t nNumberOfCoreAchievements = 0;
 
-    pGameContext.EnumerateFilteredAchievements([this, &nNumberOfAchievements, &nNumberOfCoreAchievements,
-        &nMaxPts, &nUserPts, &nUserCompleted](const Achievement& pAchievement)
+    m_vItems.BeginUpdate();
+
+    if (!vRecentAchievements.empty())
     {
-        ItemViewModel* pvmAchievement = m_vItems.GetItemAt(nNumberOfAchievements);
-        if (pvmAchievement == nullptr)
+        auto& pvmHeader = GetNextItem(&nIndex);
+        SetHeader(pvmHeader, L"Recently Earned");
+
+        for (const auto* vmAchievement : vRecentAchievements)
         {
-            pvmAchievement = &m_vItems.Add();
-            Ensures(pvmAchievement != nullptr);
-        }
+            auto& pvmAchievement = GetNextItem(&nIndex);
+            SetAchievement(pvmAchievement, *vmAchievement);
 
-        pvmAchievement->SetId(pAchievement.ID());
-        pvmAchievement->SetLabel(ra::StringPrintf(L"%s (%s points)", pAchievement.Title(), pAchievement.Points()));
-        pvmAchievement->SetDetail(ra::Widen(pAchievement.Description()));
-        pvmAchievement->SetDisabled(false);
-        pvmAchievement->Image.ChangeReference(ra::ui::ImageType::Badge, pAchievement.BadgeImageURI());
-        ++nNumberOfAchievements;
+            const auto nPoints = vmAchievement->GetPoints();
+            nMaxPts += nPoints;
 
-        if (pAchievement.GetCategory() == Achievement::Category::Core)
-        {
-            ++nNumberOfCoreAchievements;
-
-            nMaxPts += pAchievement.Points();
-            if (pAchievement.Active())
+            if (vmAchievement->GetCategory() == AssetCategory::Core)
             {
-                pvmAchievement->Image.ChangeReference(ra::ui::ImageType::Badge, pAchievement.BadgeImageURI() + "_lock");
-                pvmAchievement->SetDisabled(true);
-            }
-            else
-            {
-                nUserPts += pAchievement.Points();
+                nUserPts += nPoints;
                 ++nUserCompleted;
+                ++nNumberOfCoreAchievements;
             }
         }
 
-        if (pAchievement.Active())
+        nNumberOfAchievements += vRecentAchievements.size();
+    }
+
+    if (!vAlmostThereAchievements.empty())
+    {
+        auto& pvmHeader = GetNextItem(&nIndex);
+        SetHeader(pvmHeader, L"Almost There");
+
+        for (const auto* vmAchievement : vAlmostThereAchievements)
         {
-            const auto& pRuntime = ra::services::ServiceLocator::Get<ra::services::AchievementRuntime>();
-            const auto* pTrigger = pRuntime.GetAchievementTrigger(pAchievement.ID());
-            if (pTrigger != nullptr)
-            {
-                pvmAchievement->SetProgressMaximum(pTrigger->measured_target);
-                pvmAchievement->SetProgressValue(pTrigger->measured_value);
-            }
-            else
-            {
-                pvmAchievement->SetProgressMaximum(0);
-                pvmAchievement->SetProgressValue(0);
-            }
+            auto& pvmAchievement = GetNextItem(&nIndex);
+            SetAchievement(pvmAchievement, *vmAchievement);
+            nMaxPts += vmAchievement->GetPoints();
+
+            if (vmAchievement->GetCategory() == AssetCategory::Core)
+                ++nNumberOfCoreAchievements;
         }
-        else
+
+        nNumberOfAchievements += vAlmostThereAchievements.size();
+    }
+
+    if (!vLocalAchievements.empty())
+    {
+        auto& pvmHeader = GetNextItem(&nIndex);
+        SetHeader(pvmHeader, L"Local");
+
+        for (const auto* vmAchievement : vLocalAchievements)
         {
-            pvmAchievement->SetProgressMaximum(0);
-            pvmAchievement->SetProgressValue(0);
+            auto& pvmAchievement = GetNextItem(&nIndex);
+            SetAchievement(pvmAchievement, *vmAchievement);
+            nMaxPts += vmAchievement->GetPoints();
         }
 
-        return true;
-    });
+        nNumberOfAchievements += vLocalAchievements.size();
+    }
 
-    while (m_vItems.Count() > nNumberOfAchievements)
+    if (!vUnofficialAchievements.empty())
+    {
+        auto& pvmHeader = GetNextItem(&nIndex);
+        SetHeader(pvmHeader, L"Local");
+
+        for (const auto* vmAchievement : vUnofficialAchievements)
+        {
+            auto& pvmAchievement = GetNextItem(&nIndex);
+            SetAchievement(pvmAchievement, *vmAchievement);
+            nMaxPts += vmAchievement->GetPoints();
+        }
+
+        nNumberOfAchievements += vUnofficialAchievements.size();
+    }
+
+    if (!vLockedCoreAchievements.empty())
+    {
+        auto& pvmHeader = GetNextItem(&nIndex);
+        SetHeader(pvmHeader, L"Unearned");
+
+        for (const auto* vmAchievement : vLockedCoreAchievements)
+        {
+            auto& pvmAchievement = GetNextItem(&nIndex);
+            SetAchievement(pvmAchievement, *vmAchievement);
+            nMaxPts += vmAchievement->GetPoints();
+        }
+
+        nNumberOfAchievements += vLockedCoreAchievements.size();
+        nNumberOfCoreAchievements += vLockedCoreAchievements.size();
+    }
+
+    if (vUnlockedCoreAchievements.size() > 0)
+    {
+        auto& pvmHeader = GetNextItem(&nIndex);
+        SetHeader(pvmHeader, L"Earned");
+
+        for (const auto* vmAchievement : vUnlockedCoreAchievements)
+        {
+            auto& pvmAchievement = GetNextItem(&nIndex);
+            SetAchievement(pvmAchievement, *vmAchievement);
+
+            const auto nPoints = vmAchievement->GetPoints();
+            nMaxPts += nPoints;
+
+            nUserPts += nPoints;
+            ++nUserCompleted;
+        }
+
+        nNumberOfAchievements += vUnlockedCoreAchievements.size();
+        nNumberOfCoreAchievements += vUnlockedCoreAchievements.size();
+    }
+
+    while (m_vItems.Count() > nIndex)
         m_vItems.RemoveAt(m_vItems.Count() - 1);
+
+    m_vItems.EndUpdate();
 
     // summary
     if (nNumberOfAchievements == 0)
@@ -120,6 +324,23 @@ void OverlayAchievementsPageViewModel::Refresh()
         SetSummary(ra::StringPrintf(L"%s - %dh%02dm", m_sSummary, nPlayTimeMinutes / 60, nPlayTimeMinutes % 60));
         m_fElapsed = static_cast<double>(nPlayTimeSeconds.count() % 60);
     }
+
+    // ensure selected index is valid
+    auto nSelectedIndex = GetSelectedItemIndex();
+    const auto* vmItem = m_vItems.GetItemAt(nSelectedIndex);
+    while (vmItem && vmItem->IsHeader())
+        vmItem = m_vItems.GetItemAt(++nSelectedIndex);
+
+    if (!vmItem)
+    {
+        nSelectedIndex = 0;
+        vmItem = m_vItems.GetItemAt(nSelectedIndex);
+        while (vmItem && vmItem->IsHeader())
+            vmItem = m_vItems.GetItemAt(++nSelectedIndex);
+    }
+
+    if (nSelectedIndex < m_vItems.Count())
+        SetSelectedItemIndex(nSelectedIndex);
 }
 
 bool OverlayAchievementsPageViewModel::Update(double fElapsed)

--- a/src/ui/viewmodels/OverlayAchievementsPageViewModel.cpp
+++ b/src/ui/viewmodels/OverlayAchievementsPageViewModel.cpp
@@ -207,7 +207,7 @@ void OverlayAchievementsPageViewModel::Refresh()
     if (!vRecentAchievements.empty())
     {
         auto& pvmHeader = GetNextItem(&nIndex);
-        SetHeader(pvmHeader, L"Recently Earned");
+        SetHeader(pvmHeader, L"Recently Unlocked");
 
         for (const auto* vmAchievement : vRecentAchievements)
         {
@@ -287,7 +287,7 @@ void OverlayAchievementsPageViewModel::Refresh()
         if (nIndex > 0)
         {
             auto& pvmHeader = GetNextItem(&nIndex);
-            SetHeader(pvmHeader, L"Unearned");
+            SetHeader(pvmHeader, L"Locked");
         }
 
         for (const auto* vmAchievement : vLockedCoreAchievements)
@@ -306,7 +306,7 @@ void OverlayAchievementsPageViewModel::Refresh()
         if (nIndex > 0)
         {
             auto& pvmHeader = GetNextItem(&nIndex);
-            SetHeader(pvmHeader, L"Earned");
+            SetHeader(pvmHeader, L"Unlocked");
         }
 
         for (const auto* vmAchievement : vUnlockedCoreAchievements)
@@ -365,7 +365,7 @@ void OverlayAchievementsPageViewModel::Refresh()
             vmItem = m_vItems.GetItemAt(++nSelectedIndex);
     }
 
-    if (nSelectedIndex < m_vItems.Count())
+    if (nSelectedIndex < ra::to_signed(m_vItems.Count()))
         SetSelectedItemIndex(nSelectedIndex);
 }
 

--- a/src/ui/viewmodels/OverlayAchievementsPageViewModel.hh
+++ b/src/ui/viewmodels/OverlayAchievementsPageViewModel.hh
@@ -86,6 +86,8 @@ protected:
     std::map<ra::AchievementID, AchievementViewModel> m_vAchievementDetails;
 
 private:
+    ItemViewModel& GetNextItem(size_t* nIndex);
+
     void RenderDetail(ra::ui::drawing::ISurface& pSurface, int nX, int nY, _UNUSED int nWidth, int nHeight) const override;
 
     std::wstring m_sSummary;

--- a/src/ui/viewmodels/OverlayListPageViewModel.cpp
+++ b/src/ui/viewmodels/OverlayListPageViewModel.cpp
@@ -179,7 +179,7 @@ bool OverlayListPageViewModel::ProcessInput(const ControllerInput& pInput)
     if (pInput.m_bDownPressed)
     {
         size_t nSelectedItemIndex = gsl::narrow_cast<size_t>(GetSelectedItemIndex());
-        if (nSelectedItemIndex < ra::to_signed(m_vItems.Count()) - 1)
+        if (nSelectedItemIndex < m_vItems.Count() - 1)
         {
             ++nSelectedItemIndex;
             auto* vmItem = m_vItems.GetItemAt(nSelectedItemIndex);
@@ -191,7 +191,7 @@ bool OverlayListPageViewModel::ProcessInput(const ControllerInput& pInput)
             if (!vmItem)
                 return false;
                 
-            SetSelectedItemIndex(nSelectedItemIndex);
+            SetSelectedItemIndex(gsl::narrow_cast<int>(nSelectedItemIndex));
 
             if (nSelectedItemIndex - m_nScrollOffset >= gsl::narrow_cast<size_t>(m_nVisibleItems))
                 m_nScrollOffset = nSelectedItemIndex - m_nVisibleItems + 1;

--- a/src/ui/viewmodels/OverlayListPageViewModel.cpp
+++ b/src/ui/viewmodels/OverlayListPageViewModel.cpp
@@ -189,7 +189,7 @@ bool OverlayListPageViewModel::ProcessInput(const ControllerInput& pInput)
                 vmItem = m_vItems.GetItemAt(++nSelectedItemIndex);
 
             if (!vmItem)
-                return true;
+                return false;
                 
             SetSelectedItemIndex(nSelectedItemIndex);
 
@@ -217,7 +217,7 @@ bool OverlayListPageViewModel::ProcessInput(const ControllerInput& pInput)
                 m_nScrollOffset = std::max(nSelectedItemIndex, 0);
 
             if (!vmItem)
-                return true;
+                return false;
 
             SetSelectedItemIndex(nSelectedItemIndex);
 

--- a/src/ui/viewmodels/OverlayListPageViewModel.cpp
+++ b/src/ui/viewmodels/OverlayListPageViewModel.cpp
@@ -116,46 +116,56 @@ void OverlayListPageViewModel::RenderList(ra::ui::drawing::ISurface& pSurface, i
         if (!pItem)
             break;
 
-        auto nTextX = nX;
-        if (pItem->Image.Type() != ra::ui::ImageType::None)
+        if (pItem->IsHeader())
         {
-            pSurface.DrawImage(nX, nY, nItemSize, nItemSize, pItem->Image);
-            nTextX += nItemSize;
+            const auto sHeader = ra::StringPrintf(L"----- %s -----", pItem->GetLabel());
+            const auto szHeader = pSurface.MeasureText(nFont, sHeader);
+
+            pSurface.WriteText((nWidth - szHeader.Width) / 2, nY + nItemSize - szHeader.Height - 4, nFont, pTheme.ColorOverlayText(), sHeader);
         }
-
-        const ra::ui::Color nSubTextColor = pItem->IsDisabled() ? pTheme.ColorOverlayDisabledSubText() : pTheme.ColorOverlaySubText();
-        ra::ui::Color nTextColor = pTheme.ColorOverlayText();
-
-        const bool bSelected = (nIndex == ra::to_signed(nSelectedIndex));
-        if (bSelected)
+        else
         {
-            pSurface.FillRectangle(nTextX, nY, nWidth - nTextX, nItemSize, pTheme.ColorOverlaySelectionBackground());
-            nTextColor = pItem->IsDisabled() ?
-                pTheme.ColorOverlaySelectionDisabledText() : pTheme.ColorOverlaySelectionText();
-        }
-        else if (pItem->IsDisabled())
-        {
-            nTextColor = pTheme.ColorOverlayDisabledText();
-        }
+            auto nTextX = nX;
+            if (pItem->Image.Type() != ra::ui::ImageType::None)
+            {
+                pSurface.DrawImage(nX, nY, nItemSize, nItemSize, pItem->Image);
+                nTextX += nItemSize;
+            }
 
-        pSurface.WriteText(nTextX + 12, nY + 1, nFont, nTextColor, pItem->GetLabel());
-        pSurface.WriteText(nTextX + 12, nY + 1 + 26, nSubFont, nSubTextColor, pItem->GetDetail());
+            const ra::ui::Color nSubTextColor = pItem->IsDisabled() ? pTheme.ColorOverlayDisabledSubText() : pTheme.ColorOverlaySubText();
+            ra::ui::Color nTextColor = pTheme.ColorOverlayText();
 
-        const auto nTarget = pItem->GetProgressMaximum();
-        if (nTarget != 0)
-        {
-            const auto nProgressBarWidth = (nWidth - nTextX - 12) * 2 / 3;
-            const auto nValue = std::min(pItem->GetProgressValue(), nTarget);
-            const auto nProgressBarFillWidth = gsl::narrow_cast<int>(((static_cast<long>(nProgressBarWidth) - 2) * nValue) / nTarget);
-            const auto nProgressBarPercent = gsl::narrow_cast<int>(static_cast<long>(nValue) * 100 / nTarget);
+            const bool bSelected = (nIndex == ra::to_signed(nSelectedIndex));
+            if (bSelected)
+            {
+                pSurface.FillRectangle(nTextX, nY, nWidth - nTextX, nItemSize, pTheme.ColorOverlaySelectionBackground());
+                nTextColor = pItem->IsDisabled() ?
+                    pTheme.ColorOverlaySelectionDisabledText() : pTheme.ColorOverlaySelectionText();
+            }
+            else if (pItem->IsDisabled())
+            {
+                nTextColor = pTheme.ColorOverlayDisabledText();
+            }
 
-            pSurface.FillRectangle(nTextX + 12, nY + 1 + 26 + 25, nProgressBarWidth, 8, pTheme.ColorOverlayScrollBar());
-            pSurface.FillRectangle(nTextX + 12 + 2, nY + 1 + 26 + 25 + 2, nProgressBarFillWidth - 4, 8 - 4, pTheme.ColorOverlayScrollBarGripper());
+            pSurface.WriteText(nTextX + 12, nY + 1, nFont, nTextColor, pItem->GetLabel());
+            pSurface.WriteText(nTextX + 12, nY + 1 + 26, nSubFont, nSubTextColor, pItem->GetDetail());
 
-            const auto nProgressFont = pSurface.LoadFont(pTheme.FontOverlay(), 14, ra::ui::FontStyles::Normal);
-            const std::wstring sProgressPercent = ra::StringPrintf(L"%d%%", nProgressBarPercent);
-            const auto szProgressPercent = pSurface.MeasureText(nProgressFont, sProgressPercent);
-            pSurface.WriteText(nTextX + 12 + nProgressBarWidth + 6, nY + 1 + 26 + 25 + 4 - (szProgressPercent.Height / 2) - 1, nProgressFont, nSubTextColor, sProgressPercent);
+            const auto nTarget = pItem->GetProgressMaximum();
+            if (nTarget != 0)
+            {
+                const auto nProgressBarWidth = (nWidth - nTextX - 12) * 2 / 3;
+                const auto nValue = std::min(pItem->GetProgressValue(), nTarget);
+                const auto nProgressBarFillWidth = gsl::narrow_cast<int>(((static_cast<long>(nProgressBarWidth) - 2) * nValue) / nTarget);
+                const auto nProgressBarPercent = gsl::narrow_cast<int>(static_cast<long>(nValue) * 100 / nTarget);
+
+                pSurface.FillRectangle(nTextX + 12, nY + 1 + 26 + 25, nProgressBarWidth, 8, pTheme.ColorOverlayScrollBar());
+                pSurface.FillRectangle(nTextX + 12 + 2, nY + 1 + 26 + 25 + 2, nProgressBarFillWidth - 4, 8 - 4, pTheme.ColorOverlayScrollBarGripper());
+
+                const auto nProgressFont = pSurface.LoadFont(pTheme.FontOverlay(), 14, ra::ui::FontStyles::Normal);
+                const std::wstring sProgressPercent = ra::StringPrintf(L"%d%%", nProgressBarPercent);
+                const auto szProgressPercent = pSurface.MeasureText(nProgressFont, sProgressPercent);
+                pSurface.WriteText(nTextX + 12 + nProgressBarWidth + 6, nY + 1 + 26 + 25 + 4 - (szProgressPercent.Height / 2) - 1, nProgressFont, nSubTextColor, sProgressPercent);
+            }
         }
 
         nIndex++;
@@ -168,40 +178,51 @@ bool OverlayListPageViewModel::ProcessInput(const ControllerInput& pInput)
 {
     if (pInput.m_bDownPressed)
     {
-        const auto nSelectedItemIndex = GetSelectedItemIndex();
+        size_t nSelectedItemIndex = gsl::narrow_cast<size_t>(GetSelectedItemIndex());
         if (nSelectedItemIndex < ra::to_signed(m_vItems.Count()) - 1)
         {
-            SetSelectedItemIndex(nSelectedItemIndex + 1);
+            ++nSelectedItemIndex;
+            auto* vmItem = m_vItems.GetItemAt(nSelectedItemIndex);
 
-            if (gsl::narrow_cast<size_t>(nSelectedItemIndex) + 1 - m_nScrollOffset == gsl::narrow_cast<size_t>(m_nVisibleItems))
-                ++m_nScrollOffset;
+            // skip over header items
+            while (vmItem && vmItem->IsHeader())
+                vmItem = m_vItems.GetItemAt(++nSelectedItemIndex);
+
+            if (!vmItem)
+                return true;
+                
+            SetSelectedItemIndex(nSelectedItemIndex);
+
+            if (nSelectedItemIndex - m_nScrollOffset >= gsl::narrow_cast<size_t>(m_nVisibleItems))
+                m_nScrollOffset = nSelectedItemIndex - m_nVisibleItems + 1;
 
             if (m_bDetail)
-            {
-                auto* vmItem = m_vItems.GetItemAt(gsl::narrow_cast<size_t>(nSelectedItemIndex) + 1);
-                if (vmItem != nullptr)
-                    FetchItemDetail(*vmItem);
-            }
+                FetchItemDetail(*vmItem);
 
             return true;
         }
     }
     else if (pInput.m_bUpPressed)
     {
-        const auto nSelectedItemIndex = GetSelectedItemIndex();
+        auto nSelectedItemIndex = GetSelectedItemIndex();
         if (nSelectedItemIndex > 0)
         {
-            SetSelectedItemIndex(nSelectedItemIndex - 1);
+            auto* vmItem = m_vItems.GetItemAt(gsl::narrow_cast<size_t>(--nSelectedItemIndex));
 
-            if (nSelectedItemIndex == m_nScrollOffset)
-                --m_nScrollOffset;
+            // skip over header items
+            while (vmItem && vmItem->IsHeader())
+                vmItem = m_vItems.GetItemAt(gsl::narrow_cast<size_t>(--nSelectedItemIndex));
+
+            if (nSelectedItemIndex < m_nScrollOffset)
+                m_nScrollOffset = std::max(nSelectedItemIndex, 0);
+
+            if (!vmItem)
+                return true;
+
+            SetSelectedItemIndex(nSelectedItemIndex);
 
             if (m_bDetail)
-            {
-                auto* vmItem = m_vItems.GetItemAt(gsl::narrow_cast<size_t>(nSelectedItemIndex) - 1);
-                if (vmItem != nullptr)
-                    FetchItemDetail(*vmItem);
-            }
+                FetchItemDetail(*vmItem);
 
             return true;
         }

--- a/src/ui/viewmodels/OverlayListPageViewModel.hh
+++ b/src/ui/viewmodels/OverlayListPageViewModel.hh
@@ -127,6 +127,11 @@ public:
         /// Sets the current progress bar value.
         /// </summary>
         void SetProgressValue(unsigned int nValue) { SetValue(ProgressValueProperty, ra::to_signed(nValue)); }
+
+        /// <summary>
+        /// Gets whether the current item is a header item.
+        /// </summary>
+        bool IsHeader() const { return GetId() == 0; }
     };
 
 protected:

--- a/tests/ui/viewmodels/OverlayAchievementsPageViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/OverlayAchievementsPageViewModel_Tests.cpp
@@ -198,7 +198,7 @@ public:
         pItem = achievementsPage.GetItem(2);
         Expects(pItem != nullptr);
         Assert::IsTrue(pItem->IsHeader());
-        Assert::AreEqual(std::wstring(L"Earned"), pItem->GetLabel());
+        Assert::AreEqual(std::wstring(L"Unlocked"), pItem->GetLabel());
         Assert::IsFalse(pItem->IsDisabled());
 
         pItem = achievementsPage.GetItem(3);
@@ -247,7 +247,7 @@ public:
         pItem = achievementsPage.GetItem(1);
         Expects(pItem != nullptr);
         Assert::IsTrue(pItem->IsHeader());
-        Assert::AreEqual(std::wstring(L"Earned"), pItem->GetLabel());
+        Assert::AreEqual(std::wstring(L"Unlocked"), pItem->GetLabel());
         Assert::IsFalse(pItem->IsDisabled());
 
         pItem = achievementsPage.GetItem(2);
@@ -326,7 +326,7 @@ public:
         pItem = achievementsPage.GetItem(2);
         Expects(pItem != nullptr);
         Assert::IsTrue(pItem->IsHeader());
-        Assert::AreEqual(std::wstring(L"Earned"), pItem->GetLabel());
+        Assert::AreEqual(std::wstring(L"Unlocked"), pItem->GetLabel());
         Assert::IsFalse(pItem->IsDisabled());
 
         pItem = achievementsPage.GetItem(3);
@@ -387,7 +387,7 @@ public:
         pItem = achievementsPage.GetItem(2);
         Expects(pItem != nullptr);
         Assert::IsTrue(pItem->IsHeader());
-        Assert::AreEqual(std::wstring(L"Unearned"), pItem->GetLabel());
+        Assert::AreEqual(std::wstring(L"Locked"), pItem->GetLabel());
         Assert::IsFalse(pItem->IsDisabled());
 
         pItem = achievementsPage.GetItem(3);
@@ -399,7 +399,7 @@ public:
         pItem = achievementsPage.GetItem(4);
         Expects(pItem != nullptr);
         Assert::IsTrue(pItem->IsHeader());
-        Assert::AreEqual(std::wstring(L"Earned"), pItem->GetLabel());
+        Assert::AreEqual(std::wstring(L"Unlocked"), pItem->GetLabel());
         Assert::IsFalse(pItem->IsDisabled());
 
         pItem = achievementsPage.GetItem(5);

--- a/tests/ui/viewmodels/OverlayAchievementsPageViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/OverlayAchievementsPageViewModel_Tests.cpp
@@ -3,6 +3,7 @@
 #include "ui\viewmodels\OverlayAchievementsPageViewModel.hh"
 
 #include "tests\mocks\MockAchievementRuntime.hh"
+#include "tests\mocks\MockClock.hh"
 #include "tests\mocks\MockGameContext.hh"
 #include "tests\mocks\MockImageRepository.hh"
 #include "tests\mocks\MockOverlayManager.hh"
@@ -31,6 +32,7 @@ private:
         ra::data::mocks::MockSessionTracker mockSessionTracker;
         ra::data::mocks::MockUserContext mockUserContext;
         ra::services::mocks::MockAchievementRuntime mockAchievementRuntime;
+        ra::services::mocks::MockClock mockClock;
         ra::services::mocks::MockThreadPool mockThreadPool;
         ra::ui::mocks::MockImageRepository mockImageRepository;
         ra::ui::viewmodels::mocks::MockOverlayManager mockOverlayManager;
@@ -52,6 +54,15 @@ private:
                 return &pIter->second;
 
             return nullptr;
+        }
+
+        ra::ui::viewmodels::AchievementViewModel& NewAchievement(AssetCategory nCategory)
+        {
+            mockGameContext.NewAchievement(ra::itoe<Achievement::Category>(ra::etoi(nCategory)));
+            auto& pAssets = mockWindowManager.AssetList.Assets();
+            auto* pAsset = pAssets.GetItemAt(pAssets.Count() - 1);
+            auto* pAchievement = dynamic_cast<ra::ui::viewmodels::AchievementViewModel*>(pAsset);
+            return *pAchievement;
         }
 
         void SetProgress(ra::AchievementID nId, int nValue, int nMax)
@@ -81,12 +92,12 @@ public:
     TEST_METHOD(TestRefreshInactiveAchievement)
     {
         OverlayAchievementsPageViewModelHarness achievementsPage;
-        auto& pAch1 = achievementsPage.mockGameContext.NewAchievement(Achievement::Category::Core);
+        auto& pAch1 = achievementsPage.NewAchievement(AssetCategory::Core);
         pAch1.SetID(1);
-        pAch1.SetTitle("AchievementTitle");
-        pAch1.SetDescription("Trigger this");
+        pAch1.SetName(L"AchievementTitle");
+        pAch1.SetDescription(L"Trigger this");
         pAch1.SetPoints(5U);
-        pAch1.SetBadgeImage("BADGE_URI");
+        pAch1.SetBadge(L"BADGE_URI");
         achievementsPage.Refresh();
 
         Assert::AreEqual(std::wstring(L"Achievements"), achievementsPage.GetTitle());
@@ -104,13 +115,13 @@ public:
     TEST_METHOD(TestRefreshActiveAchievement)
     {
         OverlayAchievementsPageViewModelHarness achievementsPage;
-        auto& pAch1 = achievementsPage.mockGameContext.NewAchievement(Achievement::Category::Core);
+        auto& pAch1 = achievementsPage.NewAchievement(AssetCategory::Core);
         pAch1.SetID(1);
-        pAch1.SetTitle("AchievementTitle");
-        pAch1.SetDescription("Trigger this");
+        pAch1.SetName(L"AchievementTitle");
+        pAch1.SetDescription(L"Trigger this");
         pAch1.SetPoints(5U);
-        pAch1.SetBadgeImage("BADGE_URI");
-        pAch1.SetActive(true);
+        pAch1.SetBadge(L"BADGE_URI");
+        pAch1.SetState(AssetState::Active);
         achievementsPage.Refresh();
 
         Assert::AreEqual(std::wstring(L"Achievements"), achievementsPage.GetTitle());
@@ -125,25 +136,50 @@ public:
         Assert::AreEqual(std::string("BADGE_URI_lock"), pItem->Image.Name());
     }
 
+    TEST_METHOD(TestRefreshOnePointAchievement)
+    {
+        OverlayAchievementsPageViewModelHarness achievementsPage;
+        auto& pAch1 = achievementsPage.NewAchievement(AssetCategory::Core);
+        pAch1.SetID(1);
+        pAch1.SetName(L"AchievementTitle");
+        pAch1.SetDescription(L"Trigger this");
+        pAch1.SetPoints(1U); // should say "1 point" instead of "1 points"
+        pAch1.SetBadge(L"BADGE_URI");
+        pAch1.SetState(AssetState::Active);
+        achievementsPage.Refresh();
+
+        Assert::AreEqual(std::wstring(L"Achievements"), achievementsPage.GetTitle());
+        Assert::AreEqual(std::wstring(L"0 of 1 won (0/1)"), achievementsPage.GetSummary());
+
+        auto const* pItem = achievementsPage.GetItem(0);
+        Expects(pItem != nullptr);
+        Assert::AreEqual(1, pItem->GetId());
+        Assert::AreEqual(std::wstring(L"AchievementTitle (1 point)"), pItem->GetLabel());
+        Assert::AreEqual(std::wstring(L"Trigger this"), pItem->GetDetail());
+        Assert::IsTrue(pItem->IsDisabled());
+        Assert::AreEqual(std::string("BADGE_URI_lock"), pItem->Image.Name());
+    }
+
     TEST_METHOD(TestRefreshActiveAndInactiveAchievements)
     {
         OverlayAchievementsPageViewModelHarness achievementsPage;
-        auto& pAch1 = achievementsPage.mockGameContext.NewAchievement(Achievement::Category::Core);
+        auto& pAch1 = achievementsPage.NewAchievement(AssetCategory::Core);
         pAch1.SetID(1);
         pAch1.SetPoints(1U);
-        pAch1.SetActive(true);
-        auto& pAch2 = achievementsPage.mockGameContext.NewAchievement(Achievement::Category::Core);
+        pAch1.SetState(AssetState::Waiting);
+        auto& pAch2 = achievementsPage.NewAchievement(AssetCategory::Core);
         pAch2.SetID(2);
         pAch2.SetPoints(2U);
-        pAch2.SetActive(false);
-        auto& pAch3 = achievementsPage.mockGameContext.NewAchievement(Achievement::Category::Core);
+        pAch2.SetState(AssetState::Inactive);
+        auto& pAch3 = achievementsPage.NewAchievement(AssetCategory::Core);
         pAch3.SetID(3);
         pAch3.SetPoints(3U);
-        pAch3.SetActive(true);
-        auto& pAch4 = achievementsPage.mockGameContext.NewAchievement(Achievement::Category::Core);
+        pAch3.SetState(AssetState::Active);
+        auto& pAch4 = achievementsPage.NewAchievement(AssetCategory::Core);
         pAch4.SetID(4);
         pAch4.SetPoints(4U);
-        pAch4.SetActive(false);
+        pAch4.SetState(AssetState::Triggered);
+        achievementsPage.mockClock.AdvanceTime(std::chrono::hours(1));
         achievementsPage.Refresh();
 
         Assert::AreEqual(std::wstring(L"Achievements"), achievementsPage.GetTitle());
@@ -156,60 +192,21 @@ public:
 
         pItem = achievementsPage.GetItem(1);
         Expects(pItem != nullptr);
-        Assert::AreEqual(2, pItem->GetId());
-        Assert::IsFalse(pItem->IsDisabled());
-
-        pItem = achievementsPage.GetItem(2);
-        Expects(pItem != nullptr);
         Assert::AreEqual(3, pItem->GetId());
         Assert::IsTrue(pItem->IsDisabled());
 
-        pItem = achievementsPage.GetItem(3);
+        pItem = achievementsPage.GetItem(2);
         Expects(pItem != nullptr);
-        Assert::AreEqual(4, pItem->GetId());
+        Assert::IsTrue(pItem->IsHeader());
+        Assert::AreEqual(std::wstring(L"Earned"), pItem->GetLabel());
         Assert::IsFalse(pItem->IsDisabled());
-    }
 
-    TEST_METHOD(TestRefreshCategoryFilter)
-    {
-        OverlayAchievementsPageViewModelHarness achievementsPage;
-        auto& pAch1 = achievementsPage.mockGameContext.NewAchievement(Achievement::Category::Core);
-        pAch1.SetID(1);
-        pAch1.SetPoints(1U);
-        pAch1.SetActive(true);
-        auto& pAch2 = achievementsPage.mockGameContext.NewAchievement(Achievement::Category::Unofficial);
-        pAch2.SetID(2);
-        pAch2.SetPoints(2U);
-        pAch2.SetActive(false);
-        auto& pAch3 = achievementsPage.mockGameContext.NewAchievement(Achievement::Category::Local);
-        pAch3.SetID(3);
-        pAch3.SetPoints(3U);
-        pAch3.SetActive(true);
-        auto& pAch4 = achievementsPage.mockGameContext.NewAchievement(Achievement::Category::Core);
-        pAch4.SetID(4);
-        pAch4.SetPoints(4U);
-        pAch4.SetActive(false);
-        achievementsPage.Refresh();
-
-        Assert::AreEqual(std::wstring(L"Achievements"), achievementsPage.GetTitle());
-        Assert::AreEqual(std::wstring(L"1 of 2 won (4/5)"), achievementsPage.GetSummary());
-
-        auto* pItem = achievementsPage.GetItem(0);
-        Expects(pItem != nullptr);
-        Assert::AreEqual(1, pItem->GetId());
-        Assert::IsTrue(pItem->IsDisabled());
-
-        pItem = achievementsPage.GetItem(1);
+        pItem = achievementsPage.GetItem(3);
         Expects(pItem != nullptr);
         Assert::AreEqual(2, pItem->GetId());
         Assert::IsFalse(pItem->IsDisabled());
 
-        pItem = achievementsPage.GetItem(2);
-        Expects(pItem != nullptr);
-        Assert::AreEqual(3, pItem->GetId());
-        Assert::IsFalse(pItem->IsDisabled());
-
-        pItem = achievementsPage.GetItem(3);
+        pItem = achievementsPage.GetItem(4);
         Expects(pItem != nullptr);
         Assert::AreEqual(4, pItem->GetId());
         Assert::IsFalse(pItem->IsDisabled());
@@ -217,16 +214,61 @@ public:
         Assert::IsNull(achievementsPage.GetItem(5));
     }
 
+    TEST_METHOD(TestRefreshCategoryFilter)
+    {
+        OverlayAchievementsPageViewModelHarness achievementsPage;
+        auto& pAch1 = achievementsPage.NewAchievement(AssetCategory::Core);
+        pAch1.SetID(1);
+        pAch1.SetPoints(1U);
+        pAch1.SetState(AssetState::Active);
+        auto& pAch2 = achievementsPage.NewAchievement(AssetCategory::Unofficial);
+        pAch2.SetID(2);
+        pAch2.SetPoints(2U);
+        pAch2.SetState(AssetState::Inactive);
+        auto& pAch3 = achievementsPage.NewAchievement(AssetCategory::Local);
+        pAch3.SetID(3);
+        pAch3.SetPoints(3U);
+        pAch3.SetState(AssetState::Active);
+        auto& pAch4 = achievementsPage.NewAchievement(AssetCategory::Core);
+        pAch4.SetID(4);
+        pAch4.SetPoints(4U);
+        pAch4.SetState(AssetState::Inactive);
+        achievementsPage.Refresh();
+
+        Assert::AreEqual(std::wstring(L"Achievements"), achievementsPage.GetTitle());
+        Assert::AreEqual(std::wstring(L"1 of 2 won (4/5)"), achievementsPage.GetSummary());
+
+        // only 1 and 4 will be visible - 2 and 3 are not core, and filtered out by asset list
+        auto* pItem = achievementsPage.GetItem(0);
+        Expects(pItem != nullptr);
+        Assert::AreEqual(1, pItem->GetId());
+        Assert::IsTrue(pItem->IsDisabled());
+
+        pItem = achievementsPage.GetItem(1);
+        Expects(pItem != nullptr);
+        Assert::IsTrue(pItem->IsHeader());
+        Assert::AreEqual(std::wstring(L"Earned"), pItem->GetLabel());
+        Assert::IsFalse(pItem->IsDisabled());
+
+        pItem = achievementsPage.GetItem(2);
+        Expects(pItem != nullptr);
+        Assert::AreEqual(4, pItem->GetId());
+        Assert::IsFalse(pItem->IsDisabled());
+
+        Assert::IsNull(achievementsPage.GetItem(3));
+    }
+
     TEST_METHOD(TestRefreshLocalAchievement)
     {
         OverlayAchievementsPageViewModelHarness achievementsPage;
-        auto& pAch1 = achievementsPage.mockGameContext.NewAchievement(Achievement::Category::Local);
+        achievementsPage.mockWindowManager.AssetList.SetFilterCategory(AssetCategory::Local);
+        auto& pAch1 = achievementsPage.NewAchievement(AssetCategory::Local);
         pAch1.SetID(1);
-        pAch1.SetTitle("AchievementTitle");
-        pAch1.SetDescription("Trigger this");
+        pAch1.SetName(L"AchievementTitle");
+        pAch1.SetDescription(L"Trigger this");
         pAch1.SetPoints(5U);
-        pAch1.SetBadgeImage("BADGE_URI");
-        pAch1.SetActive(true);
+        pAch1.SetBadge(L"BADGE_URI");
+        pAch1.SetState(AssetState::Active);
         achievementsPage.Refresh();
 
         Assert::AreEqual(std::wstring(L"Achievements"), achievementsPage.GetTitle());
@@ -244,25 +286,25 @@ public:
     TEST_METHOD(TestRefreshProgressAchievements)
     {
         OverlayAchievementsPageViewModelHarness achievementsPage;
-        auto& pAch1 = achievementsPage.mockGameContext.NewAchievement(Achievement::Category::Core);
+        auto& pAch1 = achievementsPage.NewAchievement(AssetCategory::Core);
         pAch1.SetID(1);
         pAch1.SetPoints(1U);
-        pAch1.SetActive(true);
+        pAch1.SetState(AssetState::Active);
         achievementsPage.SetProgress(1U, 1, 10);
-        auto& pAch2 = achievementsPage.mockGameContext.NewAchievement(Achievement::Category::Core);
+        auto& pAch2 = achievementsPage.NewAchievement(AssetCategory::Core);
         pAch2.SetID(2);
         pAch2.SetPoints(2U);
-        pAch2.SetActive(false);
+        pAch2.SetState(AssetState::Inactive);
         achievementsPage.SetProgress(2U, 1, 10);
-        auto& pAch3 = achievementsPage.mockGameContext.NewAchievement(Achievement::Category::Core);
+        auto& pAch3 = achievementsPage.NewAchievement(AssetCategory::Core);
         pAch3.SetID(3);
         pAch3.SetPoints(3U);
-        pAch3.SetActive(true);
+        pAch3.SetState(AssetState::Active);
         achievementsPage.SetProgress(3U, 0, 0);
-        auto& pAch4 = achievementsPage.mockGameContext.NewAchievement(Achievement::Category::Core);
+        auto& pAch4 = achievementsPage.NewAchievement(AssetCategory::Core);
         pAch4.SetID(4);
         pAch4.SetPoints(4U);
-        pAch4.SetActive(false);
+        pAch4.SetState(AssetState::Inactive);
         achievementsPage.SetProgress(4U, 0, 0);
 
         achievementsPage.Refresh();
@@ -271,23 +313,108 @@ public:
 
         auto const* pItem = achievementsPage.GetItem(0);
         Expects(pItem != nullptr);
+        Assert::AreEqual(1, pItem->GetId());
         Assert::AreEqual(10U, pItem->GetProgressMaximum()); // active item with progress
         Assert::AreEqual(1U, pItem->GetProgressValue());
 
         pItem = achievementsPage.GetItem(1);
         Expects(pItem != nullptr);
-        Assert::AreEqual(0U, pItem->GetProgressMaximum()); // inactive item with progress should not display it
+        Assert::AreEqual(3, pItem->GetId());
+        Assert::AreEqual(0U, pItem->GetProgressMaximum()); // active item without progress
         Assert::AreEqual(0U, pItem->GetProgressValue());
 
         pItem = achievementsPage.GetItem(2);
         Expects(pItem != nullptr);
-        Assert::AreEqual(0U, pItem->GetProgressMaximum()); // active item without progress
-        Assert::AreEqual(0U, pItem->GetProgressValue());
+        Assert::IsTrue(pItem->IsHeader());
+        Assert::AreEqual(std::wstring(L"Earned"), pItem->GetLabel());
+        Assert::IsFalse(pItem->IsDisabled());
 
         pItem = achievementsPage.GetItem(3);
         Expects(pItem != nullptr);
+        Assert::AreEqual(2, pItem->GetId());
+        Assert::AreEqual(0U, pItem->GetProgressMaximum()); // inactive item with progress should not display it
+        Assert::AreEqual(0U, pItem->GetProgressValue());
+
+        pItem = achievementsPage.GetItem(4);
+        Expects(pItem != nullptr);
+        Assert::AreEqual(4, pItem->GetId());
         Assert::AreEqual(0U, pItem->GetProgressMaximum()); // inactive item without progress
         Assert::AreEqual(0U, pItem->GetProgressValue());
+
+        Assert::IsNull(achievementsPage.GetItem(5));
+    }
+
+    TEST_METHOD(TestRefreshAlmostThereAchievements)
+    {
+        OverlayAchievementsPageViewModelHarness achievementsPage;
+        auto& pAch1 = achievementsPage.NewAchievement(AssetCategory::Core);
+        pAch1.SetID(1);
+        pAch1.SetPoints(1U);
+        pAch1.SetState(AssetState::Active);
+        achievementsPage.SetProgress(1U, 1, 10);
+        auto& pAch2 = achievementsPage.NewAchievement(AssetCategory::Core);
+        pAch2.SetID(2);
+        pAch2.SetPoints(2U);
+        pAch2.SetState(AssetState::Inactive);
+        achievementsPage.SetProgress(2U, 1, 10);
+        auto& pAch3 = achievementsPage.NewAchievement(AssetCategory::Core);
+        pAch3.SetID(3);
+        pAch3.SetPoints(3U);
+        pAch3.SetState(AssetState::Active);
+        achievementsPage.SetProgress(3U, 9, 10);
+        auto& pAch4 = achievementsPage.NewAchievement(AssetCategory::Core);
+        pAch4.SetID(4);
+        pAch4.SetPoints(4U);
+        pAch4.SetState(AssetState::Inactive);
+        achievementsPage.SetProgress(4U, 0, 0);
+
+        achievementsPage.Refresh();
+        Assert::AreEqual(std::wstring(L"Achievements"), achievementsPage.GetTitle());
+        Assert::AreEqual(std::wstring(L"2 of 4 won (6/10)"), achievementsPage.GetSummary());
+
+        auto const* pItem = achievementsPage.GetItem(0);
+        Expects(pItem != nullptr);
+        Assert::IsTrue(pItem->IsHeader());
+        Assert::AreEqual(std::wstring(L"Almost There"), pItem->GetLabel());
+        Assert::IsFalse(pItem->IsDisabled());
+
+        pItem = achievementsPage.GetItem(1);
+        Expects(pItem != nullptr);
+        Assert::AreEqual(3, pItem->GetId());
+        Assert::AreEqual(10U, pItem->GetProgressMaximum()); // active item with >= 80% progress
+        Assert::AreEqual(9U, pItem->GetProgressValue());
+
+        pItem = achievementsPage.GetItem(2);
+        Expects(pItem != nullptr);
+        Assert::IsTrue(pItem->IsHeader());
+        Assert::AreEqual(std::wstring(L"Unearned"), pItem->GetLabel());
+        Assert::IsFalse(pItem->IsDisabled());
+
+        pItem = achievementsPage.GetItem(3);
+        Expects(pItem != nullptr);
+        Assert::AreEqual(1, pItem->GetId());
+        Assert::AreEqual(10U, pItem->GetProgressMaximum()); // active item with < 80% progress
+        Assert::AreEqual(1U, pItem->GetProgressValue());
+
+        pItem = achievementsPage.GetItem(4);
+        Expects(pItem != nullptr);
+        Assert::IsTrue(pItem->IsHeader());
+        Assert::AreEqual(std::wstring(L"Earned"), pItem->GetLabel());
+        Assert::IsFalse(pItem->IsDisabled());
+
+        pItem = achievementsPage.GetItem(5);
+        Expects(pItem != nullptr);
+        Assert::AreEqual(2, pItem->GetId());
+        Assert::AreEqual(0U, pItem->GetProgressMaximum()); // inactive item with progress should not display it
+        Assert::AreEqual(0U, pItem->GetProgressValue());
+
+        pItem = achievementsPage.GetItem(6);
+        Expects(pItem != nullptr);
+        Assert::AreEqual(4, pItem->GetId());
+        Assert::AreEqual(0U, pItem->GetProgressMaximum()); // inactive item without progress
+        Assert::AreEqual(0U, pItem->GetProgressValue());
+
+        Assert::IsNull(achievementsPage.GetItem(7));
     }
 
     TEST_METHOD(TestRefreshSession)
@@ -296,7 +423,7 @@ public:
         achievementsPage.mockGameContext.SetGameId(1U);
         achievementsPage.mockSessionTracker.MockSession(1U, 1234567879, std::chrono::minutes(347));
 
-        auto& pAch1 = achievementsPage.mockGameContext.NewAchievement(Achievement::Category::Core);
+        auto& pAch1 = achievementsPage.NewAchievement(AssetCategory::Core);
         pAch1.SetID(1);
         pAch1.SetPoints(5U);
         achievementsPage.Refresh();
@@ -311,7 +438,7 @@ public:
         achievementsPage.mockGameContext.SetGameId(1U);
         achievementsPage.mockSessionTracker.MockSession(1U, 1234567879, std::chrono::seconds(17 * 60 + 12));
 
-        auto& pAch1 = achievementsPage.mockGameContext.NewAchievement(Achievement::Category::Core);
+        auto& pAch1 = achievementsPage.NewAchievement(AssetCategory::Core);
         pAch1.SetID(1);
         pAch1.SetPoints(5U);
         achievementsPage.Refresh();
@@ -334,13 +461,15 @@ public:
     TEST_METHOD(TestFetchItemDetailLocal)
     {
         OverlayAchievementsPageViewModelHarness achievementsPage;
-        auto& pAch1 = achievementsPage.mockGameContext.NewAchievement(Achievement::Category::Local);
+        achievementsPage.mockWindowManager.AssetList.SetFilterCategory(AssetCategory::Local);
+        auto& pAch1 = achievementsPage.NewAchievement(AssetCategory::Local);
+        achievementsPage.mockGameContext.FindAchievement(pAch1.GetID())->SetID(1);
         pAch1.SetID(1);
-        pAch1.SetTitle("AchievementTitle");
-        pAch1.SetDescription("Trigger this");
+        pAch1.SetName(L"AchievementTitle");
+        pAch1.SetDescription(L"Trigger this");
         pAch1.SetPoints(5U);
-        pAch1.SetBadgeImage("BADGE_URI");
-        pAch1.SetActive(true);
+        pAch1.SetBadge(L"BADGE_URI");
+        pAch1.SetState(AssetState::Active);
 
         achievementsPage.mockServer.ExpectUncalled<ra::api::FetchAchievementInfo>();
 
@@ -357,13 +486,14 @@ public:
     TEST_METHOD(TestFetchItemDetail)
     {
         OverlayAchievementsPageViewModelHarness achievementsPage;
-        auto& pAch1 = achievementsPage.mockGameContext.NewAchievement(Achievement::Category::Core);
+        auto& pAch1 = achievementsPage.NewAchievement(AssetCategory::Core);
+        achievementsPage.mockGameContext.FindAchievement(pAch1.GetID())->SetID(1);
         pAch1.SetID(1);
-        pAch1.SetTitle("AchievementTitle");
-        pAch1.SetDescription("Trigger this");
+        pAch1.SetName(L"AchievementTitle");
+        pAch1.SetDescription(L"Trigger this");
         pAch1.SetPoints(5U);
-        pAch1.SetBadgeImage("BADGE_URI");
-        pAch1.SetActive(true);
+        pAch1.SetBadge(L"BADGE_URI");
+        pAch1.SetState(AssetState::Active);
 
         achievementsPage.mockUserContext.Initialize("User2", "ApiToken");
         achievementsPage.mockServer.HandleRequest<ra::api::FetchAchievementInfo>([](const ra::api::FetchAchievementInfo::Request& request, ra::api::FetchAchievementInfo::Response& response)

--- a/tests/ui/viewmodels/OverlayManager_Tests.cpp
+++ b/tests/ui/viewmodels/OverlayManager_Tests.cpp
@@ -4,6 +4,7 @@
 
 #include "ui\OverlayTheme.hh"
 
+#include "tests\mocks\MockAchievementRuntime.hh"
 #include "tests\mocks\MockClock.hh"
 #include "tests\mocks\MockConfiguration.hh"
 #include "tests\mocks\MockDesktop.hh"
@@ -34,6 +35,7 @@ private:
         ra::data::mocks::MockEmulatorContext mockEmulatorContext;
         ra::data::mocks::MockGameContext mockGameContext;
         ra::data::mocks::MockUserContext mockUserContext;
+        ra::services::mocks::MockAchievementRuntime mockAchievementRuntime;
         ra::services::mocks::MockClock mockClock;
         ra::services::mocks::MockConfiguration mockConfiguration;
         ra::services::mocks::MockThreadPool mockThreadPool;


### PR DESCRIPTION
Adds categories to the achievements overlay. There's currently four categories:
1) Recently Earned - any achievements earned in the last 10 minutes (ordered by time earned)
2) Almost There - any Measured achievements with >= 80% progress
3) Unearned - all achievements the player hasn't earned (excluding those in Almost There)
4) Earned - all achievements the player has earned (excluding those in Recently Earned)

![image](https://user-images.githubusercontent.com/32680403/97805909-20cb8880-1c16-11eb-8845-27e8f2fe49e3.png)
![image](https://user-images.githubusercontent.com/32680403/97805910-232de280-1c16-11eb-931c-3a3a4e59f030.png)

Previously, the entire list was in server order, which usually puts the achievements in an order that they're likely to be earned in. This leads to the player having to scroll through already earned achievements to find things they haven't earned or to check progress on things. 

The first change is to separate Earned from Unearned. When returning to a game, the list will not be scrolled, and the user most likely doesn't care about the achievements they've already earned, so the earned achievements are put at the end of the list. It might be worth noting that the server already does this, but it puts the earned achievements before the unearned achievements. Within each category (except Recently Earned), the server order is maintained.

Additionally, recently earned achievements are highlighted at the top of the list. When a player unlocks an achievement they may be in the middle of a fight or something else demanding their attention and may not understand what they just unlocked. This change makes it easy for them to check their recent unlocks to read the descriptions they may have missed.

Finally, any achievements that leverage the Measured flag will be highlighted if they are at least 80% towards completion. Previously, the player would have to find the achievement in the list before being able to toggle the overlay to monitor progress. This also highlights things that the player is close to getting that they may not have even realized were associated to achievements.

If there aren't any Recently Earned or Almost There achievements, those sections will be hidden. If both are hidden, the Unearned header will also be hidden and the list will just start with the first unearned achievement. The Earned header will always be present if there are any earned achievements.