### PR TITLE
put previous best on correct entry when rank is shared

### DIFF
--- a/tests/data/context/GameContext_Tests.cpp
+++ b/tests/data/context/GameContext_Tests.cpp
@@ -1988,6 +1988,128 @@ public:
         Assert::IsTrue(vmEntry2->IsHighlighted());
     }
 
+    TEST_METHOD(TestSubmitLeaderboardEntryScoreNotImprovedSharedRank)
+    {
+        GameContextHarness game;
+        game.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, true);
+        game.mockConfiguration.SetPopupLocation(ra::ui::viewmodels::Popup::LeaderboardScoreboard, ra::ui::viewmodels::PopupLocation::BottomRight);
+        game.mockUser.Initialize("Player", "ApiToken");
+        game.SetGameHash("hash");
+
+        unsigned int nNewScore = 0U;
+        game.mockServer.HandleRequest<ra::api::SubmitLeaderboardEntry>([&nNewScore]
+        (const ra::api::SubmitLeaderboardEntry::Request& request, ra::api::SubmitLeaderboardEntry::Response& response)
+        {
+            Assert::AreEqual(1U, request.LeaderboardId);
+            Assert::AreEqual(1234, request.Score);
+            Assert::AreEqual(std::string("hash"), request.GameHash);
+            nNewScore = request.Score;
+
+            response.Result = ra::api::ApiResult::Success;
+            response.TopEntries.push_back({ 1, "George", 1000U });
+            response.TopEntries.push_back({ 2, "Steve", 1200U });
+            response.TopEntries.push_back({ 2, "Player", 1200U });
+            response.TopEntries.push_back({ 4, "Bill", 1700U });
+
+            response.Score = 1234U;
+            response.BestScore = 1200U;
+            response.NewRank = 2;
+            return true;
+        });
+
+        game.MockLeaderboard();
+        game.SubmitLeaderboardEntry(1U, 1234U);
+
+        game.mockThreadPool.ExecuteNextTask();
+        Assert::AreEqual(1234U, nNewScore);
+
+        const auto* vmScoreboard = game.mockOverlayManager.GetScoreboard(1U);
+        Assert::IsNotNull(vmScoreboard);
+        Ensures(vmScoreboard != nullptr);
+        Assert::AreEqual(std::wstring(L"LeaderboardTitle"), vmScoreboard->GetHeaderText());
+        Assert::AreEqual({ 4U }, vmScoreboard->Entries().Count());
+
+        const auto* vmEntry2 = vmScoreboard->Entries().GetItemAt(1);
+        Assert::IsNotNull(vmEntry2);
+        Ensures(vmEntry2 != nullptr);
+        Assert::AreEqual(2, vmEntry2->GetRank());
+        Assert::AreEqual(std::wstring(L"Steve"), vmEntry2->GetUserName());
+        Assert::AreEqual(std::wstring(L"1200"), vmEntry2->GetScore());
+        Assert::IsFalse(vmEntry2->IsHighlighted());
+
+        const auto* vmEntry3 = vmScoreboard->Entries().GetItemAt(2);
+        Assert::IsNotNull(vmEntry3);
+        Ensures(vmEntry3 != nullptr);
+        Assert::AreEqual(2, vmEntry3->GetRank());
+        Assert::AreEqual(std::wstring(L"Player"), vmEntry3->GetUserName());
+        Assert::AreEqual(std::wstring(L"(1234) 1200"), vmEntry3->GetScore());
+        Assert::IsTrue(vmEntry3->IsHighlighted());
+    }
+
+    TEST_METHOD(TestSubmitLeaderboardEntryScoreNotImprovedSharedRankLastEntry)
+    {
+        GameContextHarness game;
+        game.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, true);
+        game.mockConfiguration.SetPopupLocation(ra::ui::viewmodels::Popup::LeaderboardScoreboard, ra::ui::viewmodels::PopupLocation::BottomRight);
+        game.mockUser.Initialize("Player", "ApiToken");
+        game.SetGameHash("hash");
+
+        unsigned int nNewScore = 0U;
+        game.mockServer.HandleRequest<ra::api::SubmitLeaderboardEntry>([&nNewScore]
+        (const ra::api::SubmitLeaderboardEntry::Request& request, ra::api::SubmitLeaderboardEntry::Response& response)
+        {
+            Assert::AreEqual(1U, request.LeaderboardId);
+            Assert::AreEqual(1234, request.Score);
+            Assert::AreEqual(std::string("hash"), request.GameHash);
+            nNewScore = request.Score;
+
+            response.Result = ra::api::ApiResult::Success;
+            response.TopEntries.push_back({ 1, "George", 1000U });
+            response.TopEntries.push_back({ 2, "Harold", 1100U });
+            response.TopEntries.push_back({ 2, "Roger", 1100U });
+            response.TopEntries.push_back({ 4, "Phil", 1150U });
+            response.TopEntries.push_back({ 5, "Steve", 1175U });
+            response.TopEntries.push_back({ 6, "Terry", 1200U });
+            response.TopEntries.push_back({ 6, "Edward", 1200U });
+            response.TopEntries.push_back({ 6, "Player", 1200U });
+            response.TopEntries.push_back({ 9, "Bill", 1300U });
+
+            response.Score = 1234U;
+            response.BestScore = 1200U;
+            response.NewRank = 6;
+            return true;
+        });
+
+        game.MockLeaderboard();
+        game.SubmitLeaderboardEntry(1U, 1234U);
+
+        game.mockThreadPool.ExecuteNextTask();
+        Assert::AreEqual(1234U, nNewScore);
+
+        const auto* vmScoreboard = game.mockOverlayManager.GetScoreboard(1U);
+        Assert::IsNotNull(vmScoreboard);
+        Ensures(vmScoreboard != nullptr);
+        Assert::AreEqual(std::wstring(L"LeaderboardTitle"), vmScoreboard->GetHeaderText());
+        Assert::AreEqual({ 7U }, vmScoreboard->Entries().Count());
+
+        const auto* vmEntry6 = vmScoreboard->Entries().GetItemAt(5);
+        Assert::IsNotNull(vmEntry6);
+        Ensures(vmEntry6 != nullptr);
+        Assert::AreEqual(6, vmEntry6->GetRank());
+        Assert::AreEqual(std::wstring(L"Terry"), vmEntry6->GetUserName());
+        Assert::AreEqual(std::wstring(L"1200"), vmEntry6->GetScore());
+        Assert::IsFalse(vmEntry6->IsHighlighted());
+
+        // player is entry 8, but rank 6. 7 items will be shown, 7th item should be replaced with player entry
+        const auto* vmEntry7 = vmScoreboard->Entries().GetItemAt(6);
+        Assert::IsNotNull(vmEntry7);
+        Ensures(vmEntry7 != nullptr);
+        Assert::AreEqual(6, vmEntry7->GetRank());
+        Assert::AreEqual(std::wstring(L"Player"), vmEntry7->GetUserName());
+        Assert::AreEqual(std::wstring(L"(1234) 1200"), vmEntry7->GetScore());
+        Assert::IsTrue(vmEntry7->IsHighlighted());
+    }
+
     TEST_METHOD(TestSubmitLeaderboardEntryMemoryModified)
     {
         GameContextHarness game;


### PR DESCRIPTION
The logic that was appending the player's best leaderboard score when it hasn't improved was finding the player entry by rank. When multiple users share a rank, this could potentially place the best score on another player's entry.

I've updated the code to match the username instead of the rank.