### PR TITLE
TriggerConditionViewModel::HasHitsProperty is a boolean property

### DIFF
--- a/src/ui/win32/AssetEditorDialog.cpp
+++ b/src/ui/win32/AssetEditorDialog.cpp
@@ -300,7 +300,7 @@ public:
         return GridNumberColumnBinding::DependsOn(pProperty);
     }
 
-    bool DependsOn(const ra::ui::BoolModelProperty& pProperty) const noexcept override
+    bool DependsOn(const ra::ui::BoolModelProperty& pProperty) const override
     {
         if (pProperty == TriggerConditionViewModel::HasHitsProperty)
             return true;

--- a/src/ui/win32/AssetEditorDialog.cpp
+++ b/src/ui/win32/AssetEditorDialog.cpp
@@ -294,9 +294,15 @@ public:
     {
         if (pProperty == TriggerConditionViewModel::CurrentHitsProperty)
             return true;
-        if (pProperty == TriggerConditionViewModel::HasHitsProperty)
-            return true;
         if (pProperty == TriggerConditionViewModel::TotalHitsProperty)
+            return true;
+
+        return GridNumberColumnBinding::DependsOn(pProperty);
+    }
+
+    bool DependsOn(const ra::ui::BoolModelProperty& pProperty) const noexcept override
+    {
+        if (pProperty == TriggerConditionViewModel::HasHitsProperty)
             return true;
 
         return GridNumberColumnBinding::DependsOn(pProperty);

--- a/src/ui/win32/bindings/GridNumberColumnBinding.hh
+++ b/src/ui/win32/bindings/GridNumberColumnBinding.hh
@@ -36,6 +36,7 @@ public:
     {
         return pProperty == *m_pBoundProperty;
     }
+    using GridTextColumnBindingBase::DependsOn; // inherit other overloads
 
     unsigned int Maximum() const noexcept { return m_nMaximum; }
     void SetMaximum(unsigned int nValue) noexcept { m_nMaximum = nValue; }

--- a/src/ui/win32/bindings/GridTextColumnBinding.hh
+++ b/src/ui/win32/bindings/GridTextColumnBinding.hh
@@ -40,6 +40,7 @@ public:
     {
         return pProperty == *m_pBoundProperty;
     }
+    using GridColumnBinding::DependsOn; // inherit other overloads
 
     const StringModelProperty& GetBoundProperty() const noexcept { return *m_pBoundProperty; }
 


### PR DESCRIPTION
Fixes hit count display when switching between inactive achievements. When a line in the conditions grid went from having hits to not having hits, the hits would still be displayed.

![image](https://user-images.githubusercontent.com/32680403/119272389-d82fe880-bbc2-11eb-9f50-5b9a785e9ed9.png)
https://discord.com/channels/310192285306454017/310195854642249728/846083464540323900