### PR TITLE
use serialized conditions to rebuild alt when deserialization error is present

### DIFF
--- a/src/ui/viewmodels/TriggerViewModel.cpp
+++ b/src/ui/viewmodels/TriggerViewModel.cpp
@@ -747,7 +747,7 @@ void TriggerViewModel::UpdateConditions(const GroupViewModel* pGroup)
             if (nSize >= 0)
             {
                 sBuffer.resize(nSize);
-                const auto pTrigger = rc_parse_trigger(sBuffer.data(), sTrigger.c_str(), NULL, 0);
+                const auto pTrigger = rc_parse_trigger(sBuffer.data(), sTrigger.c_str(), nullptr, 0);
                 pConditions = pTrigger->requirement;
             }
         }


### PR DESCRIPTION
fixes #821 

When a deserialization error is present in a serialized trigger, the reference to the deserialized condition is not updated, so switching between groups uses stale data. This clears out the deserialized condition when the group is modified, so it can be rebuilt if it's not available due to the deserialization error.