### PR TITLE
add totals for hit chains

### DIFF
--- a/src/ui/viewmodels/TriggerConditionViewModel.cpp
+++ b/src/ui/viewmodels/TriggerConditionViewModel.cpp
@@ -29,6 +29,7 @@ const IntModelProperty TriggerConditionViewModel::TargetSizeProperty("TriggerCon
 const IntModelProperty TriggerConditionViewModel::TargetValueProperty("TriggerConditionViewModel", "TargetValue", 0);
 const IntModelProperty TriggerConditionViewModel::CurrentHitsProperty("TriggerConditionViewModel", "CurrentHits", 0);
 const IntModelProperty TriggerConditionViewModel::RequiredHitsProperty("TriggerConditionViewModel", "RequiredHits", 0);
+const IntModelProperty TriggerConditionViewModel::TotalHitsProperty("TriggerConditionViewModel", "TotalHits", 0);
 const BoolModelProperty TriggerConditionViewModel::IsSelectedProperty("TriggerConditionViewModel", "IsSelected", false);
 const BoolModelProperty TriggerConditionViewModel::IsIndirectProperty("TriggerConditionViewModel", "IsIndirect", false);
 const BoolModelProperty TriggerConditionViewModel::HasSourceSizeProperty("TriggerConditionViewModel", "HasSourceSize", true);

--- a/src/ui/viewmodels/TriggerConditionViewModel.hh
+++ b/src/ui/viewmodels/TriggerConditionViewModel.hh
@@ -107,6 +107,10 @@ public:
     unsigned int GetRequiredHits() const { return ra::to_unsigned(GetValue(RequiredHitsProperty)); }
     void SetRequiredHits(unsigned int nValue) { SetValue(RequiredHitsProperty, ra::to_signed(nValue)); }
 
+    static const IntModelProperty TotalHitsProperty;
+    unsigned int GetTotalHits() const { return ra::to_unsigned(GetValue(TotalHitsProperty)); }
+    void SetTotalHits(unsigned int nValue) { SetValue(TotalHitsProperty, ra::to_signed(nValue)); }
+
     static const BoolModelProperty IsIndirectProperty;
     bool IsIndirect() const { return GetValue(IsIndirectProperty); }
     void SetIndirect(bool bValue) { SetValue(IsIndirectProperty, bValue); }

--- a/src/ui/viewmodels/TriggerViewModel.cpp
+++ b/src/ui/viewmodels/TriggerViewModel.cpp
@@ -683,7 +683,7 @@ void TriggerViewModel::DoFrame()
         m_vConditions.RemoveNotifyTarget(m_pConditionsMonitor);
         m_vConditions.BeginUpdate();
 
-        unsigned int nHits = 0, nConditionHits = 0;
+        unsigned int nHits = 0;
         bool bIsHitsChain = false;
 
         gsl::index nConditionIndex = 0;

--- a/src/ui/viewmodels/TriggerViewModel.hh
+++ b/src/ui/viewmodels/TriggerViewModel.hh
@@ -132,6 +132,8 @@ public:
     void DoFrame();
     void UpdateColors(const rc_trigger_t* pTrigger);
 
+    static bool BuildHitChainTooltip(std::wstring& sTooltip, const ViewModelCollection<TriggerConditionViewModel>& vmConditions, gsl::index nIndex);
+
 protected:
     // ViewModelCollectionBase::NotifyTarget
     void OnViewModelBoolValueChanged(gsl::index nIndex, const BoolModelProperty::ChangeArgs& args) override;
@@ -151,6 +153,7 @@ private:
 
     ViewModelCollection<GroupViewModel> m_vGroups;
     ViewModelCollection<TriggerConditionViewModel> m_vConditions;
+    bool m_bHasHitChain = false;
 
     class ConditionsMonitor : public ViewModelCollectionBase::NotifyTarget
     {

--- a/src/ui/win32/AssetEditorDialog.cpp
+++ b/src/ui/win32/AssetEditorDialog.cpp
@@ -281,6 +281,10 @@ public:
             return std::to_wstring(nRequiredHits);
         }
 
+        const auto nTotalHits = vmItems.GetItemValue(nIndex, TriggerConditionViewModel::TotalHitsProperty);
+        if (nTotalHits > 0)
+            return ra::StringPrintf(L"%d (%d) [%d]", nRequiredHits, nCurrentHits, nTotalHits);
+
         return ra::StringPrintf(L"%d (%d)", nRequiredHits, nCurrentHits);
     }
 
@@ -290,8 +294,22 @@ public:
             return true;
         if (pProperty == TriggerConditionViewModel::HasHitsProperty)
             return true;
+        if (pProperty == TriggerConditionViewModel::TotalHitsProperty)
+            return true;
 
         return GridNumberColumnBinding::DependsOn(pProperty);
+    }
+
+    std::wstring GetTooltip(const ra::ui::ViewModelCollectionBase& vmItems, gsl::index nIndex) const override
+    {
+        const auto* vmConditions = dynamic_cast<const ViewModelCollection<TriggerConditionViewModel>*>(&vmItems);
+        Expects(vmConditions != nullptr);
+
+        std::wstring sTooltip;
+        if (!TriggerViewModel::BuildHitChainTooltip(sTooltip, *vmConditions, nIndex))
+            sTooltip.clear();
+
+        return sTooltip;
     }
 
     HWND CreateInPlaceEditor(HWND hParent, InPlaceEditorInfo& pInfo) override


### PR DESCRIPTION
When a condition is the last part of an AddHits chain, it will now display the total hits in brackets (along with the condition-specific hits in parenthesis). Additionally, a tooltip for the hits field will show where the hits are coming from:

![image](https://user-images.githubusercontent.com/32680403/115157788-60f9b880-a048-11eb-8f12-643678ee29d7.png)
