### PR TITLE
don't invalidate memory addresses before memory is registered

### DIFF
--- a/src/data/context/EmulatorContext.cpp
+++ b/src/data/context/EmulatorContext.cpp
@@ -629,7 +629,9 @@ uint8_t EmulatorContext::ReadMemoryByte(ra::ByteAddress nAddress) const
         nAddress -= gsl::narrow_cast<ra::ByteAddress>(pBlock.size);
     }
 
-    ra::services::ServiceLocator::GetMutable<ra::services::AchievementRuntime>().InvalidateAddress(nOriginalAddress);
+    if (nOriginalAddress < m_nTotalMemorySize)
+        ra::services::ServiceLocator::GetMutable<ra::services::AchievementRuntime>().InvalidateAddress(nOriginalAddress);
+
     return 0;
 }
 

--- a/src/ui/viewmodels/MemoryViewerViewModel.hh
+++ b/src/ui/viewmodels/MemoryViewerViewModel.hh
@@ -95,12 +95,19 @@ public:
     void SetAddress(ByteAddress value)
     {
         int nSignedValue = ra::to_signed(value);
-        if (nSignedValue < 0 || m_nTotalMemorySize == 0)
-            nSignedValue = 0;
-        else if (nSignedValue >= gsl::narrow_cast<int>(m_nTotalMemorySize))
-            nSignedValue = gsl::narrow_cast<int>(m_nTotalMemorySize) - 1;
+        if (m_nTotalMemorySize > 0)
+        {
+            if (nSignedValue < 0)
+                nSignedValue = 0;
+            else if (nSignedValue >= gsl::narrow_cast<int>(m_nTotalMemorySize))
+                nSignedValue = gsl::narrow_cast<int>(m_nTotalMemorySize) - 1;
 
-        SetValue(AddressProperty, nSignedValue);
+            SetValue(AddressProperty, nSignedValue);
+        }
+        else
+        {
+            SetValue(PendingAddressProperty, gsl::narrow_cast<int>(value));
+        }
     }
 
     /// <summary>
@@ -201,6 +208,8 @@ protected:
     static constexpr int MaxLines = 128;
 
 private:
+    static const IntModelProperty PendingAddressProperty;
+
     void BuildFontSurface();
     void RenderAddresses();
     void RenderHeader();

--- a/tests/mocks/MockAchievementRuntime.hh
+++ b/tests/mocks/MockAchievementRuntime.hh
@@ -16,6 +16,21 @@ public:
     {
     }
 
+    bool IsAchievementSupported(ra::AchievementID nAchievement) noexcept
+    {
+        for (unsigned i = 0; i < m_pRuntime.trigger_count; ++i)
+        {
+            if (m_pRuntime.triggers[i].id == nAchievement)
+            {
+                const auto* pTrigger = m_pRuntime.triggers[i].trigger;
+                if (pTrigger)
+                    return pTrigger->state != RC_TRIGGER_STATE_DISABLED && !m_pRuntime.triggers[i].invalid_memref;
+            }
+        }
+
+        return false;
+    }
+
 private:
     ra::services::ServiceLocator::ServiceOverride<ra::services::AchievementRuntime> m_Override;
 };


### PR DESCRIPTION
prevents marking the entire set as unsupported if code notes are downloaded before the client registers memory regions