### PR TITLE
fix centered popup not displaying if wider than window

### DIFF
--- a/src/ui/viewmodels/OverlayManager.cpp
+++ b/src/ui/viewmodels/OverlayManager.cpp
@@ -339,11 +339,11 @@ ra::ui::Position OverlayManager::GetRenderLocation(const ra::ui::viewmodels::Pop
             break;
         case PopupLocation::TopMiddle:
         case PopupLocation::BottomMiddle:
-            nPos.X = (pSurface.GetWidth() - vmPopup.GetRenderImage().GetWidth()) / 2;
+            nPos.X = (ra::to_signed(pSurface.GetWidth()) - ra::to_signed(vmPopup.GetRenderImage().GetWidth())) / 2;
             break;
         case PopupLocation::TopRight:
         case PopupLocation::BottomRight:
-            nPos.X = pSurface.GetWidth() - vmPopup.GetRenderImage().GetWidth() - nPos.X;
+            nPos.X = (ra::to_signed(pSurface.GetWidth()) - ra::to_signed(vmPopup.GetRenderImage().GetWidth())) - nPos.X;
             break;
     }
 


### PR DESCRIPTION
When using the Top Center or Bottom Center popup positions, if the popup ended up being wider than the display area of the screen, the calculated position for it was a very high positive number, instead of a slightly negative number, so the popup would not render as expected.