### PR TITLE
show simplified scoreboard when leaderboard entry not submitted

### DIFF
--- a/src/data/context/GameContext.cpp
+++ b/src/data/context/GameContext.cpp
@@ -605,6 +605,30 @@ void GameContext::ActivateLeaderboards()
     }
 }
 
+void GameContext::ShowSimplifiedScoreboard(ra::LeaderboardID nLeaderboardId, int nScore) const
+{
+    auto& pConfiguration = ra::services::ServiceLocator::Get<ra::services::IConfiguration>();
+    if (pConfiguration.GetPopupLocation(ra::ui::viewmodels::Popup::LeaderboardScoreboard) == ra::ui::viewmodels::PopupLocation::None)
+        return;
+
+    const auto* pLeaderboard = FindLeaderboard(nLeaderboardId);
+    if (!pLeaderboard)
+        return;
+
+    ra::ui::viewmodels::ScoreboardViewModel vmScoreboard;
+    vmScoreboard.SetHeaderText(ra::Widen(pLeaderboard->Title()));
+
+    const auto& pUserName = ra::services::ServiceLocator::Get<ra::data::context::UserContext>().GetUsername();
+    auto& pEntryViewModel = vmScoreboard.Entries().Add();
+    pEntryViewModel.SetRank(0);
+    pEntryViewModel.SetScore(ra::Widen(pLeaderboard->FormatScore(nScore)));
+    pEntryViewModel.SetUserName(ra::Widen(pUserName));
+    pEntryViewModel.SetHighlighted(true);
+
+    ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().QueueScoreboard(
+        pLeaderboard->ID(), std::move(vmScoreboard));
+}
+
 void GameContext::SubmitLeaderboardEntry(ra::LeaderboardID nLeaderboardId, int nScore) const
 {
     const auto* pLeaderboard = FindLeaderboard(nLeaderboardId);
@@ -621,6 +645,7 @@ void GameContext::SubmitLeaderboardEntry(ra::LeaderboardID nLeaderboardId, int n
 
         ra::services::ServiceLocator::Get<ra::services::IAudioSystem>().PlayAudioFile(L"Overlay\\info.wav");
         ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().QueueMessage(vmPopup);
+        ShowSimplifiedScoreboard(nLeaderboardId, nScore);
         return;
     }
 
@@ -634,6 +659,7 @@ void GameContext::SubmitLeaderboardEntry(ra::LeaderboardID nLeaderboardId, int n
 
         ra::services::ServiceLocator::Get<ra::services::IAudioSystem>().PlayAudioFile(L"Overlay\\info.wav");
         ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().QueueMessage(vmPopup);
+        ShowSimplifiedScoreboard(nLeaderboardId, nScore);
         return;
     }
 
@@ -646,6 +672,7 @@ void GameContext::SubmitLeaderboardEntry(ra::LeaderboardID nLeaderboardId, int n
 
         ra::services::ServiceLocator::Get<ra::services::IAudioSystem>().PlayAudioFile(L"Overlay\\info.wav");
         ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().QueueMessage(vmPopup);
+        ShowSimplifiedScoreboard(nLeaderboardId, nScore);
         return;
     }
 
@@ -658,6 +685,7 @@ void GameContext::SubmitLeaderboardEntry(ra::LeaderboardID nLeaderboardId, int n
 
         ra::services::ServiceLocator::Get<ra::services::IAudioSystem>().PlayAudioFile(L"Overlay\\info.wav");
         ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().QueueMessage(vmPopup);
+        ShowSimplifiedScoreboard(nLeaderboardId, nScore);
         return;
     }
 

--- a/src/data/context/GameContext.hh
+++ b/src/data/context/GameContext.hh
@@ -278,6 +278,7 @@ protected:
     void LoadRichPresenceScript(const std::string& sRichPresenceScript);
     void RefreshCodeNotes();
     void AddCodeNote(ra::ByteAddress nAddress, const std::string& sAuthor, const std::wstring& sNote);
+    void ShowSimplifiedScoreboard(ra::LeaderboardID nLeaderboardId, int nScore) const;
 
     void OnActiveGameChanged();
     void OnCodeNoteChanged(ra::ByteAddress nAddress, const std::wstring& sNewNote);

--- a/src/ui/viewmodels/ScoreboardViewModel.cpp
+++ b/src/ui/viewmodels/ScoreboardViewModel.cpp
@@ -111,7 +111,7 @@ bool ScoreboardViewModel::UpdateRenderImage(double fElapsed)
                 const ra::ui::Color nTextColor = pEntry->IsHighlighted() ? pTheme.ColorLeaderboardPlayer() : pTheme.ColorLeaderboardEntry();
 
                 // rank (right aligned)
-                const auto sRank = ra::ToWString(pEntry->GetRank());
+                const auto sRank = pEntry->GetRank() ? ra::ToWString(pEntry->GetRank()) : L"-";
                 const auto nEntryRankSize = m_pSurface->MeasureText(nFontText, sRank);
                 m_pSurface->WriteText(8 + nRankSize.Width - nEntryRankSize.Width, nY, nFontText, nTextColor, sRank);
 

--- a/tests/data/context/GameContext_Tests.cpp
+++ b/tests/data/context/GameContext_Tests.cpp
@@ -1729,6 +1729,8 @@ public:
     {
         GameContextHarness game;
         game.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, false);
+        game.mockConfiguration.SetPopupLocation(ra::ui::viewmodels::Popup::LeaderboardScoreboard, ra::ui::viewmodels::PopupLocation::BottomRight);
+        game.mockUser.Initialize("Player", "ApiToken");
         game.SetGameHash("hash");
 
         game.mockServer.ExpectUncalled<ra::api::SubmitLeaderboardEntry>();
@@ -1749,12 +1751,29 @@ public:
         Assert::AreEqual(std::wstring(L"LeaderboardTitle"), pPopup->GetDescription());
         Assert::AreEqual(std::wstring(L"Submission requires Hardcore mode"), pPopup->GetDetail());
         Assert::IsTrue(pPopup->IsDetailError());
+
+        // empty leaderboard should be displayed with the non-submitted score
+        const auto* vmScoreboard = game.mockOverlayManager.GetScoreboard(1U);
+        Assert::IsNotNull(vmScoreboard);
+        Ensures(vmScoreboard != nullptr);
+        Assert::AreEqual(std::wstring(L"LeaderboardTitle"), vmScoreboard->GetHeaderText());
+        Assert::AreEqual({ 1U }, vmScoreboard->Entries().Count());
+
+        const auto* vmEntry = vmScoreboard->Entries().GetItemAt(0);
+        Assert::IsNotNull(vmEntry);
+        Ensures(vmEntry != nullptr);
+        Assert::AreEqual(0, vmEntry->GetRank());
+        Assert::AreEqual(std::wstring(L"Player"), vmEntry->GetUserName());
+        Assert::AreEqual(std::wstring(L"1234"), vmEntry->GetScore());
+        Assert::IsTrue(vmEntry->IsHighlighted());
     }
 
     TEST_METHOD(TestSubmitLeaderboardEntryCompatibilityMode)
     {
         GameContextHarness game;
         game.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, true);
+        game.mockConfiguration.SetPopupLocation(ra::ui::viewmodels::Popup::LeaderboardScoreboard, ra::ui::viewmodels::PopupLocation::BottomRight);
+        game.mockUser.Initialize("Player", "ApiToken");
         game.SetMode(ra::data::context::GameContext::Mode::CompatibilityTest);
         game.SetGameHash("hash");
 
@@ -1776,6 +1795,21 @@ public:
         Assert::AreEqual(std::wstring(L"LeaderboardTitle"), pPopup->GetDescription());
         Assert::AreEqual(std::wstring(L"Leaderboards are not submitted in test mode."), pPopup->GetDetail());
         Assert::IsFalse(pPopup->IsDetailError());
+
+        // empty leaderboard should be displayed with the non-submitted score
+        const auto* vmScoreboard = game.mockOverlayManager.GetScoreboard(1U);
+        Assert::IsNotNull(vmScoreboard);
+        Ensures(vmScoreboard != nullptr);
+        Assert::AreEqual(std::wstring(L"LeaderboardTitle"), vmScoreboard->GetHeaderText());
+        Assert::AreEqual({ 1U }, vmScoreboard->Entries().Count());
+
+        const auto* vmEntry = vmScoreboard->Entries().GetItemAt(0);
+        Assert::IsNotNull(vmEntry);
+        Ensures(vmEntry != nullptr);
+        Assert::AreEqual(0, vmEntry->GetRank());
+        Assert::AreEqual(std::wstring(L"Player"), vmEntry->GetUserName());
+        Assert::AreEqual(std::wstring(L"1234"), vmEntry->GetScore());
+        Assert::IsTrue(vmEntry->IsHighlighted());
     }
 
     TEST_METHOD(TestSubmitLeaderboardEntryLowRank)
@@ -1894,6 +1928,8 @@ public:
     TEST_METHOD(TestSubmitLeaderboardEntryMemoryModified)
     {
         GameContextHarness game;
+        game.mockConfiguration.SetPopupLocation(ra::ui::viewmodels::Popup::LeaderboardScoreboard, ra::ui::viewmodels::PopupLocation::BottomRight);
+        game.mockUser.Initialize("Player", "ApiToken");
         game.SetGameHash("hash");
 
         game.mockServer.ExpectUncalled<ra::api::SubmitLeaderboardEntry>();
@@ -1915,11 +1951,28 @@ public:
         Assert::AreEqual(std::wstring(L"LeaderboardTitle"), pPopup->GetDescription());
         Assert::AreEqual(std::wstring(L"Error: RAM tampered with"), pPopup->GetDetail());
         Assert::IsTrue(pPopup->IsDetailError());
+
+        // empty leaderboard should be displayed with the non-submitted score
+        const auto* vmScoreboard = game.mockOverlayManager.GetScoreboard(1U);
+        Assert::IsNotNull(vmScoreboard);
+        Ensures(vmScoreboard != nullptr);
+        Assert::AreEqual(std::wstring(L"LeaderboardTitle"), vmScoreboard->GetHeaderText());
+        Assert::AreEqual({ 1U }, vmScoreboard->Entries().Count());
+
+        const auto* vmEntry = vmScoreboard->Entries().GetItemAt(0);
+        Assert::IsNotNull(vmEntry);
+        Ensures(vmEntry != nullptr);
+        Assert::AreEqual(0, vmEntry->GetRank());
+        Assert::AreEqual(std::wstring(L"Player"), vmEntry->GetUserName());
+        Assert::AreEqual(std::wstring(L"1234"), vmEntry->GetScore());
+        Assert::IsTrue(vmEntry->IsHighlighted());
     }
 
     TEST_METHOD(TestSubmitLeaderboardEntryMemoryInsecure)
     {
         GameContextHarness game;
+        game.mockConfiguration.SetPopupLocation(ra::ui::viewmodels::Popup::LeaderboardScoreboard, ra::ui::viewmodels::PopupLocation::BottomRight);
+        game.mockUser.Initialize("Player", "ApiToken");
         game.SetGameHash("hash");
         game.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, true);
 
@@ -1942,6 +1995,21 @@ public:
         Assert::AreEqual(std::wstring(L"LeaderboardTitle"), pPopup->GetDescription());
         Assert::AreEqual(std::wstring(L"Error: RAM insecure"), pPopup->GetDetail());
         Assert::IsTrue(pPopup->IsDetailError());
+
+        // empty leaderboard should be displayed with the non-submitted score
+        const auto* vmScoreboard = game.mockOverlayManager.GetScoreboard(1U);
+        Assert::IsNotNull(vmScoreboard);
+        Ensures(vmScoreboard != nullptr);
+        Assert::AreEqual(std::wstring(L"LeaderboardTitle"), vmScoreboard->GetHeaderText());
+        Assert::AreEqual({ 1U }, vmScoreboard->Entries().Count());
+
+        const auto* vmEntry = vmScoreboard->Entries().GetItemAt(0);
+        Assert::IsNotNull(vmEntry);
+        Ensures(vmEntry != nullptr);
+        Assert::AreEqual(0, vmEntry->GetRank());
+        Assert::AreEqual(std::wstring(L"Player"), vmEntry->GetUserName());
+        Assert::AreEqual(std::wstring(L"1234"), vmEntry->GetScore());
+        Assert::IsTrue(vmEntry->IsHighlighted());
     }
 
     TEST_METHOD(TestLoadCodeNotes)


### PR DESCRIPTION
Requested feature for testing leaderboards, so the submitted score can be seen when not in hardcore, or when modifying memory.

Because the value isn't actually submitted to the server, we can't report the player's ranking, old score, or other players on the leaderboard. Instead, a single unranked entry is shown with the current value.

![image](https://user-images.githubusercontent.com/32680403/108609958-fe10db80-738e-11eb-83ce-7f1ed3c5b639.png)

