### PR TITLE
don't show negative values when prefer decimal is selected

### DIFF
--- a/src/ui/win32/AssetEditorDialog.cpp
+++ b/src/ui/win32/AssetEditorDialog.cpp
@@ -134,7 +134,7 @@ public:
 
         const auto& pConfiguration = ra::services::ServiceLocator::Get<ra::services::IConfiguration>();
         if (pConfiguration.IsFeatureEnabled(ra::services::Feature::PreferDecimal))
-            return std::to_wstring((unsigned)nValue);
+            return std::to_wstring(static_cast<unsigned>(nValue));
 
         return ra::StringPrintf(L"0x%02x", nValue);
     }

--- a/src/ui/win32/AssetEditorDialog.cpp
+++ b/src/ui/win32/AssetEditorDialog.cpp
@@ -134,7 +134,7 @@ public:
 
         const auto& pConfiguration = ra::services::ServiceLocator::Get<ra::services::IConfiguration>();
         if (pConfiguration.IsFeatureEnabled(ra::services::Feature::PreferDecimal))
-            return std::to_wstring(nValue);
+            return std::to_wstring((unsigned)nValue);
 
         return ra::StringPrintf(L"0x%02x", nValue);
     }

--- a/src/ui/win32/AssetEditorDialog.cpp
+++ b/src/ui/win32/AssetEditorDialog.cpp
@@ -134,7 +134,7 @@ public:
 
         const auto& pConfiguration = ra::services::ServiceLocator::Get<ra::services::IConfiguration>();
         if (pConfiguration.IsFeatureEnabled(ra::services::Feature::PreferDecimal))
-            return std::to_wstring(static_cast<unsigned>(nValue));
+            return std::to_wstring(gsl::narrow_cast<unsigned>(nValue));
 
         return ra::StringPrintf(L"0x%02x", nValue);
     }

--- a/src/ui/win32/AssetEditorDialog.cpp
+++ b/src/ui/win32/AssetEditorDialog.cpp
@@ -134,7 +134,7 @@ public:
 
         const auto& pConfiguration = ra::services::ServiceLocator::Get<ra::services::IConfiguration>();
         if (pConfiguration.IsFeatureEnabled(ra::services::Feature::PreferDecimal))
-            return std::to_wstring(gsl::narrow_cast<unsigned>(nValue));
+            return std::to_wstring(ra::to_unsigned(nValue));
 
         return ra::StringPrintf(L"0x%02x", nValue);
     }


### PR DESCRIPTION
Large values (like 0xFFFFFFFF) were previously shown as unsigned integers (4294967295) when Prefer Decimal was selected. This restores that behavior.