### PR TITLE
improvements to code note size annotations

### DIFF
--- a/src/data/context/GameContext.cpp
+++ b/src/data/context/GameContext.cpp
@@ -848,7 +848,7 @@ static unsigned int ExtractSize(const std::wstring& sNote)
 
     // "Nbit" smallest possible note - and that's just the size annotation
     if (sNote.length() < 4)
-        return 1;
+        return 0;
 
     const size_t nStop = sNote.length() - 3;
     for (size_t nIndex = 1; nIndex <= nStop; ++nIndex)
@@ -942,14 +942,15 @@ static unsigned int ExtractSize(const std::wstring& sNote)
     if (nBytesFromBits > 0)
         return nBytesFromBits;
 
-    // could not find annotation, associate note to single address
-    return 1;
+    // could not find annotation
+    return 0;
 }
 
 void GameContext::AddCodeNote(ra::ByteAddress nAddress, const std::string& sAuthor, const std::wstring& sNote)
 {
-    const unsigned int nBytes = ExtractSize(sNote);
-    m_mCodeNotes.insert_or_assign(nAddress, CodeNote{ sAuthor, sNote, nBytes });
+    const unsigned int nSize = ExtractSize(sNote);
+    const unsigned int nBytes = (nSize == 0) ? 1 : nSize;
+    m_mCodeNotes.insert_or_assign(nAddress, CodeNote{ sAuthor, sNote, nBytes, nSize });
     OnCodeNoteChanged(nAddress, sNote);
 }
 

--- a/src/data/context/GameContext.hh
+++ b/src/data/context/GameContext.hh
@@ -202,7 +202,7 @@ public:
     unsigned FindCodeNoteSize(ra::ByteAddress nAddress) const
     {
         const auto pIter = m_mCodeNotes.find(nAddress);
-        return (pIter == m_mCodeNotes.end()) ? 0 : pIter->second.Bytes;
+        return (pIter == m_mCodeNotes.end()) ? 0 : pIter->second.AnnotatedSize;
     }
 
     /// <summary>
@@ -308,6 +308,7 @@ protected:
         std::string Author;
         std::wstring Note;
         unsigned int Bytes;
+        unsigned int AnnotatedSize;
     };
     std::map<ra::ByteAddress, CodeNote> m_mCodeNotes;
 

--- a/src/ui/viewmodels/TriggerViewModel.cpp
+++ b/src/ui/viewmodels/TriggerViewModel.cpp
@@ -330,6 +330,10 @@ void TriggerViewModel::NewCondition()
             nSize = pMemoryInspector.Viewer().GetSize();
             break;
 
+        case 1:
+            nSize = MemSize::EightBit;
+            break;
+
         case 2:
             nSize = MemSize::SixteenBit;
             break;

--- a/tests/data/context/GameContext_Tests.cpp
+++ b/tests/data/context/GameContext_Tests.cpp
@@ -2336,11 +2336,15 @@ public:
         TestCodeNoteSize(L"[2byte] Test", 2U);
 
         TestCodeNoteSize(L"42=bitten", 1U);
+        TestCodeNoteSize(L"42-bitten", 1U);
         TestCodeNoteSize(L"bit by bit", 1U);
         TestCodeNoteSize(L"bit1=chest", 1U);
 
         TestCodeNoteSize(L"Bite count (16-bit)", 2U);
         TestCodeNoteSize(L"Number of bits collected (32 bits)", 4U);
+
+        TestCodeNoteSize(L"100 32-bit pointers [400 bytes]", 400U);
+        TestCodeNoteSize(L"[400 bytes] 100 32-bit pointers", 400U);
     }
 
     TEST_METHOD(TestFindCodeNoteSized)

--- a/tests/data/context/GameContext_Tests.cpp
+++ b/tests/data/context/GameContext_Tests.cpp
@@ -92,15 +92,6 @@ public:
             return pLeaderboard;
         }
 
-        unsigned int GetCodeNoteSize(ra::ByteAddress nAddress)
-        {
-            const auto pIter = m_mCodeNotes.find(nAddress);
-            if (pIter == m_mCodeNotes.end())
-                return 0U;
-
-            return pIter->second.Bytes;
-        }
-
         void RemoveNonAchievementAssets()
         {
             for (gsl::index nIndex = Assets().Count() - 1; nIndex >= 0; nIndex--)
@@ -2292,16 +2283,16 @@ public:
         game.mockThreadPool.ExecuteNextTask(); // FetchUserUnlocks and FetchCodeNotes are async
         game.mockThreadPool.ExecuteNextTask();
 
-        Assert::AreEqual(nExpectedSize, game.GetCodeNoteSize(1234U), sNote.c_str());
+        Assert::AreEqual(nExpectedSize, game.FindCodeNoteSize(1234U), sNote.c_str());
     }
 
     TEST_METHOD(TestLoadCodeNotesSized)
     {
-        TestCodeNoteSize(L"", 1U);
-        TestCodeNoteSize(L"Test", 1U);
+        TestCodeNoteSize(L"", 0U);
+        TestCodeNoteSize(L"Test", 0U);
         TestCodeNoteSize(L"16-bit Test", 2U);
         TestCodeNoteSize(L"Test 16-bit", 2U);
-        TestCodeNoteSize(L"Test 16-bi", 1U);
+        TestCodeNoteSize(L"Test 16-bi", 0U);
         TestCodeNoteSize(L"[16-bit] Test", 2U);
         TestCodeNoteSize(L"[16 bit] Test", 2U);
         TestCodeNoteSize(L"[16 Bit] Test", 2U);
@@ -2316,15 +2307,18 @@ public:
         TestCodeNoteSize(L"[128-bit] Test", 16U);
         TestCodeNoteSize(L"[17-bit] Test", 3U);
         TestCodeNoteSize(L"[100-bit] Test", 13U);
+        TestCodeNoteSize(L"[0-bit] Test", 0U);
+        TestCodeNoteSize(L"[1-bit] Test", 1U);
         TestCodeNoteSize(L"[4-bit] Test", 1U);
-        TestCodeNoteSize(L"[0-bit] Test", 1U);
-        TestCodeNoteSize(L"bit", 1U);
+        TestCodeNoteSize(L"[8-bit] Test", 1U);
+        TestCodeNoteSize(L"[9-bit] Test", 2U);
+        TestCodeNoteSize(L"bit", 0U);
         TestCodeNoteSize(L"9bit", 2U);
-        TestCodeNoteSize(L"-bit", 1U);
+        TestCodeNoteSize(L"-bit", 0U);
 
         TestCodeNoteSize(L"8 BYTE Test", 8U);
         TestCodeNoteSize(L"Test 8 BYTE", 8U);
-        TestCodeNoteSize(L"Test 8 BYT", 1U);
+        TestCodeNoteSize(L"Test 8 BYT", 0U);
         TestCodeNoteSize(L"[2 Byte] Test", 2U);
         TestCodeNoteSize(L"[4 Byte] Test", 4U);
         TestCodeNoteSize(L"[4 Byte - Float] Test", 4U);
@@ -2335,10 +2329,10 @@ public:
         TestCodeNoteSize(L"Test (6 bytes)", 6U);
         TestCodeNoteSize(L"[2byte] Test", 2U);
 
-        TestCodeNoteSize(L"42=bitten", 1U);
-        TestCodeNoteSize(L"42-bitten", 1U);
-        TestCodeNoteSize(L"bit by bit", 1U);
-        TestCodeNoteSize(L"bit1=chest", 1U);
+        TestCodeNoteSize(L"42=bitten", 0U);
+        TestCodeNoteSize(L"42-bitten", 0U);
+        TestCodeNoteSize(L"bit by bit", 0U);
+        TestCodeNoteSize(L"bit1=chest", 0U);
 
         TestCodeNoteSize(L"Bite count (16-bit)", 2U);
         TestCodeNoteSize(L"Number of bits collected (32 bits)", 4U);

--- a/tests/ui/viewmodels/TriggerViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/TriggerViewModel_Tests.cpp
@@ -749,6 +749,37 @@ public:
         Assert::AreEqual(std::string("0xH1234=16_0x 0008=2312_0xX0004=117835012"), vmTrigger.Serialize());
     }
 
+    TEST_METHOD(TestNewConditionCodeNoteSizeViewerSize)
+    {
+        std::array<uint8_t, 10> pMemory = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+        TriggerViewModelHarness vmTrigger;
+        Parse(vmTrigger, "0xH1234=16");
+        Assert::AreEqual({ 1U }, vmTrigger.Conditions().Count());
+        vmTrigger.mockGameContext.SetCodeNote({ 8U }, L"[16-bit] test");
+        vmTrigger.mockGameContext.SetCodeNote({ 2U }, L"[8-bit] test");
+        vmTrigger.mockGameContext.SetCodeNote({ 4U }, L"test");
+
+        vmTrigger.InitializeMemory(&pMemory.at(0), pMemory.size());
+        vmTrigger.mockWindowManager.MemoryInspector.Viewer().SetAddress(8);
+        vmTrigger.mockWindowManager.MemoryInspector.Viewer().SetSize(MemSize::ThirtyTwoBit);
+        vmTrigger.NewCondition();
+
+        Assert::AreEqual({ 2U }, vmTrigger.Conditions().Count());
+        Assert::AreEqual(std::string("0xH1234=16_0x 0008=2312"), vmTrigger.Serialize());
+
+        vmTrigger.mockWindowManager.MemoryInspector.Viewer().SetAddress(4);
+        vmTrigger.NewCondition();
+
+        Assert::AreEqual({ 3U }, vmTrigger.Conditions().Count());
+        Assert::AreEqual(std::string("0xH1234=16_0x 0008=2312_0xX0004=117835012"), vmTrigger.Serialize());
+
+        vmTrigger.mockWindowManager.MemoryInspector.Viewer().SetAddress(2);
+        vmTrigger.NewCondition();
+
+        Assert::AreEqual({ 4U }, vmTrigger.Conditions().Count());
+        Assert::AreEqual(std::string("0xH1234=16_0x 0008=2312_0xX0004=117835012_0xH0002=2"), vmTrigger.Serialize());
+    }
+
     TEST_METHOD(TestAddGroupNoAlts)
     {
         TriggerViewModelHarness vmTrigger;


### PR DESCRIPTION
If bit and byte both exist in a code note, give preference to byte. Allows for annotating large collections of smaller data: "[400 byte] 100x 32-bit integer"

Differentiate between explicitly specifying "[8-bit]" versus not having an annotation. Fixes a minor issue where adding conditions for an annotated "[8-bit]" address in non-8-bit mode would not create an 8-bit comparison.