### PR TITLE
don't count unlocked unofficial achievements in title placard

### DIFF
--- a/src/data/context/GameContext.cpp
+++ b/src/data/context/GameContext.cpp
@@ -313,7 +313,9 @@ void GameContext::UpdateUnlocks(const std::set<unsigned int>& vUnlockedAchieveme
     {
         vLockedAchievements.erase(nUnlockedAchievement);
         auto* pAchievement = Assets().FindAchievement(nUnlockedAchievement);
-        if (pAchievement != nullptr)
+
+        // only core achievements will be automatically activated. also, they're all we want to count
+        if (pAchievement != nullptr && pAchievement->GetCategory() == ra::data::models::AssetCategory::Core)
         {
             pAchievement->SetState(ra::data::models::AssetState::Inactive);
             ++nUnlockedCoreAchievements;


### PR DESCRIPTION
Unofficial achievements can't officially be unlocked, but they may remember being unlocked if they were in Core at some point. As such, they will be returned as part of the set of unlocked achievements for the user, which can lead to miscounting the number of unlocked achievements for the title placard.

![image](https://user-images.githubusercontent.com/32680403/144754026-01c49d8d-b9a0-4b5e-9051-4635357ded08.png)
