### PR TITLE
allow client to suspend forced repaints

### DIFF
--- a/src/Exports.cpp
+++ b/src/Exports.cpp
@@ -31,6 +31,7 @@
 #include "ui\viewmodels\WindowManager.hh"
 #include "ui\win32\Desktop.hh"
 #include "ui\win32\OverlayWindow.hh"
+#include "ui\win32\bindings\ControlBinding.hh"
 
 #include "RAInterface\RA_Emulators.h"
 
@@ -502,6 +503,10 @@ static void UpdateUIForFrameChange()
 
 API void CCONV _RA_DoAchievementsFrame()
 {
+#ifndef RA_UTEST
+    ra::ui::win32::bindings::ControlBinding::RepaintGuard guard;
+#endif
+
     // make sure we process the achievements _before_ the frozen bookmarks modify the memory
     ProcessAchievements();
 
@@ -510,6 +515,20 @@ API void CCONV _RA_DoAchievementsFrame()
 #endif
 
     CHECK_PERFORMANCE();
+}
+
+API void CCONV _RA_SuspendRepaint()
+{
+#ifndef RA_UTEST
+    ra::ui::win32::bindings::ControlBinding::SuspendRepaint();
+#endif
+}
+
+API void CCONV _RA_ResumeRepaint()
+{
+#ifndef RA_UTEST
+    ra::ui::win32::bindings::ControlBinding::ResumeRepaint();
+#endif
 }
 
 API void CCONV _RA_OnSaveState(const char* sFilename)

--- a/src/Exports.hh
+++ b/src/Exports.hh
@@ -88,6 +88,12 @@ extern "C" {
     // Perform one test for all achievements in the current set. Call this once per frame/cycle.
     API void CCONV _RA_DoAchievementsFrame();
 
+    // Temporarily disable forced redraws
+    API void CCONV _RA_SuspendRepaint();
+
+    // Resume forced redraws
+    API void CCONV _RA_ResumeRepaint();
+
     // Use in special cases where the emulator contains more than one console ID.
     API void CCONV _RA_SetConsoleID(unsigned int nConsoleID);
 

--- a/src/ui/win32/bindings/ControlBinding.hh
+++ b/src/ui/win32/bindings/ControlBinding.hh
@@ -97,18 +97,23 @@ public:
     /// </summary>
     static void ResumeRepaint();
 
-    class RepaintGuard
+    class RepaintGuard final
     {
     public:
-        RepaintGuard()
+        RepaintGuard() noexcept
         {
-            ControlBinding::SuspendRepaint();
+            GSL_SUPPRESS_F6 ControlBinding::SuspendRepaint();
         }
 
-        ~RepaintGuard()
+        ~RepaintGuard() noexcept
         {
-            ControlBinding::ResumeRepaint();
+            GSL_SUPPRESS_F6 ControlBinding::ResumeRepaint();
         }
+
+        RepaintGuard(const RepaintGuard&) noexcept = delete;
+        RepaintGuard& operator=(const RepaintGuard&) noexcept = delete;
+        RepaintGuard(RepaintGuard&&) noexcept = delete;
+        RepaintGuard& operator=(RepaintGuard&&) noexcept = delete;
     };
 
     /// <summary>

--- a/src/ui/win32/bindings/ControlBinding.hh
+++ b/src/ui/win32/bindings/ControlBinding.hh
@@ -88,6 +88,30 @@ public:
     static void ForceRepaint(HWND hWnd);
 
     /// <summary>
+    /// Delays ForceRepaint calls until resumed.
+    /// </summary>
+    static void SuspendRepaint();
+
+    /// <summary>
+    /// Resumes ForceRepaint calls.
+    /// </summary>
+    static void ResumeRepaint();
+
+    class RepaintGuard
+    {
+    public:
+        RepaintGuard()
+        {
+            ControlBinding::SuspendRepaint();
+        }
+
+        ~RepaintGuard()
+        {
+            ControlBinding::ResumeRepaint();
+        }
+    };
+
+    /// <summary>
     /// DO NOT CALL! Must be public for WINAPI interop.
     /// </summary>
     _NODISCARD virtual INT_PTR CALLBACK WndProc(_In_ HWND, _In_ UINT, _In_ WPARAM, _In_ LPARAM) noexcept(false);


### PR DESCRIPTION
Gives more control to the client over how frequently the tool windows are allowed to forcibly repaint. Primarily allows for disabling repaints while skipping rendered frames in fast forward mode.