### PR TITLE
update badge reference for item before its removed from the list

### DIFF
--- a/src/data/ModelCollectionBase.cpp
+++ b/src/data/ModelCollectionBase.cpp
@@ -248,7 +248,11 @@ void ModelCollectionBase::UpdateIndices()
         vDeletedIndices.reserve(nDeletedIndices);
 
         for (gsl::index nIndex = m_vItems.size() - 1; nIndex >= gsl::narrow_cast<gsl::index>(m_nSize); --nIndex)
-            vDeletedIndices.push_back(m_vItems.at(nIndex)->m_nCollectionIndex);
+        {
+            auto& pModel = *m_vItems.at(nIndex);
+            OnBeforeItemRemoved(pModel);
+            vDeletedIndices.push_back(pModel.m_nCollectionIndex);
+        }
 
         // use a reversed list so later indices are removed first when the callbacks are called
         std::sort(vDeletedIndices.rbegin(), vDeletedIndices.rend());

--- a/src/data/ModelCollectionBase.hh
+++ b/src/data/ModelCollectionBase.hh
@@ -199,6 +199,7 @@ protected:
     virtual void OnFrozen() noexcept(false) {}
     virtual void OnBeginUpdate() noexcept(false) {}
     virtual void OnEndUpdate() noexcept(false) {}
+    virtual void OnBeforeItemRemoved(_UNUSED ModelBase& vmModel) noexcept(false) {}
     virtual void OnItemsRemoved(_UNUSED const std::vector<gsl::index>& vDeletedIndices) noexcept(false) {}
     virtual void OnItemsAdded(_UNUSED const std::vector<gsl::index>& vNewIndices) noexcept(false) {}
     virtual void OnItemsChanged(_UNUSED const std::vector<gsl::index>& vChangedIndices) noexcept(false) {}

--- a/src/data/context/GameAssets.cpp
+++ b/src/data/context/GameAssets.cpp
@@ -89,21 +89,17 @@ void GameAssets::OnItemsAdded(const std::vector<gsl::index>& vNewIndices)
     ra::data::DataModelCollection<ra::data::models::AssetModelBase>::OnItemsAdded(vNewIndices);
 }
 
-void GameAssets::OnItemsRemoved(const std::vector<gsl::index>& vDeletedIndices)
+void GameAssets::OnBeforeItemRemoved(ModelBase& pModel)
 {
     auto* pLocalBadges = dynamic_cast<ra::data::models::LocalBadgesModel*>(FindAsset(ra::data::models::AssetType::LocalBadges, 0));
     if (pLocalBadges)
     {
-        for (const auto nIndex : vDeletedIndices)
-        {
-            const auto* pAsset = GetItemAt(nIndex);
-            const auto* pAchievement = dynamic_cast<const ra::data::models::AchievementModel*>(pAsset);
-            if (pAchievement && ra::StringStartsWith(pAchievement->GetBadge(), L"local\\"))
-                pLocalBadges->RemoveReference(pAchievement->GetBadge(), pAchievement->IsBadgeCommitted());
-        }
+        const auto* pAchievement = dynamic_cast<const ra::data::models::AchievementModel*>(&pModel);
+        if (pAchievement && ra::StringStartsWith(pAchievement->GetBadge(), L"local\\"))
+            pLocalBadges->RemoveReference(pAchievement->GetBadge(), pAchievement->IsBadgeCommitted());
     }
 
-    ra::data::DataModelCollection<ra::data::models::AssetModelBase>::OnItemsRemoved(vDeletedIndices);
+    ra::data::DataModelCollection<ra::data::models::AssetModelBase>::OnBeforeItemRemoved(pModel);
 }
 
 void GameAssets::ReloadAssets(const std::vector<ra::data::models::AssetModelBase*>& vAssetsToReload)

--- a/src/data/context/GameAssets.hh
+++ b/src/data/context/GameAssets.hh
@@ -73,7 +73,7 @@ public:
     void ResetLocalId() noexcept { m_nNextLocalId = FirstLocalId; }
 
 protected:
-    void OnItemsRemoved(const std::vector<gsl::index>& vDeletedIndices) override;
+    void OnBeforeItemRemoved(ModelBase& pModel) override;
     void OnItemsAdded(const std::vector<gsl::index>& vNewIndices) override;
 
     uint32_t m_nNextLocalId = FirstLocalId;

--- a/src/data/models/LocalBadgesModel.cpp
+++ b/src/data/models/LocalBadgesModel.cpp
@@ -1,7 +1,5 @@
 #include "LocalBadgesModel.hh"
 
-#include "data\context\GameContext.hh"
-
 #include "services\IFileSystem.hh"
 #include "services\ServiceLocator.hh"
 
@@ -113,6 +111,7 @@ void LocalBadgesModel::Commit(const std::wstring& sPreviousBadgeName, const std:
     if (pIter != m_mReferences.end())
     {
         Expects(pIter->second.nUncommittedCount > 0);
+
         --pIter->second.nUncommittedCount;
         ++pIter->second.nCommittedCount;
     }

--- a/src/ui/viewmodels/AssetListViewModel.cpp
+++ b/src/ui/viewmodels/AssetListViewModel.cpp
@@ -883,11 +883,18 @@ void AssetListViewModel::SaveSelected()
 
         if (vSelectedAssets.empty())
         {
-            RA_LOG_INFO("Saving all assets", vSelectedAssets.size());
+            RA_LOG_INFO("Saving all %u assets", pGameContext.Assets().Count());
         }
         else
         {
-            RA_LOG_INFO("Saving %u assets", vSelectedAssets.size());
+            std::string sMessage;
+            for (const auto* pAsset : vSelectedAssets)
+            {
+                if (!sMessage.empty())
+                    sMessage.push_back(',');
+                sMessage.append(std::to_string(pAsset->GetID()));
+            }
+            RA_LOG_INFO("Saving %u assets: %s", vSelectedAssets.size(), sMessage);
         }
     }
     else if (sSaveButtonText.at(0) == 'P' && sSaveButtonText.at(1) == 'u') // "Publi&sh" / "Publi&sh All"
@@ -1384,13 +1391,22 @@ void AssetListViewModel::CloneSelected()
         return;
     }
 
+    {
+        std::string sMessage;
+        for (const auto* pAsset : vSelectedAssets)
+        {
+            if (!sMessage.empty())
+                sMessage.push_back(',');
+            sMessage.append(std::to_string(pAsset->GetID()));
+        }
+        RA_LOG_INFO("Cloning %u assets: %s", vSelectedAssets.size(), sMessage);
+    }
+
     auto& pGameContext = ra::services::ServiceLocator::GetMutable<ra::data::context::GameContext>();
 
     FilteredAssets().BeginUpdate();
 
     SetFilterCategory(FilterCategory::Local);
-
-    RA_LOG_INFO("Cloning %u assets", vSelectedAssets.size());
 
     // add the cloned items
     std::vector<int> vNewIDs;


### PR DESCRIPTION
Fixes an issue where uploading multiple badges and deleting one of them could cause an exception trying to save an achievement associated to one of the other uploaded badges.

Simplified steps to reproduce:
* Clone achievement
* Clone again
* Upload badge to second achievement
* Upload badge to first achievement
* Delete first achievement
* Save second achievement