### PR TITLE
delay unsupported evaluation until memory has been registered

### DIFF
--- a/src/services/AchievementRuntime.hh
+++ b/src/services/AchievementRuntime.hh
@@ -5,6 +5,7 @@
 #include "ra_fwd.h"
 
 #include "data\Types.hh"
+#include "data\context\EmulatorContext.hh"
 
 #include "services\TextReader.hh"
 
@@ -15,7 +16,7 @@
 namespace ra {
 namespace services {
 
-class AchievementRuntime
+class AchievementRuntime : protected ra::data::context::EmulatorContext::NotifyTarget
 {
 public:
     GSL_SUPPRESS_F6 AchievementRuntime() = default;
@@ -209,6 +210,9 @@ protected:
     bool m_bPaused = false;
     rc_runtime_t m_pRuntime{};
     mutable std::mutex m_pMutex;
+
+    // EmulatorContext::NotifyTarget
+    void OnTotalMemorySizeChanged() override;
 
 private:
     bool LoadProgressV1(const std::string& sProgress, std::set<unsigned int>& vProcessedAchievementIds);


### PR DESCRIPTION
The "do you want to enable hardcore" warning dialog blocks the main thread until the user chooses yes or no, but it happens after the achievement request has asynchronously been sent to the server. If the response comes back, the unsupported check may occur before the main thread has registered its memory blocks (depending on the order of things in the emulator).

This updates the unsupported check to delay itself if no memory is registered at the time of the check.