### PR TITLE
allow pressing enter to open first asset in list

### DIFF
--- a/src/ui/win32/bindings/GridBinding.cpp
+++ b/src/ui/win32/bindings/GridBinding.cpp
@@ -1281,7 +1281,7 @@ void GridBinding::OnLvnKeyDown(const LPNMLVKEYDOWN pnmKeyDown)
             if (bAltHeld || bShiftHeld)
                 return;
 
-            const int nFirstSelectedItem = ListView_GetNextItem(m_hWnd, 0, LVNI_SELECTED);
+            const int nFirstSelectedItem = ListView_GetNextItem(m_hWnd, -1, LVNI_SELECTED);
             if (nFirstSelectedItem != -1)
                 m_pDoubleClickHandler(gsl::narrow_cast<gsl::index>(nFirstSelectedItem));
         }


### PR DESCRIPTION
The parameter to ListView_GetNextItem is the index of the previous match, by passing 0, it's assumed that the 0th item has already been checked.