### PR TITLE
don't update filters when creating new assets unless necessary

### DIFF
--- a/src/ui/viewmodels/AssetListViewModel.hh
+++ b/src/ui/viewmodels/AssetListViewModel.hh
@@ -281,6 +281,7 @@ private:
     void DoUpdateButtons();
     std::atomic_bool m_bNeedToUpdateButtons = false;
 
+    void EnsureAppearsInFilteredList(const ra::data::models::AssetModelBase& pAsset);
     bool MatchesFilter(const ra::data::models::AssetModelBase& pAsset);
     void AddOrRemoveFilteredItem(gsl::index nAssetIndex);
     bool AddOrRemoveFilteredItem(const ra::data::models::AssetModelBase& pAsset);


### PR DESCRIPTION
Prevents changing filter from "all" to "local" when cloning/creating new achievements as they would already be visible.
Also changes filter from "active" (or similar) to "all" when cloning/creating new achievements so they will be visible.