### PR TITLE
prevent exception removing all conditions from active trigger

### DIFF
--- a/src/ui/viewmodels/AssetEditorViewModel.cpp
+++ b/src/ui/viewmodels/AssetEditorViewModel.cpp
@@ -268,13 +268,13 @@ void AssetEditorViewModel::OnValueChanged(const StringModelProperty::ChangeArgs&
 
 void AssetEditorViewModel::OnValueChanged(const IntModelProperty::ChangeArgs& args)
 {
-    if (args.Property == StateProperty)
+    if (m_pAsset != nullptr)
     {
-        const auto nOldState = ra::itoe<ra::data::models::AssetState>(args.tOldValue);
-        const auto nNewState = ra::itoe<ra::data::models::AssetState>(args.tNewValue);
-
-        if (m_pAsset != nullptr)
+        if (args.Property == StateProperty)
         {
+            const auto nOldState = ra::itoe<ra::data::models::AssetState>(args.tOldValue);
+            const auto nNewState = ra::itoe<ra::data::models::AssetState>(args.tNewValue);
+
             // make sure to update the hit counts in the frame where the achievement triggers
             // before it's deactivated, which might remove it from the runtime
             if (nNewState == ra::data::models::AssetState::Triggered)
@@ -289,19 +289,15 @@ void AssetEditorViewModel::OnValueChanged(const IntModelProperty::ChangeArgs& ar
                 if (!ra::data::models::AssetModelBase::IsActive(nOldState))
                     UpdateTriggerBinding();
             }
+
+            if (nNewState == ra::data::models::AssetState::Waiting)
+                SetValue(WaitingLabelProperty, L"Waiting");
+            else if (nOldState == ra::data::models::AssetState::Waiting)
+                SetValue(WaitingLabelProperty, WaitingLabelProperty.GetDefaultValue());
+
+            UpdateAssetFrameValues();
         }
-
-        if (nNewState == ra::data::models::AssetState::Waiting)
-            SetValue(WaitingLabelProperty, L"Waiting");
-        else if (nOldState == ra::data::models::AssetState::Waiting)
-            SetValue(WaitingLabelProperty, WaitingLabelProperty.GetDefaultValue());
-
-        UpdateAssetFrameValues();
-    }
-
-    if (m_pAsset != nullptr)
-    {
-        if (args.Property == CategoryProperty)
+        else if (args.Property == CategoryProperty)
         {
             m_pAsset->SetCategory(ra::itoe<ra::data::models::AssetCategory>(args.tNewValue));
         }

--- a/src/ui/viewmodels/TriggerViewModel.cpp
+++ b/src/ui/viewmodels/TriggerViewModel.cpp
@@ -113,17 +113,22 @@ void TriggerViewModel::GroupViewModel::UpdateSerialized(std::string& sSerialized
 
 const std::string& TriggerViewModel::GroupViewModel::GetSerialized() const
 {
-    if (m_sSerialized.empty() && m_pConditionSet)
+    if (m_sSerialized == TriggerViewModel::GroupViewModel::NOT_SERIALIZED)
     {
-        ViewModelCollection<TriggerConditionViewModel> vConditions;
-        rc_condition_t* pCondition = m_pConditionSet->conditions;
-        for (; pCondition != nullptr; pCondition = pCondition->next)
-        {
-            auto& vmCondition = vConditions.Add();
-            vmCondition.InitializeFrom(*pCondition);
-        }
+        m_sSerialized.clear();
 
-        UpdateSerialized(m_sSerialized, vConditions);
+        if (m_pConditionSet)
+        {
+            ViewModelCollection<TriggerConditionViewModel> vConditions;
+            rc_condition_t* pCondition = m_pConditionSet->conditions;
+            for (; pCondition != nullptr; pCondition = pCondition->next)
+            {
+                auto& vmCondition = vConditions.Add();
+                vmCondition.InitializeFrom(*pCondition);
+            }
+
+            UpdateSerialized(m_sSerialized, vConditions);
+        }
     }
 
     return m_sSerialized;

--- a/src/ui/viewmodels/TriggerViewModel.hh
+++ b/src/ui/viewmodels/TriggerViewModel.hh
@@ -42,7 +42,7 @@ public:
 
         bool UpdateSerialized(const ViewModelCollection<TriggerConditionViewModel>& vConditions);
         const std::string& GetSerialized() const;
-        void ResetSerialized() noexcept { m_sSerialized = NOT_SERIALIZED; }
+        void ResetSerialized() { m_sSerialized = NOT_SERIALIZED; }
 
         static const IntModelProperty ColorProperty;
         Color GetColor() const { return Color(ra::to_unsigned(GetValue(ColorProperty))); }

--- a/src/ui/viewmodels/TriggerViewModel.hh
+++ b/src/ui/viewmodels/TriggerViewModel.hh
@@ -42,7 +42,7 @@ public:
 
         bool UpdateSerialized(const ViewModelCollection<TriggerConditionViewModel>& vConditions);
         const std::string& GetSerialized() const;
-        void ResetSerialized() noexcept { m_sSerialized.clear(); }
+        void ResetSerialized() noexcept { m_sSerialized = NOT_SERIALIZED; }
 
         static const IntModelProperty ColorProperty;
         Color GetColor() const { return Color(ra::to_unsigned(GetValue(ColorProperty))); }
@@ -50,7 +50,8 @@ public:
 
     private:
         static void UpdateSerialized(std::string& sSerialized, const ViewModelCollection<TriggerConditionViewModel>& vConditions);
-        mutable std::string m_sSerialized;
+        mutable std::string m_sSerialized = NOT_SERIALIZED;
+        static constexpr const char* NOT_SERIALIZED = "?";
     };
 
     ViewModelCollection<GroupViewModel>& Groups() noexcept { return m_vGroups; }


### PR DESCRIPTION
A group that had not previously been serialized had an empty serialization string. When removing all conditions from a group, the serialized string becomes empty, so no change is detected and the trigger is not reparsed. This creates a disconnect between the UI and the runtime, and the next time the frame is evaluated, attempting to update the no-longer-existing UI causes an exception.

This changes the default value for a non-serialized group to be non-empty, so the change to empty can be detected and handled appropriately.