### PR TITLE
hide challenge indicator when achievement is paused

### DIFF
--- a/src/Exports.cpp
+++ b/src/Exports.cpp
@@ -414,6 +414,14 @@ static void ProcessAchievements()
                 break;
             }
 
+            case ra::services::AchievementRuntime::ChangeType::AchievementPaused:
+            {
+                // hide the challenge indicator - it'll be reshown when unpaused
+                auto& pOverlayManager = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>();
+                pOverlayManager.RemoveChallengeIndicator(pChange.nId);
+                break;
+            }
+
             case ra::services::AchievementRuntime::ChangeType::AchievementActivated:
             {
                 // state change from Waiting, Paused, or Primed to Active.

--- a/src/services/AchievementRuntime.cpp
+++ b/src/services/AchievementRuntime.cpp
@@ -232,6 +232,9 @@ static void map_event_to_change(const rc_runtime_event_t* pRuntimeEvent)
         case RC_RUNTIME_EVENT_ACHIEVEMENT_RESET:
             nChangeType = AchievementRuntime::ChangeType::AchievementReset;
             break;
+        case RC_RUNTIME_EVENT_ACHIEVEMENT_PAUSED:
+            nChangeType = AchievementRuntime::ChangeType::AchievementPaused;
+            break;
         case RC_RUNTIME_EVENT_ACHIEVEMENT_DISABLED:
             nChangeType = AchievementRuntime::ChangeType::AchievementDisabled;
             break;

--- a/src/services/AchievementRuntime.hh
+++ b/src/services/AchievementRuntime.hh
@@ -129,6 +129,7 @@ public:
         None = 0,
         AchievementTriggered,
         AchievementReset,
+        AchievementPaused,
         LeaderboardStarted,
         LeaderboardCanceled,
         LeaderboardUpdated,


### PR DESCRIPTION
As a Paused achievement cannot trigger, it is reasonable to hide the challenge indicator while an achievement was paused. 

Previously, it was intentionally left displayed as existing achievements use Pause to prevent Resets during a challenge (i.e. when a boss regains health or the player pauses the game or opens an inventory screen). In these cases, the challenge is still active, so it makes sense to keep the indicator on screen.

There's also a bunch of achievements that use Pause to disable the achievement (either temporarily, or permanently) if the player does something wrong. In these cases, the indicator would remain on screen, which is misleading as the achievement cannot possibly trigger.

Since Trigger is a new flag, we have to assume that whoever is adding the Trigger flag will make whatever changes are necessary to support it as cleanly as possible. In that regard, as it's impossible to trigger a paused achievement, I've agreed to hide the indicator when an achievement is paused. Achievements using a Pause to prevent a Reset can simply change the Pause to an AndNext and invert the logic. i.e. ("`PauseIf A == 1; ResetIf B == 2`" becomes "`AndNext A != 1; ResetIf B == 2`").