### PR TITLE
don't throw validation error on lost focus for local badge

### DIFF
--- a/src/ui/win32/AssetEditorDialog.cpp
+++ b/src/ui/win32/AssetEditorDialog.cpp
@@ -332,6 +332,10 @@ void AssetEditorDialog::BadgeNameBinding::UpdateSourceFromText(const std::wstrin
     std::wstring sError;
     if (!sValue.empty())
     {
+        // ignore virtual tag that's hiding a more complex path
+        if (sValue == L"[local]")
+            return;
+
         // special case - don't validate if the string is entirely made of 0s.
         // the default value is "00000", which is less than the minimum.
         const wchar_t* pChar = &sValue.at(0);


### PR DESCRIPTION
Prevents the "Only values that can be represented as decimal are allowed" error when the Badge field loses focus and a local badge is selected.