### PR TITLE
assume values are hex unless 'Show Decimal' is checked

### DIFF
--- a/src/ui/win32/AssetEditorDialog.cpp
+++ b/src/ui/win32/AssetEditorDialog.cpp
@@ -141,7 +141,9 @@ public:
 
     bool SetText(ra::ui::ViewModelCollectionBase& vmItems, gsl::index nIndex, const std::wstring& sValue) override
     {
-        if (ra::StringStartsWith(sValue, L"0x") || IsAddressType(vmItems, nIndex))
+        const auto& pConfiguration = ra::services::ServiceLocator::Get<ra::services::IConfiguration>();
+        if (!pConfiguration.IsFeatureEnabled(ra::services::Feature::PreferDecimal) ||
+            ra::StringStartsWith(sValue, L"0x") || IsAddressType(vmItems, nIndex))
         {
             std::wstring sError;
             unsigned int nValue = 0U;


### PR DESCRIPTION
When 1000 is entered as a value and 'Show Decimal' is not checked, the result will be 0x1000 instead of 0x3e8. This is consistent with previous versions.