### PR TITLE
show warnings for comparison size mismatches

### DIFF
--- a/src/data/models/TriggerValidation.cpp
+++ b/src/data/models/TriggerValidation.cpp
@@ -174,7 +174,7 @@ static bool ValidateCondSet(const rc_condset_t* pCondSet, std::wstring& sError)
             if (overflow > 0xFFFFFFFFUL)
                 nMax = 0xFFFFFFFF;
             else
-                nMax = (unsigned)overflow;
+                nMax = gsl::narrow_cast<unsigned>(overflow);
         }
 
         // maximum comparison value

--- a/src/data/models/TriggerValidation.cpp
+++ b/src/data/models/TriggerValidation.cpp
@@ -8,25 +8,143 @@ namespace ra {
 namespace data {
 namespace models {
 
+MemSize TriggerValidation::MapRcheevosMemSize(char nSize) noexcept
+{
+    switch (nSize)
+    {
+        case RC_MEMSIZE_BIT_0: return MemSize::Bit_0;
+        case RC_MEMSIZE_BIT_1: return MemSize::Bit_1;
+        case RC_MEMSIZE_BIT_2: return MemSize::Bit_2;
+        case RC_MEMSIZE_BIT_3: return MemSize::Bit_3;
+        case RC_MEMSIZE_BIT_4: return MemSize::Bit_4;
+        case RC_MEMSIZE_BIT_5: return MemSize::Bit_5;
+        case RC_MEMSIZE_BIT_6: return MemSize::Bit_6;
+        case RC_MEMSIZE_BIT_7: return MemSize::Bit_7;
+        case RC_MEMSIZE_LOW: return MemSize::Nibble_Lower;
+        case RC_MEMSIZE_HIGH: return MemSize::Nibble_Upper;
+        case RC_MEMSIZE_8_BITS: return MemSize::EightBit;
+        case RC_MEMSIZE_16_BITS: return MemSize::SixteenBit;
+        case RC_MEMSIZE_24_BITS: return MemSize::TwentyFourBit;
+        case RC_MEMSIZE_32_BITS: return MemSize::ThirtyTwoBit;
+        case RC_MEMSIZE_BITCOUNT: return MemSize::BitCount;
+        case RC_MEMSIZE_16_BITS_BE: return MemSize::SixteenBitBigEndian;
+        case RC_MEMSIZE_24_BITS_BE: return MemSize::TwentyFourBitBigEndian;
+        case RC_MEMSIZE_32_BITS_BE: return MemSize::ThirtyTwoBitBigEndian;
+        default:
+            assert(!"Unsupported operand size");
+            return MemSize::EightBit;
+    }
+}
+
+static unsigned MaxValue(const rc_operand_t* pOperand)
+{
+    if (pOperand->type == RC_OPERAND_CONST)
+        return pOperand->value.num;
+
+    if (!rc_operand_is_memref(pOperand))
+        return 0xFFFFFFFF;
+
+    return MemSizeMax(TriggerValidation::MapRcheevosMemSize(pOperand->size));
+}
+
+static int ValidateRange(unsigned nMinValue, unsigned nMaxValue, char nOperator, unsigned nMax, std::wstring& sError) {
+    switch (nOperator) {
+        case RC_OPERATOR_AND:
+            if (nMinValue > nMax) {
+                sError = L"Mask has more bits than source";
+                return false;
+            }
+            else if (nMinValue == 0 && nMaxValue == 0) {
+                sError = L"Result of mask is always 0";
+                return false;
+            }
+            break;
+
+        case RC_OPERATOR_EQ:
+            if (nMinValue > nMax) {
+                sError = L"Comparison is never true";
+                return false;
+            }
+            break;
+
+        case RC_OPERATOR_NE:
+            if (nMinValue > nMax) {
+                sError = L"Comparison is always true";
+                return false;
+            }
+            break;
+
+        case RC_OPERATOR_GE:
+            if (nMinValue > nMax) {
+                sError = L"Comparison is never true";
+                return false;
+            }
+            if (nMaxValue == 0) {
+                sError = L"Comparison is always true";
+                return false;
+            }
+            break;
+
+        case RC_OPERATOR_GT:
+            if (nMinValue >= nMax) {
+                sError = L"Comparison is never true";
+                return false;
+            }
+            break;
+
+        case RC_OPERATOR_LE:
+            if (nMinValue >= nMax) {
+                sError = L"Comparison is always true";
+                return false;
+            }
+            break;
+
+        case RC_OPERATOR_LT:
+            if (nMinValue > nMax) {
+                sError = L"Comparison is always true";
+                return false;
+            }
+            if (nMaxValue == 0) {
+                sError = L"Comparison is never true";
+                return false;
+            }
+            break;
+    }
+
+    return true;
+}
+
 static bool ValidateCondSet(const rc_condset_t* pCondSet, std::wstring& sError)
 {
     bool bInAddHits = false;
     bool bIsCombining = false;
+    unsigned long long nAddSourceMax = 0;
 
     int nIndex = 1;
     const rc_condition_t* pCondition = pCondSet->conditions;
-    while (pCondition != nullptr)
+    for (; pCondition != nullptr; ++nIndex, pCondition = pCondition->next)
     {
+        unsigned nMax = MaxValue(&pCondition->operand1); // maximum possible calculated value for comparison
+
         switch (pCondition->type)
         {
+            case RC_CONDITION_ADD_SOURCE:
+                nAddSourceMax += nMax;
+                bIsCombining = true;
+                continue;
+
+            case RC_CONDITION_SUB_SOURCE:
+                if (nAddSourceMax < nMax) // ignore potential underflow - may be expected
+                    nAddSourceMax = 0xFFFFFFFF;
+                bIsCombining = true;
+                continue;
+
             case RC_CONDITION_ADD_HITS:
             case RC_CONDITION_SUB_HITS:
                 bIsCombining = true;
                 bInAddHits = true;
                 break;
 
-            case RC_CONDITION_ADD_SOURCE:
-            case RC_CONDITION_SUB_SOURCE:
             case RC_CONDITION_ADD_ADDRESS:
             case RC_CONDITION_AND_NEXT:
             case RC_CONDITION_OR_NEXT:
@@ -50,8 +168,43 @@ static bool ValidateCondSet(const rc_condset_t* pCondSet, std::wstring& sError)
                 break;
         }
 
-        ++nIndex;
-        pCondition = pCondition->next;
+        if (nAddSourceMax)
+        {
+            const unsigned long long overflow = nAddSourceMax + nMax;
+            if (overflow > 0xFFFFFFFFUL)
+                nMax = 0xFFFFFFFF;
+            else
+                nMax = (unsigned)overflow;
+        }
+
+        // maximum comparison value
+        const unsigned nMaxValue = MaxValue(&pCondition->operand2);
+
+        // minimum comparison value
+        const unsigned nMinValue = (pCondition->operand2.type == RC_OPERAND_CONST) ? pCondition->operand2.value.num : 0;
+
+        // if comparing two memrefs outside of an AddSource chain, make sure their sizes match
+        const bool bIsMemRef = rc_operand_is_memref(&pCondition->operand1);
+        if (bIsMemRef && nMaxValue != nMax && nAddSourceMax == 0 && rc_operand_is_memref(&pCondition->operand2))
+        {
+            sError = ra::StringPrintf(L"Condition %u: Comparing different memory sizes", nIndex);
+            return false;
+        }
+
+        // if nMax is from a memory reference or AddSource chain, or the right side is a memory reference,
+        // validate that nMax can fall between bMinValue and nMaxValue
+        if (bIsMemRef || nMinValue == 0 || nAddSourceMax)
+        {
+            if (!ValidateRange(nMinValue, nMaxValue, pCondition->oper, nMax, sError))
+            {
+                sError.insert(0, L"Condition : ");
+                sError.insert(10, std::to_wstring(nIndex));
+                return false;
+            }
+        }
+
+        // reset AddSource chain
+        nAddSourceMax = 0;
     }
 
     if (bIsCombining)

--- a/src/data/models/TriggerValidation.hh
+++ b/src/data/models/TriggerValidation.hh
@@ -2,6 +2,8 @@
 #define RA_DATA_TRIGGER_VALIDATION_H
 #pragma once
 
+#include "data\Types.hh"
+
 namespace ra {
 namespace data {
 namespace models {
@@ -10,6 +12,7 @@ class TriggerValidation
 {
 public:
     static bool Validate(const std::string& sTrigger, std::wstring& sError);
+    static MemSize MapRcheevosMemSize(char nSize) noexcept;
 };
 
 } // namespace models

--- a/src/ui/viewmodels/MemoryBookmarksViewModel.cpp
+++ b/src/ui/viewmodels/MemoryBookmarksViewModel.cpp
@@ -5,6 +5,7 @@
 #include "RA_StringUtils.h"
 
 #include "data\context\EmulatorContext.hh"
+#include "data\models\TriggerValidation.hh"
 
 #include "services\FrameEventQueue.hh"
 #include "services\IConfiguration.hh"
@@ -246,7 +247,7 @@ void MemoryBookmarksViewModel::LoadBookmarks(ra::services::TextReader& sBookmark
                     if (rc_parse_memref(&memaddr, &size, &address) == RC_OK)
                     {
                         vmBookmark->SetAddress(address);
-                        vmBookmark->SetSize(TriggerConditionViewModel::MapRcheevosMemSize(size));
+                        vmBookmark->SetSize(ra::data::models::TriggerValidation::MapRcheevosMemSize(size));
                     }
                 }
                 else

--- a/src/ui/viewmodels/TriggerConditionViewModel.cpp
+++ b/src/ui/viewmodels/TriggerConditionViewModel.cpp
@@ -4,6 +4,7 @@
 #include "RA_StringUtils.h"
 
 #include "data\context\GameContext.hh"
+#include "data\models\TriggerValidation.hh"
 
 #include "services\AchievementRuntime.hh"
 #include "services\IConfiguration.hh"
@@ -202,40 +203,6 @@ void TriggerConditionViewModel::SerializeAppendOperand(std::string& sBuffer, Tri
     sBuffer.append(ra::ByteAddressToString(nValue), 2);
 }
 
-static constexpr MemSize MapMemSize(char nSize) noexcept
-{
-    switch (nSize)
-    {
-        case RC_MEMSIZE_BIT_0: return MemSize::Bit_0;
-        case RC_MEMSIZE_BIT_1: return MemSize::Bit_1;
-        case RC_MEMSIZE_BIT_2: return MemSize::Bit_2;
-        case RC_MEMSIZE_BIT_3: return MemSize::Bit_3;
-        case RC_MEMSIZE_BIT_4: return MemSize::Bit_4;
-        case RC_MEMSIZE_BIT_5: return MemSize::Bit_5;
-        case RC_MEMSIZE_BIT_6: return MemSize::Bit_6;
-        case RC_MEMSIZE_BIT_7: return MemSize::Bit_7;
-        case RC_MEMSIZE_LOW: return MemSize::Nibble_Lower;
-        case RC_MEMSIZE_HIGH: return MemSize::Nibble_Upper;
-        case RC_MEMSIZE_8_BITS: return MemSize::EightBit;
-        case RC_MEMSIZE_16_BITS: return MemSize::SixteenBit;
-        case RC_MEMSIZE_24_BITS: return MemSize::TwentyFourBit;
-        case RC_MEMSIZE_32_BITS: return MemSize::ThirtyTwoBit;
-        case RC_MEMSIZE_BITCOUNT: return MemSize::BitCount;
-        case RC_MEMSIZE_16_BITS_BE: return MemSize::SixteenBitBigEndian;
-        case RC_MEMSIZE_24_BITS_BE: return MemSize::TwentyFourBitBigEndian;
-        case RC_MEMSIZE_32_BITS_BE: return MemSize::ThirtyTwoBitBigEndian;
-        default:
-            assert(!"Unsupported operand size");
-            return MemSize::EightBit;
-    }
-}
-
-GSL_SUPPRESS_F4
-MemSize TriggerConditionViewModel::MapRcheevosMemSize(char nSize) noexcept
-{
-    return MapMemSize(nSize);
-}
-
 void TriggerConditionViewModel::SetOperand(const IntModelProperty& pTypeProperty,
     const IntModelProperty& pSizeProperty, const IntModelProperty& pValueProperty, const rc_operand_t& operand)
 {
@@ -254,7 +221,7 @@ void TriggerConditionViewModel::SetOperand(const IntModelProperty& pTypeProperty
         case TriggerOperandType::Prior:
         case TriggerOperandType::BCD:
         {
-            const auto nSize = MapMemSize(operand.size);
+            const auto nSize = ra::data::models::TriggerValidation::MapRcheevosMemSize(operand.size);
             SetValue(pSizeProperty, ra::etoi(nSize));
             SetValue(pValueProperty, operand.value.memref->address);
             break;

--- a/src/ui/viewmodels/TriggerConditionViewModel.cpp
+++ b/src/ui/viewmodels/TriggerConditionViewModel.cpp
@@ -347,7 +347,7 @@ std::wstring TriggerConditionViewModel::GetValueTooltip(unsigned int nValue)
     return std::to_wstring(nValue);
 }
 
-static bool IsIndirectMemref(rc_operand_t& operand) noexcept
+static bool IsIndirectMemref(const rc_operand_t& operand) noexcept
 {
     return rc_operand_is_memref(&operand) && operand.value.memref->value.is_indirect;
 }
@@ -372,6 +372,7 @@ unsigned int TriggerConditionViewModel::GetIndirectAddress(unsigned int nAddress
     bool bIsIndirect = false;
     rc_eval_state_t oEvalState;
     memset(&oEvalState, 0, sizeof(oEvalState));
+    rc_typed_value_t value = {};
     oEvalState.peek = rc_peek_callback;
 
     gsl::index nConditionIndex = 0;
@@ -407,11 +408,15 @@ unsigned int TriggerConditionViewModel::GetIndirectAddress(unsigned int nAddress
                     oCondition.operand2.value.memref = &oTarget;
                 }
 
-                oEvalState.add_address = rc_evaluate_condition_value(&oCondition, &oEvalState);
+                rc_evaluate_condition_value(&value, &oCondition, &oEvalState);
+                rc_typed_value_convert(&value, RC_VALUE_TYPE_UNSIGNED);
+                oEvalState.add_address = value.value.u32;
             }
             else
             {
-                oEvalState.add_address = rc_evaluate_condition_value(pCondition, &oEvalState);
+                rc_evaluate_condition_value(&value, pCondition, &oEvalState);
+                rc_typed_value_convert(&value, RC_VALUE_TYPE_UNSIGNED);
+                oEvalState.add_address = value.value.u32;
                 bIsIndirect = true;
             }
         }

--- a/src/ui/viewmodels/TriggerConditionViewModel.hh
+++ b/src/ui/viewmodels/TriggerConditionViewModel.hh
@@ -137,8 +137,6 @@ public:
     void SetRowColor(Color value) { SetValue(RowColorProperty, ra::to_signed(value.ARGB)); }
     void UpdateRowColor(const rc_condition_t* pCondition);
 
-    static MemSize MapRcheevosMemSize(char nSize) noexcept;
-
 private:
     void OnValueChanged(const IntModelProperty::ChangeArgs& args) override;
     void OnValueChanged(const BoolModelProperty::ChangeArgs& args) override;

--- a/tests/data/models/TriggerValidation_Tests.cpp
+++ b/tests/data/models/TriggerValidation_Tests.cpp
@@ -61,6 +61,59 @@ public:
         AssertValidation("C:0xH1234=1_0xH2345=2.1.", L"");
         AssertValidation("D:0xH1234=1_0xH2345=2.1.", L"");
     }
+
+    TEST_METHOD(TestRangeComparisons)
+    {
+        AssertValidation("0xH1234>1", L"");
+
+        AssertValidation("0xH1234=255", L"");
+        AssertValidation("0xH1234!=255", L"");
+        AssertValidation("0xH1234>255", L"Condition 1: Comparison is never true");
+        AssertValidation("0xH1234>=255", L"");
+        AssertValidation("0xH1234<255", L"");
+        AssertValidation("0xH1234<=255", L"Condition 1: Comparison is always true");
+
+        AssertValidation("R:0xH1234<255", L"");
+        AssertValidation("R:0xH1234<=255", L"Condition 1: Comparison is always true");
+
+        AssertValidation("0xH1234=256", L"Condition 1: Comparison is never true");
+        AssertValidation("0xH1234!=256", L"Condition 1: Comparison is always true");
+        AssertValidation("0xH1234>256", L"Condition 1: Comparison is never true");
+        AssertValidation("0xH1234>=256", L"Condition 1: Comparison is never true");
+        AssertValidation("0xH1234<256", L"Condition 1: Comparison is always true");
+        AssertValidation("0xH1234<=256", L"Condition 1: Comparison is always true");
+
+        AssertValidation("0x 1234>=65535", L"");
+        AssertValidation("0x 1234>=65536", L"Condition 1: Comparison is never true");
+
+        AssertValidation("0xW1234>=16777215", L"");
+        AssertValidation("0xW1234>=16777216", L"Condition 1: Comparison is never true");
+
+        AssertValidation("0xX1234>=4294967295", L"");
+        AssertValidation("0xX1234>4294967295", L"Condition 1: Comparison is never true");
+
+        AssertValidation("0xT1234>=1", L"");
+        AssertValidation("0xT1234>1", L"Condition 1: Comparison is never true");
+
+        // AddSource max is the sum of all parts (255+255=510)
+        AssertValidation("A:0xH1234_0xH1235<510", L"");
+        AssertValidation("A:0xH1234_0xH1235<=510", L"Condition 2: Comparison is always true");
+
+        // SubSource max is always 0xFFFFFFFF
+        AssertValidation("B:0xH1234_0xH1235<510", L"");
+        AssertValidation("B:0xH1234_0xH1235<=510", L"");
+    }
+
+    TEST_METHOD(TestSizeComparisons)
+    {
+        AssertValidation("0xH1234>0xH1235", L"");
+        AssertValidation("0xH1234>0x 1235", L"Condition 1: Comparing different memory sizes");
+
+        // AddSource chain may compare different sizes without warning as the chain changes the
+        // size of the final result.
+        AssertValidation("A:0xH1234_0xH1235=0xH2345", L"");
+        AssertValidation("A:0xH1234_0xH1235=0x 2345", L"");
+    }
 };
 
 


### PR DESCRIPTION
Extension of #804.

Adds checks for comparing memory addresses with differing sizes and comparing memory addresses to values that would not fit in the memory address.

![image](https://user-images.githubusercontent.com/32680403/134786135-dd6f3c4b-463f-4824-aabb-5ba275966f90.png)

![image](https://user-images.githubusercontent.com/32680403/134786136-81e66614-9c5a-4eda-89d1-7ddcb9684db2.png)

