### PR TITLE
if user has screenshot on but notification off, give notification setting preference

### DIFF
--- a/src/ui/viewmodels/OverlaySettingsViewModel.cpp
+++ b/src/ui/viewmodels/OverlaySettingsViewModel.cpp
@@ -43,10 +43,14 @@ void OverlaySettingsViewModel::Initialize()
 {
     const auto& pConfiguration = ra::services::ServiceLocator::Get<ra::services::IConfiguration>();
     SetMessageLocation(pConfiguration.GetPopupLocation(Popup::Message));
-    SetAchievementTriggerLocation(pConfiguration.GetPopupLocation(Popup::AchievementTriggered));
+
+    // set screenshot before location so location is given preference
     SetScreenshotAchievementTrigger(pConfiguration.IsFeatureEnabled(ra::services::Feature::AchievementTriggeredScreenshot));
-    SetMasteryLocation(pConfiguration.GetPopupLocation(Popup::Mastery));
+    SetAchievementTriggerLocation(pConfiguration.GetPopupLocation(Popup::AchievementTriggered));
+
     SetScreenshotMastery(pConfiguration.IsFeatureEnabled(ra::services::Feature::MasteryNotificationScreenshot));
+    SetMasteryLocation(pConfiguration.GetPopupLocation(Popup::Mastery));
+
     SetLeaderboardStartedLocation(pConfiguration.GetPopupLocation(Popup::LeaderboardStarted));
     SetLeaderboardCanceledLocation(pConfiguration.GetPopupLocation(Popup::LeaderboardCanceled));
     SetLeaderboardTrackerLocation(pConfiguration.GetPopupLocation(Popup::LeaderboardTracker));

--- a/tests/ui/viewmodels/OverlaySettingsViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/OverlaySettingsViewModel_Tests.cpp
@@ -125,6 +125,11 @@ private:
     void ValidateFeatureInitialize(ra::services::Feature feature, std::function<bool(OverlaySettingsViewModel&)> fGetValue)
     {
         OverlaySettingsViewModelHarness vmSettings;
+
+        // screenshot toggles require the associated notification to be enabled
+        vmSettings.mockConfiguration.SetPopupLocation(ra::ui::viewmodels::Popup::AchievementTriggered, ra::ui::viewmodels::PopupLocation::BottomLeft);
+        vmSettings.mockConfiguration.SetPopupLocation(ra::ui::viewmodels::Popup::Mastery, ra::ui::viewmodels::PopupLocation::BottomLeft);
+
         vmSettings.mockConfiguration.SetFeatureEnabled(feature, false);
         vmSettings.Initialize();
         Assert::IsFalse(fGetValue(vmSettings));
@@ -248,6 +253,26 @@ public:
         Assert::IsFalse(vmSettings.ScreenshotMastery());
 
         vmSettings.SetMasteryLocation(ra::ui::viewmodels::PopupLocation::None);
+        Assert::AreEqual(ra::ui::viewmodels::PopupLocation::None, vmSettings.GetMasteryLocation());
+        Assert::IsFalse(vmSettings.ScreenshotMastery());
+    }
+
+    TEST_METHOD(TestDependencyMismatch)
+    {
+        OverlaySettingsViewModelHarness vmSettings;
+
+        // popup off has precedence over screenshot on (should disable screenshot)
+        vmSettings.mockConfiguration.SetPopupLocation(ra::ui::viewmodels::Popup::AchievementTriggered, ra::ui::viewmodels::PopupLocation::None);
+        vmSettings.mockConfiguration.SetFeatureEnabled(ra::services::Feature::AchievementTriggeredScreenshot, true);
+
+        vmSettings.mockConfiguration.SetPopupLocation(ra::ui::viewmodels::Popup::Mastery, ra::ui::viewmodels::PopupLocation::None);
+        vmSettings.mockConfiguration.SetFeatureEnabled(ra::services::Feature::MasteryNotificationScreenshot, true);
+
+        vmSettings.Initialize();
+
+        Assert::AreEqual(ra::ui::viewmodels::PopupLocation::None, vmSettings.GetAchievementTriggerLocation());
+        Assert::IsFalse(vmSettings.ScreenshotAchievementTrigger());
+
         Assert::AreEqual(ra::ui::viewmodels::PopupLocation::None, vmSettings.GetMasteryLocation());
         Assert::IsFalse(vmSettings.ScreenshotMastery());
     }


### PR DESCRIPTION
this normally shouldn't be possible without manually modifying the configuration file, but I ran into the issue when switch back and forth between the old feature (on/off) and the new feature (location) for notifications.