### PR TITLE
show Unknown Title dialog when viewing game hash in Test Compatibility mode

### DIFF
--- a/src/data/context/GameContext.hh
+++ b/src/data/context/GameContext.hh
@@ -72,7 +72,13 @@ public:
     /// <summary>
     /// Sets the game play mode.
     /// </summary>
-    void SetMode(Mode nMode) noexcept { m_nMode = nMode; }
+    void SetMode(Mode nMode)
+    {
+        m_nMode = nMode;
+
+        if (m_nGameId != 0)
+            OnActiveGameChanged();
+    }
 
     /// <summary>
     /// Gets the assets for the current game.

--- a/src/ui/viewmodels/UnknownGameViewModel.hh
+++ b/src/ui/viewmodels/UnknownGameViewModel.hh
@@ -55,6 +55,21 @@ public:
     void InitializeGameTitles();
 
     /// <summary>
+    /// Initializes the <see cref="GameTitles"/> collection (asynchronously).
+    /// </summary>
+    void InitializeTestCompatibilityMode();
+
+    /// <summary>
+    /// The <see cref="ModelProperty" /> for whether or not a game can be selected.
+    /// </summary>
+    static const BoolModelProperty IsSelectedGameEnabledProperty;
+
+    /// <summary>
+    /// Gets whether or not a game can be selected.
+    /// </summary>
+    bool IsSelectedGameEnabled() const { return GetValue(IsSelectedGameEnabledProperty); }
+
+    /// <summary>
     /// The <see cref="ModelProperty" /> for the new game name.
     /// </summary>
     static const StringModelProperty NewGameNameProperty;
@@ -133,6 +148,16 @@ public:
     /// Sets whether test mode is selected.
     /// </summary>
     void SetTestMode(bool bValue) { SetValue(TestModeProperty, bValue); }
+
+    /// <summary>
+    /// The <see cref="ModelProperty" /> for whether or not the link button is enabled.
+    /// </summary>
+    static const BoolModelProperty IsAssociateEnabledProperty;
+
+    /// <summary>
+    /// Gets whether or not the link button is enabled.
+    /// </summary>
+    bool IsAssociateEnabled() const { return GetValue(IsAssociateEnabledProperty); }
 
     /// <summary>
     /// Command handler for Associate button.

--- a/src/ui/win32/UnknownGameDialog.cpp
+++ b/src/ui/win32/UnknownGameDialog.cpp
@@ -34,13 +34,18 @@ UnknownGameDialog::UnknownGameDialog(ra::ui::viewmodels::UnknownGameViewModel& v
 
     m_bindExistingTitle.BindItems(vmUnknownGame.GameTitles());
     m_bindExistingTitle.BindSelectedItem(ra::ui::viewmodels::UnknownGameViewModel::SelectedGameIdProperty);
+    m_bindWindow.BindEnabled(IDC_RA_KNOWNGAMES, ra::ui::viewmodels::UnknownGameViewModel::IsSelectedGameEnabledProperty);
 
     m_bindNewTitle.BindText(ra::ui::viewmodels::UnknownGameViewModel::NewGameNameProperty,
         ra::ui::win32::bindings::TextBoxBinding::UpdateMode::KeyPress);
+    m_bindWindow.BindEnabled(IDC_RA_GAMETITLE, ra::ui::viewmodels::UnknownGameViewModel::IsSelectedGameEnabledProperty);
 
     m_bindWindow.BindLabel(IDC_RA_GAMENAME, ra::ui::viewmodels::UnknownGameViewModel::EstimatedGameNameProperty);
     m_bindWindow.BindLabel(IDC_RA_SYSTEMNAME, ra::ui::viewmodels::UnknownGameViewModel::SystemNameProperty);
     m_bindWindow.BindLabel(IDC_RA_CHECKSUM, ra::ui::viewmodels::UnknownGameViewModel::ChecksumProperty);
+
+    m_bindWindow.BindEnabled(IDC_RA_LINK, ra::ui::viewmodels::UnknownGameViewModel::IsAssociateEnabledProperty);
+    m_bindWindow.BindEnabled(IDOK, ra::ui::viewmodels::UnknownGameViewModel::IsSelectedGameEnabledProperty);
 }
 
 BOOL UnknownGameDialog::OnInitDialog()

--- a/tests/data/context/GameContext_Tests.cpp
+++ b/tests/data/context/GameContext_Tests.cpp
@@ -2667,6 +2667,49 @@ public:
         const auto* pNote1 = game.FindCodeNote(1234U);
         Assert::IsNull(pNote1);
     }
+
+    TEST_METHOD(TestSetModeNotify)
+    {
+        class NotifyHarness : public GameContext::NotifyTarget
+        {
+        public:
+            bool m_bNotified = false;
+
+        protected:
+            void OnActiveGameChanged() noexcept override { m_bNotified = true; }
+        };
+        NotifyHarness notifyHarness;
+
+        GameContextHarness game;
+        game.mockServer.HandleRequest<ra::api::FetchGameData>([](const ra::api::FetchGameData::Request&, ra::api::FetchGameData::Response& response)
+        {
+            response.Title = L"GameTitle";
+            response.ImageIcon = "9743";
+            return true;
+        });
+
+        Assert::AreEqual(GameContext::Mode::Normal, game.GetMode());
+
+        game.AddNotifyTarget(notifyHarness);
+        game.LoadGame(0U);
+
+        Assert::AreEqual(0U, game.GameId());
+        Assert::IsFalse(notifyHarness.m_bNotified);
+
+        game.SetMode(GameContext::Mode::CompatibilityTest);
+        Assert::AreEqual(GameContext::Mode::CompatibilityTest, game.GetMode());
+        Assert::IsFalse(notifyHarness.m_bNotified);
+
+        game.LoadGame(1U, GameContext::Mode::CompatibilityTest);
+        Assert::AreEqual(1U, game.GameId());
+        Assert::AreEqual(GameContext::Mode::CompatibilityTest, game.GetMode());
+        Assert::IsTrue(notifyHarness.m_bNotified);
+
+        notifyHarness.m_bNotified = false;
+        game.SetMode(GameContext::Mode::Normal);
+        Assert::AreEqual(GameContext::Mode::Normal, game.GetMode());
+        Assert::IsTrue(notifyHarness.m_bNotified);
+    }
 };
 
 } // namespace tests

--- a/tests/ui/viewmodels/IntegrationMenuViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/IntegrationMenuViewModel_Tests.cpp
@@ -13,10 +13,13 @@
 #include "ui\viewmodels\MemoryInspectorViewModel.hh"
 #include "ui\viewmodels\OverlaySettingsViewModel.hh"
 #include "ui\viewmodels\RichPresenceMonitorViewModel.hh"
+#include "ui\viewmodels\UnknownGameViewModel.hh"
 
+#include "tests\data\DataAsserts.hh"
 #include "tests\ui\UIAsserts.hh"
 #include "tests\mocks\MockAchievementRuntime.hh"
 #include "tests\mocks\MockConfiguration.hh"
+#include "tests\mocks\MockConsoleContext.hh"
 #include "tests\mocks\MockDesktop.hh"
 #include "tests\mocks\MockEmulatorContext.hh"
 #include "tests\mocks\MockGameContext.hh"
@@ -40,6 +43,7 @@ private:
     {
     public:
         ra::api::mocks::MockServer mockServer;
+        ra::data::context::mocks::MockConsoleContext mockConsoleContext;
         ra::data::context::mocks::MockEmulatorContext mockEmulatorContext;
         ra::data::context::mocks::MockGameContext mockGameContext;
         ra::data::context::mocks::MockUserContext mockUserContext;
@@ -530,6 +534,47 @@ public:
         menu.AssertShowWindow<ra::ui::viewmodels::GameChecksumViewModel>(IDM_RA_GETROMCHECKSUM, true, "", DialogResult::None);
     }
 
+    TEST_METHOD(TestShowGameHashTestCompatibilityModeCancel)
+    {
+        IntegrationMenuViewModelHarness menu;
+
+        bool bDialogShown = false;
+        menu.mockDesktop.ExpectWindow<ra::ui::viewmodels::UnknownGameViewModel>([&bDialogShown](ra::ui::viewmodels::UnknownGameViewModel& vmUnknown)
+        {
+            bDialogShown = true;
+
+            Assert::IsFalse(vmUnknown.IsSelectedGameEnabled());
+
+            return DialogResult::Cancel;
+        });
+
+        menu.mockGameContext.SetMode(ra::data::context::GameContext::Mode::CompatibilityTest);
+        menu.ActivateMenuItem(IDM_RA_GETROMCHECKSUM);
+
+        Assert::IsTrue(bDialogShown);
+        Assert::AreEqual(ra::data::context::GameContext::Mode::CompatibilityTest, menu.mockGameContext.GetMode());
+    }
+
+    TEST_METHOD(TestShowGameHashTestCompatibilityModeAssociate)
+    {
+        IntegrationMenuViewModelHarness menu;
+
+        bool bDialogShown = false;
+        menu.mockDesktop.ExpectWindow<ra::ui::viewmodels::UnknownGameViewModel>([&bDialogShown](ra::ui::viewmodels::UnknownGameViewModel& vmUnknown)
+        {
+            bDialogShown = true;
+
+            Assert::IsFalse(vmUnknown.IsSelectedGameEnabled());
+
+            return DialogResult::OK;
+        });
+
+        menu.mockGameContext.SetMode(ra::data::context::GameContext::Mode::CompatibilityTest);
+        menu.ActivateMenuItem(IDM_RA_GETROMCHECKSUM);
+
+        Assert::IsTrue(bDialogShown);
+        Assert::AreEqual(ra::data::context::GameContext::Mode::Normal, menu.mockGameContext.GetMode());
+    }
 };
 
 } // namespace tests


### PR DESCRIPTION
When clicking on the "View Game Hash" menu option in Test Compatibility mode, the Unknown Title dialog is shown again, but the game selector and test buttons are disabled.

The user can then link the hash via the Link button (closes #414) or Cancel to dismiss the dialog.

The selector, link and test buttons are also disabled while the list is being populated. I suspect this will address #415, but I have never been able to reproduce. I will leave that open for now.

