### PR TITLE
report line number on rich presence parse failure

### DIFF
--- a/src/services/AchievementRuntime.cpp
+++ b/src/services/AchievementRuntime.cpp
@@ -178,6 +178,8 @@ void AchievementRuntime::ActivateRichPresence(const std::string& sScript)
     else
     {
         m_nRichPresenceParseResult = rc_runtime_activate_richpresence(&m_pRuntime, sScript.c_str(), nullptr, 0);
+        if (m_nRichPresenceParseResult != RC_OK)
+            m_nRichPresenceParseResult = rc_richpresence_size_lines(sScript.c_str(), &m_nRichPresenceErrorLine);
     }
 }
 
@@ -188,7 +190,10 @@ std::wstring AchievementRuntime::GetRichPresenceDisplayString() const
         std::lock_guard<std::mutex> pLock(m_pMutex);
 
         if (m_nRichPresenceParseResult != RC_OK)
-            return ra::StringPrintf(L"Parse error %d: %s\n", m_nRichPresenceParseResult, rc_error_str(m_nRichPresenceParseResult));
+        {
+            return ra::StringPrintf(L"Parse error %d (line %d): %s", m_nRichPresenceParseResult,
+                m_nRichPresenceErrorLine, rc_error_str(m_nRichPresenceParseResult));
+        }
 
         char sRichPresence[256];
         if (rc_runtime_get_richpresence(&m_pRuntime, sRichPresence, sizeof(sRichPresence), rc_peek_callback, nullptr, nullptr) > 0)

--- a/src/services/AchievementRuntime.hh
+++ b/src/services/AchievementRuntime.hh
@@ -222,6 +222,7 @@ private:
 
     std::map<unsigned int, std::string> m_vQueuedAchievements;
     int m_nRichPresenceParseResult = RC_OK;
+    int m_nRichPresenceErrorLine = 0;
     bool m_bInitialized = false;
 };
 

--- a/tests/services/AchievementRuntime_Tests.cpp
+++ b/tests/services/AchievementRuntime_Tests.cpp
@@ -882,7 +882,7 @@ public:
         AchievementRuntimeHarness runtime;
         runtime.mockEmulatorContext.MockMemory(memory);
 
-        auto* pRichPresence = "Format:Num\nFormatType:Value\n\nDisplay:\n@Num(0xH01) @Num(d0xH01)\n";
+        const char* pRichPresence = "Format:Num\nFormatType:Value\n\nDisplay:\n@Num(0xH01) @Num(d0xH01)\n";
         runtime.ActivateRichPresence(pRichPresence);
 
         // string is evaluated with current memrefs (which will be 0)
@@ -927,6 +927,20 @@ public:
 
         runtime.ActivateRichPresence("");
         Assert::AreEqual(std::wstring(L"No Rich Presence defined."), runtime.GetRichPresenceDisplayString());
+    }
+
+    TEST_METHOD(TestActivateRichPresenceWithError)
+    {
+        std::array<unsigned char, 5> memory{ 0x00, 0x12, 0x34, 0xAB, 0x56 };
+        std::vector<ra::services::AchievementRuntime::Change> changes;
+
+        AchievementRuntimeHarness runtime;
+        runtime.mockEmulatorContext.MockMemory(memory);
+
+        const char* pRichPresence = "Format:Num\nFormatType:Value\n\nDisplay:\n@Num(0H01) @Num(d0xH01)\n";
+        runtime.ActivateRichPresence(pRichPresence);
+
+        Assert::AreEqual(std::wstring(L"Parse error -6 (line 5): Invalid operator"), runtime.GetRichPresenceDisplayString());
     }
 };
 


### PR DESCRIPTION
leverages new rcheevos functionality to capture line where parse error occurred.

![image](https://user-images.githubusercontent.com/32680403/116703934-0fc2c080-a988-11eb-9283-5497fd6482ad.png)
