### PR TITLE
ensure clone.category is local at the server checkpoint level

### DIFF
--- a/src/ui/viewmodels/AssetListViewModel.cpp
+++ b/src/ui/viewmodels/AssetListViewModel.cpp
@@ -1396,9 +1396,11 @@ void AssetListViewModel::CloneSelected()
     std::vector<int> vNewIDs;
     for (const auto* pAsset : vSelectedAssets)
     {
-        const auto& pSourceAchievement = dynamic_cast<const ra::data::models::AchievementModel*>(pAsset);
         auto& vmAchievement = pGameContext.Assets().NewAchievement();
         vmAchievement.SetCategory(ra::data::models::AssetCategory::Local);
+        vmAchievement.UpdateServerCheckpoint();
+
+        const auto* pSourceAchievement = dynamic_cast<const ra::data::models::AchievementModel*>(pAsset);
         vmAchievement.SetName(pSourceAchievement->GetName() + L" (copy)");
         vmAchievement.SetDescription(pSourceAchievement->GetDescription());
         vmAchievement.SetBadge(pSourceAchievement->GetBadge());

--- a/src/ui/viewmodels/AssetListViewModel.cpp
+++ b/src/ui/viewmodels/AssetListViewModel.cpp
@@ -1396,19 +1396,22 @@ void AssetListViewModel::CloneSelected()
     std::vector<int> vNewIDs;
     for (const auto* pAsset : vSelectedAssets)
     {
-        auto& vmAchievement = pGameContext.Assets().NewAchievement();
-        vmAchievement.SetCategory(ra::data::models::AssetCategory::Local);
-        vmAchievement.UpdateServerCheckpoint();
-
         const auto* pSourceAchievement = dynamic_cast<const ra::data::models::AchievementModel*>(pAsset);
-        vmAchievement.SetName(pSourceAchievement->GetName() + L" (copy)");
-        vmAchievement.SetDescription(pSourceAchievement->GetDescription());
-        vmAchievement.SetBadge(pSourceAchievement->GetBadge());
-        vmAchievement.SetPoints(pSourceAchievement->GetPoints());
-        vmAchievement.SetTrigger(pSourceAchievement->GetTrigger());
-        vmAchievement.SetNew();
+        if (pSourceAchievement != nullptr)
+        {
+            auto& vmAchievement = pGameContext.Assets().NewAchievement();
+            vmAchievement.SetCategory(ra::data::models::AssetCategory::Local);
+            vmAchievement.UpdateServerCheckpoint();
 
-        vNewIDs.push_back(vmAchievement.GetID());
+            vmAchievement.SetName(pSourceAchievement->GetName() + L" (copy)");
+            vmAchievement.SetDescription(pSourceAchievement->GetDescription());
+            vmAchievement.SetBadge(pSourceAchievement->GetBadge());
+            vmAchievement.SetPoints(pSourceAchievement->GetPoints());
+            vmAchievement.SetTrigger(pSourceAchievement->GetTrigger());
+            vmAchievement.SetNew();
+
+            vNewIDs.push_back(vmAchievement.GetID());
+        }
     }
 
     // select the new items and deselect everything else


### PR DESCRIPTION
fixes an issue where resetting a cloned achievement changes its category to Core