### PR TITLE
show warning indicator in achievement list

### DIFF
--- a/src/ui/viewmodels/AssetListViewModel.cpp
+++ b/src/ui/viewmodels/AssetListViewModel.cpp
@@ -113,6 +113,17 @@ void AssetListViewModel::OnDataModelStringValueChanged(gsl::index nIndex, const 
                 m_vFilteredAssets.SetItemValue(nFilteredIndex, AssetSummaryViewModel::LabelProperty, args.tNewValue);
         }
     }
+    else if (args.Property == ra::data::models::AssetModelBase::ValidationErrorProperty)
+    {
+        const auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::context::GameContext>();
+        const auto* pAsset = pGameContext.Assets().GetItemAt(nIndex);
+        if (pAsset != nullptr)
+        {
+            const auto nFilteredIndex = GetFilteredAssetIndex(*pAsset);
+            if (nFilteredIndex != -1)
+                m_vFilteredAssets.SetItemValue(nFilteredIndex, args.Property, args.tNewValue);
+        }
+    }
 }
 
 void AssetListViewModel::OnDataModelIntValueChanged(gsl::index nIndex, const IntModelProperty::ChangeArgs& args)
@@ -462,6 +473,7 @@ bool AssetListViewModel::AddOrRemoveFilteredItem(const ra::data::models::AssetMo
             pSummary->SetCategory(pAsset.GetCategory());
             pSummary->SetChanges(pAsset.GetChanges());
             pSummary->SetState(pAsset.GetState());
+            pSummary->SetWarning(pAsset.GetValidationError());
 
             const auto* pAchievement = dynamic_cast<const ra::data::models::AchievementModel*>(&pAsset);
             if (pAchievement != nullptr)

--- a/src/ui/viewmodels/AssetListViewModel.hh
+++ b/src/ui/viewmodels/AssetListViewModel.hh
@@ -227,6 +227,9 @@ public:
 
         ra::data::models::AssetChanges GetChanges() const { return ra::itoe<ra::data::models::AssetChanges>(GetValue(ra::data::models::AssetModelBase::ChangesProperty)); }
         void SetChanges(ra::data::models::AssetChanges nValue) { SetValue(ra::data::models::AssetModelBase::ChangesProperty, ra::etoi(nValue)); }
+
+        const std::wstring& GetWarning() const { return GetValue(ra::data::models::AssetModelBase::ValidationErrorProperty); }
+        void SetWarning(const std::wstring& sValue) { SetValue(ra::data::models::AssetModelBase::ValidationErrorProperty, sValue); }
     };
 
     ViewModelCollection<AssetSummaryViewModel>& FilteredAssets() noexcept { return m_vFilteredAssets; }

--- a/src/ui/win32/AssetListDialog.cpp
+++ b/src/ui/win32/AssetListDialog.cpp
@@ -141,6 +141,34 @@ public:
 
 // ------------------------------------
 
+class ChangesColumnBinding : public ra::ui::win32::bindings::GridLookupColumnBinding
+{
+public:
+    ChangesColumnBinding(const IntModelProperty& pBoundProperty, const ra::ui::viewmodels::LookupItemViewModelCollection& vmItems) noexcept
+        : ra::ui::win32::bindings::GridLookupColumnBinding(pBoundProperty, vmItems)
+    {
+    }
+
+    bool DependsOn(const ra::ui::StringModelProperty& pProperty) const noexcept override
+    {
+        return pProperty == AssetModelBase::ValidationErrorProperty;
+    }
+
+    std::wstring GetText(const ra::ui::ViewModelCollectionBase& vmItems, gsl::index nIndex) const override
+    {
+        const auto nValue = vmItems.GetItemValue(nIndex, *m_pBoundProperty);
+        const std::wstring& sLabel = m_vmItems.GetLabelForId(nValue);
+
+        const auto& sWarning = vmItems.GetItemValue(nIndex, AssetModelBase::ValidationErrorProperty);
+        if (sWarning.empty())
+            return sLabel;
+
+        return sLabel + L"\U000026A0"; // 26A0 - Warning Sign
+    }
+};
+
+// ------------------------------------
+
 AssetListDialog::AssetListDialog(AssetListViewModel& vmAssetList)
     : DialogBase(vmAssetList),
       m_bindAssets(vmAssetList),
@@ -200,10 +228,10 @@ AssetListDialog::AssetListDialog(AssetListViewModel& vmAssetList)
     pCategoryColumn->SetWidth(GridColumnBinding::WidthType::Pixels, 70);
     m_bindAssets.BindColumn(4 + nOffset, std::move(pCategoryColumn));
 
-    auto pChangesColumn = std::make_unique<ra::ui::win32::bindings::GridLookupColumnBinding>(
+    auto pChangesColumn = std::make_unique<ChangesColumnBinding>(
         AssetModelBase::ChangesProperty, vmAssetList.Changes());
     pChangesColumn->SetHeader(L"Changes");
-    pChangesColumn->SetWidth(GridColumnBinding::WidthType::Pixels, 70);
+    pChangesColumn->SetWidth(GridColumnBinding::WidthType::Pixels, 82);
     m_bindAssets.BindColumn(5 + nOffset, std::move(pChangesColumn));
 
     m_bindAssets.SetDoubleClickHandler([this](gsl::index nIndex)

--- a/tests/ui/viewmodels/AssetListViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/AssetListViewModel_Tests.cpp
@@ -1031,6 +1031,7 @@ public:
         Assert::AreEqual(5, pItem->GetPoints());
         Assert::AreEqual(AssetState::Inactive, pItem->GetState());
         Assert::AreEqual(5, vmAssetList.GetTotalPoints());
+        Assert::AreEqual(std::wstring(L""), pItem->GetWarning());
 
         vmAchievement.SetName(L"New Title");
         Assert::AreEqual(std::wstring(L"New Title"), pItem->GetLabel());
@@ -1042,6 +1043,11 @@ public:
 
         vmAchievement.SetState(AssetState::Active);
         Assert::AreEqual(AssetState::Active, pItem->GetState());
+
+        vmAchievement.SetTrigger("A:0x1234");
+        vmAchievement.UpdateLocalCheckpoint();
+        Assert::IsFalse(vmAchievement.Validate());
+        Assert::AreEqual(std::wstring(L"Final condition type expects another condition to follow."), pItem->GetWarning());
     }
 
     TEST_METHOD(TestSyncAddItem)


### PR DESCRIPTION
Informs the user when an achievement has a warning without requiring them open each achievement individually. Particularly useful as the warning is only updated when saving, and multiple achievements may be saved at the same time.

![image](https://user-images.githubusercontent.com/32680403/135758945-23c49c07-73ee-4108-8b26-e1957b5f11bc.png)
