### PR TITLE
replace checksum references with RetroAchievements hash

### DIFF
--- a/src/RA_Core.cpp
+++ b/src/RA_Core.cpp
@@ -313,7 +313,7 @@ API HMENU CCONV _RA_CreatePopupMenu()
         AppendMenu(hRA, MF_SEPARATOR, 0U, nullptr);
 
         AppendMenu(hRA, MF_STRING, IDM_RA_REPORTBROKENACHIEVEMENTS, TEXT("&Report Achievement Problem"));
-        AppendMenu(hRA, MF_STRING, IDM_RA_GETROMCHECKSUM, TEXT("Get ROM &Checksum"));
+        AppendMenu(hRA, MF_STRING, IDM_RA_GETROMCHECKSUM, TEXT("View Game H&ash"));
         //AppendMenu(hRA, MF_STRING, IDM_RA_SCANFORGAMES, TEXT("Scan &for games"));
     }
     else

--- a/src/RA_Shared.rc
+++ b/src/RA_Shared.rc
@@ -165,17 +165,17 @@ BEGIN
     LTEXT           "My Game (U)",IDC_RA_GAMENAME,48,16,197,8
     LTEXT           "System:",IDC_STATIC,8,24,27,8
     LTEXT           "Some System",IDC_RA_SYSTEMNAME,48,24,131,8
-    LTEXT           "Checksum:",IDC_STATIC,8,32,36,8
+    LTEXT           "RA Hash:",IDC_STATIC,8,32,36,8
     LTEXT           "ABCDEF0123456789",IDC_RA_CHECKSUM,48,32,131,8
     LTEXT           "Select an existing title for the game from the following list of known titles:",IDC_STATIC,4,44,241,10
     COMBOBOX        IDC_RA_KNOWNGAMES,4,54,241,137,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
     LTEXT           "Or provide an appropriate name to create a new entry:",IDC_STATIC,4,70,219,10
     EDITTEXT        IDC_RA_GAMETITLE,4,80,241,14,ES_AUTOHSCROLL | ES_WANTRETURN
-    LTEXT           "Then press 'Link' to associate the checksum to the game, or 'Test' to load the game without registering the checksum.",IDC_STATIC,4,98,241,18
+    LTEXT           "Then press 'Link' to associate the hash to the game, or 'Test' to load the game without registering the hash.",IDC_STATIC,4,98,241,18
     PUSHBUTTON      "Link",IDC_RA_LINK,4,118,66,14
     DEFPUSHBUTTON   "Test",IDOK,113,118,66,14
     PUSHBUTTON      "Cancel",IDCANCEL,179,118,66,14
-    PUSHBUTTON      "Copy Checksum",IDC_RA_COPYCHECKSUMCLIPBOARD,179,26,66,14
+    PUSHBUTTON      "Copy Hash",IDC_RA_COPYCHECKSUMCLIPBOARD,179,26,66,14
 END
 
 IDD_RA_LEADERBOARDEDITOR DIALOGEX 0, 0, 332, 310
@@ -227,7 +227,7 @@ EXSTYLE WS_EX_TOPMOST
 CAPTION "ROM Checksum"
 FONT 8, "MS Shell Dlg", 400, 0, 0x1
 BEGIN
-    LTEXT           "ROM Checksum:",IDC_RA_ROMCHECKSUMHEADER,7,7,170,11
+    LTEXT           "RetroAchievements Hash:",IDC_RA_ROMCHECKSUMHEADER,7,7,170,11
     LTEXT           "No game loaded.",IDC_RA_ROMCHECKSUMTEXT,7,17,170,10
     DEFPUSHBUTTON   "Copy To Clipboard",IDC_RA_COPYCHECKSUMCLIPBOARD,7,33,82,14
     DEFPUSHBUTTON   "OK",IDOK,127,33,50,14

--- a/src/services/GameIdentifier.cpp
+++ b/src/services/GameIdentifier.cpp
@@ -71,7 +71,7 @@ unsigned int GameIdentifier::IdentifyHash(const std::string& sMD5)
         nGameId = response.GameId;
         if (nGameId == 0) // Unknown
         {
-            RA_LOG_INFO("Could not identify game with MD5 %s", sMD5);
+            RA_LOG_INFO("Could not identify game with hash %s", sMD5);
 
             auto sEstimatedGameTitle = ra::services::ServiceLocator::Get<ra::data::context::EmulatorContext>().GetGameTitle();
 

--- a/src/ui/viewmodels/BrokenAchievementsViewModel.cpp
+++ b/src/ui/viewmodels/BrokenAchievementsViewModel.cpp
@@ -208,7 +208,7 @@ bool BrokenAchievementsViewModel::Submit()
 
     vmConfirm.SetMessage(ra::StringPrintf(L""
         "Achievement ID%s: %s\n"
-        "Game Checksum: %s\n"
+        "RetroAchievements Hash: %s\n"
         "Comment: %s",
         request.AchievementIds.size() == 1 ? "" : "s",
         sBuggedIDs, pGameContext.GameHash(), GetComment()

--- a/src/ui/viewmodels/UnknownGameViewModel.cpp
+++ b/src/ui/viewmodels/UnknownGameViewModel.cpp
@@ -86,7 +86,7 @@ bool UnknownGameViewModel::Associate()
         request.GameName = m_vGameTitles.GetLabelForId(nGameId);
 
         ra::ui::viewmodels::MessageBoxViewModel vmMessageBox;
-        vmMessageBox.SetHeader(ra::StringPrintf(L"Are you sure you want to add a new checksum to '%s'?", request.GameName));
+        vmMessageBox.SetHeader(ra::StringPrintf(L"Are you sure you want to add a new hash to '%s'?", request.GameName));
         vmMessageBox.SetMessage(L"You should not do this unless you are certain that the new title is compatible. You can use 'Test' mode to check compatibility.");
         vmMessageBox.SetButtons(ra::ui::viewmodels::MessageBoxViewModel::Buttons::YesNo);
         if (vmMessageBox.ShowModal(*this) == DialogResult::No)

--- a/tests/ui/viewmodels/BrokenAchievementsViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/BrokenAchievementsViewModel_Tests.cpp
@@ -322,7 +322,7 @@ public:
             bDialogSeen = true;
 
             Assert::AreEqual(std::wstring(L"Are you sure that you want to create a triggered at the wrong time ticket for Title3?"), vmMessageBox.GetHeader());
-            Assert::AreEqual(std::wstring(L"Achievement ID: 3\nGame Checksum: HASH\nComment: I tried."), vmMessageBox.GetMessage());
+            Assert::AreEqual(std::wstring(L"Achievement ID: 3\nRetroAchievements Hash: HASH\nComment: I tried."), vmMessageBox.GetMessage());
 
             return ra::ui::DialogResult::No;
         });
@@ -348,7 +348,7 @@ public:
             bDialogSeen = true;
 
             Assert::AreEqual(std::wstring(L"Are you sure that you want to create 2 did not trigger tickets for GAME?"), vmMessageBox.GetHeader());
-            Assert::AreEqual(std::wstring(L"Achievement IDs: 3,5\nGame Checksum: HASH\nComment: I tried."), vmMessageBox.GetMessage());
+            Assert::AreEqual(std::wstring(L"Achievement IDs: 3,5\nRetroAchievements Hash: HASH\nComment: I tried."), vmMessageBox.GetMessage());
 
             return ra::ui::DialogResult::No;
         });

--- a/tests/ui/viewmodels/UnknownGameViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/UnknownGameViewModel_Tests.cpp
@@ -158,7 +158,7 @@ public:
 
         vmUnknownGame.mockDesktop.ExpectWindow<ra::ui::viewmodels::MessageBoxViewModel>([](ra::ui::viewmodels::MessageBoxViewModel& vmMessageBox)
         {
-            Assert::AreEqual(std::wstring(L"Are you sure you want to add a new checksum to 'Game 40'?"), vmMessageBox.GetHeader());
+            Assert::AreEqual(std::wstring(L"Are you sure you want to add a new hash to 'Game 40'?"), vmMessageBox.GetHeader());
             return ra::ui::DialogResult::Yes;
         });
 


### PR DESCRIPTION
The hash that we generate to uniquely identify games is more-often-than-not different from the full-file hash that would be expected if described as a checksum.

This replaces references to "checksum" in the RetroAchievements menu, Unknown Title dialog, Broken Achievements dialog, and View Hash dialog with "RetroAchievements hash", "RA hash", or "hash" as permitted by space and context. Code references to checksum were not refactored at this time.

