### PR TITLE
highlight ranged notes in memory inspector

### DIFF
--- a/src/data/context/GameContext.cpp
+++ b/src/data/context/GameContext.cpp
@@ -849,7 +849,7 @@ void GameContext::AddCodeNote(ra::ByteAddress nAddress, const std::string& sAuth
     auto nIndex = sNote.find(L"yte");
     if (nIndex != std::string::npos && nIndex >= 2) // have to have room for the 'b' of bytes plus at least one digit
     {
-        wchar_t c = sNote.at(--nIndex);
+        const wchar_t c = sNote.at(--nIndex);
         if (c == L'b' || c == L'B')
             bIsBytes = true;
     }

--- a/src/data/context/GameContext.cpp
+++ b/src/data/context/GameContext.cpp
@@ -916,14 +916,19 @@ ra::ByteAddress GameContext::FindCodeNoteStart(ra::ByteAddress nAddress) const
     if (pIter != m_mCodeNotes.end() && pIter->first == nAddress)
         return nAddress;
 
-    // lower_bound returns the first item _after_ the search value. we want to look at the item _before_.
+    // lower_bound returns the first item _after_ the search value. scan all items before
+    // the found item to see if any of them contain the target address. have to scan
+    // all items because a singular note may exist within a range.
     if (pIter != m_mCodeNotes.begin())
     {
-        --pIter;
+        do
+        {
+            --pIter;
 
-        // check to see if the item before the search value contains the search value
-        if (pIter->first + pIter->second.Bytes > nAddress)
-            return pIter->first;
+            if (pIter->second.Bytes > 1 && pIter->second.Bytes + pIter->first > nAddress)
+                return pIter->first;
+
+        } while (pIter != m_mCodeNotes.begin());
     }
 
     return 0xFFFFFFFF;

--- a/src/data/context/GameContext.cpp
+++ b/src/data/context/GameContext.cpp
@@ -843,53 +843,51 @@ void GameContext::RefreshCodeNotes()
 void GameContext::AddCodeNote(ra::ByteAddress nAddress, const std::string& sAuthor, const std::wstring& sNote)
 {
     unsigned int nBytes = 1;
+    bool bIsBytes = false;
 
     // attempt to match "X byte", "X Byte", "XX bytes", or "XX Bytes"
     auto nIndex = sNote.find(L"yte");
-    if (nIndex != std::string::npos && nIndex >= 3)
+    if (nIndex != std::string::npos && nIndex >= 2) // have to have room for the 'b' of bytes plus at least one digit
     {
         wchar_t c = sNote.at(--nIndex);
         if (c == L'b' || c == L'B')
-        {
-            c = sNote.at(--nIndex);
-            if (c == L'-' || c == L' ')
-                c = sNote.at(--nIndex);
-
-            if (c >= L'0' && c <= L'9')
-            {
-                int nMultiplier = 1;
-                nBytes = 0;
-                do
-                {
-                    nBytes += (c - L'0') * nMultiplier;
-                    if (nIndex == 0)
-                        break;
-
-                    nMultiplier *= 10;
-                    c = sNote.at(--nIndex);
-                } while (c >= L'0' && c <= L'9');
-            }
-        }
+            bIsBytes = true;
     }
 
-    if (nBytes == 1)
+    if (!bIsBytes)
     {
-        // attempt to match "16-bit" or "32-bit"
+        // attempt to match "N bit" or "N bits"
         nIndex = sNote.find(L"Bit");
         if (nIndex == std::string::npos)
             nIndex = sNote.find(L"bit");
+    }
 
-        if (nIndex != std::string::npos && nIndex >= 3)
+    if (nIndex != std::string::npos && nIndex >= 2)
+    {
+        // allow "N-bits", "N bits" or "Nbits". ignore if any other character appears between "N" and "bits"
+        wchar_t c = sNote.at(--nIndex);
+        if (c == L'-' || c == L' ')
+            c = sNote.at(--nIndex);
+
+        if (c >= L'0' && c <= L'9')
         {
-            wchar_t c = sNote.at(--nIndex);
-            if (c == L'-' || c == L' ')
-                c = sNote.at(--nIndex);
+            int nMultiplier = 1;
+            nBytes = 0;
+            do
+            {
+                nBytes += (c - L'0') * nMultiplier;
+                if (nIndex == 0)
+                    break;
 
-            if (c == L'6' && sNote.at(nIndex - 1) == L'1')
-                nBytes = 2;
-            else if (c == L'2' && sNote.at(nIndex - 1) == L'3')
-                nBytes = 4;
+                nMultiplier *= 10;
+                c = sNote.at(--nIndex);
+            } while (c >= L'0' && c <= L'9');
         }
+
+        if (nBytes == 0) // sanity check
+            nBytes = 1;
+        else if (!bIsBytes) // convert bits to bytes, rounding up
+            nBytes = (nBytes + 7) / 8;
     }
 
     m_mCodeNotes.insert_or_assign(nAddress, CodeNote{ sAuthor, sNote, nBytes });

--- a/src/ui/EditorTheme.hh
+++ b/src/ui/EditorTheme.hh
@@ -30,6 +30,7 @@ public:
     Color ColorNormal() const noexcept { return m_colorNormal; }
     Color ColorSelected() const noexcept { return m_colorSelected; }
     Color ColorHasNote() const noexcept { return m_colorHasNote; }
+    Color ColorHasSurrogateNote() const noexcept { return m_colorHasSurrogateNote; }
     Color ColorHasBookmark() const noexcept { return m_colorHasBookmark; }
     Color ColorFrozen() const noexcept { return m_colorFrozen; }
     Color ColorHeader() const noexcept { return m_colorHeader; }
@@ -57,6 +58,7 @@ private:
     Color m_colorNormal{ 255, 0, 0, 0 };
     Color m_colorSelected{ 255, 255, 0, 0 };
     Color m_colorHasNote{ 255, 0, 0, 255 };
+    Color m_colorHasSurrogateNote{ 255, 32, 64, 160 };
     Color m_colorHasBookmark{ 255, 0, 160, 0 };
     Color m_colorFrozen{ 255, 255, 200, 0 };
     Color m_colorHeader{ 255, 128, 128, 128 };

--- a/src/ui/Theme.cpp
+++ b/src/ui/Theme.cpp
@@ -183,6 +183,7 @@ void EditorTheme::LoadFromFile()
             ReadColor(m_colorNormal, colors, "Normal");
             ReadColor(m_colorSelected, colors, "Selected");
             ReadColor(m_colorHasNote, colors, "HasNote");
+            ReadColor(m_colorHasSurrogateNote, colors, "HasSurrogateNote");
             ReadColor(m_colorHasBookmark, colors, "HasBookmark");
             ReadColor(m_colorFrozen, colors, "Frozen");
             ReadColor(m_colorHeader, colors, "Header");

--- a/src/ui/viewmodels/MemoryViewerViewModel.cpp
+++ b/src/ui/viewmodels/MemoryViewerViewModel.cpp
@@ -183,13 +183,14 @@ void MemoryViewerViewModel::UpdateColors()
 
     // apply code notes
     const auto nStopAddress = nFirstAddress + nVisibleLines * 16;
-    pGameContext.EnumerateCodeNotes([nFirstAddress, nStopAddress, this](ra::ByteAddress nAddress, unsigned nBytes, const std::wstring& sNote) {
+    pGameContext.EnumerateCodeNotes([nFirstAddress, nStopAddress, this](ra::ByteAddress nAddress, unsigned nBytes, const std::wstring&) {
         if (nAddress + nBytes <= nFirstAddress)
             return true;
         if (nAddress >= nStopAddress)
             return false;
 
         uint8_t* pOffset = m_pColor;
+        Expects(pOffset != nullptr);
         if (nAddress < nFirstAddress)
         {
             nBytes -= (nFirstAddress - nAddress);

--- a/src/ui/viewmodels/MemoryViewerViewModel.cpp
+++ b/src/ui/viewmodels/MemoryViewerViewModel.cpp
@@ -209,7 +209,7 @@ void MemoryViewerViewModel::UpdateColors()
 
         if (nBytes > 1)
         {
-            nBytes = std::min(nBytes, nStopAddress - nAddress);
+            nBytes = std::min(nBytes, nStopAddress - nAddress + 1);
             for (unsigned i = 1; i < nBytes; ++i)
             {
                 ++pOffset;

--- a/src/ui/viewmodels/MemoryViewerViewModel.hh
+++ b/src/ui/viewmodels/MemoryViewerViewModel.hh
@@ -73,6 +73,7 @@ public:
         Selected,        // selected
         Cursor,          // selected and highlighted
         HasNote,         // has notes
+        HasSurrogateNote,// part of a multibyte note
         HasBookmark,     // has bookmark
         Frozen,          // has frozen bookmark
 

--- a/tests/data/context/GameContext_Tests.cpp
+++ b/tests/data/context/GameContext_Tests.cpp
@@ -2170,20 +2170,27 @@ public:
         game.mockThreadPool.ExecuteNextTask(); // FetchUserUnlocks and FetchCodeNotes are async
         game.mockThreadPool.ExecuteNextTask();
 
-        Assert::AreEqual(nExpectedSize, game.GetCodeNoteSize(1234U));
+        Assert::AreEqual(nExpectedSize, game.GetCodeNoteSize(1234U), sNote.c_str());
     }
 
     TEST_METHOD(TestLoadCodeNotesSized)
     {
         TestCodeNoteSize(L"Test", 1U);
+        TestCodeNoteSize(L"16-bit Test", 2U);
         TestCodeNoteSize(L"[16-bit] Test", 2U);
         TestCodeNoteSize(L"[16 bit] Test", 2U);
         TestCodeNoteSize(L"[16 Bit] Test", 2U);
+        TestCodeNoteSize(L"[24-bit] Test", 3U);
         TestCodeNoteSize(L"[32-bit] Test", 4U);
         TestCodeNoteSize(L"[32 bit] Test", 4U);
         TestCodeNoteSize(L"[32bit] Test", 4U);
         TestCodeNoteSize(L"Test [16-bit]", 2U);
         TestCodeNoteSize(L"Test (16-bit)", 2U);
+        TestCodeNoteSize(L"[64-bit] Test", 8U);
+        TestCodeNoteSize(L"[128-bit] Test", 16U);
+        TestCodeNoteSize(L"[17-bit] Test", 3U);
+        TestCodeNoteSize(L"[100-bit] Test", 13U);
+
         TestCodeNoteSize(L"[2 Byte] Test", 2U);
         TestCodeNoteSize(L"[4 Byte] Test", 4U);
         TestCodeNoteSize(L"[4 Byte - Float] Test", 4U);
@@ -2193,8 +2200,10 @@ public:
         TestCodeNoteSize(L"[2-byte] Test", 2U);
         TestCodeNoteSize(L"Test (6 bytes)", 6U);
         TestCodeNoteSize(L"[2byte] Test", 2U);
+
         TestCodeNoteSize(L"4=bitten", 1U);
         TestCodeNoteSize(L"bit by bit", 1U);
+        TestCodeNoteSize(L"bit1=chest", 1U);
     }
 
     TEST_METHOD(TestFindCodeNoteSized)


### PR DESCRIPTION
Provides a secondary color for memory associated to a ranged code note in the memory viewer

![image](https://user-images.githubusercontent.com/32680403/125560780-a14b371d-c829-486d-b98a-68d7c546df77.png)

Here, you can see several `[32-bit]` values (the first few are pointers) and one `[16-bit]` value. Also works with large byte ranges.

Includes support for arbitrarily sized bit ranges (i.e. `[24-bit]`, `[128-bit]`, `[999-bit]`). Previously only 16-bit and 32-bit were detected. Arbitrarily sized byte ranges were already supported.