### PR TITLE
attempt to validate image format before attaching to achievement

### DIFF
--- a/src/api/impl/ConnectedServer.cpp
+++ b/src/api/impl/ConnectedServer.cpp
@@ -393,13 +393,8 @@ static bool DoUpload(const std::string& sHost, const char* restrict sApiName, co
         return false;
     }
 
-    std::string sExt = "png";
-    const auto nIndex = sFilePath.find_last_of('.');
-    if (nIndex != std::string::npos)
-    {
-        sExt = ra::Narrow(&sFilePath.at(nIndex + 1));
-        ra::StringMakeLowercase(sExt);
-    }
+    std::string sExt = ra::Narrow(pFileSystem.GetExtension(sFilePath));
+    ra::StringMakeLowercase(sExt);
 
     const auto& pUserContext = ra::services::ServiceLocator::Get<ra::data::context::UserContext>();
     RA_LOG_INFO("%s Request: file=%s (%zu bytes)", sApiName, sFilePath, nFileSize);

--- a/src/data/context/EmulatorContext.cpp
+++ b/src/data/context/EmulatorContext.cpp
@@ -107,7 +107,7 @@ void EmulatorContext::Initialize(EmulatorID nEmulatorId, const char* sClientName
                 const auto& pDesktop = ra::services::ServiceLocator::Get<ra::ui::IDesktop>();
                 const auto sFileName = pDesktop.GetRunningExecutable();
                 const auto& pFileSystem = ra::services::ServiceLocator::Get<ra::services::IFileSystem>();
-                m_sClientName = pFileSystem.RemoveExtension(pFileSystem.GetFileName(sFileName));
+                m_sClientName = ra::Narrow(pFileSystem.RemoveExtension(pFileSystem.GetFileName(sFileName)));
             }
             m_nEmulatorId = EmulatorID::UnknownEmulator;
             break;

--- a/src/services/IFileSystem.hh
+++ b/src/services/IFileSystem.hh
@@ -99,12 +99,17 @@ public:
     /// <summary>
     /// Gets the filename portion of a path.
     /// </summary>
-    virtual std::string GetFileName(const std::string& sPath) const = 0;
+    virtual std::wstring GetFileName(const std::wstring& sPath) const = 0;
+
+    /// <summary>
+    /// Gets the extension portion of a path.
+    /// </summary>
+    virtual std::wstring GetExtension(const std::wstring& sPath) const = 0;
 
     /// <summary>
     /// Removes the extension from a filename.
     /// </summary>
-    virtual std::string RemoveExtension(const std::string& sPath) const = 0;
+    virtual std::wstring RemoveExtension(const std::wstring& sPath) const = 0;
 
 protected:
     IFileSystem() noexcept = default;

--- a/src/services/impl/WindowsFileSystem.cpp
+++ b/src/services/impl/WindowsFileSystem.cpp
@@ -38,20 +38,29 @@ const std::wstring& WindowsFileSystem::MakeAbsolute(std::wstring& sBuffer, const
     return sBuffer;
 }
 
-std::string WindowsFileSystem::GetFileName(const std::string& sPath) const
+std::wstring WindowsFileSystem::GetFileName(const std::wstring& sPath) const
 {
-    const auto nIndex = sPath.find_last_of("/\\");
+    const auto nIndex = sPath.find_last_of(L"/\\");
     if (nIndex != std::string::npos)
-        return std::string(sPath, nIndex + 1);
+        return std::wstring(sPath, nIndex + 1);
 
     return sPath;
 }
 
-std::string WindowsFileSystem::RemoveExtension(const std::string& sPath) const
+std::wstring WindowsFileSystem::GetExtension(const std::wstring& sPath) const
 {
-    const auto nIndex = sPath.find_last_of("/\\.");
+    const auto nIndex = sPath.find_last_of(L"/\\.");
     if (nIndex != std::string::npos && sPath.at(nIndex) == '.')
-        return std::string(sPath, 0, nIndex);
+        return std::wstring(sPath, nIndex + 1);
+
+    return L"";
+}
+
+std::wstring WindowsFileSystem::RemoveExtension(const std::wstring& sPath) const
+{
+    const auto nIndex = sPath.find_last_of(L"/\\.");
+    if (nIndex != std::string::npos && sPath.at(nIndex) == '.')
+        return std::wstring(sPath, 0, nIndex);
 
     return sPath;
 }

--- a/src/services/impl/WindowsFileSystem.hh
+++ b/src/services/impl/WindowsFileSystem.hh
@@ -34,8 +34,9 @@ public:
     std::unique_ptr<TextWriter> CreateTextFile(const std::wstring& sPath) const override;
     std::unique_ptr<TextWriter> AppendTextFile(const std::wstring& sPath) const override;
 
-    std::string GetFileName(const std::string& sPath) const override;
-    std::string RemoveExtension(const std::string& sPath) const override;
+    std::wstring GetFileName(const std::wstring& sPath) const override;
+    std::wstring GetExtension(const std::wstring& sPath) const override;
+    std::wstring RemoveExtension(const std::wstring& sPath) const override;
 
 private:
     const std::wstring& MakeAbsolute(std::wstring& sBuffer, const std::wstring& sPath) const noexcept;

--- a/src/ui/IDesktop.hh
+++ b/src/ui/IDesktop.hh
@@ -51,7 +51,7 @@ public:
     /// <summary>
     /// Gets the path/filename of the currently running executable.
     /// </summary>
-    virtual std::string GetRunningExecutable() const = 0;
+    virtual std::wstring GetRunningExecutable() const = 0;
 
     /// <summary>
     /// Gets a string representing the current operating system and its version.

--- a/src/ui/win32/Desktop.cpp
+++ b/src/ui/win32/Desktop.cpp
@@ -167,11 +167,11 @@ void Desktop::SetMainHWnd(HWND hWnd)
     g_RAMainWnd = hWnd;
 }
 
-std::string Desktop::GetRunningExecutable() const
+std::wstring Desktop::GetRunningExecutable() const
 {
-    char buffer[MAX_PATH];
-    GetModuleFileNameA(nullptr, buffer, sizeof(buffer));
-    return std::string(buffer);
+    wchar_t buffer[MAX_PATH];
+    GetModuleFileNameW(nullptr, buffer, sizeof(buffer)/sizeof(buffer[0]));
+    return std::wstring(buffer);
 }
 
 std::string Desktop::GetWindowsVersionString()

--- a/src/ui/win32/Desktop.hh
+++ b/src/ui/win32/Desktop.hh
@@ -28,7 +28,7 @@ public:
 
     HWND GetMainHWnd() const noexcept;
     void SetMainHWnd(HWND hWnd);
-    std::string GetRunningExecutable() const override;
+    std::wstring GetRunningExecutable() const override;
     std::string GetOSVersionString() const override { return GetWindowsVersionString(); }
     static std::string GetWindowsVersionString();
 

--- a/tests/data/context/EmulatorContext_Tests.cpp
+++ b/tests/data/context/EmulatorContext_Tests.cpp
@@ -1017,7 +1017,7 @@ public:
     TEST_METHOD(TestInitializeUnknownEmulator)
     {
         EmulatorContextHarness emulator;
-        emulator.mockDesktop.SetRunningExecutable("C:\\Games\\Emulator\\RATest.exe");
+        emulator.mockDesktop.SetRunningExecutable(L"C:\\Games\\Emulator\\RATest.exe");
         emulator.Initialize(ra::itoe<EmulatorID>(9999), nullptr);
         Assert::AreEqual(ra::etoi(EmulatorID::UnknownEmulator), ra::etoi(emulator.GetEmulatorId()));
         Assert::AreEqual(std::string("RATest"), emulator.GetClientName());

--- a/tests/mocks/MockDesktop.hh
+++ b/tests/mocks/MockDesktop.hh
@@ -86,8 +86,8 @@ public:
 
     void ResetExpectedWindows() noexcept { m_bDialogShown = false; m_vHandlers.clear(); }
 
-    std::string GetRunningExecutable() const override { return m_sExecutable; }
-    void SetRunningExecutable(const std::string& sExecutable) { m_sExecutable = sExecutable; }
+    std::wstring GetRunningExecutable() const override { return m_sExecutable; }
+    void SetRunningExecutable(const std::wstring& sExecutable) { m_sExecutable = sExecutable; }
 
     std::string GetOSVersionString() const override { return "UnitTests"; }
 
@@ -112,7 +112,7 @@ private:
     std::vector<DialogHandler> m_vHandlers;
     mutable bool m_bDialogShown = false;
     mutable std::string m_sLastOpenedUrl;
-    std::string m_sExecutable;
+    std::wstring m_sExecutable;
     bool m_bDebuggerPresent = false;
 };
 

--- a/tests/mocks/MockFileSystem.hh
+++ b/tests/mocks/MockFileSystem.hh
@@ -187,20 +187,29 @@ public:
         return std::unique_ptr<TextWriter>(pWriter.release());
     }
 
-    std::string GetFileName(const std::string& sPath) const override
+    std::wstring GetFileName(const std::wstring& sPath) const override
     {
-        const auto nIndex = sPath.find_last_of("/\\");
+        const auto nIndex = sPath.find_last_of(L"/\\");
         if (nIndex != std::string::npos)
-            return std::string(sPath, nIndex + 1);
+            return std::wstring(sPath, nIndex + 1);
 
         return sPath;
     }
 
-    std::string RemoveExtension(const std::string& sPath) const override
+    std::wstring GetExtension(const std::wstring& sPath) const override
     {
-        const auto nIndex = sPath.find_last_of("/\\.");
+        const auto nIndex = sPath.find_last_of(L"/\\.");
         if (nIndex != std::string::npos && sPath.at(nIndex) == '.')
-            return std::string(sPath, 0, nIndex);
+            return std::wstring(sPath, nIndex + 1);
+
+        return L"";
+    }
+
+    std::wstring RemoveExtension(const std::wstring& sPath) const override
+    {
+        const auto nIndex = sPath.find_last_of(L"/\\.");
+        if (nIndex != std::string::npos && sPath.at(nIndex) == '.')
+            return std::wstring(sPath, 0, nIndex);
 
         return sPath;
     }

--- a/tests/mocks/MockImageRepository.hh
+++ b/tests/mocks/MockImageRepository.hh
@@ -46,7 +46,7 @@ public:
 
     std::string StoreImage(_UNUSED ImageType nType, _UNUSED const std::wstring& sPath) override
     {
-        return ra::Narrow(sPath);
+        return "REPO:" + ra::Narrow(sPath);
     }
 
     std::wstring GetFilename(_UNUSED ImageType nType, const std::string& sName) const override


### PR DESCRIPTION
The server relies on the file extension to determine how to process an image. If an image is uploaded with the wrong extension, it will end up being converted to a blank image.

This attempts to detect incorrectly named files (i.e. bmp masquerading as a png) and prevent attaching it to the achievement.