### PR TITLE
capture hitcounts of deactivated achievements for post-trigger examination

### DIFF
--- a/src/RA_Integration.vcxproj
+++ b/src/RA_Integration.vcxproj
@@ -85,6 +85,7 @@
     <ClCompile Include="data\ModelPropertyContainer.cpp" />
     <ClCompile Include="data\models\AchievementModel.cpp" />
     <ClCompile Include="data\models\AssetModelBase.cpp" />
+    <ClCompile Include="data\models\CapturedTriggerHits.cpp" />
     <ClCompile Include="data\models\LocalBadgesModel.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='DebugUnicode|Win32'">Create</PrecompiledHeader>
@@ -242,6 +243,7 @@
     <ClInclude Include="data\ModelPropertyContainer.hh" />
     <ClInclude Include="data\models\AchievementModel.hh" />
     <ClInclude Include="data\models\AssetModelBase.hh" />
+    <ClInclude Include="data\models\CapturedTriggerHits.hh" />
     <ClInclude Include="data\models\LocalBadgesModel.hh" />
     <ClInclude Include="data\Types.hh" />
     <ClInclude Include="Exports.hh" />

--- a/src/RA_Integration.vcxproj.filters
+++ b/src/RA_Integration.vcxproj.filters
@@ -384,6 +384,9 @@
     <ClCompile Include="data\models\LocalBadgesModel.cpp">
       <Filter>Data\Models</Filter>
     </ClCompile>
+    <ClCompile Include="data\models\CapturedTriggerHits.cpp">
+      <Filter>Data\Models</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="RA_Achievement.h">
@@ -948,6 +951,9 @@
       <Filter>UI\Win32</Filter>
     </ClInclude>
     <ClInclude Include="data\models\LocalBadgesModel.hh">
+      <Filter>Data\Models</Filter>
+    </ClInclude>
+    <ClInclude Include="data\models\CapturedTriggerHits.hh">
       <Filter>Data\Models</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/data/models/AchievementModel.hh
+++ b/src/data/models/AchievementModel.hh
@@ -4,6 +4,8 @@
 
 #include "AssetModelBase.hh"
 
+#include "CapturedTriggerHits.hh"
+
 namespace ra {
 namespace data {
 namespace models {
@@ -101,6 +103,8 @@ public:
     void Serialize(ra::services::TextWriter& pWriter) const override;
     bool Deserialize(ra::Tokenizer& pTokenizer) override;
 
+    const CapturedTriggerHits& GetCapturedHits() const noexcept { return m_pCapturedTriggerHits; }
+
 protected:
     void OnValueChanged(const IntModelProperty::ChangeArgs& args) override;
     void OnValueChanged(const StringModelProperty::ChangeArgs& args) override;
@@ -108,8 +112,13 @@ protected:
     void CommitTransaction() override;
 
 private:
+    void HandleStateChanged(AssetState nOldState, AssetState nNewState);
+
     AssetDefinition m_pTrigger;
     std::chrono::system_clock::time_point m_tUnlock;
+    std::wstring m_sUnlockRichPresence;
+
+    CapturedTriggerHits m_pCapturedTriggerHits;
 };
 
 } // namespace models

--- a/src/data/models/AssetModelBase.hh
+++ b/src/data/models/AssetModelBase.hh
@@ -154,6 +154,7 @@ public:
     /// Gets whether or not the asset is in an active state.
     /// </summary>
     bool IsActive() const { return IsActive(GetState()); }
+    static bool IsActive(AssetState nState) noexcept;
 
     /// <summary>
     /// Activates the asset.
@@ -285,8 +286,6 @@ protected:
 
     void CommitTransaction() override;
     void RevertTransaction() override;
-
-    static bool IsActive(AssetState nState) noexcept;
 
 private:
     static const std::string& GetAssetDefinition(const AssetDefinition& pAsset, AssetChanges nState) noexcept;

--- a/src/data/models/CapturedTriggerHits.cpp
+++ b/src/data/models/CapturedTriggerHits.cpp
@@ -1,0 +1,83 @@
+#include "CapturedTriggerHits.hh"
+
+#include "RA_md5factory.h"
+
+namespace ra {
+namespace data {
+namespace models {
+
+static void CaptureCondSetHitCounts(const rc_condset_t* pCondSet, std::vector<unsigned>& vCapturedHitCounts)
+{
+    const rc_condition_t* pCondition = pCondSet->conditions;
+    while (pCondition != nullptr)
+    {
+        vCapturedHitCounts.push_back(pCondition->current_hits);
+        pCondition = pCondition->next;
+    }
+}
+
+static void CaptureHitCounts(const rc_trigger_t* pTrigger, std::vector<unsigned>& vCapturedHitCounts)
+{
+    if (pTrigger->requirement)
+        CaptureCondSetHitCounts(pTrigger->requirement, vCapturedHitCounts);
+
+    const rc_condset_t* pCondSet = pTrigger->alternative;
+    while (pCondSet)
+    {
+        CaptureCondSetHitCounts(pCondSet, vCapturedHitCounts);
+        pCondSet = pCondSet->next;
+    }
+}
+
+static void RestoreCondSetHitCounts(rc_condset_t* pCondSet, const std::vector<unsigned>& vCapturedHitCounts, gsl::index& nIndex)
+{
+    rc_condition_t* pCondition = pCondSet->conditions;
+    while (pCondition != nullptr)
+    {
+        pCondition->current_hits = vCapturedHitCounts.at(nIndex++);
+        pCondition = pCondition->next;
+    }
+}
+
+static void RestoreHitCounts(rc_trigger_t* pTrigger, const std::vector<unsigned>& vCapturedHitCounts)
+{
+    gsl::index nIndex = 0;
+    if (pTrigger->requirement)
+        RestoreCondSetHitCounts(pTrigger->requirement, vCapturedHitCounts, nIndex);
+
+    rc_condset_t* pCondSet = pTrigger->alternative;
+    while (pCondSet)
+    {
+        RestoreCondSetHitCounts(pCondSet, vCapturedHitCounts, nIndex);
+        pCondSet = pCondSet->next;
+    }
+}
+
+void CapturedTriggerHits::Capture(const rc_trigger_t* pTrigger, const std::string& sTrigger)
+{
+    m_vCapturedHitCounts.clear();
+
+    m_sCapturedHitsMD5 = RAGenerateMD5(sTrigger);
+
+    if (pTrigger->has_hits)
+        CaptureHitCounts(pTrigger, m_vCapturedHitCounts);
+}
+
+bool CapturedTriggerHits::Restore(rc_trigger_t* pTrigger, const std::string& sTrigger) const
+{
+    if (m_sCapturedHitsMD5.empty())
+        return false;
+
+    const auto sCapturedHitsMD5 = RAGenerateMD5(sTrigger);
+    if (sCapturedHitsMD5 != m_sCapturedHitsMD5)
+        return false;
+
+    if (!m_vCapturedHitCounts.empty())
+        RestoreHitCounts(pTrigger, m_vCapturedHitCounts);
+
+    return true;
+}
+
+} // namespace models
+} // namespace data
+} // namespace ra

--- a/src/data/models/CapturedTriggerHits.hh
+++ b/src/data/models/CapturedTriggerHits.hh
@@ -1,0 +1,28 @@
+#ifndef RA_DATA_CAPTURED_TRIGGER_HITS_H
+#define RA_DATA_CAPTURED_TRIGGER_HITS_H
+#pragma once
+
+#include "CapturedTriggerHits.hh"
+
+#include <rcheevos\include\rcheevos.h>
+
+namespace ra {
+namespace data {
+namespace models {
+
+class CapturedTriggerHits
+{
+public:
+    void Capture(const rc_trigger_t* pTrigger, const std::string& sTrigger);
+    bool Restore(rc_trigger_t* pTrigger, const std::string& sTrigger) const;
+
+private:
+    std::vector<unsigned> m_vCapturedHitCounts;
+    std::string m_sCapturedHitsMD5;
+};
+
+} // namespace models
+} // namespace data
+} // namespace ra
+
+#endif RA_DATA_CAPTURED_TRIGGER_HITS_H

--- a/src/ui/viewmodels/TriggerViewModel.cpp
+++ b/src/ui/viewmodels/TriggerViewModel.cpp
@@ -383,13 +383,14 @@ void TriggerViewModel::InitializeFrom(const rc_trigger_t& pTrigger)
     UpdateConditions(&vmCoreGroup);
 }
 
-void TriggerViewModel::InitializeFrom(const std::string& sTrigger)
+void TriggerViewModel::InitializeFrom(const std::string& sTrigger, const ra::data::models::CapturedTriggerHits& pCapturedHits)
 {
     const auto nSize = rc_trigger_size(sTrigger.c_str());
     if (nSize > 0)
     {
         m_sTriggerBuffer.resize(nSize);
         m_pTrigger = rc_parse_trigger(m_sTriggerBuffer.data(), sTrigger.c_str(), nullptr, 0);
+        pCapturedHits.Restore(m_pTrigger, sTrigger);
         InitializeFrom(*m_pTrigger);
     }
     else

--- a/src/ui/viewmodels/TriggerViewModel.hh
+++ b/src/ui/viewmodels/TriggerViewModel.hh
@@ -2,6 +2,8 @@
 #define RA_UI_TRIGGERVIEWMODEL_H
 #pragma once
 
+#include "data\models\CapturedTriggerHits.hh"
+
 #include "ui\ViewModelBase.hh"
 #include "ui\ViewModelCollection.hh"
 
@@ -73,7 +75,7 @@ public:
     void SerializeAppend(std::string& sBuffer) const;
 
     void InitializeFrom(const rc_trigger_t& pTrigger);
-    void InitializeFrom(const std::string& sTrigger);
+    void InitializeFrom(const std::string& sTrigger, const ra::data::models::CapturedTriggerHits& pCapturedHits);
     void UpdateFrom(const rc_trigger_t& pTrigger);
     void UpdateFrom(const std::string& sTrigger);
 

--- a/src/ui/win32/AssetEditorDialog.cpp
+++ b/src/ui/win32/AssetEditorDialog.cpp
@@ -253,14 +253,7 @@ void AssetEditorDialog::DecimalPreferredBinding::OnValueChanged()
 bool AssetEditorDialog::ActiveCheckBoxBinding::IsActive() const
 {
     const auto& vmAssetEditor = GetViewModel<ra::ui::viewmodels::AssetEditorViewModel&>();
-    switch (vmAssetEditor.GetState())
-    {
-        case ra::data::models::AssetState::Inactive:
-        case ra::data::models::AssetState::Triggered:
-            return false;
-        default:
-            return true;
-    }
+    return ra::data::models::AssetModelBase::IsActive(vmAssetEditor.GetState());
 }
 
 void AssetEditorDialog::ActiveCheckBoxBinding::SetHWND(DialogBase& pDialog, HWND hControl)

--- a/src/ui/win32/AssetEditorDialog.hh
+++ b/src/ui/win32/AssetEditorDialog.hh
@@ -68,6 +68,20 @@ private:
         AssetEditorDialog* m_pOwner;
     };
 
+    class ActiveCheckBoxBinding : public ra::ui::win32::bindings::ControlBinding
+    {
+    public:
+        explicit ActiveCheckBoxBinding(ViewModelBase& vmViewModel) noexcept :
+            ra::ui::win32::bindings::ControlBinding(vmViewModel) {}
+
+        void SetHWND(DialogBase& pDialog, HWND hControl) override;
+        void OnCommand() override;
+
+    protected:
+        void OnViewModelIntValueChanged(const IntModelProperty::ChangeArgs& args) override;
+        bool IsActive() const;
+    };
+
     ra::ui::win32::bindings::NumericTextBoxBinding m_bindID;
     ra::ui::win32::bindings::TextBoxBinding m_bindName;
     ra::ui::win32::bindings::TextBoxBinding m_bindDescription;
@@ -77,6 +91,7 @@ private:
 
     ra::ui::win32::bindings::CheckBoxBinding m_bindPauseOnReset;
     ra::ui::win32::bindings::CheckBoxBinding m_bindPauseOnTrigger;
+    ActiveCheckBoxBinding m_bindActive;
     DecimalPreferredBinding m_bindDecimalPreferred;
 
     ra::ui::win32::bindings::GridBinding m_bindGroups;

--- a/tests/RA_Integration.Tests.vcxproj
+++ b/tests/RA_Integration.Tests.vcxproj
@@ -298,6 +298,7 @@
     <ClCompile Include="..\src\data\DataModelBase.cpp" />
     <ClCompile Include="..\src\data\models\AchievementModel.cpp" />
     <ClCompile Include="..\src\data\models\AssetModelBase.cpp" />
+    <ClCompile Include="..\src\data\models\CapturedTriggerHits.cpp" />
     <ClCompile Include="..\src\data\models\LocalBadgesModel.cpp" />
     <ClCompile Include="..\src\pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>

--- a/tests/RA_Integration.Tests.vcxproj.filters
+++ b/tests/RA_Integration.Tests.vcxproj.filters
@@ -429,6 +429,9 @@
     <ClCompile Include="..\src\data\models\LocalBadgesModel.cpp">
       <Filter>Code</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\data\models\CapturedTriggerHits.cpp">
+      <Filter>Code</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="base.props" />

--- a/tests/ui/viewmodels/TriggerViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/TriggerViewModel_Tests.cpp
@@ -43,7 +43,8 @@ private:
 
     void Parse(TriggerViewModel& vmTrigger, const std::string& sInput)
     {
-        vmTrigger.InitializeFrom(sInput);
+        ra::data::models::CapturedTriggerHits pCapturedHits;
+        vmTrigger.InitializeFrom(sInput, pCapturedHits);
     }
 
     void ParseAndRegenerate(const std::string& sInput)


### PR DESCRIPTION
When an achievement triggers, it is deactivated, which sometimes deallocated the trigger data. It is desirable to remember the hit counts so a triggered achievement may be examined. This implements that functionality.