### PR TITLE
update asset version when changing from committed value to empty

### DIFF
--- a/src/data/models/AssetModelBase.cpp
+++ b/src/data/models/AssetModelBase.cpp
@@ -425,9 +425,12 @@ void AssetModelBase::SetAssetDefinition(AssetDefinition& pAsset, const std::stri
     else
     {
         // after local checkpoint
+        const auto nState = GetAssetDefinitionState(pAsset);
+
         if (pAsset.m_bLocalModified && sValue == pAsset.m_sLocalDefinition)
         {
-            if (!pAsset.m_sCurrentDefinition.empty())
+            // value being set to unpublished value
+            if (nState != AssetChanges::Unpublished)
             {
                 pAsset.m_sCurrentDefinition.clear();
                 UpdateAssetDefinitionVersion(pAsset, AssetChanges::Unpublished);
@@ -435,7 +438,8 @@ void AssetModelBase::SetAssetDefinition(AssetDefinition& pAsset, const std::stri
         }
         else if (!pAsset.m_bLocalModified && sValue == pAsset.m_sCoreDefinition)
         {
-            if (!pAsset.m_sCurrentDefinition.empty())
+            // value being set to core value (and no unpublished value exists)
+            if (nState != AssetChanges::None)
             {
                 pAsset.m_sCurrentDefinition.clear();
                 UpdateAssetDefinitionVersion(pAsset, AssetChanges::None);
@@ -443,7 +447,13 @@ void AssetModelBase::SetAssetDefinition(AssetDefinition& pAsset, const std::stri
         }
         else if (pAsset.m_sCurrentDefinition != sValue)
         {
+            // value being changed
             pAsset.m_sCurrentDefinition = sValue;
+            UpdateAssetDefinitionVersion(pAsset, AssetChanges::Modified);
+        }
+        else if (sValue.empty() && !GetAssetDefinition(pAsset, nState).empty())
+        {
+            // value being changed to empty string
             UpdateAssetDefinitionVersion(pAsset, AssetChanges::Modified);
         }
     }

--- a/tests/data/models/AssetModelBase_Tests.cpp
+++ b/tests/data/models/AssetModelBase_Tests.cpp
@@ -435,6 +435,36 @@ public:
         Assert::AreEqual(std::wstring(L"Name"), asset.GetName());
         Assert::AreEqual(AssetChanges::Unpublished, asset.GetChanges());
     }
+
+    TEST_METHOD(TestSetDefinitionToBlank)
+    {
+        AssetDefinitionViewModelHarness asset;
+        asset.SetName(L"ServerName");
+        asset.SetCategory(AssetCategory::Core);
+        asset.SetDefinition("ServerDefinition");
+        asset.CreateServerCheckpoint();
+        asset.CreateLocalCheckpoint();
+
+        Assert::AreEqual(AssetChanges::None, asset.GetChanges());
+
+        asset.SetDefinition("");
+        Assert::AreEqual(AssetChanges::Modified, asset.GetChanges());
+
+        asset.SetDefinition("ServerDefinition");
+        Assert::AreEqual(AssetChanges::None, asset.GetChanges());
+
+        asset.SetDefinition("LocalDefinition");
+        Assert::AreEqual(AssetChanges::Modified, asset.GetChanges());
+
+        asset.UpdateLocalCheckpoint();
+        Assert::AreEqual(AssetChanges::Unpublished, asset.GetChanges());
+
+        asset.SetDefinition("");
+        Assert::AreEqual(AssetChanges::Modified, asset.GetChanges());
+
+        asset.SetDefinition("LocalDefinition");
+        Assert::AreEqual(AssetChanges::Unpublished, asset.GetChanges());
+    }
 };
 
 const StringModelProperty AssetModelBase_Tests::AssetModelHarness::StringProperty("AssetModelHarness", "String", L"");


### PR DESCRIPTION
fixes an issue where deleting all conditions from an active core achievement (with no other modifications) would cause an exception.