### PR TITLE
immediately update bookmark value when bookmark size changes

### DIFF
--- a/src/ui/viewmodels/MemoryBookmarksViewModel.cpp
+++ b/src/ui/viewmodels/MemoryBookmarksViewModel.cpp
@@ -74,10 +74,24 @@ void MemoryBookmarksViewModel::OnValueChanged(const BoolModelProperty::ChangeArg
 GSL_SUPPRESS_F6
 void MemoryBookmarksViewModel::OnViewModelIntValueChanged(gsl::index nIndex, const IntModelProperty::ChangeArgs& args)
 {
-    if (args.Property == MemoryBookmarkViewModel::FormatProperty ||
-        args.Property == MemoryBookmarkViewModel::SizeProperty)
+    if (args.Property == MemoryBookmarkViewModel::FormatProperty)
     {
         m_bModified = true;
+    }
+    else if (args.Property == MemoryBookmarkViewModel::SizeProperty)
+    {
+        m_bModified = true;
+
+        auto* pBookmark = m_vBookmarks.GetItemAt(nIndex);
+        Expects(pBookmark != nullptr);
+
+        const auto& pEmulatorContext = ra::services::ServiceLocator::Get<ra::data::context::EmulatorContext>();
+        const auto nValue = pEmulatorContext.ReadMemory(pBookmark->GetAddress(), pBookmark->GetSize());
+
+        m_bIgnoreValueChanged = true;
+        pBookmark->SetCurrentValue(nValue);
+        m_bIgnoreValueChanged = false;
+
     }
     else if (args.Property == MemoryBookmarkViewModel::BehaviorProperty)
     {

--- a/tests/ui/viewmodels/MemoryBookmarksViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/MemoryBookmarksViewModel_Tests.cpp
@@ -936,6 +936,40 @@ public:
         Assert::AreEqual(0U, bookmark5.GetPreviousValue());
         Assert::AreEqual(0U, bookmark5.GetChanges());
     }
+
+    TEST_METHOD(TestUpdateCurrentValueOnSizeChange)
+    {
+        MemoryBookmarksViewModelHarness bookmarks;
+        bookmarks.AddBookmark(4U, MemSize::SixteenBit);
+        auto& bookmark1 = *bookmarks.Bookmarks().GetItemAt(0);
+
+        std::array<uint8_t, 64> memory = {};
+        for (uint8_t i = 0; i < memory.size(); ++i)
+            memory.at(i) = i;
+        bookmarks.mockEmulatorContext.MockMemory(memory);
+
+        bookmarks.DoFrame(); // initialize current and previous values
+
+        Assert::AreEqual(0x0504U, bookmark1.GetCurrentValue());
+        bookmark1.SetChanges(0U);
+
+        memory.at(5) = 0x17;
+        bookmarks.DoFrame();
+
+        Assert::AreEqual(0x1704U, bookmark1.GetCurrentValue());
+        Assert::AreEqual(0x0504U, bookmark1.GetPreviousValue());
+        Assert::AreEqual(1U, bookmark1.GetChanges());
+
+        bookmark1.SetSize(MemSize::EightBit);
+        Assert::AreEqual(0x04U, bookmark1.GetCurrentValue());
+        Assert::AreEqual(0x0504U, bookmark1.GetPreviousValue());
+        Assert::AreEqual(1U, bookmark1.GetChanges());
+
+        bookmark1.SetSize(MemSize::ThirtyTwoBit);
+        Assert::AreEqual(0x07061704U, bookmark1.GetCurrentValue());
+        Assert::AreEqual(0x0504U, bookmark1.GetPreviousValue());
+        Assert::AreEqual(1U, bookmark1.GetChanges());
+    }
 };
 
 } // namespace tests


### PR DESCRIPTION
Fixes a display issue where the bookmark value would not update if the size was changed while the emulator is paused.