### PR TITLE
disable Reset button when only new items are selected

### DIFF
--- a/src/data/ModelCollectionBase.cpp
+++ b/src/data/ModelCollectionBase.cpp
@@ -328,11 +328,21 @@ void ModelCollectionBase::NotifyModelValueChanged(gsl::index nIndex, const BoolM
     if (nIndex < 0)
         return;
 
-    // Updating property values after inserting or removing items while updates are suspended causes synchronization
-    // errors in the GridBinding. This exception serves as a reminder until the problem can be resolved.
-    Expects(nIndex == m_vItems.at(gsl::narrow_cast<size_t>(nIndex))->m_nCollectionIndex);
-
-    OnModelValueChanged(nIndex, args);
+    const auto nCollectionIndex = m_vItems.at(gsl::narrow_cast<size_t>(nIndex))->m_nCollectionIndex;
+    if (IsUpdating())
+    {
+        // if updates are suspended, only raise events for items that haven't moved. OnItemsChanged events
+        // will be raised for moved items when the update suspension is resumed.
+        if (nIndex == nCollectionIndex)
+            OnModelValueChanged(nIndex, args);
+    }
+    else
+    {
+        // raising property changed events for the wrong index causes synchronization errors for the GridBinding.
+        // that should only happen when updates are suspended, so generate an error if we see it here.
+        Expects(nIndex == nCollectionIndex);
+        OnModelValueChanged(nIndex, args);
+    }
 }
 
 void ModelCollectionBase::NotifyModelValueChanged(gsl::index nIndex, const StringModelProperty::ChangeArgs& args)
@@ -341,11 +351,21 @@ void ModelCollectionBase::NotifyModelValueChanged(gsl::index nIndex, const Strin
     if (nIndex < 0)
         return;
 
-    // Updating property values after inserting or removing items while updates are suspended causes synchronization
-    // errors in the GridBinding. This exception serves as a reminder until the problem can be resolved.
-    Expects(nIndex == m_vItems.at(gsl::narrow_cast<size_t>(nIndex))->m_nCollectionIndex);
-
-    OnModelValueChanged(nIndex, args);
+    const auto nCollectionIndex = m_vItems.at(gsl::narrow_cast<size_t>(nIndex))->m_nCollectionIndex;
+    if (IsUpdating())
+    {
+        // if updates are suspended, only raise events for items that haven't moved. OnItemsChanged events
+        // will be raised for moved items when the update suspension is resumed.
+        if (nIndex == nCollectionIndex)
+            OnModelValueChanged(nIndex, args);
+    }
+    else
+    {
+        // raising property changed events for the wrong index causes synchronization errors for the GridBinding.
+        // that should only happen when updates are suspended, so generate an error if we see it here.
+        Expects(nIndex == nCollectionIndex);
+        OnModelValueChanged(nIndex, args);
+    }
 }
 
 void ModelCollectionBase::NotifyModelValueChanged(gsl::index nIndex, const IntModelProperty::ChangeArgs& args)
@@ -354,11 +374,21 @@ void ModelCollectionBase::NotifyModelValueChanged(gsl::index nIndex, const IntMo
     if (nIndex < 0)
         return;
 
-    // Updating property values after inserting or removing items while updates are suspended causes synchronization
-    // errors in the GridBinding. This exception serves as a reminder until the problem can be resolved.
-    Expects(nIndex == m_vItems.at(gsl::narrow_cast<size_t>(nIndex))->m_nCollectionIndex);
-
-    OnModelValueChanged(nIndex, args);
+    const auto nCollectionIndex = m_vItems.at(gsl::narrow_cast<size_t>(nIndex))->m_nCollectionIndex;
+    if (IsUpdating())
+    {
+        // if updates are suspended, only raise events for items that haven't moved. OnItemsChanged events
+        // will be raised for moved items when the update suspension is resumed.
+        if (nIndex == nCollectionIndex)
+            OnModelValueChanged(nIndex, args);
+    }
+    else
+    {
+        // raising property changed events for the wrong index causes synchronization errors for the GridBinding.
+        // that should only happen when updates are suspended, so generate an error if we see it here.
+        Expects(nIndex == nCollectionIndex);
+        OnModelValueChanged(nIndex, args);
+    }
 }
 
 } // namespace data

--- a/src/data/models/AssetModelBase.cpp
+++ b/src/data/models/AssetModelBase.cpp
@@ -549,6 +549,19 @@ bool AssetModelBase::IsActive(AssetState nState) noexcept
     }
 }
 
+const char* AssetModelBase::GetAssetTypeString(AssetType nType) noexcept
+{
+    switch (nType)
+    {
+        case AssetType::None: return "None";
+        case AssetType::Achievement: return "Achievement";
+        case AssetType::Leaderboard: return "Leaderboard";
+        case AssetType::LocalBadges: return "LocalBadges";
+        default: return "Unknown";
+    }
+}
+
+
 } // namespace models
 } // namespace data
 } // namespace ra

--- a/src/data/models/AssetModelBase.hh
+++ b/src/data/models/AssetModelBase.hh
@@ -266,8 +266,12 @@ public:
     /// <summary>
     /// Discards any changes made since the server checkpoint and repopulates the local checkpoint using Deserialize.
     /// </summary>
-    /// <param name="pTokenizer"></param>
     void ResetLocalCheckpoint(ra::Tokenizer& pTokenizer);
+
+    /// <summary>
+    /// Gets a human-readable string for the AssetType enum values.
+    /// </summary>
+    static const char* GetAssetTypeString(AssetType nType) noexcept;
 
 protected:
     /// <summary>

--- a/src/ui/viewmodels/AssetListViewModel.cpp
+++ b/src/ui/viewmodels/AssetListViewModel.cpp
@@ -542,6 +542,7 @@ void AssetListViewModel::DoUpdateButtons()
     bool bHasInactiveSelection = false;
     bool bHasModifiedSelection = false;
     bool bHasUnpublishedSelection = false;
+    bool bHasNonNewSelection = false;
     bool bHasSelection = false;
     bool bHasModified = false;
     bool bHasUnpublished = false;
@@ -605,14 +606,19 @@ void AssetListViewModel::DoUpdateButtons()
 
                     switch (pItem->GetChanges())
                     {
-                        case ra::data::models::AssetChanges::Modified:
                         case ra::data::models::AssetChanges::New:
                             bHasModifiedSelection = true;
                             break;
+                        case ra::data::models::AssetChanges::Modified:
+                            bHasNonNewSelection = true;
+                            bHasModifiedSelection = true;
+                            break;
                         case ra::data::models::AssetChanges::Unpublished:
+                            bHasNonNewSelection = true;
                             bHasUnpublishedSelection = true;
                             break;
                         default:
+                            bHasNonNewSelection = true;
                             break;
                     }
                 }
@@ -697,11 +703,15 @@ void AssetListViewModel::DoUpdateButtons()
     if (bGameLoaded)
     {
         if (bHasSelection)
+        {
             SetValue(ResetButtonTextProperty, L"&Reset");
+            SetValue(CanResetProperty, bHasNonNewSelection);
+        }
         else
+        {
             SetValue(ResetButtonTextProperty, ResetButtonTextProperty.GetDefaultValue());
-
-        SetValue(CanResetProperty, true);
+            SetValue(CanResetProperty, true);
+        }
     }
     else
     {
@@ -1097,7 +1107,7 @@ void AssetListViewModel::ResetSelected()
     }
     else
     {
-        // reset selection, remove any "new" items and get the AssetViewModel for the others
+        // reset selection, remove "new" items and get the AssetViewModel for the others
         for (auto* pItem : vSelectedAssets)
         {
             const auto nType = pItem->GetType();

--- a/src/ui/viewmodels/AssetListViewModel.cpp
+++ b/src/ui/viewmodels/AssetListViewModel.cpp
@@ -166,7 +166,9 @@ void AssetListViewModel::OnDataModelIntValueChanged(gsl::index nIndex, const Int
         const auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::context::GameContext>();
         const auto* pAsset = pGameContext.Assets().GetItemAt(nIndex);
         if (pAsset != nullptr)
+        {
             RA_LOG_INFO("%s %u category changed from %d to %d", ra::data::models::AssetModelBase::GetAssetTypeString(pAsset->GetType()), pAsset->GetID(), args.tOldValue, args.tNewValue);
+        }
 
         UpdateTotals();
 
@@ -1273,6 +1275,8 @@ void AssetListViewModel::CreateNew()
     if (!CanCreate())
         return;
 
+    RA_LOG_INFO("Creating new achievement");
+
     auto& pGameContext = ra::services::ServiceLocator::GetMutable<ra::data::context::GameContext>();
     const auto& pUserContext = ra::services::ServiceLocator::GetMutable<ra::data::context::UserContext>();
 
@@ -1341,6 +1345,8 @@ void AssetListViewModel::CloneSelected()
     FilteredAssets().BeginUpdate();
 
     SetFilterCategory(FilterCategory::Local);
+
+    RA_LOG_INFO("Cloning %u assets", vSelectedAssets.size());
 
     // add the cloned items
     std::vector<int> vNewIDs;

--- a/src/ui/viewmodels/AssetListViewModel.cpp
+++ b/src/ui/viewmodels/AssetListViewModel.cpp
@@ -163,6 +163,11 @@ void AssetListViewModel::OnDataModelIntValueChanged(gsl::index nIndex, const Int
     // these properties potentially affect visibility
     if (args.Property == ra::data::models::AssetModelBase::CategoryProperty)
     {
+        const auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::context::GameContext>();
+        const auto* pAsset = pGameContext.Assets().GetItemAt(nIndex);
+        if (pAsset != nullptr)
+            RA_LOG_INFO("%s %u category changed from %d to %d", ra::data::models::AssetModelBase::GetAssetTypeString(pAsset->GetType()), pAsset->GetID(), args.tOldValue, args.tNewValue);
+
         UpdateTotals();
 
         if (GetFilterCategory() != FilterCategory::All)
@@ -204,6 +209,9 @@ void AssetListViewModel::OnDataModelIntValueChanged(gsl::index nIndex, const Int
             gsl::index nFilteredIndex = -1;
             const auto nType = pAsset->GetType();
 
+            RA_LOG_INFO("%s %u ID changed from %d to %d", ra::data::models::AssetModelBase::GetAssetTypeString(pAsset->GetType()), pAsset->GetID(), args.tOldValue, args.tNewValue);
+
+            // have to find the filtered item using the old ID
             for (gsl::index nScanIndex = 0; nScanIndex < gsl::narrow_cast<gsl::index>(m_vFilteredAssets.Count()); ++nScanIndex)
             {
                 auto* pItem = m_vFilteredAssets.GetItemAt(nScanIndex);
@@ -870,6 +878,15 @@ void AssetListViewModel::SaveSelected()
             ra::ui::viewmodels::MessageBoxViewModel::ShowErrorMessage(L"Unable to save", sErrorMessage);
             return;
         }
+
+        if (vSelectedAssets.empty())
+        {
+            RA_LOG_INFO("Saving all assets", vSelectedAssets.size());
+        }
+        else
+        {
+            RA_LOG_INFO("Saving %u assets", vSelectedAssets.size());
+        }
     }
     else if (sSaveButtonText.at(0) == 'P' && sSaveButtonText.at(1) == 'u') // "Publi&sh" / "Publi&sh All"
     {
@@ -1094,6 +1111,8 @@ void AssetListViewModel::ResetSelected()
     std::vector<ra::data::models::AssetModelBase*> vAssetsToReset;
     if (vSelectedAssets.empty())
     {
+        RA_LOG_INFO("Resetting all assets");
+
         // reset all - first remove any "new" items
         for (gsl::index nIndex = gsl::narrow_cast<gsl::index>(pGameContext.Assets().Count()) - 1; nIndex >= 0; --nIndex)
         {
@@ -1128,7 +1147,18 @@ void AssetListViewModel::ResetSelected()
 
         // if there were any non-new items, reload them from disk
         if (!vAssetsToReset.empty())
+        {
+            std::string sMessage;
+            for (const auto* pAsset : vAssetsToReset)
+            {
+                if (!sMessage.empty())
+                    sMessage.push_back(',');
+                sMessage.append(std::to_string(pAsset->GetID()));
+            }
+            RA_LOG_INFO("Resetting %zu assets: %s", vAssetsToReset.size(), sMessage);
+
             pGameContext.Assets().ReloadAssets(vAssetsToReset);
+        }
     }
 
     pGameContext.Assets().EndUpdate();
@@ -1199,6 +1229,15 @@ void AssetListViewModel::RevertSelected()
 
     if (vmMessageBox.ShowModal() == DialogResult::No)
         return;
+
+    std::string sMessage;
+    for (const auto* pAsset : vAssetsToReset)
+    {
+        if (!sMessage.empty())
+            sMessage.push_back(',');
+        sMessage.append(std::to_string(pAsset->GetID()));
+    }
+    RA_LOG_INFO("Reverting %zu assets: %s", vAssetsToReset.size(), sMessage);
 
     auto& pGameContext = ra::services::ServiceLocator::GetMutable<ra::data::context::GameContext>();
     auto& pAssets = pGameContext.Assets();

--- a/tests/ui/viewmodels/AssetListViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/AssetListViewModel_Tests.cpp
@@ -92,8 +92,9 @@ private:
     enum class ResetButtonState
     {
         Reset,
+        ResetDisabled,
         ResetAll,
-        Disabled
+        ResetAllDisabled
     };
 
     enum class RevertButtonState
@@ -224,12 +225,17 @@ private:
                     Assert::IsTrue(CanReset());
                     break;
 
+                case ResetButtonState::ResetDisabled:
+                    Assert::AreEqual(std::wstring(L"&Reset"), GetValue(ResetButtonTextProperty));
+                    Assert::IsFalse(CanReset());
+                    break;
+
                 case ResetButtonState::ResetAll:
                     Assert::AreEqual(std::wstring(L"&Reset All"), GetValue(ResetButtonTextProperty));
                     Assert::IsTrue(CanReset());
                     break;
 
-                case ResetButtonState::Disabled:
+                case ResetButtonState::ResetAllDisabled:
                     Assert::AreEqual(std::wstring(L"&Reset All"), GetValue(ResetButtonTextProperty));
                     Assert::IsFalse(CanReset());
                     break;
@@ -1054,7 +1060,7 @@ public:
 
         vmAssetList.AssertButtonState(
             ActivateButtonState::Disabled, SaveButtonState::SaveAllDisabled,
-            ResetButtonState::Disabled, RevertButtonState::Disabled,
+            ResetButtonState::ResetAllDisabled, RevertButtonState::Disabled,
             CreateButtonState::Disabled, CloneButtonState::Disabled
         );
 
@@ -1065,7 +1071,7 @@ public:
 
         vmAssetList.AssertButtonState(
             ActivateButtonState::Disabled, SaveButtonState::SaveAllDisabled,
-            ResetButtonState::Disabled, RevertButtonState::Disabled,
+            ResetButtonState::ResetAllDisabled, RevertButtonState::Disabled,
             CreateButtonState::Disabled, CloneButtonState::Disabled
         );
     }
@@ -1416,7 +1422,7 @@ public:
 
         vmAssetList.AssertButtonState(
             ActivateButtonState::Activate, SaveButtonState::Save,
-            ResetButtonState::Reset, RevertButtonState::Delete,
+            ResetButtonState::ResetDisabled, RevertButtonState::Delete,
             CreateButtonState::Enabled, CloneButtonState::Enabled
         );
     }
@@ -2914,20 +2920,19 @@ public:
         Assert::AreEqual(AssetChanges::Unpublished, pAsset->GetChanges());
     }
 
-    TEST_METHOD(TestResetSelectedNew)
+    TEST_METHOD(TestResetSelectedSomeNew)
     {
         AssetListViewModelHarness vmAssetList;
         vmAssetList.MockGameId(22U);
-        vmAssetList.AddThreeAchievements();
+        vmAssetList.AddNewAchievement(5, L"Ach1", L"Test1", L"12345", "0xH1234=1");
+        vmAssetList.AddAchievement(AssetCategory::Local, 5, L"Test2", L"Desc2", L"12345", "0xH1234=1");
+        vmAssetList.SetFilterCategory(AssetListViewModel::FilterCategory::Local);
         vmAssetList.FilteredAssets().GetItemAt(0)->SetSelected(true);
+        vmAssetList.FilteredAssets().GetItemAt(1)->SetSelected(true);
+
+        // if new and non-new items are selected, allow the user to reset. new items will be discarded
         vmAssetList.ForceUpdateButtons();
         vmAssetList.AssertButtonState(ResetButtonState::Reset);
-
-        vmAssetList.MockUserFileContents("1:\"0xH1234=0\":Test:::::User:0:0:0:::00000\n");
-        auto* pAsset = vmAssetList.mockGameContext.Assets().FindAchievement({ 1U });
-        Assert::IsNotNull(pAsset);
-        Ensures(pAsset != nullptr);
-        pAsset->SetNew();
 
         bool bDialogShown = false;
         vmAssetList.mockDesktop.ExpectWindow<MessageBoxViewModel>([&bDialogShown](MessageBoxViewModel&)
@@ -2936,13 +2941,53 @@ public:
             return DialogResult::Yes;
         });
 
+        vmAssetList.MockUserFileContents("2:\"0xH2345=0\":Test2:::::User:0:0:0:::00000\n");
+
         vmAssetList.ResetSelected();
 
         Assert::IsTrue(bDialogShown);
 
         // item marked as new should be removed, and not restored from the file.
-        // NOTE: new items should not be in the file. this is mostly just testing the removal of new items.
+        // other item will be updated from file
         Assert::IsNull(vmAssetList.mockGameContext.Assets().FindAchievement({ 1U }));
+        const auto* pAch2 = vmAssetList.mockGameContext.Assets().FindAchievement({ 2U });
+        Assert::IsNotNull(pAch2);
+        Ensures(pAch2 != nullptr);
+        Assert::AreEqual(std::string("0xH2345=0"), pAch2->GetTrigger());
+    }
+
+    TEST_METHOD(TestResetSelectedAllSomeNew)
+    {
+        AssetListViewModelHarness vmAssetList;
+        vmAssetList.MockGameId(22U);
+        vmAssetList.AddNewAchievement(5, L"Ach1", L"Test1", L"12345", "0xH1234=1");
+        vmAssetList.AddAchievement(AssetCategory::Local, 5, L"Test2", L"Desc2", L"12345", "0xH1234=1");
+        vmAssetList.SetFilterCategory(AssetListViewModel::FilterCategory::Local);
+
+        // if new and non-new items are selected, allow the user to reset. new items will be discarded
+        vmAssetList.ForceUpdateButtons();
+        vmAssetList.AssertButtonState(ResetButtonState::ResetAll);
+
+        bool bDialogShown = false;
+        vmAssetList.mockDesktop.ExpectWindow<MessageBoxViewModel>([&bDialogShown](MessageBoxViewModel&)
+        {
+            bDialogShown = true;
+            return DialogResult::Yes;
+        });
+
+        vmAssetList.MockUserFileContents("2:\"0xH2345=0\":Test2:::::User:0:0:0:::00000\n");
+
+        vmAssetList.ResetSelected();
+
+        Assert::IsTrue(bDialogShown);
+
+        // item marked as new should be removed, and not restored from the file.
+        // other item will be updated from file
+        Assert::IsNull(vmAssetList.mockGameContext.Assets().FindAchievement({ 1U }));
+        const auto* pAch2 = vmAssetList.mockGameContext.Assets().FindAchievement({ 2U });
+        Assert::IsNotNull(pAch2);
+        Ensures(pAch2 != nullptr);
+        Assert::AreEqual(std::string("0xH2345=0"), pAch2->GetTrigger());
     }
 
     TEST_METHOD(TestResetSelectedAllNewFromFile)


### PR DESCRIPTION
Reset deletes items not found in the local file, so is no different than delete when only new items are selected. This disables the reset button when only new items are selected to minimize confusion. 

If no items are selected, all new items will be discarded, as the intent is to reset everything back to the file state.

If some new items and some non-new items are selected, the new items will be discarded and the non-new items will be reloaded from the disk.

