### PR TITLE
change category on LocalBadgesModel to Local

### DIFF
--- a/src/data/context/GameAssets.cpp
+++ b/src/data/context/GameAssets.cpp
@@ -129,6 +129,10 @@ void GameAssets::ReloadAssets(const std::vector<ra::data::models::AssetModelBase
                 if (pAsset->GetChanges() != ra::data::models::AssetChanges::None ||
                     pAsset->GetCategory() == ra::data::models::AssetCategory::Local)
                 {
+                    // ignore LocalBadges container
+                    if (pAsset->GetType() == ra::data::models::AssetType::LocalBadges)
+                        continue;
+
                     vRemainingAssetsToReload.push_back(pAsset);
                 }
             }

--- a/src/data/models/LocalBadgesModel.cpp
+++ b/src/data/models/LocalBadgesModel.cpp
@@ -14,6 +14,7 @@ namespace models {
 LocalBadgesModel::LocalBadgesModel() noexcept
 {
     GSL_SUPPRESS_F6 SetValue(TypeProperty, ra::etoi(AssetType::LocalBadges));
+    GSL_SUPPRESS_F6 SetValue(CategoryProperty, ra::etoi(AssetCategory::Local));
     GSL_SUPPRESS_F6 SetName(L"Local Badges");
 }
 

--- a/tests/data/models/LocalBadgesModel_Tests.cpp
+++ b/tests/data/models/LocalBadgesModel_Tests.cpp
@@ -40,7 +40,7 @@ public:
         Assert::AreEqual(0U, badges.GetID());
         Assert::AreEqual(std::wstring(L"Local Badges"), badges.GetName());
         Assert::AreEqual(std::wstring(L""), badges.GetDescription());
-        Assert::AreEqual(AssetCategory::Core, badges.GetCategory());
+        Assert::AreEqual(AssetCategory::Local, badges.GetCategory());
         Assert::AreEqual(AssetState::Inactive, badges.GetState());
         Assert::AreEqual(AssetChanges::None, badges.GetChanges());
         Assert::IsFalse(badges.NeedsSerialized());


### PR DESCRIPTION
prevent non-hardcore warning from being displayed when opening a game without any core achievements