### PR TITLE
allow client to enable forced repainting without needing a new DLL

### DIFF
--- a/src/Exports.hh
+++ b/src/Exports.hh
@@ -88,6 +88,10 @@ extern "C" {
     // Perform one test for all achievements in the current set. Call this once per frame/cycle.
     API void CCONV _RA_DoAchievementsFrame();
 
+    // Enables forced repainting for controls when InvalidateWindow doesn't cause them to update
+    // properly. Seems to primarily be an issue when integrating with an application using SDL.
+    API void CCONV _RA_SetForceRepaint(bool bEnable);
+
     // Temporarily disable forced redraws
     API void CCONV _RA_SuspendRepaint();
 

--- a/src/ui/win32/bindings/ControlBinding.hh
+++ b/src/ui/win32/bindings/ControlBinding.hh
@@ -83,6 +83,16 @@ public:
     }
 
     /// <summary>
+    /// If set to true, UpdateWindow will be called when a control is Invalidated.
+    /// </summary>
+    static void SetNeedsUpdateWindow(bool bValue) noexcept { s_bNeedsUpdateWindow = bValue; }
+
+    /// <summary>
+    /// Determines if UpdateWindow should be called when invalidating a control.
+    /// </summary>
+    static bool NeedsUpdateWindow() noexcept { return s_bNeedsUpdateWindow; }
+
+    /// <summary>
     /// Calls Invalidate() or UpdateWindow() to cause the control to repaint
     /// </summary>
     static void ForceRepaint(HWND hWnd);
@@ -161,6 +171,8 @@ protected:
 private:
     DialogBase* m_pDialog = nullptr;
     WNDPROC m_pOriginalWndProc = nullptr;
+
+    static bool s_bNeedsUpdateWindow;
 };
 
 } // namespace bindings


### PR DESCRIPTION
Right now, there's a hard-coded switch inside the DLL to enable forced repainting for RALibretro because of the way the SDL library interacts with the Windows message queue. Oricutron has a similar issue and was also added to the hard-coded switch. This replaces the switch with a boolean (very minor performance gain), and exposes a function allowing the emulator to set the boolean without needing to change code in the DLL.