### PR TITLE
add validation warnings to achievement editor

### DIFF
--- a/src/RA_Integration.vcxproj
+++ b/src/RA_Integration.vcxproj
@@ -56,6 +56,7 @@
     <ClCompile Include="data\models\CapturedTriggerHits.cpp" />
     <ClCompile Include="data\models\LeaderboardModel.cpp" />
     <ClCompile Include="data\models\LocalBadgesModel.cpp" />
+    <ClCompile Include="data\models\TriggerValidation.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
@@ -204,6 +205,7 @@
     <ClInclude Include="data\models\CapturedTriggerHits.hh" />
     <ClInclude Include="data\models\LeaderboardModel.hh" />
     <ClInclude Include="data\models\LocalBadgesModel.hh" />
+    <ClInclude Include="data\models\TriggerValidation.hh" />
     <ClInclude Include="data\Types.hh" />
     <ClInclude Include="Exports.hh" />
     <ClInclude Include="pch.h" />

--- a/src/RA_Integration.vcxproj.filters
+++ b/src/RA_Integration.vcxproj.filters
@@ -381,6 +381,9 @@
     <ClCompile Include="ui\viewmodels\IntegrationMenuViewModel.cpp">
       <Filter>UI\ViewModels</Filter>
     </ClCompile>
+    <ClCompile Include="data\models\TriggerValidation.cpp">
+      <Filter>Data\Models</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="RA_Leaderboard.h">
@@ -946,6 +949,9 @@
     </ClInclude>
     <ClInclude Include="ui\viewmodels\IntegrationMenuViewModel.hh">
       <Filter>UI\ViewModels</Filter>
+    </ClInclude>
+    <ClInclude Include="data\models\TriggerValidation.hh">
+      <Filter>Data\Models</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/data/models/AchievementModel.cpp
+++ b/src/data/models/AchievementModel.cpp
@@ -3,6 +3,7 @@
 #include "data\context\GameContext.hh"
 
 #include "data\models\LocalBadgesModel.hh"
+#include "data\models\TriggerValidation.hh"
 
 #include "services\AchievementRuntime.hh"
 #include "services\IClock.hh"
@@ -114,6 +115,12 @@ void AchievementModel::CommitTransaction()
     }
 
     AssetModelBase::CommitTransaction();
+}
+
+bool AchievementModel::ValidateAsset(std::wstring& sError)
+{
+    const auto& sTrigger = GetLocalAssetDefinition(m_pTrigger);
+    return TriggerValidation::Validate(sTrigger, sError);
 }
 
 void AchievementModel::DoFrame()

--- a/src/data/models/AchievementModel.hh
+++ b/src/data/models/AchievementModel.hh
@@ -136,6 +136,8 @@ protected:
 
     void CommitTransaction() override;
 
+    bool ValidateAsset(std::wstring& sErrorMessage) override;
+
 private:
     void HandleStateChanged(AssetState nOldState, AssetState nNewState);
 

--- a/src/data/models/AssetModelBase.cpp
+++ b/src/data/models/AssetModelBase.cpp
@@ -14,6 +14,7 @@ const IntModelProperty AssetModelBase::StateProperty("AssetModelBase", "State", 
 const IntModelProperty AssetModelBase::ChangesProperty("AssetModelBase", "Changes", ra::etoi(AssetChanges::None));
 const IntModelProperty AssetModelBase::CreationTimeProperty("AssetModelBase", "CreationTime", 0);
 const IntModelProperty AssetModelBase::UpdatedTimeProperty("AssetModelBase", "UpdatedTime", 0);
+const StringModelProperty AssetModelBase::ValidationErrorProperty("AssetModelBase", "ValidationError", L"");
 
 AssetModelBase::AssetModelBase() noexcept
 {
@@ -174,6 +175,7 @@ void AssetModelBase::CreateLocalCheckpoint()
     BeginTransaction();       // start transaction for in-memory changes
 
     SetValue(ChangesProperty, bModified ? ra::etoi(AssetChanges::Unpublished) : ra::etoi(AssetChanges::None));
+    Validate();
 }
 
 void AssetModelBase::UpdateLocalCheckpoint()
@@ -194,6 +196,7 @@ void AssetModelBase::UpdateServerCheckpoint()
     BeginTransaction();      // start transaction for in-memory changes
 
     SetValue(ChangesProperty, ra::etoi(AssetChanges::None));
+    Validate();
 }
 
 void AssetModelBase::RestoreLocalCheckpoint()
@@ -215,6 +218,7 @@ void AssetModelBase::RestoreServerCheckpoint()
     BeginTransaction();      // start transaction for in-memory changes
 
     SetValue(ChangesProperty, ra::etoi(AssetChanges::None));
+    Validate();
     EndUpdate();
 }
 
@@ -242,6 +246,7 @@ void AssetModelBase::SetNew()
 void AssetModelBase::SetDeleted()
 {
     SetValue(ChangesProperty, ra::etoi(AssetChanges::Deleted));
+    SetValue(ValidationErrorProperty, ValidationErrorProperty.GetDefaultValue());
 }
 
 bool AssetModelBase::HasUnpublishedChanges() const noexcept
@@ -571,6 +576,14 @@ const char* AssetModelBase::GetAssetTypeString(AssetType nType) noexcept
     }
 }
 
+bool AssetModelBase::Validate()
+{
+    std::wstring sError;
+    const bool bResult = ValidateAsset(sError);
+
+    SetValue(ValidationErrorProperty, sError);
+    return bResult;
+}
 
 } // namespace models
 } // namespace data

--- a/src/data/models/AssetModelBase.hh
+++ b/src/data/models/AssetModelBase.hh
@@ -200,6 +200,25 @@ public:
     virtual void Deactivate() noexcept(false) {}
 
     /// <summary>
+    /// The <see cref="ModelProperty" /> for the reason why the asset is not valid.
+    /// </summary>
+    static const StringModelProperty ValidationErrorProperty;
+
+    /// <summary>
+    /// Gets the reason why the asset is not valid.
+    /// </summary>
+    const std::wstring& GetValidationError() const { return GetValue(ValidationErrorProperty); }
+
+    /// <summary>
+    /// Updates the <see cref="ValidationErrorProperty" />.
+    /// </summary>
+    /// <returns>
+    /// <c>true</c> if the asset is valid (GetValidationError will return empty string).
+    /// <c>false</c> if the asset is not valid (GetValidationError will return more information about why).
+    /// </returns>
+    bool Validate();
+
+    /// <summary>
     /// Updates the asset for the current frame.
     /// </summary>
     virtual void DoFrame() noexcept(false) {}
@@ -302,6 +321,8 @@ protected:
     bool GetLocalValue(const BoolModelProperty& pProperty) const;
     const std::wstring& GetLocalValue(const StringModelProperty& pProperty) const;
     int GetLocalValue(const IntModelProperty& pProperty) const;
+
+    virtual bool ValidateAsset(std::wstring& sErrorMessage) noexcept(false) { (void)sErrorMessage; return true; }
 
     static void WriteNumber(ra::services::TextWriter& pWriter, const uint32_t nValue);
     static void WriteQuoted(ra::services::TextWriter& pWriter, const std::string& sText);

--- a/src/data/models/CapturedTriggerHits.hh
+++ b/src/data/models/CapturedTriggerHits.hh
@@ -2,8 +2,6 @@
 #define RA_DATA_CAPTURED_TRIGGER_HITS_H
 #pragma once
 
-#include "CapturedTriggerHits.hh"
-
 namespace ra {
 namespace data {
 namespace models {

--- a/src/data/models/LeaderboardModel.cpp
+++ b/src/data/models/LeaderboardModel.cpp
@@ -2,6 +2,8 @@
 
 #include "data\context\GameContext.hh"
 
+#include "data\models\TriggerValidation.hh"
+
 #include "services\AchievementRuntime.hh"
 #include "services\ServiceLocator.hh"
 
@@ -48,6 +50,32 @@ void LeaderboardModel::OnValueChanged(const IntModelProperty::ChangeArgs& args)
     }
 
     AssetModelBase::OnValueChanged(args);
+}
+
+bool LeaderboardModel::ValidateAsset(std::wstring& sError)
+{
+    const auto& sStartTrigger = GetLocalAssetDefinition(m_pStartTrigger);
+    if (!TriggerValidation::Validate(sStartTrigger, sError))
+    {
+        sError.insert(0, L"Start: ");
+        return false;
+    }
+
+    const auto& sSubmitTrigger = GetLocalAssetDefinition(m_pSubmitTrigger);
+    if (!TriggerValidation::Validate(sSubmitTrigger, sError))
+    {
+        sError.insert(0, L"Submit: ");
+        return false;
+    }
+
+    const auto& sCancelTrigger = GetLocalAssetDefinition(m_pCancelTrigger);
+    if (!TriggerValidation::Validate(sCancelTrigger, sError))
+    {
+        sError.insert(0, L"Cancel: ");
+        return false;
+    }
+
+    return true;
 }
 
 void LeaderboardModel::DoFrame()

--- a/src/data/models/LeaderboardModel.hh
+++ b/src/data/models/LeaderboardModel.hh
@@ -141,6 +141,8 @@ public:
 protected:
     void OnValueChanged(const IntModelProperty::ChangeArgs& args) override;
 
+    bool ValidateAsset(std::wstring& sErrorMessage) override;
+
 private:
     void HandleStateChanged(AssetState nOldState, AssetState nNewState);
 

--- a/src/data/models/TriggerValidation.cpp
+++ b/src/data/models/TriggerValidation.cpp
@@ -1,0 +1,112 @@
+#include "TriggerValidation.hh"
+
+#include "RA_StringUtils.h"
+
+#include <rcheevos/include/rc_runtime_types.h>
+
+namespace ra {
+namespace data {
+namespace models {
+
+static bool ValidateCondSet(const rc_condset_t* pCondSet, std::wstring& sError)
+{
+    bool bInAddHits = false;
+    bool bIsCombining = false;
+
+    int nIndex = 1;
+    const rc_condition_t* pCondition = pCondSet->conditions;
+    while (pCondition != nullptr)
+    {
+        switch (pCondition->type)
+        {
+            case RC_CONDITION_ADD_HITS:
+            case RC_CONDITION_SUB_HITS:
+                bIsCombining = true;
+                bInAddHits = true;
+                break;
+
+            case RC_CONDITION_ADD_SOURCE:
+            case RC_CONDITION_SUB_SOURCE:
+            case RC_CONDITION_ADD_ADDRESS:
+            case RC_CONDITION_AND_NEXT:
+            case RC_CONDITION_OR_NEXT:
+            case RC_CONDITION_RESET_NEXT_IF:
+                bIsCombining = true;
+                break;
+
+            default:
+                if (bInAddHits)
+                {
+                    if (pCondition->required_hits == 0)
+                    {
+                        sError = ra::StringPrintf(L"Condition %u: Final condition in AddHits chain must have a hit target.", nIndex);
+                        return false;
+                    }
+
+                    bInAddHits = false;
+                }
+
+                bIsCombining = false;
+                break;
+        }
+
+        ++nIndex;
+        pCondition = pCondition->next;
+    }
+
+    if (bIsCombining)
+    {
+        sError = L"Final condition type expects another condition to follow.";
+        return false;
+    }
+
+    return true;
+}
+
+static bool ValidateTrigger(const rc_trigger_t* pTrigger, std::wstring& sError)
+{
+    if (pTrigger->requirement && !ValidateCondSet(pTrigger->requirement, sError))
+    {
+        if (pTrigger->alternative != nullptr)
+            sError.insert(0, L"Core: ");
+
+        return false;
+    }
+
+    int nAlt = 1;
+    const rc_condset_t* pCondSet = pTrigger->alternative;
+    while (pCondSet != nullptr)
+    {
+        if (!ValidateCondSet(pCondSet, sError))
+        {
+            sError.insert(0, L"Alt : ");
+            sError.insert(4, std::to_wstring(nAlt));
+            return false;
+        }
+
+        ++nAlt;
+        pCondSet = pCondSet->next;
+    }
+
+    return true;
+}
+
+bool TriggerValidation::Validate(const std::string& sTrigger, std::wstring& sError)
+{
+    const auto nSize = rc_trigger_size(sTrigger.c_str());
+    if (nSize < 0)
+    {
+        sError = ra::Widen(rc_error_str(nSize));
+        return false;
+    }
+
+    std::string sTriggerBuffer;
+    sTriggerBuffer.resize(nSize);
+    const auto* pTrigger = rc_parse_trigger(sTriggerBuffer.data(), sTrigger.c_str(), nullptr, 0);
+
+    return ValidateTrigger(pTrigger, sError);
+}
+
+} // namespace models
+} // namespace data
+} // namespace ra

--- a/src/data/models/TriggerValidation.hh
+++ b/src/data/models/TriggerValidation.hh
@@ -1,0 +1,19 @@
+#ifndef RA_DATA_TRIGGER_VALIDATION_H
+#define RA_DATA_TRIGGER_VALIDATION_H
+#pragma once
+
+namespace ra {
+namespace data {
+namespace models {
+
+class TriggerValidation
+{
+public:
+    static bool Validate(const std::string& sTrigger, std::wstring& sError);
+};
+
+} // namespace models
+} // namespace data
+} // namespace ra
+
+#endif RA_DATA_TRIGGER_VALIDATION_H

--- a/src/rcheevos.vcxproj
+++ b/src/rcheevos.vcxproj
@@ -175,7 +175,8 @@
     <Lib />
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClInclude Include="..\rcheevos\include\rcheevos.h" />
+    <ClInclude Include="..\rcheevos\include\rc_runtime.h" />
+    <ClInclude Include="..\rcheevos\include\rc_runtime_types.h" />
     <ClInclude Include="..\rcheevos\src\rcheevos\compat.h" />
     <ClInclude Include="..\rcheevos\src\rcheevos\internal.h" />
     <ClCompile Include="..\rcheevos\src\rapi\rc_api_common.c">
@@ -190,6 +191,7 @@
     </ClCompile>
     <ClCompile Include="..\rcheevos\src\rcheevos\memref.c" />
     <ClCompile Include="..\rcheevos\src\rcheevos\richpresence.c" />
+    <ClInclude Include="..\rcheevos\src\rcheevos\rc_internal.h" />
     <ClInclude Include="..\rcheevos\src\rhash\md5.h" />
     <ClCompile Include="..\lua\lapi.c" />
     <ClCompile Include="..\lua\lauxlib.c" />

--- a/src/rcheevos.vcxproj.filters
+++ b/src/rcheevos.vcxproj.filters
@@ -106,9 +106,6 @@
     <ClCompile Include="..\rcheevos\src\rcheevos\compat.c">
       <Filter>rcheevos</Filter>
     </ClCompile>
-    <ClInclude Include="..\rcheevos\include\rcheevos.h">
-      <Filter>rcheevos</Filter>
-    </ClInclude>
     <ClInclude Include="..\rcheevos\src\rcheevos\internal.h">
       <Filter>rcheevos</Filter>
     </ClInclude>
@@ -151,6 +148,15 @@
   <ItemGroup>
     <ClInclude Include="..\rcheevos\src\rhash\md5.h">
       <Filter>rhash</Filter>
+    </ClInclude>
+    <ClInclude Include="..\rcheevos\src\rcheevos\rc_internal.h">
+      <Filter>rcheevos</Filter>
+    </ClInclude>
+    <ClInclude Include="..\rcheevos\include\rc_runtime.h">
+      <Filter>rcheevos</Filter>
+    </ClInclude>
+    <ClInclude Include="..\rcheevos\include\rc_runtime_types.h">
+      <Filter>rcheevos</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/src/ui/viewmodels/AssetEditorViewModel.cpp
+++ b/src/ui/viewmodels/AssetEditorViewModel.cpp
@@ -102,6 +102,7 @@ void AssetEditorViewModel::LoadAsset(ra::data::models::AssetModelBase* pAsset)
         SetDescription(pAsset->GetDescription());
         SetState(pAsset->GetState());
         SetCategory(pAsset->GetCategory());
+        SetValue(AssetValidationWarningProperty, pAsset->GetValidationError());
 
         // normally this happens in OnValueChanged, but only if m_pAsset is set, which doesn't happen until later
         // and we don't want the other stuff in OnValueChanged to run right now
@@ -165,6 +166,7 @@ void AssetEditorViewModel::LoadAsset(ra::data::models::AssetModelBase* pAsset)
         SetPauseOnTrigger(PauseOnTriggerProperty.GetDefaultValue());
         SetWindowTitle(L"Achievement Editor");
         SetValue(WaitingLabelProperty, WaitingLabelProperty.GetDefaultValue());
+        SetValue(AssetValidationWarningProperty, AssetValidationErrorProperty.GetDefaultValue());
 
         ra::data::models::CapturedTriggerHits pCapturedHits;
         Trigger().InitializeFrom("", pCapturedHits);
@@ -187,6 +189,8 @@ void AssetEditorViewModel::OnDataModelStringValueChanged(const StringModelProper
         SetName(args.tNewValue);
     else if (args.Property == ra::data::models::AchievementModel::BadgeProperty)
         SetBadge(args.tNewValue);
+    else if (args.Property == ra::data::models::AssetModelBase::ValidationErrorProperty)
+        SetValue(AssetValidationWarningProperty, args.tNewValue);
 }
 
 void AssetEditorViewModel::OnDataModelIntValueChanged(const IntModelProperty::ChangeArgs& args)

--- a/src/ui/viewmodels/AssetEditorViewModel.cpp
+++ b/src/ui/viewmodels/AssetEditorViewModel.cpp
@@ -26,6 +26,8 @@ const BoolModelProperty AssetEditorViewModel::DecimalPreferredProperty("AssetEdi
 const BoolModelProperty AssetEditorViewModel::IsAssetLoadedProperty("AssetEditorViewModel", "IsAssetLoaded", false);
 const BoolModelProperty AssetEditorViewModel::HasAssetValidationErrorProperty("AssetEditorViewModel", "HasAssetValidationError", false);
 const StringModelProperty AssetEditorViewModel::AssetValidationErrorProperty("AssetEditorViewModel", "AssetValidationError", L"");
+const BoolModelProperty AssetEditorViewModel::HasAssetValidationWarningProperty("AssetEditorViewModel", "HasAssetValidationWarning", false);
+const StringModelProperty AssetEditorViewModel::AssetValidationWarningProperty("AssetEditorViewModel", "AssetValidationWarning", L"");
 const BoolModelProperty AssetEditorViewModel::HasMeasuredProperty("AssetEditorViewModel", "HasMeasured", false);
 const StringModelProperty AssetEditorViewModel::MeasuredValueProperty("AssetEditorViewModel", "MeasuredValue", L"[Not Active]");
 const StringModelProperty AssetEditorViewModel::WaitingLabelProperty("AssetEditorViewModel", "WaitingLabel", L"Active");
@@ -270,6 +272,8 @@ void AssetEditorViewModel::OnValueChanged(const StringModelProperty::ChangeArgs&
 
     if (args.Property == AssetValidationErrorProperty)
         SetValue(HasAssetValidationErrorProperty, !args.tNewValue.empty());
+    else if (args.Property == AssetValidationWarningProperty)
+        SetValue(HasAssetValidationWarningProperty, !args.tNewValue.empty());
 
     WindowViewModelBase::OnValueChanged(args);
 }

--- a/src/ui/viewmodels/AssetEditorViewModel.hh
+++ b/src/ui/viewmodels/AssetEditorViewModel.hh
@@ -57,6 +57,26 @@ public:
     /// </summary>
     const std::wstring& GetAssetValidationError() const { return GetValue(AssetValidationErrorProperty); }
 
+    /// <summary>
+    /// The <see cref="ModelProperty" /> for whether or not an AssetValidationWarning is set.
+    /// </summary>
+    static const BoolModelProperty HasAssetValidationWarningProperty;
+
+    /// <summary>
+    /// Gets whether or not an AssetValidationWarning is set.
+    /// </summary>
+    bool HasAssetValidationWarning() const { return GetValue(HasAssetValidationWarningProperty); }
+
+    /// <summary>
+    /// The <see cref="ModelProperty" /> for the reason why the asset is not valid.
+    /// </summary>
+    static const StringModelProperty AssetValidationWarningProperty;
+
+    /// <summary>
+    /// Gets the reason why the asset is not valid.
+    /// </summary>
+    const std::wstring& GetAssetValidationWarning() const { return GetValue(AssetValidationWarningProperty); }
+
     // ===== Common =====
 
     /// <summary>

--- a/src/ui/win32/AssetEditorDialog.cpp
+++ b/src/ui/win32/AssetEditorDialog.cpp
@@ -845,7 +845,9 @@ INT_PTR CALLBACK AssetEditorDialog::DialogProc(HWND hDlg, UINT uMsg, WPARAM wPar
                             NMTTDISPINFO* pnmTtDispInfo;
                             GSL_SUPPRESS_TYPE1{ pnmTtDispInfo = reinterpret_cast<NMTTDISPINFO*>(lParam); }
                             Expects(pnmTtDispInfo != nullptr);
-                            GSL_SUPPRESS_TYPE3 pnmTtDispInfo->lpszText = const_cast<LPTSTR>(vmAssetEditor->GetAssetValidationError().c_str());
+                            const auto& sError = (vmAssetEditor->HasAssetValidationError()) ?
+                                vmAssetEditor->GetAssetValidationError() : vmAssetEditor->GetAssetValidationWarning();
+                            GSL_SUPPRESS_TYPE3 pnmTtDispInfo->lpszText = const_cast<LPTSTR>(sError.c_str());
                             return 0;
                         }
                     }

--- a/src/ui/win32/AssetEditorDialog.cpp
+++ b/src/ui/win32/AssetEditorDialog.cpp
@@ -515,6 +515,12 @@ AssetEditorDialog::ErrorIconBinding::~ErrorIconBinding()
         ::DestroyIcon(m_hErrorIcon);
         m_hErrorIcon = nullptr;
     }
+
+    if (m_hWarningIcon)
+    {
+        ::DestroyIcon(m_hWarningIcon);
+        m_hWarningIcon = nullptr;
+    }
 }
 
 void AssetEditorDialog::ErrorIconBinding::SetHWND(DialogBase& pDialog, HWND hControl)
@@ -526,6 +532,8 @@ void AssetEditorDialog::ErrorIconBinding::SetHWND(DialogBase& pDialog, HWND hCon
 void AssetEditorDialog::ErrorIconBinding::OnViewModelBoolValueChanged(const BoolModelProperty::ChangeArgs& args)
 {
     if (args.Property == AssetEditorViewModel::HasAssetValidationErrorProperty)
+        UpdateImage();
+    else if (args.Property == AssetEditorViewModel::HasAssetValidationWarningProperty)
         UpdateImage();
 }
 
@@ -557,19 +565,33 @@ void AssetEditorDialog::ErrorIconBinding::SetErrorIcon()
         GSL_SUPPRESS_TYPE1::SendMessage(m_hWnd, STM_SETICON, reinterpret_cast<WPARAM>(m_hErrorIcon), NULL);
 }
 
+void AssetEditorDialog::ErrorIconBinding::SetWarningIcon()
+{
+    if (!m_hWarningIcon)
+        m_hWarningIcon = GetIcon(SIID_WARNING, MAKEINTRESOURCE(OIC_WARNING));
+
+    if (m_hWarningIcon)
+        GSL_SUPPRESS_TYPE1::SendMessage(m_hWnd, STM_SETICON, reinterpret_cast<WPARAM>(m_hWarningIcon), NULL);
+}
+
 void AssetEditorDialog::ErrorIconBinding::UpdateImage()
 {
-    if (m_hWnd)
+    if (!m_hWnd)
+        return;
+
+    if (GetValue(AssetEditorViewModel::HasAssetValidationErrorProperty))
     {
-        if (GetValue(AssetEditorViewModel::HasAssetValidationErrorProperty))
-        {
-            SetErrorIcon();
-            ShowWindow(m_hWnd, SW_SHOW);
-        }
-        else
-        {
-            ShowWindow(m_hWnd, SW_HIDE);
-        }
+        SetErrorIcon();
+        ShowWindow(m_hWnd, SW_SHOW);
+    }
+    else if (GetValue(AssetEditorViewModel::HasAssetValidationWarningProperty))
+    {
+        SetWarningIcon();
+        ShowWindow(m_hWnd, SW_SHOW);
+    }
+    else
+    {
+        ShowWindow(m_hWnd, SW_HIDE);
     }
 }
 

--- a/src/ui/win32/AssetEditorDialog.hh
+++ b/src/ui/win32/AssetEditorDialog.hh
@@ -117,8 +117,10 @@ private:
     private:
         void UpdateImage();
         void SetErrorIcon();
+        void SetWarningIcon();
 
         HICON m_hErrorIcon = nullptr;
+        HICON m_hWarningIcon = nullptr;
     };
 
     ra::ui::win32::bindings::NumericTextBoxBinding m_bindID;

--- a/src/ui/win32/AssetEditorDialog.hh
+++ b/src/ui/win32/AssetEditorDialog.hh
@@ -102,6 +102,25 @@ private:
         bool m_bWideId = false;
     };
 
+    class ErrorIconBinding : public ra::ui::win32::bindings::ControlBinding
+    {
+    public:
+        ErrorIconBinding(ViewModelBase& vmViewModel) noexcept
+            : ra::ui::win32::bindings::ControlBinding(vmViewModel) {}
+        ~ErrorIconBinding();
+
+    protected:
+        void SetHWND(DialogBase& pDialog, HWND hControl) override;
+
+        void OnViewModelBoolValueChanged(const BoolModelProperty::ChangeArgs& args) override;
+
+    private:
+        void UpdateImage();
+        void SetErrorIcon();
+
+        HICON m_hErrorIcon = nullptr;
+    };
+
     ra::ui::win32::bindings::NumericTextBoxBinding m_bindID;
     ra::ui::win32::bindings::TextBoxBinding m_bindName;
     ra::ui::win32::bindings::TextBoxBinding m_bindDescription;
@@ -109,6 +128,7 @@ private:
     ra::ui::win32::bindings::ImageBinding m_bindBadgeImage;
     ra::ui::win32::bindings::NumericTextBoxBinding m_bindPoints;
 
+    ErrorIconBinding m_bindErrorIcon;
     ra::ui::win32::bindings::CheckBoxBinding m_bindMeasuredAsPercent;
     ra::ui::win32::bindings::CheckBoxBinding m_bindDebugHighlights;
     ra::ui::win32::bindings::CheckBoxBinding m_bindPauseOnReset;
@@ -119,7 +139,6 @@ private:
     ra::ui::win32::bindings::GridBinding m_bindGroups;
     ConditionsGridBinding m_bindConditions;
 
-    HICON m_hErrorIcon = nullptr;
     HWND m_hTooltip = nullptr;
 };
 

--- a/tests/RA_Integration.Tests.vcxproj
+++ b/tests/RA_Integration.Tests.vcxproj
@@ -301,6 +301,7 @@
     <ClCompile Include="..\src\data\models\CapturedTriggerHits.cpp" />
     <ClCompile Include="..\src\data\models\LeaderboardModel.cpp" />
     <ClCompile Include="..\src\data\models\LocalBadgesModel.cpp" />
+    <ClCompile Include="..\src\data\models\TriggerValidation.cpp" />
     <ClCompile Include="..\src\pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
@@ -374,6 +375,7 @@
     <ClCompile Include="data\models\AssetModelBase_Tests.cpp" />
     <ClCompile Include="data\models\LeaderboardModel_Tests.cpp" />
     <ClCompile Include="data\models\LocalBadgesModel_Tests.cpp" />
+    <ClCompile Include="data\models\TriggerValidation_Tests.cpp" />
     <ClCompile Include="Exports_Tests.cpp" />
     <ClCompile Include="services\AchievementRuntime_Tests.cpp" />
     <ClCompile Include="services\FileLocalStorage_Tests.cpp" />

--- a/tests/RA_Integration.Tests.vcxproj.filters
+++ b/tests/RA_Integration.Tests.vcxproj.filters
@@ -429,6 +429,12 @@
     <ClCompile Include="ui\viewmodels\IntegrationMenuViewModel_Tests.cpp">
       <Filter>Tests\UI\ViewModels</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\data\models\TriggerValidation.cpp">
+      <Filter>Code</Filter>
+    </ClCompile>
+    <ClCompile Include="data\models\TriggerValidation_Tests.cpp">
+      <Filter>Tests\Data\Models</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="base.props" />

--- a/tests/data/models/TriggerValidation_Tests.cpp
+++ b/tests/data/models/TriggerValidation_Tests.cpp
@@ -1,0 +1,70 @@
+#include "CppUnitTest.h"
+
+#include "data\models\TriggerValidation.hh"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace ra {
+namespace data {
+namespace models {
+namespace tests {
+
+TEST_CLASS(TriggerValidation_Tests)
+{
+private:
+    void AssertValidation(const std::string& sTrigger, const std::wstring& sExpectedError)
+    {
+        std::wstring sError;
+        const bool bResult = TriggerValidation::Validate(sTrigger, sError);
+        Assert::AreEqual(sExpectedError, sError);
+        Assert::AreEqual(bResult, sExpectedError.empty());
+    }
+
+public:
+    TEST_METHOD(TestEmpty)
+    {
+        AssertValidation("", L"");
+    }
+
+    TEST_METHOD(TestValid)
+    {
+        AssertValidation("0xH1234=1_0xH2345=2S0xH3456=1S0xH3456=2", L"");
+    }
+
+    TEST_METHOD(TestLastConditionCombining)
+    {
+        AssertValidation("0xH1234=1_A:0xH2345=2", L"Final condition type expects another condition to follow.");
+        AssertValidation("0xH1234=1_B:0xH2345=2", L"Final condition type expects another condition to follow.");
+        AssertValidation("0xH1234=1_C:0xH2345=2", L"Final condition type expects another condition to follow.");
+        AssertValidation("0xH1234=1_D:0xH2345=2", L"Final condition type expects another condition to follow.");
+        AssertValidation("0xH1234=1_N:0xH2345=2", L"Final condition type expects another condition to follow.");
+        AssertValidation("0xH1234=1_O:0xH2345=2", L"Final condition type expects another condition to follow.");
+        AssertValidation("0xH1234=1_Z:0xH2345=2", L"Final condition type expects another condition to follow.");
+
+        AssertValidation("0xH1234=1_A:0xH2345=2S0x3456=1", L"Core: Final condition type expects another condition to follow.");
+        AssertValidation("0x3456=1S0xH1234=1_A:0xH2345=2", L"Alt 1: Final condition type expects another condition to follow.");
+    }
+
+    TEST_METHOD(TestMiddleConditionCombining)
+    {
+        AssertValidation("A:0xH1234=1_0xH2345=2", L"");
+        AssertValidation("B:0xH1234=1_0xH2345=2", L"");
+        AssertValidation("N:0xH1234=1_0xH2345=2", L"");
+        AssertValidation("O:0xH1234=1_0xH2345=2", L"");
+        AssertValidation("Z:0xH1234=1_0xH2345=2", L"");
+    }
+
+    TEST_METHOD(TestAddHitsChainWithoutTarget)
+    {
+        AssertValidation("C:0xH1234=1_0xH2345=2", L"Condition 2: Final condition in AddHits chain must have a hit target.");
+        AssertValidation("D:0xH1234=1_0xH2345=2", L"Condition 2: Final condition in AddHits chain must have a hit target.");
+        AssertValidation("C:0xH1234=1_0xH2345=2.1.", L"");
+        AssertValidation("D:0xH1234=1_0xH2345=2.1.", L"");
+    }
+};
+
+
+} // namespace tests
+} // namespace models
+} // namespace data
+} // namespace ra


### PR DESCRIPTION
Initially just reports when the last condition has a modifier flag:
![image](https://user-images.githubusercontent.com/32680403/134087578-74ee6934-3ab3-4fd2-9999-fa67d21d61af.png)

Also reports when an AddHits chain does not have a target hit count (closes #476):
![image](https://user-images.githubusercontent.com/32680403/134087620-f2a55fcc-2024-4d33-b7ea-fe3e2e45efe5.png)

More validation will be added in the future (i.e. comparing 8-bit memory address to value greater than 255)

These are non-blocking errors (you can still save and promote).

The error is also only evaluated when loading or saving. This prevents the indicator from flashing while the achievement is being edited.