### PR TITLE
fix conversion of decimal-like values to hex when prefer decimal off

### DIFF
--- a/src/ui/win32/AssetEditorDialog.cpp
+++ b/src/ui/win32/AssetEditorDialog.cpp
@@ -189,7 +189,7 @@ public:
                     return false;
                 }
 
-                vmItems.SetItemValue(nIndex, *m_pBoundProperty, sValue);
+                vmItems.SetItemValue(nIndex, *m_pBoundProperty, ra::StringPrintf(L"0x%02x", nValue));
                 return true;
             }
         }


### PR DESCRIPTION
When entering a value of "10" with "Show Decimal" off, it should be converted to "0x10", not "0x0a".