### PR TITLE
increase column widths for addresses on systems with more than 16MB of RAM

### DIFF
--- a/src/ui/viewmodels/MemoryInspectorViewModel.cpp
+++ b/src/ui/viewmodels/MemoryInspectorViewModel.cpp
@@ -323,6 +323,8 @@ void MemoryInspectorViewModel::OnActiveGameChanged()
         SetWindowTitle(L"Memory Inspector");
         SetValue(CanModifyNotesProperty, true);
     }
+
+    Search().ClearResults();
 }
 
 void MemoryInspectorViewModel::OnEndGameLoad()

--- a/src/ui/viewmodels/MemorySearchViewModel.cpp
+++ b/src/ui/viewmodels/MemorySearchViewModel.cpp
@@ -33,6 +33,7 @@ const StringModelProperty MemorySearchViewModel::FilterSummaryProperty("MemorySe
 const IntModelProperty MemorySearchViewModel::ResultCountProperty("MemorySearchViewModel", "ResultCount", 0);
 const StringModelProperty MemorySearchViewModel::ResultCountTextProperty("MemorySearchViewModel", "ResultCountText", L"0");
 const IntModelProperty MemorySearchViewModel::ResultMemSizeProperty("MemorySearchViewModel", "ResultMemSize", ra::etoi(MemSize::EightBit));
+const IntModelProperty MemorySearchViewModel::TotalMemorySizeProperty("MemorySearchViewModel", "TotalMemorySize", 0);
 const IntModelProperty MemorySearchViewModel::ScrollOffsetProperty("MemorySearchViewModel", "ScrollOffset", 0);
 const IntModelProperty MemorySearchViewModel::ScrollMaximumProperty("MemorySearchViewModel", "ScrollMaximum", 0);
 const StringModelProperty MemorySearchViewModel::SelectedPageProperty("MemorySearchViewModel", "SelectedPageProperty", L"0/0");
@@ -263,6 +264,7 @@ void MemorySearchViewModel::OnTotalMemorySizeChanged()
     m_vPredefinedFilterRanges.EndUpdate();
 
     SetValue(CanBeginNewSearchProperty, (nTotalBankSize > 0U));
+    SetValue(TotalMemorySizeProperty, nTotalBankSize);
 }
 
 void MemorySearchViewModel::OnPredefinedFilterRangeChanged()
@@ -446,6 +448,23 @@ bool MemorySearchViewModel::ParseFilterRange(_Out_ ra::ByteAddress& nStart, _Out
     }
 
     return (*ptr == '\0');
+}
+
+void MemorySearchViewModel::ClearResults()
+{
+    if (m_bIsContinuousFiltering)
+        ToggleContinuousFilter();
+
+    m_vSelectedAddresses.clear();
+    m_vSearchResults.clear();
+    m_vResults.Clear();
+
+    SetValue(FilterSummaryProperty, FilterSummaryProperty.GetDefaultValue());
+    SetValue(SelectedPageProperty, SelectedPageProperty.GetDefaultValue());
+    SetValue(ScrollOffsetProperty, 0);
+    SetValue(ScrollMaximumProperty, 0);
+    SetValue(ResultCountProperty, 0);
+    SetValue(ResultMemSizeProperty, ResultMemSizeProperty.GetDefaultValue());
 }
 
 void MemorySearchViewModel::BeginNewSearch()

--- a/src/ui/viewmodels/MemorySearchViewModel.hh
+++ b/src/ui/viewmodels/MemorySearchViewModel.hh
@@ -211,6 +211,11 @@ public:
     /// </summary>
     const std::wstring& GetFilterSummary() const { return GetValue(FilterSummaryProperty); }
 
+    /// <summary>
+    /// The <see cref="ModelProperty" /> for the total memory size.
+    /// </summary>
+    static const IntModelProperty TotalMemorySizeProperty;
+
     class SearchResultViewModel : public ViewModelBase
     {
     public:
@@ -320,6 +325,11 @@ public:
     {
         return m_vResults;
     }
+
+    /// <summary>
+    /// Resets the results list.
+    /// </summary>
+    void ClearResults();
 
     /// <summary>
     /// The <see cref="ModelProperty" /> for the memory size of result items.

--- a/src/ui/win32/MemoryBookmarksDialog.cpp
+++ b/src/ui/win32/MemoryBookmarksDialog.cpp
@@ -47,14 +47,14 @@ void MemoryBookmarksDialog::Presenter::OnClosed() noexcept { m_pDialog.reset(); 
 
 // ------------------------------------
 
-MemoryBookmarksDialog::BookmarksGridBinding::BookmarksGridBinding(ViewModelBase& vmViewModel) noexcept
+MemoryBookmarksDialog::BookmarksGridBinding::BookmarksGridBinding(ViewModelBase& vmViewModel)
     : ra::ui::win32::bindings::GridBinding(vmViewModel)
 {
     auto& pEmulatorContext = ra::services::ServiceLocator::GetMutable<ra::data::context::EmulatorContext>();
     pEmulatorContext.AddNotifyTarget(*this);
 }
 
-MemoryBookmarksDialog::BookmarksGridBinding::~BookmarksGridBinding() noexcept
+MemoryBookmarksDialog::BookmarksGridBinding::~BookmarksGridBinding()
 {
     auto& pEmulatorContext = ra::services::ServiceLocator::GetMutable<ra::data::context::EmulatorContext>();
     pEmulatorContext.RemoveNotifyTarget(*this);

--- a/src/ui/win32/MemoryBookmarksDialog.cpp
+++ b/src/ui/win32/MemoryBookmarksDialog.cpp
@@ -47,6 +47,33 @@ void MemoryBookmarksDialog::Presenter::OnClosed() noexcept { m_pDialog.reset(); 
 
 // ------------------------------------
 
+MemoryBookmarksDialog::BookmarksGridBinding::BookmarksGridBinding(ViewModelBase& vmViewModel) noexcept
+    : ra::ui::win32::bindings::GridBinding(vmViewModel)
+{
+    auto& pEmulatorContext = ra::services::ServiceLocator::GetMutable<ra::data::context::EmulatorContext>();
+    pEmulatorContext.AddNotifyTarget(*this);
+}
+
+MemoryBookmarksDialog::BookmarksGridBinding::~BookmarksGridBinding() noexcept
+{
+    auto& pEmulatorContext = ra::services::ServiceLocator::GetMutable<ra::data::context::EmulatorContext>();
+    pEmulatorContext.RemoveNotifyTarget(*this);
+}
+
+void MemoryBookmarksDialog::BookmarksGridBinding::OnTotalMemorySizeChanged()
+{
+    for (auto& pColumn : m_vColumns)
+    {
+        auto* pAddressColumn = dynamic_cast<ra::ui::win32::bindings::GridAddressColumnBinding*>(pColumn.get());
+        if (pAddressColumn != nullptr)
+            pAddressColumn->UpdateWidth();
+    }
+
+    UpdateLayout();
+}
+
+// ------------------------------------
+
 class GridBookmarkValueColumnBinding : public ra::ui::win32::bindings::GridTextColumnBinding
 {
 public:
@@ -80,6 +107,8 @@ public:
         return true;
     }
 };
+
+// ------------------------------------
 
 MemoryBookmarksDialog::MemoryBookmarksDialog(MemoryBookmarksViewModel& vmMemoryBookmarks)
     : DialogBase(vmMemoryBookmarks),

--- a/src/ui/win32/MemoryBookmarksDialog.hh
+++ b/src/ui/win32/MemoryBookmarksDialog.hh
@@ -2,6 +2,8 @@
 #define RA_UI_WIN32_DLG_MEMORYBOOKMARKS_H
 #pragma once
 
+#include "data/context/EmulatorContext.hh"
+
 #include "ui/viewmodels/MemoryBookmarksViewModel.hh"
 #include "ui/win32/bindings/GridBinding.hh"
 #include "ui/win32/DialogBase.hh"
@@ -38,7 +40,18 @@ protected:
     BOOL OnCommand(WORD nCommand) override;
 
 private:
-    ra::ui::win32::bindings::GridBinding m_bindBookmarks;
+    class BookmarksGridBinding : public ra::ui::win32::bindings::GridBinding,
+        protected ra::data::context::EmulatorContext::NotifyTarget
+    {
+    public:
+        explicit BookmarksGridBinding(ViewModelBase& vmViewModel) noexcept;
+        ~BookmarksGridBinding() noexcept;
+
+    protected:
+        void OnTotalMemorySizeChanged() override;
+    };
+
+    BookmarksGridBinding m_bindBookmarks;
 };
 
 } // namespace win32

--- a/src/ui/win32/MemoryBookmarksDialog.hh
+++ b/src/ui/win32/MemoryBookmarksDialog.hh
@@ -44,8 +44,12 @@ private:
         protected ra::data::context::EmulatorContext::NotifyTarget
     {
     public:
-        explicit BookmarksGridBinding(ViewModelBase& vmViewModel) noexcept;
-        ~BookmarksGridBinding() noexcept;
+        explicit BookmarksGridBinding(ViewModelBase& vmViewModel);
+        GSL_SUPPRESS_F6 ~BookmarksGridBinding();
+        BookmarksGridBinding(const BookmarksGridBinding&) noexcept = delete;
+        BookmarksGridBinding& operator=(const BookmarksGridBinding&) noexcept = delete;
+        BookmarksGridBinding(BookmarksGridBinding&&) noexcept = delete;
+        BookmarksGridBinding& operator=(BookmarksGridBinding&&) noexcept = delete;
 
     protected:
         void OnTotalMemorySizeChanged() override;

--- a/src/ui/win32/MemoryInspectorDialog.cpp
+++ b/src/ui/win32/MemoryInspectorDialog.cpp
@@ -74,7 +74,8 @@ void MemoryInspectorDialog::SearchResultsGridBinding::OnLvnItemChanged(const LPN
 
 void MemoryInspectorDialog::SearchResultsGridBinding::OnViewModelIntValueChanged(const IntModelProperty::ChangeArgs& args)
 {
-    if (args.Property == MemorySearchViewModel::ResultMemSizeProperty)
+    if (args.Property == MemorySearchViewModel::ResultMemSizeProperty ||
+        args.Property == MemorySearchViewModel::TotalMemorySizeProperty)
     {
         int nWidth = 0;
         const auto& vmMemory = GetViewModel<MemorySearchViewModel>();
@@ -90,11 +91,9 @@ void MemoryInspectorDialog::SearchResultsGridBinding::OnViewModelIntValueChanged
         m_vColumns.at(1)->SetWidth(GridColumnBinding::WidthType::Pixels, nWidth);
 
         // address column
-        const auto& pEmulatorContext = ra::services::ServiceLocator::Get<ra::data::context::EmulatorContext>();
-        nMaxChars = (pEmulatorContext.TotalMemorySize() > 0x10000) ? 8 : 6; // 0x123456 or 0x1234
+        nWidth = ra::ui::win32::bindings::GridAddressColumnBinding::CalculateWidth();
         if (nSize == MemSize::Nibble_Lower)
-            ++nMaxChars; // 0x1234L
-        nWidth = (nCharWidth * nMaxChars) + nPadding * 2;
+            nWidth += nCharWidth; // 0x1234L
         m_vColumns.at(0)->SetWidth(GridColumnBinding::WidthType::Pixels, nWidth);
 
         UpdateLayout();

--- a/src/ui/win32/bindings/GridAddressColumnBinding.cpp
+++ b/src/ui/win32/bindings/GridAddressColumnBinding.cpp
@@ -32,15 +32,14 @@ void GridAddressColumnBinding::UpdateWidth()
 
 unsigned GridAddressColumnBinding::CalculateWidth()
 {
+    unsigned nMaxChars = 6; // 0x1234
+
     const auto& pEmulatorContext = ra::services::ServiceLocator::Get<ra::data::context::EmulatorContext>();
     const auto nTotalMemorySize = pEmulatorContext.TotalMemorySize();
-    unsigned nMaxChars;
     if (nTotalMemorySize > 0x1000000)
         nMaxChars = 10; // 0x12345678
     else if (nTotalMemorySize > 0x10000)
         nMaxChars = 8; // 0x123456
-    else
-        nMaxChars = 6; // 0x1234
 
     constexpr int nCharWidth = 6;
     constexpr int nPadding = 6;

--- a/src/ui/win32/bindings/GridAddressColumnBinding.cpp
+++ b/src/ui/win32/bindings/GridAddressColumnBinding.cpp
@@ -25,6 +25,28 @@ bool GridAddressColumnBinding::HandleDoubleClick(const ra::ui::ViewModelCollecti
     return false;
 }
 
+void GridAddressColumnBinding::UpdateWidth()
+{
+    SetWidth(GridColumnBinding::WidthType::Pixels, CalculateWidth());
+}
+
+unsigned GridAddressColumnBinding::CalculateWidth()
+{
+    const auto& pEmulatorContext = ra::services::ServiceLocator::Get<ra::data::context::EmulatorContext>();
+    const auto nTotalMemorySize = pEmulatorContext.TotalMemorySize();
+    unsigned nMaxChars;
+    if (nTotalMemorySize > 0x1000000)
+        nMaxChars = 10; // 0x12345678
+    else if (nTotalMemorySize > 0x10000)
+        nMaxChars = 8; // 0x123456
+    else
+        nMaxChars = 6; // 0x1234
+
+    constexpr int nCharWidth = 6;
+    constexpr int nPadding = 6;
+    return (nCharWidth * nMaxChars) + nPadding * 2;
+}
+
 } // namespace bindings
 } // namespace win32
 } // namespace ui

--- a/src/ui/win32/bindings/GridAddressColumnBinding.hh
+++ b/src/ui/win32/bindings/GridAddressColumnBinding.hh
@@ -17,6 +17,7 @@ public:
     GridAddressColumnBinding(const IntModelProperty& pBoundProperty) noexcept
         : m_pBoundProperty(&pBoundProperty)
     {
+        UpdateWidth();
     }
 
     std::wstring GetText(const ra::ui::ViewModelCollectionBase& vmItems, gsl::index nIndex) const override
@@ -31,6 +32,9 @@ public:
     }
 
     bool HandleDoubleClick(const ra::ui::ViewModelCollectionBase& vmItems, gsl::index nIndex) override;
+
+    void UpdateWidth();
+    static unsigned CalculateWidth();
 
 protected:
     const IntModelProperty* m_pBoundProperty = nullptr;

--- a/src/ui/win32/bindings/GridAddressColumnBinding.hh
+++ b/src/ui/win32/bindings/GridAddressColumnBinding.hh
@@ -14,7 +14,7 @@ namespace bindings {
 class GridAddressColumnBinding : public GridColumnBinding
 {
 public:
-    GridAddressColumnBinding(const IntModelProperty& pBoundProperty) noexcept
+    GridAddressColumnBinding(const IntModelProperty& pBoundProperty)
         : m_pBoundProperty(&pBoundProperty)
     {
         UpdateWidth();

--- a/src/ui/win32/bindings/GridBinding.hh
+++ b/src/ui/win32/bindings/GridBinding.hh
@@ -85,6 +85,8 @@ protected:
 
     // ViewModelBase::NotifyTarget
     void OnViewModelIntValueChanged(const IntModelProperty::ChangeArgs& args) override;
+    using ViewModelBase::NotifyTarget::OnViewModelBoolValueChanged;
+    using ViewModelBase::NotifyTarget::OnViewModelStringValueChanged;
 
     // ViewModelCollectionBase::NotifyTarget
     void OnViewModelIntValueChanged(gsl::index nIndex, const IntModelProperty::ChangeArgs& args) override;

--- a/tests/ui/viewmodels/MemoryInspectorViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/MemoryInspectorViewModel_Tests.cpp
@@ -466,7 +466,7 @@ public:
         MemoryInspectorViewModelHarness inspector;
         inspector.mockGameContext.SetGameId({ 3 });
 
-        std::array<uint8_t, 32> memory;
+        std::array<uint8_t, 32> memory{};
         for (size_t i = 0; i < memory.size(); ++i)
             memory.at(i) = gsl::narrow_cast<unsigned char>(i);
 

--- a/tests/ui/viewmodels/MemoryInspectorViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/MemoryInspectorViewModel_Tests.cpp
@@ -461,6 +461,34 @@ public:
         Assert::IsTrue(inspector.CanModifyCodeNotes());
     }
 
+    TEST_METHOD(TestActiveGameChangedClearsSearchResults)
+    {
+        MemoryInspectorViewModelHarness inspector;
+        inspector.mockGameContext.SetGameId({ 3 });
+
+        std::array<uint8_t, 32> memory;
+        for (size_t i = 0; i < memory.size(); ++i)
+            memory.at(i) = gsl::narrow_cast<unsigned char>(i);
+
+        inspector.mockEmulatorContext.MockMemory(memory);
+        inspector.Search().BeginNewSearch();
+
+        inspector.Search().SetComparisonType(ComparisonType::GreaterThan);
+        inspector.Search().SetValueType(ra::services::SearchFilterType::InitialValue);
+
+        memory.at(10) = 20;
+        memory.at(20) = 30;
+        inspector.Search().ApplyFilter();
+        Assert::AreEqual({ 2U }, inspector.Search().GetResultCount());
+        Assert::AreEqual({ 2U }, inspector.Search().Results().Count());
+
+        inspector.mockGameContext.SetGameId({ 4 });
+        inspector.mockGameContext.NotifyActiveGameChanged();
+
+        Assert::AreEqual({ 0U }, inspector.Search().GetResultCount());
+        Assert::AreEqual({ 0U }, inspector.Search().Results().Count());
+    }
+
     TEST_METHOD(TestEndGameLoad)
     {
         MemoryInspectorViewModelHarness inspector;


### PR DESCRIPTION
prevents collapsing (0x12345...) in search results and bookmarks