### PR TITLE
fix display of non-ASCII characters in ListView controls

### DIFF
--- a/src/ui/win32/Desktop.cpp
+++ b/src/ui/win32/Desktop.cpp
@@ -199,9 +199,10 @@ std::string Desktop::GetOSVersionString() const
 }
 
 
-void Desktop::OpenUrl(const std::string& sUrl) const noexcept
+void Desktop::OpenUrl(const std::string& sUrl) const
 {
-    ShellExecute(nullptr, TEXT("open"), sUrl.c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+    const auto sNativeUrl = NativeStr(sUrl);
+    ShellExecute(nullptr, TEXT("open"), sNativeUrl.c_str(), nullptr, nullptr, SW_SHOWNORMAL);
 }
 
 std::unique_ptr<ra::ui::drawing::ISurface> Desktop::CaptureClientArea(const WindowViewModelBase& vmViewModel) const
@@ -246,9 +247,9 @@ static bool IsSuspiciousProcessRunning()
         {
             do
             {
-                if (strlen(pe32.szExeFile) >= 15)
+                if (tcslen_s(pe32.szExeFile) >= 15)
                 {
-                    std::string sFilename = pe32.szExeFile;
+                    std::string sFilename = ra::Narrow(pe32.szExeFile);
                     std::transform(sFilename.begin(), sFilename.end(), sFilename.begin(), [](char c) noexcept
                     {
                         return gsl::narrow_cast<char>(std::tolower(c));

--- a/src/ui/win32/Desktop.hh
+++ b/src/ui/win32/Desktop.hh
@@ -22,7 +22,7 @@ public:
     void GetWorkArea(ra::ui::Position& oUpperLeftCorner, ra::ui::Size& oSize) const override;
     ra::ui::Size GetClientSize(const WindowViewModelBase& vmViewModel) const noexcept override;
 
-    void OpenUrl(const std::string& sUrl) const noexcept override;
+    void OpenUrl(const std::string& sUrl) const override;
 
     void Shutdown() noexcept override;
 

--- a/src/ui/win32/OverlayWindow.cpp
+++ b/src/ui/win32/OverlayWindow.cpp
@@ -154,7 +154,7 @@ void OverlayWindow::CreateOverlayWindow()
     m_hOverlayWnd = CreateWindowEx(
         (WS_EX_NOACTIVATE | WS_EX_TRANSPARENT | WS_EX_LAYERED),
         wndEx.lpszClassName,
-        "TransparentOverlayWindow",
+        TEXT("TransparentOverlayWindow"),
         (WS_POPUP),
         CW_USEDEFAULT, CW_USEDEFAULT, rcMainWindowClientArea.right, rcMainWindowClientArea.bottom,
         m_hWnd, nullptr, wndEx.hInstance, nullptr);

--- a/src/ui/win32/bindings/GridBinding.cpp
+++ b/src/ui/win32/bindings/GridBinding.cpp
@@ -229,22 +229,19 @@ void GridBinding::UpdateItems(gsl::index nColumn)
     }
     else
     {
-        std::string sText;
+        std::wstring sText;
 
-        LV_ITEM item{};
+        LV_ITEMW item{};
         item.mask = LVIF_TEXT;
         item.iSubItem = gsl::narrow_cast<int>(nColumn);
 
         for (gsl::index i = 0; ra::to_unsigned(i) < m_vmItems->Count(); ++i)
         {
-            sText = NativeStr(pColumn.GetText(*m_vmItems, i));
+            sText = pColumn.GetText(*m_vmItems, i);
             item.pszText = sText.data();
             item.iItem = gsl::narrow_cast<int>(i);
 
-            if (i < nItems)
-                ListView_SetItem(m_hWnd, &item);
-            else
-                ListView_InsertItem(m_hWnd, &item);
+            SNDMSG(m_hWnd, (i < nItems) ? LVM_SETITEMW : LVM_INSERTITEMW, 0, (LPARAM)(&item));
         }
     }
 
@@ -303,8 +300,8 @@ void GridBinding::OnViewModelIntValueChanged(gsl::index nIndex, const IntModelPr
         return;
     }
 
-    std::string sText;
-    LV_ITEM item{};
+    std::wstring sText;
+    LV_ITEMW item{};
     item.mask = LVIF_TEXT;
     item.iItem = gsl::narrow_cast<int>(nIndex);
 
@@ -318,9 +315,9 @@ void GridBinding::OnViewModelIntValueChanged(gsl::index nIndex, const IntModelPr
                 m_nSortIndex = -1;
 
             item.iSubItem = gsl::narrow_cast<int>(nColumnIndex);
-            sText = NativeStr(pColumn.GetText(*m_vmItems, nIndex));
+            sText = pColumn.GetText(*m_vmItems, nIndex);
             item.pszText = sText.data();
-            ListView_SetItem(m_hWnd, &item);
+            SNDMSG(m_hWnd, LVM_SETITEMW, 0, (LPARAM)&item);
 
             m_bForceRepaint = true;
         }
@@ -329,8 +326,8 @@ void GridBinding::OnViewModelIntValueChanged(gsl::index nIndex, const IntModelPr
 
 void GridBinding::OnViewModelBoolValueChanged(gsl::index nIndex, const BoolModelProperty::ChangeArgs& args)
 {
-    std::string sText;
-    LV_ITEM item{};
+    std::wstring sText;
+    LV_ITEMW item{};
     item.mask = LVIF_TEXT;
     item.iItem = gsl::narrow_cast<int>(nIndex);
 
@@ -344,9 +341,9 @@ void GridBinding::OnViewModelBoolValueChanged(gsl::index nIndex, const BoolModel
                 m_nSortIndex = -1;
 
             item.iSubItem = gsl::narrow_cast<int>(nColumnIndex);
-            sText = NativeStr(pColumn.GetText(*m_vmItems, nIndex));
+            sText = pColumn.GetText(*m_vmItems, nIndex);
             item.pszText = sText.data();
-            ListView_SetItem(m_hWnd, &item);
+            SNDMSG(m_hWnd, LVM_SETITEMW, 0, (LPARAM)&item);
 
             m_bForceRepaint = true;
         }
@@ -355,8 +352,8 @@ void GridBinding::OnViewModelBoolValueChanged(gsl::index nIndex, const BoolModel
 
 void GridBinding::OnViewModelStringValueChanged(gsl::index nIndex, const StringModelProperty::ChangeArgs& args)
 {
-    std::string sText;
-    LV_ITEM item{};
+    std::wstring sText;
+    LV_ITEMW item{};
     item.mask = LVIF_TEXT;
     item.iItem = gsl::narrow_cast<int>(nIndex);
 
@@ -370,9 +367,9 @@ void GridBinding::OnViewModelStringValueChanged(gsl::index nIndex, const StringM
                 m_nSortIndex = -1;
 
             item.iSubItem = gsl::narrow_cast<int>(nColumnIndex);
-            sText = NativeStr(pColumn.GetText(*m_vmItems, nIndex));
+            sText = pColumn.GetText(*m_vmItems, nIndex);
             item.pszText = sText.data();
-            ListView_SetItem(m_hWnd, &item);
+            SNDMSG(m_hWnd, LVM_SETITEMW, 0, (LPARAM)&item);
 
             m_bForceRepaint = true;
         }
@@ -418,9 +415,9 @@ void GridBinding::UpdateRow(gsl::index nIndex, bool bExisting)
     if (m_pUpdateSelectedItems)
         return;
 
-    std::string sText;
+    std::wstring sText;
 
-    LV_ITEM item{};
+    LV_ITEMW item{};
     item.mask = LVIF_TEXT;
     item.iItem = gsl::narrow_cast<int>(nIndex);
     item.iSubItem = 0;
@@ -428,13 +425,10 @@ void GridBinding::UpdateRow(gsl::index nIndex, bool bExisting)
     const auto& pColumn = *m_vColumns.at(0);
     nIndex -= m_nScrollOffset;
 
-    sText = NativeStr(pColumn.GetText(*m_vmItems, nIndex));
+    sText = pColumn.GetText(*m_vmItems, nIndex);
     item.pszText = sText.data();
 
-    if (bExisting)
-        ListView_SetItem(m_hWnd, &item);
-    else
-        ListView_InsertItem(m_hWnd, &item);
+    SNDMSG(m_hWnd, bExisting ? LVM_SETITEMW : LVM_INSERTITEMW, 0, (LPARAM)&item);
 
     const auto* pCheckBoxColumn = dynamic_cast<const GridCheckBoxColumnBinding*>(&pColumn);
     if (pCheckBoxColumn != nullptr)
@@ -445,11 +439,11 @@ void GridBinding::UpdateRow(gsl::index nIndex, bool bExisting)
 
     for (gsl::index i = 1; ra::to_unsigned(i) < m_vColumns.size(); ++i)
     {
-        sText = NativeStr(m_vColumns.at(i)->GetText(*m_vmItems, nIndex));
+        sText = m_vColumns.at(i)->GetText(*m_vmItems, nIndex);
 
         item.pszText = sText.data();
         item.iSubItem = gsl::narrow_cast<int>(i);
-        ListView_SetItem(m_hWnd, &item);
+        SNDMSG(m_hWnd, LVM_SETITEMW, 0, (LPARAM)&item);
     }
 
     if (m_pIsSelectedProperty)

--- a/src/ui/win32/bindings/GridBinding.hh
+++ b/src/ui/win32/bindings/GridBinding.hh
@@ -116,13 +116,13 @@ private:
 
     HWND m_hTooltip = nullptr;
     int m_nTooltipLocation = 0;
-    std::string m_sTooltip;
+    ra::tstring m_sTooltip;
 
     const IntModelProperty* m_pRowColorProperty = nullptr;
 
     const IntModelProperty* m_pScrollOffsetProperty = nullptr;
     const IntModelProperty* m_pScrollMaximumProperty = nullptr;
-    std::string m_sDispInfo;
+    ra::tstring m_sDispInfo;
     std::function<void(gsl::index, gsl::index, bool)> m_pUpdateSelectedItems = nullptr;
 
     HWND m_hInPlaceEditor = nullptr;

--- a/src/ui/win32/bindings/MultiLineGridBinding.cpp
+++ b/src/ui/win32/bindings/MultiLineGridBinding.cpp
@@ -211,16 +211,16 @@ void MultiLineGridBinding::UpdateItems(gsl::index nColumn)
 {
     const auto& pColumn = *m_vColumns.at(nColumn);
     const auto nItems = ListView_GetItemCount(m_hWnd);
-    std::string sText;
+    std::wstring sText;
 
-    LV_ITEM item{};
+    LV_ITEMW item{};
     item.mask = LVIF_TEXT;
     item.iSubItem = gsl::narrow_cast<int>(nColumn);
 
     gsl::index nLine = 0;
     for (gsl::index i = 0; ra::to_unsigned(i) < m_vmItems->Count(); ++i)
     {
-        sText = NativeStr(pColumn.GetText(*m_vmItems, i));
+        sText = pColumn.GetText(*m_vmItems, i);
         item.pszText = sText.data();
         item.iItem = gsl::narrow_cast<int>(nLine);
 
@@ -239,10 +239,8 @@ void MultiLineGridBinding::UpdateItems(gsl::index nColumn)
                         --nIndex2;
                     sText.at(nIndex2) = '\0';
 
-                    if (nLine < nItems)
-                        ListView_SetItem(m_hWnd, &item);
-                    else
-                        ListView_InsertItem(m_hWnd, &item);
+                    GSL_SUPPRESS_TYPE1
+                    SNDMSG(m_hWnd, (nLine < nItems) ? LVM_SETITEMW : LVM_INSERTITEMW, 0, reinterpret_cast<LPARAM>(&item));
 
                     item.pszText = nIndex < sText.length() ? &sText.at(nIndex) : &sText.at(nIndex2);
                     item.iItem = gsl::narrow_cast<int>(++nLine);
@@ -254,10 +252,8 @@ void MultiLineGridBinding::UpdateItems(gsl::index nColumn)
 
             for (unsigned int nIndex = nItemLine; nIndex < pItemMetrics.nNumLines; ++nIndex)
             {
-                if (nLine < nItems)
-                    ListView_SetItem(m_hWnd, &item);
-                else
-                    ListView_InsertItem(m_hWnd, &item);
+                GSL_SUPPRESS_TYPE1
+                SNDMSG(m_hWnd, (nLine < nItems) ? LVM_SETITEMW : LVM_INSERTITEMW, 0, reinterpret_cast<LPARAM>(&item));
 
                 sText.at(0) = '\0';
                 item.pszText = sText.data();
@@ -265,10 +261,8 @@ void MultiLineGridBinding::UpdateItems(gsl::index nColumn)
             }
         }
 
-        if (nLine < nItems)
-            ListView_SetItem(m_hWnd, &item);
-        else
-            ListView_InsertItem(m_hWnd, &item);
+        GSL_SUPPRESS_TYPE1
+        SNDMSG(m_hWnd, (nLine < nItems) ? LVM_SETITEMW : LVM_INSERTITEMW, 0, reinterpret_cast<LPARAM>(&item));
 
         ++nLine;
     }


### PR DESCRIPTION
Uses the `LVM_SETITEMW` and `LVM_UPDATEITEMW` messages explicitly to allow for passing unicode text. The `ListView_SetItem` and `ListView_UpdateItem` macros compile down to non-Unicode versions because of other compile options that cannot be changed at this time.