### PR TITLE
show tooltip for addresses in ranged code notes

### DIFF
--- a/src/data/context/GameContext.hh
+++ b/src/data/context/GameContext.hh
@@ -161,6 +161,14 @@ public:
     }
 
     /// <summary>
+    /// Returns the address of the first byte containing the specified code note.
+    /// </summary>
+    /// <returns>
+    ///  Returns 0xFFFFFFFF if not found.
+    /// </returns>
+    ra::ByteAddress FindCodeNoteStart(ra::ByteAddress nAddress) const;
+
+    /// <summary>
     /// Returns the note associated with the specified address.
     /// </summary>
     /// <returns>

--- a/src/ui/viewmodels/TriggerConditionViewModel.cpp
+++ b/src/ui/viewmodels/TriggerConditionViewModel.cpp
@@ -421,8 +421,8 @@ std::wstring TriggerConditionViewModel::GetAddressTooltip(unsigned int nAddress,
     const auto nStartAddress = pGameContext.FindCodeNoteStart(nAddress);
     if (nStartAddress != nAddress && nStartAddress != 0xFFFFFFFF)
     {
-        sAddress = ra::StringPrintf(L"%s [%d/%d]", ra::ByteAddressToString(nStartAddress),
-            nAddress - nStartAddress + 1, pGameContext.FindCodeNoteSize(nStartAddress));
+        sAddress = ra::StringPrintf(L"%s [%s+%d]", ra::ByteAddressToString(nAddress),
+            ra::ByteAddressToString(nStartAddress), nAddress - nStartAddress);
     }
     else
     {

--- a/src/ui/viewmodels/TriggerConditionViewModel.cpp
+++ b/src/ui/viewmodels/TriggerConditionViewModel.cpp
@@ -415,12 +415,24 @@ unsigned int TriggerConditionViewModel::GetIndirectAddress(unsigned int nAddress
 
 std::wstring TriggerConditionViewModel::GetAddressTooltip(unsigned int nAddress, bool bIsIndirect)
 {
-    auto sAddress = ra::ByteAddressToString(nAddress);
-    if (bIsIndirect)
-        sAddress.append(" (indirect)");
-
     const auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::context::GameContext>();
-    const auto* pNote = pGameContext.FindCodeNote(nAddress);
+    std::wstring sAddress;
+
+    const auto nStartAddress = pGameContext.FindCodeNoteStart(nAddress);
+    if (nStartAddress != nAddress && nStartAddress != 0xFFFFFFFF)
+    {
+        sAddress = ra::StringPrintf(L"%s [%d/%d]", ra::ByteAddressToString(nStartAddress),
+            nAddress - nStartAddress + 1, pGameContext.FindCodeNoteSize(nStartAddress));
+    }
+    else
+    {
+        sAddress = ra::Widen(ra::ByteAddressToString(nAddress));
+    }
+
+    if (bIsIndirect)
+        sAddress.append(L" (indirect)");
+
+    const auto* pNote = (nStartAddress != 0xFFFFFFFF) ? pGameContext.FindCodeNote(nStartAddress) : nullptr;
     if (!pNote)
         return ra::StringPrintf(L"%s\r\n[No code note]", sAddress);
 

--- a/tests/ui/viewmodels/TriggerConditionViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/TriggerConditionViewModel_Tests.cpp
@@ -392,6 +392,18 @@ public:
         Assert::AreEqual(std::wstring(L"0x0009\r\nThis is another note."), condition.GetTooltip(TriggerConditionViewModel::TargetValueProperty));
     }
 
+    TEST_METHOD(TestTooltipAddressMultiByteNote)
+    {
+        TriggerConditionViewModelHarness condition;
+        condition.mockGameContext.SetCodeNote({ 8U }, L"[8 bytes] This is a note.");
+
+        condition.Parse("0xH0008=3");
+        Assert::AreEqual(std::wstring(L"0x0008\r\n[8 bytes] This is a note."), condition.GetTooltip(TriggerConditionViewModel::SourceValueProperty));
+
+        condition.Parse("0xH000C=3");
+        Assert::AreEqual(std::wstring(L"0x0008 [5/8]\r\n[8 bytes] This is a note."), condition.GetTooltip(TriggerConditionViewModel::SourceValueProperty));
+    }
+
     TEST_METHOD(TestTooltipValueDecimal)
     {
         TriggerConditionViewModelHarness condition;
@@ -498,6 +510,22 @@ public:
         vmTrigger.SetMemory({ 1 }, 3);
         Assert::AreEqual(std::wstring(L"0x0005 (indirect)\r\nThis is another note."), pCondition->GetTooltip(TriggerConditionViewModel::SourceValueProperty));
         Assert::AreEqual(std::wstring(L"0x0007 (indirect)\r\n[No code note]"), pCondition->GetTooltip(TriggerConditionViewModel::TargetValueProperty));
+    }
+
+    TEST_METHOD(TestTooltipIndirectAddressMultiByteNote)
+    {
+        IndirectAddressTriggerViewModelHarness vmTrigger;
+        vmTrigger.Parse("I:0xH0001_0xH0002=0xH0004");
+        vmTrigger.mockConfiguration.SetFeatureEnabled(ra::services::Feature::PreferDecimal, true);
+        vmTrigger.mockGameContext.SetCodeNote({ 4U }, L"[8 bytes] This is a note.");
+
+        const auto* pCondition = vmTrigger.Conditions().GetItemAt(1);
+        Expects(pCondition != nullptr);
+        Assert::IsTrue(pCondition->IsIndirect());
+
+        // $0001 = 1, 1+2 = $0003, 1+4 = $0005
+        Assert::AreEqual(std::wstring(L"0x0003 (indirect)\r\n[No code note]"), pCondition->GetTooltip(TriggerConditionViewModel::SourceValueProperty));
+        Assert::AreEqual(std::wstring(L"0x0004 [2/8] (indirect)\r\n[8 bytes] This is a note."), pCondition->GetTooltip(TriggerConditionViewModel::TargetValueProperty));
     }
 
     TEST_METHOD(TestTooltipIndirectAddressMultiplyNoCodeNote)

--- a/tests/ui/viewmodels/TriggerConditionViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/TriggerConditionViewModel_Tests.cpp
@@ -401,7 +401,7 @@ public:
         Assert::AreEqual(std::wstring(L"0x0008\r\n[8 bytes] This is a note."), condition.GetTooltip(TriggerConditionViewModel::SourceValueProperty));
 
         condition.Parse("0xH000C=3");
-        Assert::AreEqual(std::wstring(L"0x0008 [5/8]\r\n[8 bytes] This is a note."), condition.GetTooltip(TriggerConditionViewModel::SourceValueProperty));
+        Assert::AreEqual(std::wstring(L"0x000c [0x0008+4]\r\n[8 bytes] This is a note."), condition.GetTooltip(TriggerConditionViewModel::SourceValueProperty));
     }
 
     TEST_METHOD(TestTooltipValueDecimal)
@@ -525,7 +525,7 @@ public:
 
         // $0001 = 1, 1+2 = $0003, 1+4 = $0005
         Assert::AreEqual(std::wstring(L"0x0003 (indirect)\r\n[No code note]"), pCondition->GetTooltip(TriggerConditionViewModel::SourceValueProperty));
-        Assert::AreEqual(std::wstring(L"0x0004 [2/8] (indirect)\r\n[8 bytes] This is a note."), pCondition->GetTooltip(TriggerConditionViewModel::TargetValueProperty));
+        Assert::AreEqual(std::wstring(L"0x0005 [0x0004+1] (indirect)\r\n[8 bytes] This is a note."), pCondition->GetTooltip(TriggerConditionViewModel::TargetValueProperty));
     }
 
     TEST_METHOD(TestTooltipIndirectAddressMultiplyNoCodeNote)


### PR DESCRIPTION
When an address doesn't have an explicit code note but does fall in the range of another address's code note annotations, the tooltip will now show the containing range (similar to search results).

Here, the address is $c617, which does not have a code note, but $c559 has a code note indicating it covers the 285 bytes between $c559 and $c7dd. Since $c617 falls in that range, that tooltip is displayed, with an annotation that the actual address is 191 bytes into the annotated range.
![image](https://user-images.githubusercontent.com/32680403/112737485-894a3780-8f20-11eb-9c5d-9c66ede05be6.png)

Right+clicking on the address will still take you directly to the address.