### PR TITLE
limit tool windows available in hardcore

### DIFF
--- a/src/Exports.cpp
+++ b/src/Exports.cpp
@@ -55,6 +55,35 @@ API int CCONV _RA_HardcoreModeIsActive()
     return pConfiguration.IsFeatureEnabled(ra::services::Feature::Hardcore);
 }
 
+API bool CCONV _RA_WarnDisableHardcore(const char* sActivity)
+{
+    // already disabled, just return success
+    auto& pConfiguration = ra::services::ServiceLocator::GetMutable<ra::services::IConfiguration>();
+    if (!pConfiguration.IsFeatureEnabled(ra::services::Feature::Hardcore))
+        return true;
+
+    // if no activity specified, just proceed to disabling without prompting
+    if (sActivity && *sActivity)
+    {
+        // prompt. if user doesn't consent, return failure - caller should not continue
+        ra::ui::viewmodels::MessageBoxViewModel vmMessageBox;
+        vmMessageBox.SetHeader(L"Disable Hardcore mode?");
+        vmMessageBox.SetMessage(L"You cannot " + ra::Widen(sActivity) + L" while Hardcore mode is active.");
+        vmMessageBox.SetButtons(ra::ui::viewmodels::MessageBoxViewModel::Buttons::YesNo);
+        vmMessageBox.SetIcon(ra::ui::viewmodels::MessageBoxViewModel::Icon::Warning);
+        if (vmMessageBox.ShowModal() != ra::ui::DialogResult::Yes)
+            return false;
+    }
+
+    RA_LOG_INFO("User chose to disable hardcore to %s", sActivity);
+
+    // user consented, switch to non-hardcore mode
+    ra::services::ServiceLocator::GetMutable<ra::data::context::EmulatorContext>().DisableHardcoreMode();
+
+    // return success
+    return true;
+}
+
 #ifndef RA_UTEST
 API void CCONV _RA_UpdateHWnd(HWND hMainHWND)
 {

--- a/src/RA_Core.cpp
+++ b/src/RA_Core.cpp
@@ -215,35 +215,6 @@ API bool CCONV _RA_ConfirmLoadNewRom(bool bQuittingApp)
     return (vmMessageBox.ShowModal() == ra::ui::DialogResult::Yes);
 }
 
-API bool CCONV _RA_WarnDisableHardcore(const char* sActivity)
-{
-    // already disabled, just return success
-    auto& pConfiguration = ra::services::ServiceLocator::GetMutable<ra::services::IConfiguration>();
-    if (!pConfiguration.IsFeatureEnabled(ra::services::Feature::Hardcore))
-        return true;
-
-    // if no activity specified, just proceed to disabling without prompting
-    if (sActivity && *sActivity)
-    {
-        // prompt. if user doesn't consent, return failure - caller should not continue
-        ra::ui::viewmodels::MessageBoxViewModel vmMessageBox;
-        vmMessageBox.SetHeader(L"Disable Hardcore mode?");
-        vmMessageBox.SetMessage(L"You cannot " + ra::Widen(sActivity) + L" while Hardcore mode is active.");
-        vmMessageBox.SetButtons(ra::ui::viewmodels::MessageBoxViewModel::Buttons::YesNo);
-        vmMessageBox.SetIcon(ra::ui::viewmodels::MessageBoxViewModel::Icon::Warning);
-        if (vmMessageBox.ShowModal() != ra::ui::DialogResult::Yes)
-            return false;
-    }
-
-    RA_LOG_INFO("User chose to disable hardcore to %s", sActivity);
-
-    // user consented, switch to non-hardcore mode
-    ra::services::ServiceLocator::GetMutable<ra::data::context::EmulatorContext>().DisableHardcoreMode();
-
-    // return success
-    return true;
-}
-
 API void CCONV _RA_OnReset()
 {
     // if there's no game loaded, there shouldn't be any active achievements or popups to clear - except maybe the
@@ -400,15 +371,18 @@ API void CCONV _RA_InvokeDialog(LPARAM nID)
             break;
 
         case IDM_RA_FILES_ACHIEVEMENTEDITOR:
-            ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::WindowManager>().AssetEditor.Show();
+            if (_RA_WarnDisableHardcore("edit assets"))
+                ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::WindowManager>().AssetEditor.Show();
             break;
 
         case IDM_RA_FILES_MEMORYFINDER:
-            ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::WindowManager>().MemoryInspector.Show();
+            if (_RA_WarnDisableHardcore("inspect memory"))
+                ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::WindowManager>().MemoryInspector.Show();
             break;
 
         case IDM_RA_FILES_MEMORYBOOKMARKS:
-            ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::WindowManager>().MemoryBookmarks.Show();
+            if (_RA_WarnDisableHardcore("view memory bookmarks"))
+                ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::WindowManager>().MemoryBookmarks.Show();
             break;
 
         case IDM_RA_FILES_LOGIN:

--- a/src/data/context/EmulatorContext.cpp
+++ b/src/data/context/EmulatorContext.cpp
@@ -370,6 +370,10 @@ void EmulatorContext::DisableHardcoreMode()
     {
         pConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, false);
 
+        // updating the enabled-ness of the buttons of the asset list
+        auto& pWindowManager = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::WindowManager>();
+        pWindowManager.AssetList.UpdateButtons();
+
         RebuildMenu();
 
         auto& pGameContext = ra::services::ServiceLocator::GetMutable<ra::data::context::GameContext>();
@@ -420,6 +424,26 @@ bool EmulatorContext::EnableHardcoreMode(bool bShowWarning)
     // User has agreed to reset the emulator, or no game is loaded. Enabled hardcore!
     pConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, true);
 
+    // close any windows not permitted in hardcore
+    auto& pWindowManager = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::WindowManager>();
+    auto& pDesktop = ra::services::ServiceLocator::Get<ra::ui::IDesktop>();
+
+    if (pWindowManager.MemoryInspector.IsVisible())
+        pDesktop.CloseWindow(pWindowManager.MemoryInspector);
+
+    if (pWindowManager.MemoryBookmarks.IsVisible())
+        pDesktop.CloseWindow(pWindowManager.MemoryBookmarks);
+
+    if (pWindowManager.AssetEditor.IsVisible())
+        pDesktop.CloseWindow(pWindowManager.AssetEditor);
+
+    if (pWindowManager.CodeNotes.IsVisible())
+        pDesktop.CloseWindow(pWindowManager.CodeNotes);
+
+    // updating the enabled-ness of the buttons of the asset list
+    pWindowManager.AssetList.UpdateButtons();
+
+    // update the integration menu
     RebuildMenu();
 
     // when enabling hardcore mode, force a system reset

--- a/src/ui/viewmodels/AssetListViewModel.cpp
+++ b/src/ui/viewmodels/AssetListViewModel.cpp
@@ -369,6 +369,9 @@ gsl::index AssetListViewModel::GetFilteredAssetIndex(const ra::data::models::Ass
 
 void AssetListViewModel::OpenEditor(const AssetSummaryViewModel* pAsset)
 {
+    if (!_RA_WarnDisableHardcore("edit assets"))
+        return;
+
     ra::data::models::AssetModelBase* vmAsset = nullptr;
 
     if (pAsset)
@@ -451,6 +454,7 @@ void AssetListViewModel::DoUpdateButtons()
     bool bHasModified = false;
     bool bHasUnpublished = false;
     bool bHasUnofficial = false;
+    const bool bHardcore = _RA_HardcoreModeIsActive();
 
     const bool bGameLoaded = (GetGameId() != 0);
     if (!bGameLoaded)
@@ -461,7 +465,7 @@ void AssetListViewModel::DoUpdateButtons()
     }
     else
     {
-        SetValue(CanCreateProperty, true);
+        SetValue(CanCreateProperty, !bHardcore);
         SetValue(CanActivateProperty, m_vFilteredAssets.Count() > 0);
 
         for (size_t i = 0; i < m_vFilteredAssets.Count(); ++i)
@@ -544,12 +548,12 @@ void AssetListViewModel::DoUpdateButtons()
     if (bHasInactiveSelection)
     {
         SetValue(ActivateButtonTextProperty, L"&Activate");
-        SetValue(CanCloneProperty, true);
+        SetValue(CanCloneProperty, !bHardcore);
     }
     else if (bHasActiveSelection)
     {
         SetValue(ActivateButtonTextProperty, L"De&activate");
-        SetValue(CanCloneProperty, true);
+        SetValue(CanCloneProperty, !bHardcore);
     }
     else
     {
@@ -1048,6 +1052,9 @@ void AssetListViewModel::RevertSelected()
 
 void AssetListViewModel::CreateNew()
 {
+    if (!CanCreate())
+        return;
+
     auto& pGameContext = ra::services::ServiceLocator::GetMutable<ra::data::context::GameContext>();
     const auto& pUserContext = ra::services::ServiceLocator::GetMutable<ra::data::context::UserContext>();
 

--- a/src/ui/viewmodels/AssetListViewModel.hh
+++ b/src/ui/viewmodels/AssetListViewModel.hh
@@ -175,6 +175,7 @@ public:
     const ViewModelCollection<AssetSummaryViewModel>& FilteredAssets() const noexcept { return m_vFilteredAssets; }
 
     void OpenEditor(const AssetSummaryViewModel* pAsset);
+    void UpdateButtons();
 
     /// <summary>
     /// The <see cref="ModelProperty" /> for the index of the asset that should be made visible.
@@ -220,7 +221,6 @@ private:
         std::function<bool(const ra::data::models::AssetModelBase&)> pFilterFunction = nullptr);
 
     void UpdateTotals();
-    void UpdateButtons();
     void DoUpdateButtons();
     std::atomic_bool m_bNeedToUpdateButtons = false;
 

--- a/tests/Exports_Tests.cpp
+++ b/tests/Exports_Tests.cpp
@@ -91,6 +91,69 @@ public:
     }
 
 private:
+    class WarnDisableHardcoreHarness
+    {
+    public:
+        MockConfiguration mockConfiguration;
+        MockDesktop mockDesktop;
+        MockEmulatorContext mockEmulatorContext;
+    };
+
+    TEST_METHOD(TestWarnDisableHardcoreNotEnabled)
+    {
+        WarnDisableHardcoreHarness harness;
+        harness.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, false);
+
+        Assert::IsTrue(_RA_WarnDisableHardcore("test"));
+        Assert::IsFalse(harness.mockDesktop.WasDialogShown());
+        Assert::IsFalse(harness.mockConfiguration.IsFeatureEnabled(ra::services::Feature::Hardcore));
+    }
+
+    TEST_METHOD(TestWarnDisableHardcoreAborted)
+    {
+        WarnDisableHardcoreHarness harness;
+        harness.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, true);
+
+        bool bWasShown = false;
+        harness.mockDesktop.ExpectWindow<ra::ui::viewmodels::MessageBoxViewModel>([&bWasShown](ra::ui::viewmodels::MessageBoxViewModel& vmMessageBox)
+        {
+            Assert::AreEqual(std::wstring(L"Disable Hardcore mode?"), vmMessageBox.GetHeader());
+            Assert::AreEqual(std::wstring(L"You cannot test while Hardcore mode is active."), vmMessageBox.GetMessage());
+            Assert::AreEqual(ra::ui::viewmodels::MessageBoxViewModel::Buttons::YesNo, vmMessageBox.GetButtons());
+            Assert::AreEqual(ra::ui::viewmodels::MessageBoxViewModel::Icon::Warning, vmMessageBox.GetIcon());
+            bWasShown = true;
+
+            return ra::ui::DialogResult::No;
+        });
+
+        Assert::IsFalse(_RA_WarnDisableHardcore("test"));
+        Assert::IsTrue(bWasShown);
+        Assert::IsTrue(harness.mockConfiguration.IsFeatureEnabled(ra::services::Feature::Hardcore));
+    }
+
+    TEST_METHOD(TestWarnDisableHardcoreAllowed)
+    {
+        WarnDisableHardcoreHarness harness;
+        harness.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, true);
+
+        bool bWasShown = false;
+        harness.mockDesktop.ExpectWindow<ra::ui::viewmodels::MessageBoxViewModel>([&bWasShown](ra::ui::viewmodels::MessageBoxViewModel& vmMessageBox)
+        {
+            Assert::AreEqual(std::wstring(L"Disable Hardcore mode?"), vmMessageBox.GetHeader());
+            Assert::AreEqual(std::wstring(L"You cannot test while Hardcore mode is active."), vmMessageBox.GetMessage());
+            Assert::AreEqual(ra::ui::viewmodels::MessageBoxViewModel::Buttons::YesNo, vmMessageBox.GetButtons());
+            Assert::AreEqual(ra::ui::viewmodels::MessageBoxViewModel::Icon::Warning, vmMessageBox.GetIcon());
+            bWasShown = true;
+
+            return ra::ui::DialogResult::Yes;
+        });
+
+        Assert::IsTrue(_RA_WarnDisableHardcore("test"));
+        Assert::IsTrue(bWasShown);
+        Assert::IsFalse(harness.mockConfiguration.IsFeatureEnabled(ra::services::Feature::Hardcore));
+    }
+
+private:
     class AttemptLoginHarness
     {
     public:

--- a/tests/mocks/MockDesktop.hh
+++ b/tests/mocks/MockDesktop.hh
@@ -104,6 +104,7 @@ private:
                 return nResult;
         }
 
+        vmViewModel.SetIsVisible(true);
         return ra::ui::DialogResult::None;
     }
 

--- a/tests/ui/viewmodels/CodeNotesViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/CodeNotesViewModel_Tests.cpp
@@ -7,6 +7,7 @@
 #include "tests\mocks\MockDesktop.hh"
 #include "tests\mocks\MockEmulatorContext.hh"
 #include "tests\mocks\MockGameContext.hh"
+#include "tests\mocks\MockLocalStorage.hh"
 #include "tests\mocks\MockWindowManager.hh"
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
@@ -25,6 +26,7 @@ private:
         ra::data::context::mocks::MockEmulatorContext mockEmulatorContext;
         ra::data::context::mocks::MockGameContext mockGameContext;
         ra::services::mocks::MockConfiguration mockConfiguration;
+        ra::services::mocks::MockLocalStorage mockLocalStorage;
         ra::ui::mocks::MockDesktop mockDesktop;
         ra::ui::viewmodels::mocks::MockWindowManager mockWindowManager;
 


### PR DESCRIPTION
Makes the internal tool windows behave like tool windows in the emulators. The Memory Inspector, Bookmarks window, and Achievement Editor will no longer open if the player is in hardcore mode. Attempting to open them will prompt the user to disable hardcore mode, and enabling hardcore mode will close them.