### PR TITLE
update achievement count/total points when filters change

### DIFF
--- a/src/ui/viewmodels/AssetListViewModel.cpp
+++ b/src/ui/viewmodels/AssetListViewModel.cpp
@@ -261,7 +261,7 @@ void AssetListViewModel::UpdateTotals()
     for (gsl::index nIndex = 0; nIndex < gsl::narrow_cast<gsl::index>(m_vFilteredAssets.Count()); ++nIndex)
     {
         auto* pAsset = m_vFilteredAssets.GetItemAt(nIndex);
-        if (pAsset->GetType() == ra::data::models::AssetType::Achievement)
+        if (pAsset && pAsset->GetType() == ra::data::models::AssetType::Achievement)
         {
             ++nAchievementCount;
             nTotalPoints += pAsset->GetPoints();

--- a/src/ui/viewmodels/AssetListViewModel.hh
+++ b/src/ui/viewmodels/AssetListViewModel.hh
@@ -282,7 +282,8 @@ private:
     std::atomic_bool m_bNeedToUpdateButtons = false;
 
     bool MatchesFilter(const ra::data::models::AssetModelBase& pAsset);
-    void AddOrRemoveFilteredItem(const ra::data::models::AssetModelBase& pAsset);
+    void AddOrRemoveFilteredItem(gsl::index nAssetIndex);
+    bool AddOrRemoveFilteredItem(const ra::data::models::AssetModelBase& pAsset);
     gsl::index GetFilteredAssetIndex(const ra::data::models::AssetModelBase& pAsset) const;
     void ApplyFilter();
 

--- a/tests/ui/viewmodels/AssetListViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/AssetListViewModel_Tests.cpp
@@ -792,6 +792,29 @@ public:
         Assert::AreEqual(1, vmAssetList.FilteredAssets().GetItemAt(2)->GetId()); // item changed to match filter appears at end of list
     }
 
+    TEST_METHOD(TestChangeFilter)
+    {
+        AssetListViewModelHarness vmAssetList;
+        vmAssetList.SetFilterCategory(AssetListViewModel::FilterCategory::Core);
+
+        vmAssetList.AddAchievement(AssetCategory::Core, 5, L"Ach1");
+        vmAssetList.AddAchievement(AssetCategory::Unofficial, 10, L"Ach2");
+        vmAssetList.AddAchievement(AssetCategory::Core, 15, L"Ach3");
+
+        Assert::AreEqual({ 3U }, vmAssetList.mockGameContext.Assets().Count());
+        Assert::AreEqual({ 2U }, vmAssetList.FilteredAssets().Count());
+        Assert::AreEqual(20, vmAssetList.GetTotalPoints());
+        Assert::AreEqual(1, vmAssetList.FilteredAssets().GetItemAt(0)->GetId());
+        Assert::AreEqual(3, vmAssetList.FilteredAssets().GetItemAt(1)->GetId());
+
+        vmAssetList.SetFilterCategory(AssetListViewModel::FilterCategory::Unofficial);
+
+        Assert::AreEqual({ 3U }, vmAssetList.mockGameContext.Assets().Count());
+        Assert::AreEqual({ 1U }, vmAssetList.FilteredAssets().Count());
+        Assert::AreEqual(10, vmAssetList.GetTotalPoints());
+        Assert::AreEqual(2, vmAssetList.FilteredAssets().GetItemAt(0)->GetId());
+    }
+
     TEST_METHOD(TestSpecialFilterActive)
     {
         AssetListViewModelHarness vmAssetList;
@@ -927,6 +950,7 @@ public:
         Assert::AreEqual(std::wstring(L"Title"), pItem->GetLabel());
         Assert::AreEqual(5, pItem->GetPoints());
         Assert::AreEqual(AssetState::Inactive, pItem->GetState());
+        Assert::AreEqual(5, vmAssetList.GetTotalPoints());
 
         vmAchievement.SetName(L"New Title");
         Assert::AreEqual(std::wstring(L"New Title"), pItem->GetLabel());
@@ -934,6 +958,7 @@ public:
 
         vmAchievement.SetPoints(10);
         Assert::AreEqual(10, pItem->GetPoints());
+        Assert::AreEqual(10, vmAssetList.GetTotalPoints());
 
         vmAchievement.SetState(AssetState::Active);
         Assert::AreEqual(AssetState::Active, pItem->GetState());


### PR DESCRIPTION
The achievement count/total points fields were modified to only report the number of core achievements and their points, as the filters (like Active/Modified/etc) would change the visibility of achievements in the list. This has the unwanted side effect of only showing Core totals when viewing Local achievements. This is not very useful when developing a set before publishing it.

I've updated the behavior to tally the totals for whatever is visible. If the user wants to get back to the full Core tallies, they can select Core/All as their filters.