### PR TITLE
Support for invalid memory regions

### DIFF
--- a/src/Exports.cpp
+++ b/src/Exports.cpp
@@ -373,6 +373,18 @@ static void ProcessAchievements()
                 break;
             }
 
+            case ra::services::AchievementRuntime::ChangeType::AchievementDisabled:
+            {
+                auto* vmAchievement = pGameContext.Assets().FindAchievement(pChange.nId);
+                if (vmAchievement)
+                {
+                    RA_LOG_WARN("Achievement #%u disabled: address %s not supported by current core", pChange.nId, ra::ByteAddressToString(pChange.nValue));
+                    vmAchievement->SetState(ra::data::models::AssetState::Disabled);
+                }
+
+                break;
+            }
+
             case ra::services::AchievementRuntime::ChangeType::LeaderboardStarted:
             {
                 const auto* pLeaderboard = pGameContext.FindLeaderboard(pChange.nId);

--- a/src/data/context/ConsoleContext.cpp
+++ b/src/data/context/ConsoleContext.cpp
@@ -3,7 +3,7 @@
 #include "RA_Log.h"
 #include "RA_StringUtils.h"
 
-#include <rconsoles.h>
+#include <rc_consoles.h>
 
 namespace ra {
 namespace data {

--- a/src/data/context/EmulatorContext.cpp
+++ b/src/data/context/EmulatorContext.cpp
@@ -526,6 +526,17 @@ void EmulatorContext::OnTotalMemorySizeChanged()
     }
 }
 
+bool EmulatorContext::HasInvalidRegions() const noexcept
+{
+    for (const auto& pBlock : m_vMemoryBlocks)
+    {
+        if (!pBlock.read)
+            return true;
+    }
+
+    return false;
+}
+
 bool EmulatorContext::IsValidAddress(ra::ByteAddress nAddress) const noexcept
 {
     const ra::ByteAddress nOriginalAddress = nAddress;

--- a/src/data/context/EmulatorContext.cpp
+++ b/src/data/context/EmulatorContext.cpp
@@ -526,6 +526,25 @@ void EmulatorContext::OnTotalMemorySizeChanged()
     }
 }
 
+bool EmulatorContext::IsValidAddress(ra::ByteAddress nAddress) const noexcept
+{
+    const ra::ByteAddress nOriginalAddress = nAddress;
+    for (const auto& pBlock : m_vMemoryBlocks)
+    {
+        if (nAddress < pBlock.size)
+        {
+            if (pBlock.read)
+                return true;
+
+            break;
+        }
+
+        nAddress -= gsl::narrow_cast<ra::ByteAddress>(pBlock.size);
+    }
+
+    return false;
+}
+
 uint8_t EmulatorContext::ReadMemoryByte(ra::ByteAddress nAddress) const noexcept
 {
     const ra::ByteAddress nOriginalAddress = nAddress;

--- a/src/data/context/EmulatorContext.cpp
+++ b/src/data/context/EmulatorContext.cpp
@@ -556,7 +556,7 @@ bool EmulatorContext::IsValidAddress(ra::ByteAddress nAddress) const noexcept
     return false;
 }
 
-uint8_t EmulatorContext::ReadMemoryByte(ra::ByteAddress nAddress) const noexcept
+uint8_t EmulatorContext::ReadMemoryByte(ra::ByteAddress nAddress) const
 {
     const ra::ByteAddress nOriginalAddress = nAddress;
     for (const auto& pBlock : m_vMemoryBlocks)

--- a/src/data/context/EmulatorContext.hh
+++ b/src/data/context/EmulatorContext.hh
@@ -203,7 +203,7 @@ public:
     /// <summary>
     /// Reads memory from the emulator.
     /// </summary>
-    uint8_t ReadMemoryByte(ra::ByteAddress nAddress) const noexcept;
+    uint8_t ReadMemoryByte(ra::ByteAddress nAddress) const;
 
     /// <summary>
     /// Reads memory from the emulator.

--- a/src/data/context/EmulatorContext.hh
+++ b/src/data/context/EmulatorContext.hh
@@ -186,6 +186,11 @@ public:
     size_t TotalMemorySize() const noexcept { return m_nTotalMemorySize; }
 
     /// <summary>
+    /// Determines if the specified address is valid.
+    /// </summary>
+    bool IsValidAddress(ra::ByteAddress nAddress) const noexcept;
+
+    /// <summary>
     /// Reads memory from the emulator.
     /// </summary>
     uint32_t ReadMemory(ra::ByteAddress nAddress, MemSize nSize) const;

--- a/src/data/context/EmulatorContext.hh
+++ b/src/data/context/EmulatorContext.hh
@@ -186,6 +186,11 @@ public:
     size_t TotalMemorySize() const noexcept { return m_nTotalMemorySize; }
 
     /// <summary>
+    /// Determines if any invalid regions were registered.
+    /// </summary>
+    bool HasInvalidRegions() const noexcept;
+
+    /// <summary>
     /// Determines if the specified address is valid.
     /// </summary>
     bool IsValidAddress(ra::ByteAddress nAddress) const noexcept;

--- a/src/data/context/GameContext.cpp
+++ b/src/data/context/GameContext.cpp
@@ -326,7 +326,7 @@ void GameContext::UpdateUnlocks(const std::set<unsigned int>& vUnlockedAchieveme
         auto* pAchievement = Assets().FindAchievement(nAchievementId);
         if (pAchievement && pAchievement->GetCategory() == ra::data::models::AssetCategory::Core)
         {
-            if (!pAchievement->IsActive())
+            if (!pAchievement->IsActive() && pAchievement->GetState() != ra::data::models::AssetState::Disabled)
                 pAchievement->SetState(ra::data::models::AssetState::Waiting);
 
 #ifndef RA_UTEST

--- a/src/data/context/GameContext.cpp
+++ b/src/data/context/GameContext.cpp
@@ -305,12 +305,16 @@ void GameContext::UpdateUnlocks(const std::set<unsigned int>& vUnlockedAchieveme
         vLockedAchievements.insert(pAchievement->ID());
 
     // deactivate anything the player has already unlocked
+    size_t nUnlockedCoreAchievements = 0U;
     for (const auto nUnlockedAchievement : vUnlockedAchievements)
     {
         vLockedAchievements.erase(nUnlockedAchievement);
-        auto* pAchievement = FindAchievement(nUnlockedAchievement);
+        auto* pAchievement = Assets().FindAchievement(nUnlockedAchievement);
         if (pAchievement != nullptr)
-            pAchievement->SetActive(false);
+        {
+            pAchievement->SetState(ra::data::models::AssetState::Inactive);
+            ++nUnlockedCoreAchievements;
+        }
     }
 
 #ifndef RA_UTEST
@@ -319,14 +323,15 @@ void GameContext::UpdateUnlocks(const std::set<unsigned int>& vUnlockedAchieveme
     // activate any core achievements the player hasn't earned and pre-fetch the locked image
     for (auto nAchievementId : vLockedAchievements)
     {
-        auto* pAchievement = FindAchievement(nAchievementId);
-        if (pAchievement && pAchievement->GetCategory() == Achievement::Category::Core)
+        auto* pAchievement = Assets().FindAchievement(nAchievementId);
+        if (pAchievement && pAchievement->GetCategory() == ra::data::models::AssetCategory::Core)
         {
-            pAchievement->SetActive(true);
+            if (!pAchievement->IsActive())
+                pAchievement->SetState(ra::data::models::AssetState::Waiting);
 
 #ifndef RA_UTEST
-            if (!pAchievement->BadgeImageURI().empty())
-                pImageRepository.FetchImage(ra::ui::ImageType::Badge, pAchievement->BadgeImageURI() + "_lock");
+            if (!pAchievement->GetBadge().empty())
+                pImageRepository.FetchImage(ra::ui::ImageType::Badge, ra::Narrow(pAchievement->GetBadge()) + "_lock");
 #endif
         }
     }
@@ -339,11 +344,11 @@ void GameContext::UpdateUnlocks(const std::set<unsigned int>& vUnlockedAchieveme
         auto* pPopup = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().GetMessage(nPopup);
         if (pPopup != nullptr)
         {
-            size_t nUnlockedCoreAchievements = 0U;
-            for (auto& pAchievement : m_vAchievements)
+            const auto nDisabledAchievements = ra::services::ServiceLocator::GetMutable<ra::services::AchievementRuntime>().DetectUnsupportedAchievements();
+            if (nDisabledAchievements != 0)
             {
-                if (pAchievement->GetCategory() == Achievement::Category::Core && !pAchievement->Active())
-                    ++nUnlockedCoreAchievements;
+                const auto sDescription = ra::StringPrintf(L"%s (%s unsupported)", pPopup->GetDescription(), nDisabledAchievements);
+                pPopup->SetDescription(sDescription);
             }
 
             pPopup->SetDetail(ra::StringPrintf(L"You have earned %u achievements", nUnlockedCoreAchievements));

--- a/src/data/models/AchievementModel.cpp
+++ b/src/data/models/AchievementModel.cpp
@@ -122,7 +122,7 @@ void AchievementModel::DoFrame()
     const auto* pTrigger = pRuntime.GetAchievementTrigger(GetID());
     if (pTrigger == nullptr)
     {
-        if (GetState() != AssetState::Triggered)
+        if (IsActive())
             SetState(AssetState::Inactive);
     }
     else

--- a/src/data/models/AchievementModel.cpp
+++ b/src/data/models/AchievementModel.cpp
@@ -151,7 +151,6 @@ void AchievementModel::DoFrame()
     }
 }
 
-
 void AchievementModel::HandleStateChanged(AssetState nOldState, AssetState nNewState)
 {
     if (!ra::services::ServiceLocator::Exists<ra::services::AchievementRuntime>())

--- a/src/data/models/AchievementModel.cpp
+++ b/src/data/models/AchievementModel.cpp
@@ -144,6 +144,9 @@ void AchievementModel::DoFrame()
             case RC_TRIGGER_STATE_WAITING:
                 SetState(AssetState::Waiting);
                 break;
+            case RC_TRIGGER_STATE_DISABLED:
+                SetState(AssetState::Disabled);
+                break;
         }
     }
 }

--- a/src/data/models/AssetModelBase.cpp
+++ b/src/data/models/AssetModelBase.cpp
@@ -540,6 +540,7 @@ bool AssetModelBase::IsActive(AssetState nState) noexcept
     {
         case AssetState::Inactive:
         case AssetState::Triggered:
+        case AssetState::Disabled:
             return false;
         default:
             return true;

--- a/src/data/models/AssetModelBase.hh
+++ b/src/data/models/AssetModelBase.hh
@@ -35,6 +35,7 @@ enum class AssetState
     Triggered,
     Waiting,
     Paused,
+    Disabled,
 };
 
 enum class AssetChanges

--- a/src/services/AchievementRuntime.cpp
+++ b/src/services/AchievementRuntime.cpp
@@ -54,7 +54,7 @@ int AchievementRuntime::ActivateAchievement(ra::AchievementID nId, const std::st
     return rc_runtime_activate_achievement(&m_pRuntime, nId, sTrigger.c_str(), nullptr, 0);
 }
 
-rc_trigger_t* AchievementRuntime::GetAchievementTrigger(ra::AchievementID nId, const std::string& sTrigger) noexcept
+rc_trigger_t* AchievementRuntime::GetAchievementTrigger(ra::AchievementID nId, const std::string& sTrigger)
 {
     if (!m_bInitialized)
         return nullptr;
@@ -83,7 +83,7 @@ rc_trigger_t* AchievementRuntime::GetAchievementTrigger(ra::AchievementID nId, c
     return nullptr;
 }
 
-void AchievementRuntime::DeactivateAchievement(ra::AchievementID nId) noexcept
+void AchievementRuntime::DeactivateAchievement(ra::AchievementID nId)
 {
     // NOTE: rc_runtime_deactivate_achievement will either reset the trigger or free it
     // we want to keep it so the user can examine the hit counts after an incorrect trigger
@@ -91,7 +91,7 @@ void AchievementRuntime::DeactivateAchievement(ra::AchievementID nId) noexcept
     DetachAchievementTrigger(nId);
 }
 
-rc_trigger_t* AchievementRuntime::DetachAchievementTrigger(ra::AchievementID nId) noexcept
+rc_trigger_t* AchievementRuntime::DetachAchievementTrigger(ra::AchievementID nId)
 {
     if (!m_bInitialized)
         return nullptr;
@@ -113,7 +113,7 @@ rc_trigger_t* AchievementRuntime::DetachAchievementTrigger(ra::AchievementID nId
     return nullptr;
 }
 
-void AchievementRuntime::ReleaseAchievementTrigger(ra::AchievementID nId, _In_ rc_trigger_t* pTrigger) noexcept
+void AchievementRuntime::ReleaseAchievementTrigger(ra::AchievementID nId, _In_ rc_trigger_t* pTrigger)
 {
     if (!m_bInitialized)
         return;
@@ -142,7 +142,7 @@ void AchievementRuntime::ReleaseAchievementTrigger(ra::AchievementID nId, _In_ r
 #pragma warning(pop)
 }
 
-void AchievementRuntime::UpdateAchievementId(ra::AchievementID nOldId, ra::AchievementID nNewId) noexcept
+void AchievementRuntime::UpdateAchievementId(ra::AchievementID nOldId, ra::AchievementID nNewId)
 {
     if (!m_bInitialized)
         return;
@@ -155,7 +155,7 @@ void AchievementRuntime::UpdateAchievementId(ra::AchievementID nOldId, ra::Achie
     }
 }
 
-int AchievementRuntime::ActivateLeaderboard(unsigned int nId, const std::string& sDefinition) noexcept
+int AchievementRuntime::ActivateLeaderboard(unsigned int nId, const std::string& sDefinition)
 {
     std::lock_guard<std::mutex> pLock(m_pMutex);
     EnsureInitialized();
@@ -163,7 +163,7 @@ int AchievementRuntime::ActivateLeaderboard(unsigned int nId, const std::string&
     return rc_runtime_activate_lboard(&m_pRuntime, nId, sDefinition.c_str(), nullptr, 0);
 }
 
-void AchievementRuntime::ActivateRichPresence(const std::string& sScript) noexcept
+void AchievementRuntime::ActivateRichPresence(const std::string& sScript)
 {
     std::lock_guard<std::mutex> pLock(m_pMutex);
     EnsureInitialized();
@@ -252,7 +252,7 @@ static void map_event_to_change(const rc_runtime_event_t* pRuntimeEvent)
     g_pChanges->emplace_back(AchievementRuntime::Change{ nChangeType, pRuntimeEvent->id, pRuntimeEvent->value });
 }
 
-_Use_decl_annotations_ void AchievementRuntime::Process(std::vector<Change>& changes) noexcept
+_Use_decl_annotations_ void AchievementRuntime::Process(std::vector<Change>& changes)
 {
     if (!m_bInitialized || m_bPaused)
         return;
@@ -785,7 +785,7 @@ int AchievementRuntime::SaveProgressToBuffer(char* pBuffer, int nBufferSize) con
     return nSize;
 }
 
-void AchievementRuntime::InvalidateAddress(ra::ByteAddress nAddress)
+void AchievementRuntime::InvalidateAddress(ra::ByteAddress nAddress) noexcept
 {
     // this should only be called from DetectUnsupportedAchievements or indirectly via Process,
     // both of which aquire the lock, so we shouldn't try to acquire it here.

--- a/src/services/AchievementRuntime.cpp
+++ b/src/services/AchievementRuntime.cpp
@@ -760,6 +760,11 @@ int AchievementRuntime::SaveProgressToBuffer(char* pBuffer, int nBufferSize) con
     return nSize;
 }
 
+void AchievementRuntime::InvalidateAddress(ra::ByteAddress nAddress)
+{
+    rc_runtime_invalidate_address(&m_pRuntime, nAddress);
+}
+
 } // namespace services
 } // namespace ra
 

--- a/src/services/AchievementRuntime.hh
+++ b/src/services/AchievementRuntime.hh
@@ -42,12 +42,12 @@ public:
     /// <summary>
     /// Removes an achievement from the processing queue.
     /// </summary>
-    void DeactivateAchievement(ra::AchievementID nId) noexcept;
+    void DeactivateAchievement(ra::AchievementID nId);
 
     /// <summary>
     /// Updates any references using the provided ID to a new value
     /// </summary>
-    void UpdateAchievementId(ra::AchievementID nOldId, ra::AchievementID nNewId) noexcept;
+    void UpdateAchievementId(ra::AchievementID nOldId, ra::AchievementID nNewId);
 
     /// <summary>
     /// Gets the raw trigger for the achievement (if active)
@@ -74,22 +74,22 @@ public:
     /// <summary>
     /// Gets the raw trigger for the achievement (if ever active)
     /// </summary>
-    rc_trigger_t* GetAchievementTrigger(ra::AchievementID nId, const std::string& sTrigger) noexcept;
+    rc_trigger_t* GetAchievementTrigger(ra::AchievementID nId, const std::string& sTrigger);
 
     /// <summary>
     /// Gets the raw trigger for the achievement (if active)
     /// </summary>
-    rc_trigger_t* DetachAchievementTrigger(ra::AchievementID nId) noexcept;
+    rc_trigger_t* DetachAchievementTrigger(ra::AchievementID nId);
 
     /// <summary>
     /// Removes an achievement from the processing queue.
     /// </summary>
-    void ReleaseAchievementTrigger(ra::AchievementID nId, _In_ rc_trigger_t* pTrigger) noexcept;
+    void ReleaseAchievementTrigger(ra::AchievementID nId, _In_ rc_trigger_t* pTrigger);
 
     /// <summary>
     /// Adds a leaderboard to the processing queue.
     /// </summary>
-    int ActivateLeaderboard(unsigned int nId, const std::string& sDefinition) noexcept;
+    int ActivateLeaderboard(unsigned int nId, const std::string& sDefinition);
 
     /// <summary>
     /// Removes a leaderboard from the processing queue.
@@ -104,7 +104,7 @@ public:
     /// Specifies the rich presence to process each frame.
     /// </summary>
     /// <remarks>Only updates the memrefs each frame (for deltas), the script is not processed here.</remarks>
-    void ActivateRichPresence(const std::string& sScript) noexcept;
+    void ActivateRichPresence(const std::string& sScript);
 
     /// <summary>
     /// Gets whether or not the loaded game has a rich presence script.
@@ -146,7 +146,7 @@ public:
     /// <summary>
     /// Processes all active achievements for the current frame.
     /// </summary>
-    virtual void Process(_Inout_ std::vector<Change>& changes) noexcept;
+    virtual void Process(_Inout_ std::vector<Change>& changes);
 
     /// <summary>
     /// Loads HitCount data for active achievements from a save state file.
@@ -199,7 +199,7 @@ public:
             rc_runtime_reset(&m_pRuntime);
     }
 
-    void InvalidateAddress(ra::ByteAddress nAddress);
+    void InvalidateAddress(ra::ByteAddress nAddress) noexcept;
 
     size_t DetectUnsupportedAchievements();
 

--- a/src/services/AchievementRuntime.hh
+++ b/src/services/AchievementRuntime.hh
@@ -132,6 +132,8 @@ public:
         LeaderboardCanceled,
         LeaderboardUpdated,
         LeaderboardTriggered,
+        AchievementDisabled,
+        LeaderboardDisabled,
     };
 
     struct Change
@@ -204,6 +206,7 @@ public:
 protected:
     bool m_bPaused = false;
     rc_runtime_t m_pRuntime{};
+    mutable std::mutex m_pMutex;
 
 private:
     bool LoadProgressV1(const std::string& sProgress, std::set<unsigned int>& vProcessedAchievementIds);

--- a/src/services/AchievementRuntime.hh
+++ b/src/services/AchievementRuntime.hh
@@ -199,6 +199,8 @@ public:
 
     void InvalidateAddress(ra::ByteAddress nAddress);
 
+    size_t DetectUnsupportedAchievements();
+
 protected:
     bool m_bPaused = false;
     rc_runtime_t m_pRuntime{};

--- a/src/services/AchievementRuntime.hh
+++ b/src/services/AchievementRuntime.hh
@@ -197,6 +197,8 @@ public:
             rc_runtime_reset(&m_pRuntime);
     }
 
+    void InvalidateAddress(ra::ByteAddress nAddress);
+
 protected:
     bool m_bPaused = false;
     rc_runtime_t m_pRuntime{};

--- a/src/ui/viewmodels/AssetListViewModel.cpp
+++ b/src/ui/viewmodels/AssetListViewModel.cpp
@@ -47,6 +47,7 @@ AssetListViewModel::AssetListViewModel() noexcept
     m_vStates.Add(ra::etoi(ra::data::models::AssetState::Active), L"Active");
     m_vStates.Add(ra::etoi(ra::data::models::AssetState::Paused), L"Paused");
     m_vStates.Add(ra::etoi(ra::data::models::AssetState::Triggered), L"Triggered");
+    m_vStates.Add(ra::etoi(ra::data::models::AssetState::Disabled), L"Disabled");
 
     m_vCategories.Add(ra::etoi(ra::data::models::AssetCategory::Core), L"Core");
     m_vCategories.Add(ra::etoi(ra::data::models::AssetCategory::Unofficial), L"Unofficial");

--- a/src/ui/viewmodels/MemoryViewerViewModel.cpp
+++ b/src/ui/viewmodels/MemoryViewerViewModel.cpp
@@ -834,7 +834,7 @@ void MemoryViewerViewModel::BuildFontSurface()
             case TextColor::Frozen:       nColor = pEditorTheme.ColorFrozen(); break;
         }
 
-        for (size_t j = 0; j < g_sHexChars.size(); ++j)
+        for (int j = 0; j < gsl::narrow_cast<int>(g_sHexChars.size()); ++j)
         {
             sHexChar.at(0) = g_sHexChars.at(j);
             m_pFontSurface->WriteText(j * m_szChar.Width, i * m_szChar.Height - 1, m_nFont, nColor, sHexChar);

--- a/src/ui/viewmodels/MemoryViewerViewModel.cpp
+++ b/src/ui/viewmodels/MemoryViewerViewModel.cpp
@@ -834,7 +834,7 @@ void MemoryViewerViewModel::BuildFontSurface()
             case TextColor::Frozen:       nColor = pEditorTheme.ColorFrozen(); break;
         }
 
-        for (int j = 0; j < g_sHexChars.size(); ++j)
+        for (size_t j = 0; j < g_sHexChars.size(); ++j)
         {
             sHexChar.at(0) = g_sHexChars.at(j);
             m_pFontSurface->WriteText(j * m_szChar.Width, i * m_szChar.Height - 1, m_nFont, nColor, sHexChar);

--- a/src/ui/viewmodels/MemoryViewerViewModel.hh
+++ b/src/ui/viewmodels/MemoryViewerViewModel.hh
@@ -184,6 +184,7 @@ protected:
 
     uint8_t* m_pMemory;
     uint8_t* m_pColor;
+    uint8_t* m_pInvalid;
 
     ra::ui::Size m_szChar;
     int m_nSelectedNibble = 0;

--- a/tests/data/DataAsserts.hh
+++ b/tests/data/DataAsserts.hh
@@ -94,6 +94,8 @@ std::wstring ToString<ra::data::models::AssetState>(
             return L"Waiting";
         case ra::data::models::AssetState::Paused:
             return L"Paused";
+        case ra::data::models::AssetState::Disabled:
+            return L"Disabled";
         default:
             return std::to_wstring(static_cast<int>(nAssetState));
     }

--- a/tests/data/context/GameContext_Tests.cpp
+++ b/tests/data/context/GameContext_Tests.cpp
@@ -910,15 +910,15 @@ public:
         game.mockThreadPool.ExecuteNextTask(); // FetchUserUnlocks and FetchCodeNotes are async
         game.mockThreadPool.ExecuteNextTask();
 
-        const auto* pAch1 = game.FindAchievement(5U);
+        const auto* pAch1 = game.Assets().FindAchievement(5U);
         Assert::IsNotNull(pAch1);
         Ensures(pAch1 != nullptr);
-        Assert::IsTrue(pAch1->Active());
+        Assert::IsTrue(pAch1->IsActive());
 
-        const auto* pAch2 = game.FindAchievement(7U);
+        const auto* pAch2 = game.Assets().FindAchievement(7U);
         Assert::IsNotNull(pAch2);
         Ensures(pAch2 != nullptr);
-        Assert::IsFalse(pAch2->Active());
+        Assert::IsFalse(pAch2->IsActive());
     }
 
     TEST_METHOD(TestLoadGameUserUnlocksCompatibilityMode)
@@ -947,15 +947,15 @@ public:
         game.mockThreadPool.ExecuteNextTask(); // FetchUserUnlocks and FetchCodeNotes are async
         game.mockThreadPool.ExecuteNextTask();
 
-        const auto* pAch1 = game.FindAchievement(5U);
+        const auto* pAch1 = game.Assets().FindAchievement(5U);
         Assert::IsNotNull(pAch1);
         Ensures(pAch1 != nullptr);
-        Assert::IsTrue(pAch1->Active());
+        Assert::IsTrue(pAch1->IsActive());
 
-        const auto* pAch2 = game.FindAchievement(7U);
+        const auto* pAch2 = game.Assets().FindAchievement(7U);
         Assert::IsNotNull(pAch2);
         Ensures(pAch2 != nullptr);
-        Assert::IsTrue(pAch2->Active());
+        Assert::IsTrue(pAch2->IsActive());
     }
 
     TEST_METHOD(TestLoadGamePausesRuntime)

--- a/tests/ui/viewmodels/AssetListViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/AssetListViewModel_Tests.cpp
@@ -381,7 +381,7 @@ public:
         Assert::AreEqual(0, vmAssetList.GetTotalPoints());
         Assert::AreEqual(true, vmAssetList.IsProcessingActive());
 
-        Assert::AreEqual({ 5U }, vmAssetList.States().Count());
+        Assert::AreEqual({ 6U }, vmAssetList.States().Count());
         Assert::AreEqual((int)AssetState::Inactive, vmAssetList.States().GetItemAt(0)->GetId());
         Assert::AreEqual(std::wstring(L"Inactive"), vmAssetList.States().GetItemAt(0)->GetLabel());
         Assert::AreEqual((int)AssetState::Waiting, vmAssetList.States().GetItemAt(1)->GetId());
@@ -392,6 +392,8 @@ public:
         Assert::AreEqual(std::wstring(L"Paused"), vmAssetList.States().GetItemAt(3)->GetLabel());
         Assert::AreEqual((int)AssetState::Triggered, vmAssetList.States().GetItemAt(4)->GetId());
         Assert::AreEqual(std::wstring(L"Triggered"), vmAssetList.States().GetItemAt(4)->GetLabel());
+        Assert::AreEqual((int)AssetState::Disabled, vmAssetList.States().GetItemAt(5)->GetId());
+        Assert::AreEqual(std::wstring(L"Disabled"), vmAssetList.States().GetItemAt(5)->GetLabel());
 
         Assert::AreEqual({ 3U }, vmAssetList.Categories().Count());
         Assert::AreEqual((int)AssetCategory::Core, vmAssetList.Categories().GetItemAt(0)->GetId());

--- a/tests/ui/viewmodels/CodeNotesViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/CodeNotesViewModel_Tests.cpp
@@ -51,6 +51,14 @@ private:
 
             mockGameContext.SetCodeNote(0x0040, L"[10 bytes] Inventory");
         }
+
+        void PopulateMemory()
+        {
+            std::array<uint8_t, 100> memory = {};
+            for (uint8_t i = 0; i < memory.size(); ++i)
+                memory.at(i) = i;
+            mockEmulatorContext.MockMemory(memory);
+        }
     };
 
     void AssertRow(CodeNotesViewModelHarness& notes, gsl::index nRow, ra::ByteAddress nAddress,
@@ -408,6 +416,7 @@ public:
     {
         CodeNotesViewModelHarness notes;
         notes.PopulateNotes();
+        notes.PopulateMemory();
         Assert::AreEqual({ 0U }, notes.Notes().Count());
 
         notes.SetIsVisible(true);

--- a/tests/ui/viewmodels/MemoryBookmarksViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/MemoryBookmarksViewModel_Tests.cpp
@@ -5,6 +5,7 @@
 
 #include "tests\ui\UIAsserts.hh"
 
+#include "tests\mocks\MockAchievementRuntime.hh"
 #include "tests\mocks\MockConfiguration.hh"
 #include "tests\mocks\MockDesktop.hh"
 #include "tests\mocks\MockEmulatorContext.hh"
@@ -54,6 +55,7 @@ private:
     public:
         ra::data::context::mocks::MockEmulatorContext mockEmulatorContext;
         ra::data::context::mocks::MockGameContext mockGameContext;
+        ra::services::mocks::MockAchievementRuntime mockAchievementRuntime;
         ra::services::mocks::MockConfiguration mockConfiguration;
         ra::services::mocks::MockFileSystem mockFileSystem;
         ra::services::mocks::MockFrameEventQueue mockFrameEventQueue;

--- a/tests/ui/viewmodels/OverlayAchievementsPageViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/OverlayAchievementsPageViewModel_Tests.cpp
@@ -303,6 +303,7 @@ public:
         Assert::AreEqual(std::wstring(L"2 of 4 won (4/10)"), achievementsPage.GetSummary());
 
         auto const* pItem = achievementsPage.GetItem(0);
+        Expects(pItem != nullptr);
         Assert::IsTrue(pItem->IsHeader());
         Assert::AreEqual(std::wstring(L"Unsupported"), pItem->GetLabel());
         Assert::IsFalse(pItem->IsDisabled());
@@ -354,6 +355,7 @@ public:
         Assert::AreEqual(std::wstring(L"0 of 2 won (0/6)"), achievementsPage.GetSummary());
 
         auto const* pItem = achievementsPage.GetItem(0);
+        Expects(pItem != nullptr);
         Assert::IsTrue(pItem->IsHeader());
         Assert::AreEqual(std::wstring(L"Unsupported"), pItem->GetLabel());
         Assert::IsFalse(pItem->IsDisabled());

--- a/tests/ui/viewmodels/OverlayAchievementsPageViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/OverlayAchievementsPageViewModel_Tests.cpp
@@ -223,6 +223,154 @@ public:
         Assert::IsNull(achievementsPage.GetItem(5));
     }
 
+    TEST_METHOD(TestRefreshActiveAndDisabledAchievements)
+    {
+        OverlayAchievementsPageViewModelHarness achievementsPage;
+        auto& pAch1 = achievementsPage.NewAchievement(AssetCategory::Core);
+        pAch1.SetID(1);
+        pAch1.SetPoints(1U);
+        pAch1.SetState(AssetState::Waiting);
+        auto& pAch2 = achievementsPage.NewAchievement(AssetCategory::Core);
+        pAch2.SetID(2);
+        pAch2.SetPoints(2U);
+        pAch2.SetState(AssetState::Disabled);
+        auto& pAch3 = achievementsPage.NewAchievement(AssetCategory::Core);
+        pAch3.SetID(3);
+        pAch3.SetPoints(3U);
+        pAch3.SetState(AssetState::Active);
+        auto& pAch4 = achievementsPage.NewAchievement(AssetCategory::Core);
+        pAch4.SetID(4);
+        pAch4.SetPoints(4U);
+        pAch4.SetState(AssetState::Disabled);
+        achievementsPage.mockClock.AdvanceTime(std::chrono::hours(1));
+        achievementsPage.Refresh();
+
+        Assert::AreEqual(std::wstring(L"Achievements"), achievementsPage.GetTitle());
+        Assert::AreEqual(std::wstring(L"0 of 4 won (0/10)"), achievementsPage.GetSummary());
+
+        auto const* pItem = achievementsPage.GetItem(0);
+        Expects(pItem != nullptr);
+        Assert::AreEqual(1, pItem->GetId());
+        Assert::IsTrue(pItem->IsDisabled());
+
+        pItem = achievementsPage.GetItem(1);
+        Expects(pItem != nullptr);
+        Assert::AreEqual(3, pItem->GetId());
+        Assert::IsTrue(pItem->IsDisabled());
+
+        pItem = achievementsPage.GetItem(2);
+        Expects(pItem != nullptr);
+        Assert::IsTrue(pItem->IsHeader());
+        Assert::AreEqual(std::wstring(L"Unsupported"), pItem->GetLabel());
+        Assert::IsFalse(pItem->IsDisabled());
+
+        pItem = achievementsPage.GetItem(3);
+        Expects(pItem != nullptr);
+        Assert::AreEqual(2, pItem->GetId());
+        Assert::IsTrue(pItem->IsDisabled());
+
+        pItem = achievementsPage.GetItem(4);
+        Expects(pItem != nullptr);
+        Assert::AreEqual(4, pItem->GetId());
+        Assert::IsTrue(pItem->IsDisabled());
+
+        Assert::IsNull(achievementsPage.GetItem(5));
+    }
+
+    TEST_METHOD(TestRefreshInactiveAndDisabledAchievements)
+    {
+        OverlayAchievementsPageViewModelHarness achievementsPage;
+        auto& pAch1 = achievementsPage.NewAchievement(AssetCategory::Core);
+        pAch1.SetID(1);
+        pAch1.SetPoints(1U);
+        pAch1.SetState(AssetState::Inactive);
+        auto& pAch2 = achievementsPage.NewAchievement(AssetCategory::Core);
+        pAch2.SetID(2);
+        pAch2.SetPoints(2U);
+        pAch2.SetState(AssetState::Disabled);
+        auto& pAch3 = achievementsPage.NewAchievement(AssetCategory::Core);
+        pAch3.SetID(3);
+        pAch3.SetPoints(3U);
+        pAch3.SetState(AssetState::Triggered);
+        auto& pAch4 = achievementsPage.NewAchievement(AssetCategory::Core);
+        pAch4.SetID(4);
+        pAch4.SetPoints(4U);
+        pAch4.SetState(AssetState::Disabled);
+        achievementsPage.mockClock.AdvanceTime(std::chrono::hours(1));
+        achievementsPage.Refresh();
+
+        Assert::AreEqual(std::wstring(L"Achievements"), achievementsPage.GetTitle());
+        Assert::AreEqual(std::wstring(L"2 of 4 won (4/10)"), achievementsPage.GetSummary());
+
+        auto const* pItem = achievementsPage.GetItem(0);
+        Assert::IsTrue(pItem->IsHeader());
+        Assert::AreEqual(std::wstring(L"Unsupported"), pItem->GetLabel());
+        Assert::IsFalse(pItem->IsDisabled());
+
+        pItem = achievementsPage.GetItem(1);
+        Expects(pItem != nullptr);
+        Assert::AreEqual(2, pItem->GetId());
+        Assert::IsTrue(pItem->IsDisabled());
+
+        pItem = achievementsPage.GetItem(2);
+        Expects(pItem != nullptr);
+        Assert::AreEqual(4, pItem->GetId());
+        Assert::IsTrue(pItem->IsDisabled());
+
+        pItem = achievementsPage.GetItem(3);
+        Expects(pItem != nullptr);
+        Assert::IsTrue(pItem->IsHeader());
+        Assert::AreEqual(std::wstring(L"Unlocked"), pItem->GetLabel());
+        Assert::IsFalse(pItem->IsDisabled());
+
+        pItem = achievementsPage.GetItem(4);
+        Expects(pItem != nullptr);
+        Assert::AreEqual(1, pItem->GetId());
+        Assert::IsFalse(pItem->IsDisabled());
+
+        pItem = achievementsPage.GetItem(5);
+        Expects(pItem != nullptr);
+        Assert::AreEqual(3, pItem->GetId());
+        Assert::IsFalse(pItem->IsDisabled());
+
+        Assert::IsNull(achievementsPage.GetItem(6));
+    }
+
+    TEST_METHOD(TestRefreshDisabledAchievements)
+    {
+        OverlayAchievementsPageViewModelHarness achievementsPage;
+        auto& pAch2 = achievementsPage.NewAchievement(AssetCategory::Core);
+        pAch2.SetID(2);
+        pAch2.SetPoints(2U);
+        pAch2.SetState(AssetState::Disabled);
+        auto& pAch4 = achievementsPage.NewAchievement(AssetCategory::Core);
+        pAch4.SetID(4);
+        pAch4.SetPoints(4U);
+        pAch4.SetState(AssetState::Disabled);
+        achievementsPage.mockClock.AdvanceTime(std::chrono::hours(1));
+        achievementsPage.Refresh();
+
+        Assert::AreEqual(std::wstring(L"Achievements"), achievementsPage.GetTitle());
+        Assert::AreEqual(std::wstring(L"0 of 2 won (0/6)"), achievementsPage.GetSummary());
+
+        auto const* pItem = achievementsPage.GetItem(0);
+        Assert::IsTrue(pItem->IsHeader());
+        Assert::AreEqual(std::wstring(L"Unsupported"), pItem->GetLabel());
+        Assert::IsFalse(pItem->IsDisabled());
+
+        pItem = achievementsPage.GetItem(1);
+        Expects(pItem != nullptr);
+        Assert::AreEqual(2, pItem->GetId());
+        Assert::IsTrue(pItem->IsDisabled());
+
+        pItem = achievementsPage.GetItem(2);
+        Expects(pItem != nullptr);
+        Assert::AreEqual(4, pItem->GetId());
+        Assert::IsTrue(pItem->IsDisabled());
+
+        Assert::IsNull(achievementsPage.GetItem(3));
+    }
+
     TEST_METHOD(TestRefreshCategoryFilter)
     {
         OverlayAchievementsPageViewModelHarness achievementsPage;


### PR DESCRIPTION
Allows the client to register invalid memory regions. Any achievements referencing these regions are disabled and reported as unsupported (mimics behavior from RetroArch).

![image](https://user-images.githubusercontent.com/32680403/105637785-72a63800-5e2c-11eb-9b88-5df51986075b.png)

Unsupported achievements show up as a separate category in the overlay, appearing after any locked achievements and before any unlocked achievements:

![image](https://user-images.githubusercontent.com/32680403/105637827-ad0fd500-5e2c-11eb-8980-142d41b420fa.png)

Additionally, the memory inspector now clearly indicates unsupported memory.

![image](https://user-images.githubusercontent.com/32680403/105637850-d9c3ec80-5e2c-11eb-85a3-73edb7f4acd3.png)

Search results and bookmarks still show "00" instead of "--".