### PR TITLE
ignore BOM when loading RP from file

### DIFF
--- a/src/data/context/GameContext.cpp
+++ b/src/data/context/GameContext.cpp
@@ -797,6 +797,10 @@ void GameContext::ReloadRichPresenceScript()
             sRichPresence.append(sLine);
             sRichPresence.append("\n");
         }
+
+        // remove UTF-8 BOM if present
+        if (ra::StringStartsWith(sRichPresence, "\xef\xbb\xbf"))
+            sRichPresence.erase(0, 3);
     }
 
     const auto sFileRichPresenceMD5 = RAGenerateMD5(sRichPresence);


### PR DESCRIPTION
A file explicitly saved in UTF-8 format will normally have a BOM which indicates the file is UTF-8 formatted. Since the DLL reads the file in binary mode, it has to be responsible for detecting (and ignoring) the BOM. If the BOM is passed to rcheevos, it can confuse the parser.