### PR TITLE
don't check for trigger changes when updating hit counts

### DIFF
--- a/src/ui/viewmodels/TriggerViewModel.cpp
+++ b/src/ui/viewmodels/TriggerViewModel.cpp
@@ -644,6 +644,7 @@ void TriggerViewModel::DoFrame()
     auto* pGroup = m_vGroups.GetItemAt(GetSelectedGroupIndex());
     if (pGroup != nullptr)
     {
+        m_vConditions.RemoveNotifyTarget(m_pConditionsMonitor);
         m_vConditions.BeginUpdate();
 
         gsl::index nConditionIndex = 0;
@@ -657,6 +658,7 @@ void TriggerViewModel::DoFrame()
         }
 
         m_vConditions.EndUpdate();
+        m_vConditions.AddNotifyTarget(m_pConditionsMonitor);
     }
 }
 

--- a/tests/ui/viewmodels/AssetEditorViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/AssetEditorViewModel_Tests.cpp
@@ -115,6 +115,20 @@ public:
         Assert::IsFalse(editor.IsAssetLoaded());
     }
 
+    TEST_METHOD(TestLoadAchievementTrigger)
+    {
+        AssetEditorViewModelHarness editor;
+        AchievementModel achievement;
+        achievement.SetTrigger("0xH1234=6.1.");
+        achievement.CreateServerCheckpoint();
+        achievement.CreateLocalCheckpoint();
+
+        editor.LoadAsset(&achievement);
+
+        Assert::AreEqual(std::string("0xH1234=6.1."), editor.Trigger().Serialize());
+        Assert::IsFalse(achievement.IsModified());
+    }
+
     TEST_METHOD(TestSyncId)
     {
         AssetEditorViewModelHarness editor;


### PR DESCRIPTION
Prevents marking an achievement as modified when updating the hit counts in the achievement editor if the trigger was generated using an old serialization format (i.e. `0xH1234=10(1)` instead of `0xH1234=10.1.`.