### PR TITLE
fix disappearing results for singular text match

### DIFF
--- a/src/services/SearchResults.cpp
+++ b/src/services/SearchResults.cpp
@@ -567,8 +567,8 @@ public:
                 // adjust the block size to account for the length of the string to ensure
                 // the block contains the whole string
                 // (duplicates the AddBlock function, but replaces "GetPadding()-1" with "nCompareLength")
-                const unsigned int nBlockSize = vMatches.back() - vMatches.front() + nCompareLength;
-                MemBlock& newBlock = AddBlock(srNew, vMatches.front(), nBlockSize);
+                const size_t nBlockSize = vMatches.back() - vMatches.front() + nCompareLength;
+                MemBlock& newBlock = AddBlock(srNew, vMatches.front(), gsl::narrow_cast<unsigned int>(nBlockSize));
                 memcpy(newBlock.GetBytes(), &vMemory.at(vMatches.front() - block.GetAddress()), nBlockSize);
 
                 vMatches.clear();

--- a/src/services/SearchResults.cpp
+++ b/src/services/SearchResults.cpp
@@ -500,12 +500,20 @@ public:
     // populates a vector of addresses that match the specified filter when applied to a previous search result
     void ApplyFilter(SearchResults& srNew, const SearchResults& srPrevious) const override
     {
+        size_t nCompareLength = 16; // maximum length for generic search
         std::vector<unsigned char> vSearchText;
         GetSearchText(vSearchText, srNew.GetFilterString());
 
-        // can't match 0 characters!
         if (vSearchText.empty())
-            return;
+        {
+            // can't match 0 characters!
+            if (srNew.GetFilterType() == SearchFilterType::Constant)
+                return;
+        }
+        else
+        {
+            nCompareLength = vSearchText.size();
+        }
 
         unsigned int nLargestBlock = 0U;
         for (auto& block : GetBlocks(srPrevious))
@@ -530,7 +538,7 @@ public:
                 case SearchFilterType::Constant:
                     for (unsigned int i = 0; i < nStop; ++i)
                     {
-                        if (CompareMemory(&vMemory.at(i), &vSearchText.at(0), vSearchText.size(), srNew.GetFilterComparison()))
+                        if (CompareMemory(&vMemory.at(i), &vSearchText.at(0), nCompareLength, srNew.GetFilterComparison()))
                         {
                             const unsigned int nAddress = block.GetAddress() + i;
                             AddMatch(vMatches, srPrevious, nAddress);
@@ -542,7 +550,7 @@ public:
                 case SearchFilterType::LastKnownValue:
                     for (unsigned int i = 0; i < nStop; ++i)
                     {
-                        if (CompareMemory(&vMemory.at(i), block.GetBytes() + i, vSearchText.size(), srNew.GetFilterComparison()))
+                        if (CompareMemory(&vMemory.at(i), block.GetBytes() + i, nCompareLength, srNew.GetFilterComparison()))
                         {
                             const unsigned int nAddress = block.GetAddress() + i;
                             AddMatch(vMatches, srPrevious, nAddress);
@@ -556,10 +564,12 @@ public:
                 auto& vMatchingAddresses = GetMatchingAddresses(srNew);
                 vMatchingAddresses.insert(vMatchingAddresses.end(), vMatches.begin(), vMatches.end());
 
-                // adjust the last entry to account for the length of the string to ensure
+                // adjust the block size to account for the length of the string to ensure
                 // the block contains the whole string
-                vMatches.back() += gsl::narrow_cast<ra::ByteAddress>(vSearchText.size() - 1);
-                AddBlock(srNew, vMatches, vMemory, block.GetAddress());
+                // (duplicates the AddBlock function, but replaces "GetPadding()-1" with "nCompareLength")
+                const unsigned int nBlockSize = vMatches.back() - vMatches.front() + nCompareLength;
+                MemBlock& newBlock = AddBlock(srNew, vMatches.front(), nBlockSize);
+                memcpy(newBlock.GetBytes(), &vMemory.at(vMatches.front() - block.GetAddress()), nBlockSize);
 
                 vMatches.clear();
             }

--- a/tests/services/SearchResults_Tests.cpp
+++ b/tests/services/SearchResults_Tests.cpp
@@ -1240,6 +1240,30 @@ public:
         Assert::AreEqual(24U, result.nAddress);
     }
 
+    TEST_METHOD(TestInitializeFromResultsAsciiTextSingleMatch)
+    {
+        std::array<unsigned char, 36> memory{
+            'S', 'h', 'e', ' ', 's', 'e', 'l', 'l', 's', ' ', 's', 'e', 'a', 's', 'h', 'e',
+            'l', 'l', 's', ' ', 'b', 'y', ' ', 't', 'h', 'e', ' ', 's', 'e', 'a', 's', 'h',
+            'o', 'r', 'e', '.'
+        };
+        ra::data::context::mocks::MockEmulatorContext mockEmulatorContext;
+        mockEmulatorContext.MockMemory(memory);
+
+        SearchResults results1;
+        results1.Initialize(0U, memory.size(), ra::services::SearchType::AsciiText);
+        Assert::AreEqual(memory.size(), results1.MatchingAddressCount());
+
+        SearchResults results2;
+        results2.Initialize(results1, ComparisonType::Equals, ra::services::SearchFilterType::Constant, L"by");
+        Assert::AreEqual({ 1U }, results2.MatchingAddressCount());
+        Assert::IsTrue(results2.ContainsAddress(20U));
+
+        SearchResults::Result result;
+        Assert::IsTrue(results2.GetMatchingAddress(0U, result));
+        Assert::AreEqual(20U, result.nAddress);
+    }
+
     TEST_METHOD(TestInitializeFromResultsAsciiTextComparison)
     {
         std::array<unsigned char, 36> memory{


### PR DESCRIPTION
Fixes an issue where filtering text search results would sometimes cause a portion of the list to disappear.

If a matching block (chunk of memory) contained only one match, the adjustment to include the entire string was discarding the front of the string, so the lookup for the string was failing, and all entries after the failure were left uninitialized.

Also changes any values outside the ASCII range to the unicode replacement character.