### PR TITLE
fix code note size extraction when string contains multiple 'bit' substrings

### DIFF
--- a/src/data/context/GameContext.cpp
+++ b/src/data/context/GameContext.cpp
@@ -841,56 +841,95 @@ void GameContext::RefreshCodeNotes()
     });
 }
 
-void GameContext::AddCodeNote(ra::ByteAddress nAddress, const std::string& sAuthor, const std::wstring& sNote)
+static unsigned int ExtractSize(const std::wstring& sNote)
 {
-    unsigned int nBytes = 1;
     bool bIsBytes = false;
 
-    // attempt to match "X byte", "X Byte", "XX bytes", or "XX Bytes"
-    auto nIndex = sNote.find(L"yte");
-    if (nIndex != std::string::npos && nIndex >= 2) // have to have room for the 'b' of bytes plus at least one digit
-    {
-        const wchar_t c = sNote.at(--nIndex);
-        if (c == L'b' || c == L'B')
-            bIsBytes = true;
-    }
+    // "Nbit" smallest possible note - and that's just the size annotation
+    if (sNote.length() < 4)
+        return 1;
 
-    if (!bIsBytes)
+    const size_t nStop = sNote.length() - 3;
+    for (size_t nIndex = 1; nIndex <= nStop; ++nIndex)
     {
-        // attempt to match "N bit" or "N bits"
-        nIndex = sNote.find(L"Bit");
-        if (nIndex == std::string::npos)
-            nIndex = sNote.find(L"bit");
-    }
+        wchar_t c = sNote.at(nIndex);
+        if (c != L'b' && c != L'B')
+            continue;
 
-    if (nIndex != std::string::npos && nIndex >= 2)
-    {
-        // allow "N-bits", "N bits" or "Nbits". ignore if any other character appears between "N" and "bits"
-        wchar_t c = sNote.at(--nIndex);
-        if (c == L'-' || c == L' ')
-            c = sNote.at(--nIndex);
-
-        if (c >= L'0' && c <= L'9')
+        c = sNote.at(nIndex + 1);
+        if (c == L'i' || c == L'I')
         {
-            int nMultiplier = 1;
-            nBytes = 0;
-            do
-            {
-                nBytes += (c - L'0') * nMultiplier;
-                if (nIndex == 0)
-                    break;
+            c = sNote.at(nIndex + 2);
+            if (c != L't' && c != L'T')
+                continue;
 
-                nMultiplier *= 10;
-                c = sNote.at(--nIndex);
-            } while (c >= L'0' && c <= L'9');
+            // found "bit"
+            bIsBytes = false;
+        }
+        else if (c == L'y' || c == L'Y')
+        {
+            if (nIndex == nStop)
+                continue;
+
+            c = sNote.at(nIndex + 2);
+            if (c != L't' && c != L'T')
+                continue;
+
+            c = sNote.at(nIndex + 3);
+            if (c != L'e' && c != L'E')
+                continue;
+
+            // found "byte"
+            bIsBytes = true;
+        }
+        else
+        {
+            continue;
         }
 
-        if (nBytes == 0) // sanity check
-            nBytes = 1;
-        else if (!bIsBytes) // convert bits to bytes, rounding up
-            nBytes = (nBytes + 7) / 8;
+        // ignore single space or hyphen preceding "bit" or "byte"
+        size_t nScan = nIndex - 1;
+        c = sNote.at(nScan);
+        if (c == ' ' || c == '-')
+        {
+            if (nScan == 0)
+                continue;
+
+            c = sNote.at(--nScan);
+        }
+
+        // extract the number
+        unsigned int nBytes = 0;
+        int nMultiplier = 1;
+        while (c <= L'9' && c >= L'0')
+        {
+            nBytes += (c - L'0') * nMultiplier;
+
+            if (nScan == 0)
+                break;
+
+            nMultiplier *= 10;
+            c = sNote.at(--nScan);
+        }
+
+        // if a number was found, return it
+        if (nBytes > 0)
+        {
+            if (bIsBytes)
+                return nBytes;
+
+            // convert bits to bytes, rounding up
+            return (nBytes + 7) / 8;
+        }
     }
 
+    // could not find annotation, associate note to single address
+    return 1;
+}
+
+void GameContext::AddCodeNote(ra::ByteAddress nAddress, const std::string& sAuthor, const std::wstring& sNote)
+{
+    const unsigned int nBytes = ExtractSize(sNote);
     m_mCodeNotes.insert_or_assign(nAddress, CodeNote{ sAuthor, sNote, nBytes });
     OnCodeNoteChanged(nAddress, sNote);
 }

--- a/tests/data/context/GameContext_Tests.cpp
+++ b/tests/data/context/GameContext_Tests.cpp
@@ -2297,8 +2297,11 @@ public:
 
     TEST_METHOD(TestLoadCodeNotesSized)
     {
+        TestCodeNoteSize(L"", 1U);
         TestCodeNoteSize(L"Test", 1U);
         TestCodeNoteSize(L"16-bit Test", 2U);
+        TestCodeNoteSize(L"Test 16-bit", 2U);
+        TestCodeNoteSize(L"Test 16-bi", 1U);
         TestCodeNoteSize(L"[16-bit] Test", 2U);
         TestCodeNoteSize(L"[16 bit] Test", 2U);
         TestCodeNoteSize(L"[16 Bit] Test", 2U);
@@ -2308,13 +2311,20 @@ public:
         TestCodeNoteSize(L"[32bit] Test", 4U);
         TestCodeNoteSize(L"Test [16-bit]", 2U);
         TestCodeNoteSize(L"Test (16-bit)", 2U);
+        TestCodeNoteSize(L"Test (16 bits)", 2U);
         TestCodeNoteSize(L"[64-bit] Test", 8U);
         TestCodeNoteSize(L"[128-bit] Test", 16U);
         TestCodeNoteSize(L"[17-bit] Test", 3U);
         TestCodeNoteSize(L"[100-bit] Test", 13U);
         TestCodeNoteSize(L"[4-bit] Test", 1U);
         TestCodeNoteSize(L"[0-bit] Test", 1U);
+        TestCodeNoteSize(L"bit", 1U);
+        TestCodeNoteSize(L"9bit", 2U);
+        TestCodeNoteSize(L"-bit", 1U);
 
+        TestCodeNoteSize(L"8 BYTE Test", 8U);
+        TestCodeNoteSize(L"Test 8 BYTE", 8U);
+        TestCodeNoteSize(L"Test 8 BYT", 1U);
         TestCodeNoteSize(L"[2 Byte] Test", 2U);
         TestCodeNoteSize(L"[4 Byte] Test", 4U);
         TestCodeNoteSize(L"[4 Byte - Float] Test", 4U);
@@ -2325,9 +2335,12 @@ public:
         TestCodeNoteSize(L"Test (6 bytes)", 6U);
         TestCodeNoteSize(L"[2byte] Test", 2U);
 
-        TestCodeNoteSize(L"4=bitten", 1U);
+        TestCodeNoteSize(L"42=bitten", 1U);
         TestCodeNoteSize(L"bit by bit", 1U);
         TestCodeNoteSize(L"bit1=chest", 1U);
+
+        TestCodeNoteSize(L"Bite count (16-bit)", 2U);
+        TestCodeNoteSize(L"Number of bits collected (32 bits)", 4U);
     }
 
     TEST_METHOD(TestFindCodeNoteSized)


### PR DESCRIPTION
Fixes size detection for things like:
```
Weapon - Pike - Tortoise Bite (16bit)
```

Previously, it would find the "Bit" in "Bite" and not see a leading number, so assume the annotation was not present. It was not scanning for all occurrences of "bit" in the string. This changes the algorithm to look for multiple matching substrings.