### PR TITLE
revalidate assets after memory is initialized to check for out of range addresses

### DIFF
--- a/src/data/models/AchievementModel.cpp
+++ b/src/data/models/AchievementModel.cpp
@@ -119,7 +119,7 @@ void AchievementModel::CommitTransaction()
 
 bool AchievementModel::ValidateAsset(std::wstring& sError)
 {
-    const auto& sTrigger = GetLocalAssetDefinition(m_pTrigger);
+    const auto& sTrigger = GetAssetDefinition(m_pTrigger);
     return TriggerValidation::Validate(sTrigger, sError, AssetType::Achievement);
 }
 

--- a/src/data/models/LeaderboardModel.cpp
+++ b/src/data/models/LeaderboardModel.cpp
@@ -70,21 +70,21 @@ void LeaderboardModel::OnValueChanged(const IntModelProperty::ChangeArgs& args)
 
 bool LeaderboardModel::ValidateAsset(std::wstring& sError)
 {
-    const auto& sStartTrigger = GetLocalAssetDefinition(m_pStartTrigger);
+    const auto& sStartTrigger = GetAssetDefinition(m_pStartTrigger);
     if (!TriggerValidation::Validate(sStartTrigger, sError, AssetType::Leaderboard))
     {
         sError.insert(0, L"Start: ");
         return false;
     }
 
-    const auto& sSubmitTrigger = GetLocalAssetDefinition(m_pSubmitTrigger);
+    const auto& sSubmitTrigger = GetAssetDefinition(m_pSubmitTrigger);
     if (!TriggerValidation::Validate(sSubmitTrigger, sError, AssetType::Leaderboard))
     {
         sError.insert(0, L"Submit: ");
         return false;
     }
 
-    const auto& sCancelTrigger = GetLocalAssetDefinition(m_pCancelTrigger);
+    const auto& sCancelTrigger = GetAssetDefinition(m_pCancelTrigger);
     if (!TriggerValidation::Validate(sCancelTrigger, sError, AssetType::Leaderboard))
     {
         sError.insert(0, L"Cancel: ");


### PR DESCRIPTION
Ensures committed Unofficial/Local achievements with invalid memory addresses get flagged when reopening the game.