### PR TITLE
attempt to provide more detail on network failures

### DIFF
--- a/src/api/impl/ConnectedServer.cpp
+++ b/src/api/impl/ConnectedServer.cpp
@@ -30,6 +30,11 @@ _NODISCARD static bool HandleHttpError(_In_ const ra::services::Http::Response& 
         const bool bRetry = pHttpRequester.IsRetryable(ra::etoi(httpResponse.StatusCode()));
         pResponse.Result = bRetry ? ApiResult::Incomplete : ApiResult::Error;
         pResponse.ErrorMessage = ra::BuildString("HTTP error code: ", ra::etoi(httpResponse.StatusCode()));
+
+        const auto& pStatusCodeText = pHttpRequester.GetStatusCodeText(ra::etoi(httpResponse.StatusCode()));
+        if (!pStatusCodeText.empty())
+            pResponse.ErrorMessage = ra::StringPrintf("%s (%s)", pResponse.ErrorMessage, pStatusCodeText);
+
         return true;
     }
 

--- a/src/services/IHttpRequester.hh
+++ b/src/services/IHttpRequester.hh
@@ -35,6 +35,12 @@ public:
     /// </summary>
     _NODISCARD virtual bool IsRetryable(unsigned int nStatusCode) const noexcept = 0;
 
+    /// <summary>
+    /// Gets a friendly summary to display for the specified status code.
+    /// </summary>
+    /// <returns>A summary description of the error code, or empty string if unknown.</returns>
+    virtual std::string GetStatusCodeText(unsigned int nStatusCode) const = 0;
+
 protected:
     IHttpRequester() noexcept = default;
 };

--- a/src/services/impl/WindowsHttpRequester.hh
+++ b/src/services/impl/WindowsHttpRequester.hh
@@ -21,6 +21,8 @@ public:
 
     bool IsRetryable(unsigned int nStatusCode) const noexcept override;
 
+    std::string GetStatusCodeText(unsigned int nStatusCode) const override;
+
 private:
     std::wstring m_sUserAgent;
 };

--- a/tests/api/ConnectedServer_Tests.cpp
+++ b/tests/api/ConnectedServer_Tests.cpp
@@ -187,7 +187,7 @@ public:
 
         // "Success:false" without error message results in Failed call, not Error call
         Assert::AreEqual(ApiResult::Error, response.Result);
-        Assert::AreEqual(std::string("HTTP error code: 401"), response.ErrorMessage);
+        Assert::AreEqual(std::string("HTTP error code: 401 (err401)"), response.ErrorMessage);
         Assert::AreEqual(std::string(""), response.Username);
         Assert::AreEqual(std::string(""), response.ApiToken);
         Assert::AreEqual(0U, response.Score);
@@ -238,7 +238,7 @@ public:
 
         // "Success:false" without error message results in Failed call, not Error call
         Assert::AreEqual(ApiResult::Error, response.Result);
-        Assert::AreEqual(std::string("HTTP error code: 403"), response.ErrorMessage);
+        Assert::AreEqual(std::string("HTTP error code: 403 (err403)"), response.ErrorMessage);
     }
 
     TEST_METHOD(TestAwardAchievementFailed403WithMessage)
@@ -281,7 +281,7 @@ public:
         auto response = server.Login(request);
 
         Assert::AreEqual(ApiResult::Error, response.Result);
-        Assert::AreEqual(std::string("HTTP error code: 404"), response.ErrorMessage);
+        Assert::AreEqual(std::string("HTTP error code: 404 (err404)"), response.ErrorMessage);
         Assert::AreEqual(std::string(""), response.Username);
         Assert::AreEqual(std::string(""), response.ApiToken);
         Assert::AreEqual(0U, response.Score);

--- a/tests/mocks/MockHttpRequester.hh
+++ b/tests/mocks/MockHttpRequester.hh
@@ -32,7 +32,7 @@ public:
         return false;
     }
 
-    std::string GetStatusCodeText(unsigned int nStatusCode) const noexcept override
+    std::string GetStatusCodeText(unsigned int nStatusCode) const override
     {
         return ra::StringPrintf("err%u", nStatusCode);
     }

--- a/tests/mocks/MockHttpRequester.hh
+++ b/tests/mocks/MockHttpRequester.hh
@@ -32,6 +32,11 @@ public:
         return false;
     }
 
+    std::string GetStatusCodeText(unsigned int nStatusCode) const noexcept override
+    {
+        return ra::StringPrintf("err%u", nStatusCode);
+    }
+
 private:
     ServiceLocator::ServiceOverride<IHttpRequester> m_Override;
     std::string m_sUserAgent;


### PR DESCRIPTION
Expands the error message to include a system-provided message (when available) in addition to an error code.

![image](https://user-images.githubusercontent.com/32680403/99178090-296b9680-26cd-11eb-8a77-410ab587ad7d.png)

This only affects errors that are caught after the DLL has loaded. Any errors that occur while trying to download or validate the DLL version will still only report the error code.