### PR TITLE
show error when invalid RP is the only RP available

### DIFF
--- a/src/services/AchievementRuntime.hh
+++ b/src/services/AchievementRuntime.hh
@@ -115,7 +115,16 @@ public:
         if (!m_bInitialized)
             return false;
 
-        return (m_pRuntime.richpresence != nullptr && m_pRuntime.richpresence->richpresence != nullptr);
+        /* valid rich presence */
+        if (m_pRuntime.richpresence != nullptr && m_pRuntime.richpresence->richpresence != nullptr)
+            return true;
+
+        /* invalid rich presence */
+        if (m_nRichPresenceParseResult != RC_OK)
+            return true;
+
+        /* no rich presence */
+        return false;
     }
 
     /// <summary>

--- a/tests/services/AchievementRuntime_Tests.cpp
+++ b/tests/services/AchievementRuntime_Tests.cpp
@@ -881,9 +881,11 @@ public:
 
         AchievementRuntimeHarness runtime;
         runtime.mockEmulatorContext.MockMemory(memory);
+        Assert::IsFalse(runtime.HasRichPresence());
 
         const char* pRichPresence = "Format:Num\nFormatType:Value\n\nDisplay:\n@Num(0xH01) @Num(d0xH01)\n";
         runtime.ActivateRichPresence(pRichPresence);
+        Assert::IsTrue(runtime.HasRichPresence());
 
         // string is evaluated with current memrefs (which will be 0)
         Assert::AreEqual(std::wstring(L"0 0"), runtime.GetRichPresenceDisplayString());
@@ -918,15 +920,19 @@ public:
 
         AchievementRuntimeHarness runtime;
         runtime.mockEmulatorContext.MockMemory(memory);
+        Assert::IsFalse(runtime.HasRichPresence());
 
         runtime.ActivateRichPresence("Display:\nHello, World\n");
         Assert::AreEqual(std::wstring(L"Hello, World"), runtime.GetRichPresenceDisplayString());
+        Assert::IsTrue(runtime.HasRichPresence());
 
         runtime.ActivateRichPresence("Display:\nNew String\n");
         Assert::AreEqual(std::wstring(L"New String"), runtime.GetRichPresenceDisplayString());
+        Assert::IsTrue(runtime.HasRichPresence());
 
         runtime.ActivateRichPresence("");
         Assert::AreEqual(std::wstring(L"No Rich Presence defined."), runtime.GetRichPresenceDisplayString());
+        Assert::IsFalse(runtime.HasRichPresence());
     }
 
     TEST_METHOD(TestActivateRichPresenceWithError)
@@ -939,6 +945,7 @@ public:
 
         const char* pRichPresence = "Format:Num\nFormatType:Value\n\nDisplay:\n@Num(0H01) @Num(d0xH01)\n";
         runtime.ActivateRichPresence(pRichPresence);
+        Assert::IsTrue(runtime.HasRichPresence());
 
         Assert::AreEqual(std::wstring(L"Parse error -6 (line 5): Invalid operator"), runtime.GetRichPresenceDisplayString());
     }


### PR DESCRIPTION
When adding the initial rich presence to a game, if an error is present, the monitor would not report the error and would not start watching the file. If an error was introduced after the monitor started watching the file, it would be reported normally. This fixes the first case so an error can be reported on initial load of the rich presence script.