### PR TITLE
show indirect addresses in tooltip

### DIFF
--- a/src/ui/viewmodels/TriggerConditionViewModel.hh
+++ b/src/ui/viewmodels/TriggerConditionViewModel.hh
@@ -105,6 +105,11 @@ public:
     unsigned int GetRequiredHits() const { return ra::to_unsigned(GetValue(RequiredHitsProperty)); }
     void SetRequiredHits(unsigned int nValue) { SetValue(RequiredHitsProperty, ra::to_signed(nValue)); }
 
+    static const BoolModelProperty IsIndirectProperty;
+    bool IsIndirect() const { return GetValue(IsIndirectProperty); }
+    void SetIndirect(bool bValue) { SetValue(IsIndirectProperty, bValue); }
+    unsigned int GetIndirectAddress(unsigned int nAddress) const;
+
     static const BoolModelProperty IsSelectedProperty;
     bool IsSelected() const { return GetValue(IsSelectedProperty); }
     void SetSelected(bool bValue) { SetValue(IsSelectedProperty, bValue); }
@@ -113,6 +118,7 @@ public:
     void SerializeAppend(std::string& sBuffer) const;
 
     void InitializeFrom(const struct rc_condition_t& pCondition);
+    void SetTriggerViewModel(const ViewModelBase* pTriggerViewModel) noexcept { m_pTriggerViewModel = pTriggerViewModel; }
 
     std::wstring GetTooltip(const IntModelProperty& nProperty) const;
 
@@ -126,13 +132,15 @@ private:
 
     void SerializeAppendOperand(std::string& sBuffer, TriggerOperandType nType, MemSize nSize, unsigned int nValue) const;
 
-    std::wstring GetValueTooltip(TriggerOperandType nType, unsigned int nValue) const;
-    std::wstring GetAddressTooltip(unsigned int nAddress) const;
+    static std::wstring GetValueTooltip(unsigned int nValue);
+    static std::wstring GetAddressTooltip(unsigned int nAddress, bool bIsIndirect);
 
     void SetOperand(const IntModelProperty& pTypeProperty, const IntModelProperty& pSizeProperty,
         const IntModelProperty& pValueProperty, const rc_operand_t& operand);
 
     static bool IsModifying(TriggerConditionType nType) noexcept;
+
+    const ViewModelBase* m_pTriggerViewModel = nullptr;
 };
 
 } // namespace viewmodels

--- a/src/ui/viewmodels/TriggerViewModel.hh
+++ b/src/ui/viewmodels/TriggerViewModel.hh
@@ -84,6 +84,7 @@ public:
     void InitializeFrom(const std::string& sTrigger, const ra::data::models::CapturedTriggerHits& pCapturedHits);
     void UpdateFrom(const rc_trigger_t& pTrigger);
     void UpdateFrom(const std::string& sTrigger);
+    rc_trigger_t* GetTriggerFromString() const noexcept { return m_pTrigger; }
 
     void RemoveSelectedConditions();
     void CopySelectedConditionsToClipboard();
@@ -139,6 +140,7 @@ protected:
 
 private:
     void UpdateVersion();
+    void InitializeGroups(const rc_trigger_t& pTrigger);
     void UpdateConditions(const GroupViewModel* pGroup);
 
     void DeselectAllConditions();

--- a/src/ui/win32/AssetEditorDialog.cpp
+++ b/src/ui/win32/AssetEditorDialog.cpp
@@ -182,7 +182,13 @@ public:
     {
         if (IsAddressType(vmItems, nIndex))
         {
-            const auto nAddress = vmItems.GetItemValue(nIndex, *m_pBoundProperty);
+            auto nAddress = vmItems.GetItemValue(nIndex, *m_pBoundProperty);
+            if (vmItems.GetItemValue(nIndex, TriggerConditionViewModel::IsIndirectProperty))
+            {
+                const auto* pConditionViewModel = dynamic_cast<const TriggerConditionViewModel*>(vmItems.GetViewModelAt(nIndex));
+                Expects(pConditionViewModel != nullptr);
+                nAddress = pConditionViewModel->GetIndirectAddress(nAddress);
+            }
 
             auto& pMemoryInspector = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::WindowManager>().MemoryInspector;
             pMemoryInspector.SetCurrentAddress(nAddress);


### PR DESCRIPTION
When hovering over a memory reference in a condition following an AddAddress condition, the tooltip was being shown for the offset. Similarly, right+clicking on the offset would take you to the offset. In both cases, it's desirable to show/use the adjusted address. That's what this PR does.

In this case, the value at $0087 is 0x43:
![image](https://user-images.githubusercontent.com/32680403/110228498-dbb6ac00-7ebe-11eb-87ed-817bccc93a16.png)

The tooltip shows "0x0143 (indirect)" instead of "0x0100". If 0x0143 had a code note, it would be displayed. The code note for 0x0100 will not be displayed. Right+clicking on the 0x0100 would take you to the address 0x0143 in the memory viewer.

Note: The tooltip is evaluate at the time of hover. It does not update in real time if the pointer value changes. It will update the next time the tooltip is rendered if you mouse off and back. Similarly, the address jumped to in the memory viewer is calculated when the user right+clicks, and may not correspond to the address in the tooltip if the pointer value has changed.