### PR TITLE
fix pause-on-change for non-8-bit bookmarks

### DIFF
--- a/src/ui/viewmodels/MemoryBookmarksViewModel.cpp
+++ b/src/ui/viewmodels/MemoryBookmarksViewModel.cpp
@@ -322,7 +322,7 @@ void MemoryBookmarksViewModel::DoFrame()
                 {
                     pBookmark.SetRowColor(ra::ui::Color(0xFFFFC0C0));
 
-                    const auto nSizeIndex = m_vSizes.FindItemIndex(MemoryBookmarkViewModel::SizeProperty, ra::etoi(pBookmark.GetSize()));
+                    const auto nSizeIndex = m_vSizes.FindItemIndex(LookupItemViewModel::IdProperty, ra::etoi(pBookmark.GetSize()));
                     Expects(nSizeIndex >= 0);
 
                     auto sMessage = ra::StringPrintf(L"%s %s",


### PR DESCRIPTION
Fixes the `Assertion failure at src\ui\viewmodels\memorybookmarksviewmodel.cpp: 326: nSizeIndex >= 0` error that occurs when using the Pause feature on bookmarks of any size other than 8-bit.