### PR TITLE
update freeze button text to reflect behavior of button

### DIFF
--- a/src/ui/viewmodels/MemoryBookmarksViewModel.hh
+++ b/src/ui/viewmodels/MemoryBookmarksViewModel.hh
@@ -19,7 +19,8 @@ namespace viewmodels {
 
 class MemoryBookmarksViewModel : public WindowViewModelBase,
     protected ra::data::context::GameContext::NotifyTarget,
-    protected ra::data::context::EmulatorContext::NotifyTarget
+    protected ra::data::context::EmulatorContext::NotifyTarget,
+    protected ra::ui::ViewModelCollectionBase::NotifyTarget
 {
 public:
     GSL_SUPPRESS_F6 MemoryBookmarksViewModel() noexcept;
@@ -335,6 +336,9 @@ public:
     /// <returns>Number of bookmarks that were removed</returns>
     int RemoveSelectedBookmarks();
 
+    static const StringModelProperty FreezeButtonTextProperty;
+    const std::wstring& GetFreezeButtonText() const { return GetValue(FreezeButtonTextProperty); }
+
     /// <summary>
     /// Freezes the selected items. Or, if they're already all frozen, unfreezes them.
     /// </summary>
@@ -379,10 +383,18 @@ protected:
     // ra::data::context::EmulatorContext::NotifyTarget
     void OnByteWritten(ra::ByteAddress, uint8_t) override;
 
+    // ra::ui::ViewModelCollectionBase::NotifyTarget
+    void OnViewModelBoolValueChanged(gsl::index nIndex, const BoolModelProperty::ChangeArgs& args) override;
+    void OnViewModelIntValueChanged(gsl::index nIndex, const IntModelProperty::ChangeArgs& args) override;
+    void OnEndViewModelCollectionUpdate() override;
+
     bool IsModified() const;
     size_t m_nUnmodifiedBookmarkCount = 0;
 
 private:
+    bool ShouldFreeze() const;
+    void UpdateFreezeButtonText();
+
     ViewModelCollection<MemoryBookmarkViewModel> m_vBookmarks;
     LookupItemViewModelCollection m_vSizes;
     LookupItemViewModelCollection m_vFormats;

--- a/src/ui/win32/MemoryBookmarksDialog.cpp
+++ b/src/ui/win32/MemoryBookmarksDialog.cpp
@@ -86,6 +86,8 @@ MemoryBookmarksDialog::MemoryBookmarksDialog(MemoryBookmarksViewModel& vmMemoryB
       m_bindBookmarks(vmMemoryBookmarks)
 {
     m_bindWindow.SetInitialPosition(RelativePosition::After, RelativePosition::Near, "Memory Bookmarks");
+    m_bindWindow.BindLabel(IDC_RA_FREEZE, MemoryBookmarksViewModel::FreezeButtonTextProperty);
+
     m_bindBookmarks.SetShowGridLines(true);
     m_bindBookmarks.BindIsSelected(MemoryBookmarksViewModel::MemoryBookmarkViewModel::IsSelectedProperty);
     m_bindBookmarks.BindRowColor(MemoryBookmarksViewModel::MemoryBookmarkViewModel::RowColorProperty);

--- a/tests/ui/viewmodels/MemoryBookmarksViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/MemoryBookmarksViewModel_Tests.cpp
@@ -549,11 +549,13 @@ public:
         bookmarks.AddBookmark(2345U, MemSize::EightBit);
         bookmarks.AddBookmark(4567U, MemSize::EightBit);
         bookmarks.AddBookmark(6789U, MemSize::EightBit);
+        Assert::AreEqual(std::wstring(L"Freeze"), bookmarks.GetFreezeButtonText());
 
         // no selected items are frozen - freeze them all
         bookmarks.Bookmarks().GetItemAt(1)->SetSelected(true);
         bookmarks.Bookmarks().GetItemAt(3)->SetSelected(true);
 
+        Assert::AreEqual(std::wstring(L"Freeze"), bookmarks.GetFreezeButtonText());
         bookmarks.ToggleFreezeSelected();
 
         Assert::AreEqual({ 4U }, bookmarks.Bookmarks().Count());
@@ -561,11 +563,13 @@ public:
         Assert::AreEqual(MemoryBookmarksViewModel::BookmarkBehavior::Frozen, bookmarks.Bookmarks().GetItemAt(1)->GetBehavior());
         Assert::AreEqual(MemoryBookmarksViewModel::BookmarkBehavior::None, bookmarks.Bookmarks().GetItemAt(2)->GetBehavior());
         Assert::AreEqual(MemoryBookmarksViewModel::BookmarkBehavior::Frozen, bookmarks.Bookmarks().GetItemAt(3)->GetBehavior());
+        Assert::AreEqual(std::wstring(L"Unfreeze"), bookmarks.GetFreezeButtonText());
 
-        // some selected items are frozen - freeze the rest
+        // some selected items are frozen - freeze the rest (items 2 and 3 are selected)
         bookmarks.Bookmarks().GetItemAt(1)->SetSelected(false);
         bookmarks.Bookmarks().GetItemAt(2)->SetSelected(true);
 
+        Assert::AreEqual(std::wstring(L"Freeze"), bookmarks.GetFreezeButtonText());
         bookmarks.ToggleFreezeSelected();
 
         Assert::AreEqual({ 4U }, bookmarks.Bookmarks().Count());
@@ -573,11 +577,13 @@ public:
         Assert::AreEqual(MemoryBookmarksViewModel::BookmarkBehavior::Frozen, bookmarks.Bookmarks().GetItemAt(1)->GetBehavior());
         Assert::AreEqual(MemoryBookmarksViewModel::BookmarkBehavior::Frozen, bookmarks.Bookmarks().GetItemAt(2)->GetBehavior());
         Assert::AreEqual(MemoryBookmarksViewModel::BookmarkBehavior::Frozen, bookmarks.Bookmarks().GetItemAt(3)->GetBehavior());
+        Assert::AreEqual(std::wstring(L"Unfreeze"), bookmarks.GetFreezeButtonText());
 
-        // all selected items are frozen - unfreeze them
+        // all selected items are frozen - unfreeze them (items 1 and 3 are selected)
         bookmarks.Bookmarks().GetItemAt(1)->SetSelected(true);
         bookmarks.Bookmarks().GetItemAt(2)->SetSelected(false);
 
+        Assert::AreEqual(std::wstring(L"Unfreeze"), bookmarks.GetFreezeButtonText());
         bookmarks.ToggleFreezeSelected();
 
         Assert::AreEqual({ 4U }, bookmarks.Bookmarks().Count());
@@ -585,6 +591,7 @@ public:
         Assert::AreEqual(MemoryBookmarksViewModel::BookmarkBehavior::None, bookmarks.Bookmarks().GetItemAt(1)->GetBehavior());
         Assert::AreEqual(MemoryBookmarksViewModel::BookmarkBehavior::Frozen, bookmarks.Bookmarks().GetItemAt(2)->GetBehavior());
         Assert::AreEqual(MemoryBookmarksViewModel::BookmarkBehavior::None, bookmarks.Bookmarks().GetItemAt(3)->GetBehavior());
+        Assert::AreEqual(std::wstring(L"Freeze"), bookmarks.GetFreezeButtonText());
     }
 
     TEST_METHOD(TestClearAllChanges)


### PR DESCRIPTION
Changes text to "unfreeze" when only frozen bookmarks are selected.