### PR TITLE
use non-secure URL if TLS1.2 not enabled on Windows7/Vista/XP

### DIFF
--- a/src/api/impl/ConnectedServer.cpp
+++ b/src/api/impl/ConnectedServer.cpp
@@ -25,6 +25,12 @@ namespace ra {
 namespace api {
 namespace impl {
 
+ConnectedServer::ConnectedServer(const std::string& sHost)
+    : m_sHost(sHost)
+{
+    rc_api_set_host(sHost.c_str());
+}
+
 _NODISCARD static bool HandleHttpError(_In_ const ra::services::Http::StatusCode nStatusCode,
                                        _Inout_ ApiResponseBase& pResponse)
 {

--- a/src/api/impl/ConnectedServer.hh
+++ b/src/api/impl/ConnectedServer.hh
@@ -11,7 +11,7 @@ namespace impl {
 class ConnectedServer : public ServerBase
 {
 public:
-    explicit ConnectedServer(const std::string& sHost) : m_sHost(sHost) {}
+    explicit ConnectedServer(const std::string& sHost);
 
     const char* Name() const noexcept override { return m_sHost.c_str(); }
 

--- a/src/services/impl/JsonFileConfiguration.cpp
+++ b/src/services/impl/JsonFileConfiguration.cpp
@@ -8,6 +8,12 @@
 #include "services\IFileSystem.hh"
 #include "services\ServiceLocator.hh"
 
+#ifndef RA_UTEST
+#include "services\impl\StringTextWriter.hh"
+#include "services\impl\WindowsHttpRequester.hh"
+#include "ui\win32\Desktop.hh"
+#endif
+
 namespace ra {
 namespace services {
 namespace impl {
@@ -337,6 +343,42 @@ void JsonFileConfiguration::UpdateHost()
         m_sHostName = "retroachievements.org";
         m_sHostUrl = "https://retroachievements.org";
         m_sImageHostUrl = "http://i.retroachievements.org";
+
+#ifndef RA_UTEST
+        const auto sOSVersion = ra::ui::win32::Desktop::GetWindowsVersionString();
+        if (ra::StringStartsWith(sOSVersion, "WindowsNT "))
+        {
+            // Windows 7 (and Vista and XP) only support TLS 1.0 by default. Windows 8+ support TLS 1.2.
+            // https://social.msdn.microsoft.com/Forums/windowsdesktop/en-US/b27a9ddd-d8f7-408c-8029-cf5f8f9ddbef/winhttp-winhttpcallbackstatusflagsecuritychannelerror-on-win7?forum=vcgeneral
+            // The server requires at least TLS 1.2 due to security issues in TLS 1.0 and 1.1.
+
+            // If this is a one of the vulnerable operating systems, try to make a secure request.
+            // https://docs.microsoft.com/en-us/windows/win32/sysinfo/operating-system-version
+            // https://docs.microsoft.com/en-us/windows/win32/secauthn/protocols-in-tls-ssl--schannel-ssp-
+            const auto nVersion = std::atof(&sOSVersion.at(9));
+            if (nVersion < 6.2) // Windows 8
+            {
+                // Try to make a secure request, and if it fails with ERROR_WINHTTP_SECURE_FAILURE,
+                // switch to a non-secure host
+                ra::services::Http::Request request(m_sHostUrl + "/dorequest.php?r=latestclient&e=0");
+                std::string sResponse;
+                ra::services::impl::StringTextWriter pWriter(sResponse);
+
+                ra::services::impl::WindowsHttpRequester httpRequester;
+                const auto nStatusCode = httpRequester.Request(request, pWriter);
+
+                if (nStatusCode == 12175) // ERROR_WINHTTP_SECURE_FAILURE
+                {
+                    ::MessageBoxA(NULL,
+                        "An error occurred trying to communicate with the server via secure protocols. Switching to non-secure protocols.\n\n"
+                        "retroachievements.org requires TLS 1.2 or higher. You may need to manually enable it on this operating system. Note that non-secure protocols are deprecated and will no longer be allowed at some point in the future.",
+                        "Security Error", MB_OK);
+                    m_sHostUrl = "http://retroachievements.org";
+                }
+            }
+        }
+#endif
+
     }
     else
     {

--- a/src/services/impl/JsonFileConfiguration.cpp
+++ b/src/services/impl/JsonFileConfiguration.cpp
@@ -369,7 +369,7 @@ void JsonFileConfiguration::UpdateHost()
 
                 if (nStatusCode == 12175) // ERROR_WINHTTP_SECURE_FAILURE
                 {
-                    ::MessageBoxA(NULL,
+                    ::MessageBoxA(nullptr,
                         "An error occurred trying to communicate with the server via secure protocols. Switching to non-secure protocols.\n\n"
                         "retroachievements.org requires TLS 1.2 or higher. You may need to manually enable it on this operating system. Note that non-secure protocols are deprecated and will no longer be allowed at some point in the future.",
                         "Security Error", MB_OK);

--- a/src/ui/win32/Desktop.cpp
+++ b/src/ui/win32/Desktop.cpp
@@ -172,7 +172,7 @@ std::string Desktop::GetRunningExecutable() const
     return std::string(buffer);
 }
 
-std::string Desktop::GetOSVersionString() const
+std::string Desktop::GetWindowsVersionString()
 {
     // https://msdn.microsoft.com/en-us/library/windows/desktop/ms724832(v=vs.85).aspx
     // https://msdn.microsoft.com/en-us/library/windows/desktop/ms724429(v=vs.85).aspx
@@ -199,7 +199,6 @@ std::string Desktop::GetOSVersionString() const
 
     return "Windows";
 }
-
 
 void Desktop::OpenUrl(const std::string& sUrl) const
 {

--- a/src/ui/win32/Desktop.hh
+++ b/src/ui/win32/Desktop.hh
@@ -29,7 +29,8 @@ public:
     HWND GetMainHWnd() const noexcept;
     void SetMainHWnd(HWND hWnd);
     std::string GetRunningExecutable() const override;
-    std::string GetOSVersionString() const override;
+    std::string GetOSVersionString() const override { return GetWindowsVersionString(); }
+    static std::string GetWindowsVersionString();
 
     std::unique_ptr<ra::ui::drawing::ISurface> CaptureClientArea(const WindowViewModelBase& vmViewModel) const override;
 


### PR DESCRIPTION
#667 switched the default host from http://retroachievements.org to https://retroachievements.org. The server is configured to require TLS 1.2 for HTTPS traffic, but that's not available by default for older Windows operating systems. As a result, attempting to use the new DLL on those operating systems resulted in a 12175 (security) error. 

Rather than enable the older (vulnerable) TLS flavors on the server, we've opted to switch back to http://retroachievements.org if a call to https://retroachievements.org fails with a 12175 error. However, this is not a long term solution as we want to move the traffic to https. The compromise is to show a nag dialog each time the user logs in reminding them to install/enable TLS 1.2.

![image](https://user-images.githubusercontent.com/32680403/116831609-b3b99100-ab6d-11eb-9572-e7ec5f95129f.png)

Instructions (untested) for each OS:
* [Windows 7](https://support.microsoft.com/en-us/topic/update-to-enable-tls-1-1-and-tls-1-2-as-default-secure-protocols-in-winhttp-in-windows-c4bd73d2-31d7-761e-0178-11268bb10392)
* [Windows Vista](https://johnhaller.com/useful-stuff/enable-tls-1.1-and-1.2-on-windows-vista)
* [Windows XP](https://www.smartftp.com/en-us/support/kb/2754)