### PR TITLE
don't toggle redraw enable when not necessary

### DIFF
--- a/src/Exports.cpp
+++ b/src/Exports.cpp
@@ -301,7 +301,9 @@ API unsigned int CCONV _RA_IdentifyHash(const char* sHash)
 
 API void CCONV _RA_ActivateGame(unsigned int nGameId)
 {
+    _RA_SuspendRepaint();
     ra::services::ServiceLocator::GetMutable<ra::services::GameIdentifier>().ActivateGame(nGameId);
+    _RA_ResumeRepaint();
 }
 
 API int CCONV _RA_OnLoadNewRom(const BYTE* pROM, unsigned int nROMSize)

--- a/src/ui/viewmodels/MemorySearchViewModel.cpp
+++ b/src/ui/viewmodels/MemorySearchViewModel.cpp
@@ -348,7 +348,6 @@ void MemorySearchViewModel::DoFrame()
         return;
     }
 
-    m_bNeedsRedraw = false;
     m_vResults.BeginUpdate();
 
     const auto& pEmulatorContext = ra::services::ServiceLocator::Get<ra::data::context::EmulatorContext>();
@@ -370,13 +369,6 @@ void MemorySearchViewModel::DoFrame()
     }
 
     m_vResults.EndUpdate();
-}
-
-bool MemorySearchViewModel::NeedsRedraw() noexcept
-{
-    const bool bNeedsRedraw = m_bNeedsRedraw;
-    m_bNeedsRedraw = false;
-    return bNeedsRedraw;
 }
 
 inline static constexpr auto ParseAddress(const wchar_t* ptr, ra::ByteAddress& address) noexcept
@@ -1024,18 +1016,6 @@ void MemorySearchViewModel::OnViewModelBoolValueChanged(gsl::index nIndex, const
 
         SetValue(HasSelectionProperty, (m_vSelectedAddresses.size() > 0));
     }
-}
-
-void MemorySearchViewModel::OnViewModelIntValueChanged(gsl::index, const IntModelProperty::ChangeArgs&) noexcept
-{
-    // assume color
-    m_bNeedsRedraw = true;
-}
-
-void MemorySearchViewModel::OnViewModelStringValueChanged(gsl::index, const StringModelProperty::ChangeArgs&) noexcept
-{
-    // assume text
-    m_bNeedsRedraw = true;
 }
 
 void MemorySearchViewModel::NextPage()

--- a/src/ui/viewmodels/MemorySearchViewModel.hh
+++ b/src/ui/viewmodels/MemorySearchViewModel.hh
@@ -35,8 +35,6 @@ public:
 
     void DoFrame();
 
-    bool NeedsRedraw() noexcept;
-
     class PredefinedFilterRangeViewModel : public LookupItemViewModel
     {
     public:
@@ -452,8 +450,6 @@ protected:
 
     // ViewModelCollectionBase::NotifyTarget
     void OnViewModelBoolValueChanged(gsl::index nIndex, const BoolModelProperty::ChangeArgs& args) override;
-    void OnViewModelIntValueChanged(gsl::index nIndex, const IntModelProperty::ChangeArgs& args) noexcept override;
-    void OnViewModelStringValueChanged(gsl::index nIndex, const StringModelProperty::ChangeArgs& args) noexcept override;
 
     // EmulatorContext::NotifyTarget
     void OnTotalMemorySizeChanged() override;
@@ -482,7 +478,6 @@ private:
     ViewModelCollection<SearchResultViewModel> m_vResults;
     bool m_bIsContinuousFiltering = false;
     std::chrono::steady_clock::time_point m_tLastContinuousFilter;
-    bool m_bNeedsRedraw = false;
     bool m_bScrolling = false;
     bool m_bSelectingFilter = false;
 

--- a/src/ui/win32/MemoryInspectorDialog.cpp
+++ b/src/ui/win32/MemoryInspectorDialog.cpp
@@ -48,16 +48,6 @@ void MemoryInspectorDialog::Presenter::OnClosed() noexcept { m_pDialog.reset(); 
 
 // ------------------------------------
 
-void MemoryInspectorDialog::SearchResultsGridBinding::Invalidate()
-{
-    if (GetViewModel<MemorySearchViewModel>().NeedsRedraw())
-    {
-        GridBinding::Invalidate();
-
-        ControlBinding::ForceRepaint(m_hWnd);
-    }
-}
-
 void MemoryInspectorDialog::SearchResultsGridBinding::OnLvnItemChanged(const LPNMLISTVIEW pnmListView)
 {
     GridBinding::OnLvnItemChanged(pnmListView);

--- a/src/ui/win32/MemoryInspectorDialog.hh
+++ b/src/ui/win32/MemoryInspectorDialog.hh
@@ -66,9 +66,6 @@ private:
         void OnLvnItemChanged(const LPNMLISTVIEW pnmListView) override;
 
         void OnViewModelIntValueChanged(const IntModelProperty::ChangeArgs& args) override;
-
-    protected:
-        void Invalidate() override;
     };
 
     SearchResultsGridBinding m_bindSearchResults;

--- a/src/ui/win32/bindings/ControlBinding.cpp
+++ b/src/ui/win32/bindings/ControlBinding.cpp
@@ -32,12 +32,17 @@ ControlBinding::~ControlBinding() noexcept
 
 void ControlBinding::ForceRepaint(HWND hWnd)
 {
+    ::InvalidateRect(hWnd, nullptr, FALSE);
+
+    if (NeedsUpdateWindow())
+        RedrawWindow(hWnd);
+}
+
+void ControlBinding::RedrawWindow(HWND hWnd)
+{
     if (g_nSuspendRepaintCount == 0)
     {
-        ::InvalidateRect(hWnd, nullptr, FALSE);
-
-        if (NeedsUpdateWindow())
-            ::UpdateWindow(hWnd);
+        ::UpdateWindow(hWnd);
     }
     else
     {
@@ -65,13 +70,7 @@ void ControlBinding::ResumeRepaint()
         if (!vSuspendedRepaintWnds.empty())
         {
             for (HWND hWnd : vSuspendedRepaintWnds)
-                ::InvalidateRect(hWnd, nullptr, FALSE);
-
-            if (NeedsUpdateWindow())
-            {
-                for (HWND hWnd : vSuspendedRepaintWnds)
-                    ::UpdateWindow(hWnd);
-            }
+                ::UpdateWindow(hWnd);
         }
     }
     else

--- a/src/ui/win32/bindings/ControlBinding.hh
+++ b/src/ui/win32/bindings/ControlBinding.hh
@@ -98,6 +98,11 @@ public:
     static void ForceRepaint(HWND hWnd);
 
     /// <summary>
+    /// Calls UpdateWindow() to cause the control to repaint
+    /// </summary>
+    static void RedrawWindow(HWND hWnd);
+
+    /// <summary>
     /// Delays ForceRepaint calls until resumed.
     /// </summary>
     static void SuspendRepaint();

--- a/src/ui/win32/bindings/GridBinding.cpp
+++ b/src/ui/win32/bindings/GridBinding.cpp
@@ -571,11 +571,6 @@ void GridBinding::UpdateSelectedItemStates()
     }
 }
 
-void GridBinding::Invalidate()
-{
-    InvalidateRect(m_hWnd, nullptr, FALSE);
-}
-
 void GridBinding::BindIsSelected(const BoolModelProperty& pIsSelectedProperty)
 {
     m_pIsSelectedProperty = &pIsSelectedProperty;

--- a/src/ui/win32/bindings/GridBinding.cpp
+++ b/src/ui/win32/bindings/GridBinding.cpp
@@ -536,31 +536,25 @@ void GridBinding::CheckForScrollBar()
 void GridBinding::OnBeginViewModelCollectionUpdate() noexcept
 {
     m_bForceRepaint = false;
-
-    if (m_hWnd)
-        SendMessage(m_hWnd, WM_SETREDRAW, FALSE, 0);
 }
 
 void GridBinding::OnEndViewModelCollectionUpdate()
 {
     if (m_hWnd)
     {
-        // enable redraw before calling CheckForScrollBar to ensure metrics are updated
-        SendMessage(m_hWnd, WM_SETREDRAW, TRUE, 0);
-
         CheckForScrollBar();
 
-        UpdateSelectedItemStates();
+        if (m_bUpdateSelectedItemStates)
+        {
+            m_bUpdateSelectedItemStates = false;
+            UpdateSelectedItemStates();
+        }
 
         if (m_bForceRepaint && m_nAdjustingScrollOffset == 0)
         {
             m_bForceRepaint = false;
 
             ControlBinding::ForceRepaint(m_hWnd);
-        }
-        else
-        {
-            Invalidate();
         }
     }
 }
@@ -790,6 +784,10 @@ void GridBinding::OnLvnItemChanged(const LPNMLISTVIEW pnmListView)
                 m_vmItems->SetItemValue(nIndex, *m_pIsSelectedProperty, true);
             else if (pnmListView->uOldState & LVIS_SELECTED)
                 m_vmItems->SetItemValue(nIndex, *m_pIsSelectedProperty, false);
+        }
+        else
+        {
+            m_bUpdateSelectedItemStates = true;
         }
     }
 

--- a/src/ui/win32/bindings/GridBinding.cpp
+++ b/src/ui/win32/bindings/GridBinding.cpp
@@ -298,7 +298,10 @@ void GridBinding::OnViewModelIntValueChanged(gsl::index nIndex, const IntModelPr
     if (m_pRowColorProperty && *m_pRowColorProperty == args.Property)
     {
         if (m_nAdjustingScrollOffset == 0)
+        {
             ListView_RedrawItems(m_hWnd, nIndex, nIndex);
+            m_bForceRepaintItems = true;
+        }
         return;
     }
 
@@ -323,7 +326,8 @@ void GridBinding::OnViewModelIntValueChanged(gsl::index nIndex, const IntModelPr
             GSL_SUPPRESS_TYPE1
             SNDMSG(m_hWnd, LVM_SETITEMW, 0, reinterpret_cast<LPARAM>(&item));
 
-            m_bForceRepaint = true;
+            ListView_RedrawItems(m_hWnd, nIndex, nIndex);
+            m_bForceRepaintItems = true;
         }
     }
 }
@@ -357,7 +361,8 @@ void GridBinding::OnViewModelBoolValueChanged(gsl::index nIndex, const BoolModel
             GSL_SUPPRESS_TYPE1
             SNDMSG(m_hWnd, LVM_SETITEMW, 0, reinterpret_cast<LPARAM>(&item));
 
-            m_bForceRepaint = true;
+            ListView_RedrawItems(m_hWnd, nIndex, nIndex);
+            m_bForceRepaintItems = true;
         }
     }
 }
@@ -388,7 +393,8 @@ void GridBinding::OnViewModelStringValueChanged(gsl::index nIndex, const StringM
             GSL_SUPPRESS_TYPE1
             SNDMSG(m_hWnd, LVM_SETITEMW, 0, reinterpret_cast<LPARAM>(&item));
 
-            m_bForceRepaint = true;
+            ListView_RedrawItems(m_hWnd, nIndex, nIndex);
+            m_bForceRepaintItems = true;
         }
     }
 }
@@ -536,6 +542,7 @@ void GridBinding::CheckForScrollBar()
 void GridBinding::OnBeginViewModelCollectionUpdate() noexcept
 {
     m_bForceRepaint = false;
+    m_bForceRepaintItems = false;
 }
 
 void GridBinding::OnEndViewModelCollectionUpdate()
@@ -550,11 +557,20 @@ void GridBinding::OnEndViewModelCollectionUpdate()
             UpdateSelectedItemStates();
         }
 
-        if (m_bForceRepaint && m_nAdjustingScrollOffset == 0)
+        if (m_nAdjustingScrollOffset == 0)
         {
-            m_bForceRepaint = false;
+            if (m_bForceRepaint)
+            {
+                m_bForceRepaint = false;
+                m_bForceRepaintItems = false;
 
-            ControlBinding::ForceRepaint(m_hWnd);
+                ControlBinding::ForceRepaint(m_hWnd);
+            }
+            else if (m_bForceRepaintItems)
+            {
+                m_bForceRepaintItems = false;
+                ControlBinding::RedrawWindow(m_hWnd);
+            }
         }
     }
 }
@@ -648,34 +664,37 @@ INT_PTR CALLBACK GridBinding::WndProc(HWND hControl, UINT uMsg, WPARAM wParam, L
     switch (uMsg)
     {
         case WM_MOUSEMOVE:
-            LVHITTESTINFO lvHitTestInfo;
-            GetCursorPos(&lvHitTestInfo.pt);
-            ScreenToClient(m_hWnd, &lvHitTestInfo.pt);
-
-            int nTooltipLocation = -1;
-            if (ListView_SubItemHitTest(m_hWnd, &lvHitTestInfo) != -1)
-                nTooltipLocation = lvHitTestInfo.iItem * 256 + lvHitTestInfo.iSubItem;
-
-            // if the mouse has moved to a new grid cell, hide the toolip
-            if (nTooltipLocation != m_nTooltipLocation)
+            if (m_hTooltip)
             {
-                m_nTooltipLocation = nTooltipLocation;
-                m_sTooltip.clear();
+                LVHITTESTINFO lvHitTestInfo;
+                GetCursorPos(&lvHitTestInfo.pt);
+                ScreenToClient(m_hWnd, &lvHitTestInfo.pt);
 
-                if (IsWindowVisible(m_hTooltip))
-                {
-                    // tooltip is visible, just hide it
-                    SendMessage(m_hTooltip, TTM_POP, 0, 0);
-                }
-                else
-                {
-                    // tooltip is not visible. if we told the tooltip to not display in the TTM_GETDISPINFO handler by
-                    // setting lpszText to empty string, it won't try to display again unless we tell it to, so do so now
-                    SendMessage(m_hTooltip, TTM_POPUP, 0, 0);
+                int nTooltipLocation = -1;
+                if (ListView_SubItemHitTest(m_hWnd, &lvHitTestInfo) != -1)
+                    nTooltipLocation = lvHitTestInfo.iItem * 256 + lvHitTestInfo.iSubItem;
 
-                    // but we don't want the tooltip to immediately display when entering a new cell, so immediately
-                    // hide it. the normal hover behavior will make it display as expected after a normal hover wait time.
-                    SendMessage(m_hTooltip, TTM_POP, 0, 0);
+                // if the mouse has moved to a new grid cell, hide the toolip
+                if (nTooltipLocation != m_nTooltipLocation)
+                {
+                    m_nTooltipLocation = nTooltipLocation;
+                    m_sTooltip.clear();
+
+                    if (IsWindowVisible(m_hTooltip))
+                    {
+                        // tooltip is visible, just hide it
+                        SendMessage(m_hTooltip, TTM_POP, 0, 0);
+                    }
+                    else
+                    {
+                        // tooltip is not visible. if we told the tooltip to not display in the TTM_GETDISPINFO handler by
+                        // setting lpszText to empty string, it won't try to display again unless we tell it to, so do so now
+                        SendMessage(m_hTooltip, TTM_POPUP, 0, 0);
+
+                        // but we don't want the tooltip to immediately display when entering a new cell, so immediately
+                        // hide it. the normal hover behavior will make it display as expected after a normal hover wait time.
+                        SendMessage(m_hTooltip, TTM_POP, 0, 0);
+                    }
                 }
             }
             break;

--- a/src/ui/win32/bindings/GridBinding.hh
+++ b/src/ui/win32/bindings/GridBinding.hh
@@ -111,6 +111,7 @@ private:
     bool m_bShowGridLines = false;
     bool m_bHasScrollbar = false;
     bool m_bForceRepaint = false;
+    bool m_bForceRepaintItems = false;
     bool m_bUpdateSelectedItemStates = false;
     int m_nAdjustingScrollOffset = 0;
 

--- a/src/ui/win32/bindings/GridBinding.hh
+++ b/src/ui/win32/bindings/GridBinding.hh
@@ -80,7 +80,6 @@ protected:
     void CheckForScrollBar();
     int GetVisibleItemIndex(int iItem);
     gsl::index GetRealItemIndex(gsl::index iItem) const;
-    virtual void Invalidate() noexcept(false);
 
     INT_PTR CALLBACK WndProc(HWND hControl, UINT uMsg, WPARAM wParam, LPARAM lParam) override;
 

--- a/src/ui/win32/bindings/GridBinding.hh
+++ b/src/ui/win32/bindings/GridBinding.hh
@@ -112,6 +112,7 @@ private:
     bool m_bShowGridLines = false;
     bool m_bHasScrollbar = false;
     bool m_bForceRepaint = false;
+    bool m_bUpdateSelectedItemStates = false;
     int m_nAdjustingScrollOffset = 0;
 
     size_t m_nColumnsCreated = 0;


### PR DESCRIPTION
Prevents overhead refreshing grids when nothing changes. The BeginUpdate/EndUpdate cycle is used when synchronizing hit counts from the achievement runtime to the UI. If the hit counts don't change, then the UI doesn't need to be updated, but because the WM_SETREDRAW message was being called in BeginUpdate/EndUpdate, it was forcing a repaint even when nothing changed.

The WM_SETREDRAW handling was originally added to prevent refreshing for each item being updated in the grid, but I believe that issue has been better handled by #652, where repaints are queued while processing a frame, then executed at the end of the frame.