### PR TITLE
show bookmark description on pause dialog

### DIFF
--- a/src/services/FrameEventQueue.cpp
+++ b/src/services/FrameEventQueue.cpp
@@ -9,17 +9,6 @@
 namespace ra {
 namespace services {
 
-void FrameEventQueue::QueuePauseOnChange(MemSize nSize, ra::ByteAddress nAddress)
-{
-    for (const auto& pChange : m_vMemChanges)
-    {
-        if (pChange.nAddress == nAddress && pChange.nSize == nSize)
-            return;
-    }
-
-    m_vMemChanges.emplace_back(nAddress, nSize);
-}
-
 void FrameEventQueue::DoFrame()
 {
     std::wstring sPauseMessage;
@@ -51,14 +40,8 @@ void FrameEventQueue::DoFrame()
             sPauseMessage.append(L"\n");
 
         sPauseMessage.append(L"The following bookmarks have changed:");
-
-        const auto& pAssetEditor = ra::services::ServiceLocator::Get<ra::ui::viewmodels::WindowManager>().AssetEditor;
         for (const auto& pChange : m_vMemChanges)
-        {
-            sPauseMessage.append(ra::StringPrintf(L"\n* %s %s",
-                pAssetEditor.Trigger().OperandSizes().GetLabelForId(ra::etoi(pChange.nSize)),
-                ra::ByteAddressToString(pChange.nAddress)));
-        }
+            sPauseMessage.append(ra::StringPrintf(L"\n* %s", pChange));
 
         m_vMemChanges.clear();
     }

--- a/src/services/FrameEventQueue.hh
+++ b/src/services/FrameEventQueue.hh
@@ -20,7 +20,10 @@ public:
     FrameEventQueue(FrameEventQueue&&) noexcept = delete;
     FrameEventQueue& operator=(FrameEventQueue&&) noexcept = delete;
 
-    void QueuePauseOnChange(MemSize nSize, ra::ByteAddress nAddress);
+    void QueuePauseOnChange(const std::wstring& sMemDescription)
+    {
+        m_vMemChanges.insert(sMemDescription);
+    }
 
     void QueuePauseOnReset(const std::wstring& sTriggerName)
     {
@@ -35,18 +38,7 @@ public:
     void DoFrame();
 
 protected:
-    struct MemChange
-    {
-        MemChange(ra::ByteAddress nAddress, MemSize nSize) noexcept
-            : nAddress(nAddress), nSize(nSize)
-        {
-        }
-
-        ra::ByteAddress nAddress;
-        MemSize nSize;
-    };
-
-    std::vector<MemChange> m_vMemChanges;
+    std::set<std::wstring> m_vMemChanges;
     std::vector<std::wstring> m_vResetTriggers;
     std::vector<std::wstring> m_vTriggeredTriggers;
 };

--- a/src/ui/viewmodels/MemoryBookmarksViewModel.cpp
+++ b/src/ui/viewmodels/MemoryBookmarksViewModel.cpp
@@ -319,8 +319,40 @@ void MemoryBookmarksViewModel::DoFrame()
                 {
                     pBookmark.SetRowColor(ra::ui::Color(0xFFFFC0C0));
 
+                    const auto nSizeIndex = m_vSizes.FindItemIndex(MemoryBookmarkViewModel::SizeProperty, ra::etoi(pBookmark.GetSize()));
+                    Expects(nSizeIndex >= 0);
+
+                    auto sMessage = ra::StringPrintf(L"%s %s",
+                        m_vSizes.GetItemAt(nSizeIndex)->GetLabel(),
+                        ra::ByteAddressToString(pBookmark.GetAddress()));
+
+                    // remove leading space of " 8-bit"
+                    if (isspace(sMessage.at(0)))
+                        sMessage.erase(0, 1);
+
+                    const auto& pDescription = pBookmark.GetDescription();
+                    if (!pDescription.empty())
+                    {
+                        auto nDescriptionLength = pDescription.find(L'\n');
+                        if (nDescriptionLength == std::string::npos)
+                        {
+                            if (pDescription.length() < 40)
+                            {
+                                nDescriptionLength = pDescription.length();
+                            }
+                            else
+                            {
+                                nDescriptionLength = pDescription.find_last_of(L' ', 40);
+                                if (nDescriptionLength == std::string::npos)
+                                    nDescriptionLength = 40;
+                            }
+                        }
+                        sMessage.append(L": ");
+                        sMessage.append(pDescription, 0, nDescriptionLength);
+                    }
+
                     auto& pFrameEventQueue = ra::services::ServiceLocator::GetMutable<ra::services::FrameEventQueue>();
-                    pFrameEventQueue.QueuePauseOnChange(pBookmark.GetSize(), pBookmark.GetAddress());
+                    pFrameEventQueue.QueuePauseOnChange(sMessage);
                 }
 
                 m_bIgnoreValueChanged = true;

--- a/tests/mocks/MockFrameEventQueue.hh
+++ b/tests/mocks/MockFrameEventQueue.hh
@@ -20,6 +20,11 @@ public:
     size_t NumResetTriggers() const noexcept { return m_vResetTriggers.size(); }
     size_t NumMemoryChanges() const noexcept { return m_vMemChanges.size(); }
 
+    bool ContainsMemoryChange(const std::wstring& sChange) const
+    {
+        return (m_vMemChanges.find(sChange) != m_vMemChanges.end());
+    }
+
     void Reset() noexcept
     {
         m_vTriggeredTriggers.clear();

--- a/tests/services/FrameEventQueue_Tests.cpp
+++ b/tests/services/FrameEventQueue_Tests.cpp
@@ -185,7 +185,7 @@ public:
             return ra::ui::DialogResult::OK;
         });
 
-        eventQueue.QueuePauseOnChange(MemSize::EightBit, { 0x1234U });
+        eventQueue.QueuePauseOnChange(L"8-bit 0x1234");
         Assert::AreEqual({ 1U }, eventQueue.NumMemoryChanges());
         Assert::AreEqual({ 0U }, eventQueue.NumResetTriggers());
         Assert::AreEqual({ 0U }, eventQueue.NumTriggeredTriggers());
@@ -211,16 +211,16 @@ public:
             bSawDialog = true;
 
             Assert::AreEqual(std::wstring(L"The emulator has been paused."), vmMessageBox.GetHeader());
-            Assert::AreEqual(std::wstring(L"The following bookmarks have changed:\n* 16-bit 0x2345\n* 32-bit 0x3456\n* 32-bit 0x2345"), vmMessageBox.GetMessage());
+            Assert::AreEqual(std::wstring(L"The following bookmarks have changed:\n* 16-bit 0x2345\n* 32-bit 0x2345\n* 32-bit 0x3456"), vmMessageBox.GetMessage());
 
             return ra::ui::DialogResult::OK;
         });
 
-        eventQueue.QueuePauseOnChange(MemSize::SixteenBit, { 0x2345U });
-        eventQueue.QueuePauseOnChange(MemSize::ThirtyTwoBit, { 0x3456U });
-        eventQueue.QueuePauseOnChange(MemSize::SixteenBit, { 0x2345U }); // duplicate ignored
-        eventQueue.QueuePauseOnChange(MemSize::ThirtyTwoBit, { 0x2345U }); // same address, different size allowed
-        eventQueue.QueuePauseOnChange(MemSize::ThirtyTwoBit, { 0x2345U }); // duplicate ignored
+        eventQueue.QueuePauseOnChange(L"16-bit 0x2345");
+        eventQueue.QueuePauseOnChange(L"32-bit 0x3456");
+        eventQueue.QueuePauseOnChange(L"16-bit 0x2345"); // duplicate ignored
+        eventQueue.QueuePauseOnChange(L"32-bit 0x2345"); // same address, different size allowed
+        eventQueue.QueuePauseOnChange(L"32-bit 0x2345"); // duplicate ignored
 
         Assert::AreEqual({ 3U }, eventQueue.NumMemoryChanges());
         Assert::AreEqual({ 0U }, eventQueue.NumResetTriggers());
@@ -255,7 +255,7 @@ public:
             return ra::ui::DialogResult::OK;
         });
 
-        eventQueue.QueuePauseOnChange(MemSize::EightBit, { 0x1234U });
+        eventQueue.QueuePauseOnChange(L"8-bit 0x1234");
         eventQueue.QueuePauseOnTrigger(L"You did it!");
         eventQueue.QueuePauseOnReset(L"You did it again!");
         Assert::AreEqual({ 1U }, eventQueue.NumMemoryChanges());


### PR DESCRIPTION
If a bookmark has a description (either a code note or manually entered), the first line (up to 40 characters) will be displayed in addition to the address when the bookmark triggers a pause.

![image](https://user-images.githubusercontent.com/32680403/100690137-21555d00-3343-11eb-9c01-64463487b470.png)
