### PR TITLE
always assume addresses are hex

### DIFF
--- a/src/ui/win32/AssetEditorDialog.cpp
+++ b/src/ui/win32/AssetEditorDialog.cpp
@@ -141,7 +141,7 @@ public:
 
     bool SetText(ra::ui::ViewModelCollectionBase& vmItems, gsl::index nIndex, const std::wstring& sValue) override
     {
-        if (ra::StringStartsWith(sValue, L"0x"))
+        if (ra::StringStartsWith(sValue, L"0x") || IsAddressType(vmItems, nIndex))
         {
             std::wstring sError;
             unsigned int nValue = 0U;


### PR DESCRIPTION
When entering "1234" as a memory address (instead of "0x1234"), the value will no longer be converted to "0x04d2". The conversion will still occur for value fields.

Also prevent "only decimal numbers are allowed" error if entering a non-decimal address: "04d2"