### PR TITLE
prevent crash when closing game with invalid asset in editor

### DIFF
--- a/src/data/context/GameContext.cpp
+++ b/src/data/context/GameContext.cpp
@@ -46,7 +46,7 @@ void GameContext::LoadGame(unsigned int nGameId, Mode nMode)
 {
     // remove the current asset from the asset editor
     auto& vmWindowManager = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::WindowManager>();
-    vmWindowManager.AssetEditor.LoadAsset(nullptr);
+    vmWindowManager.AssetEditor.LoadAsset(nullptr, true);
 
     // reset the runtime
     auto& pRuntime = ra::services::ServiceLocator::GetMutable<ra::services::AchievementRuntime>();

--- a/src/ui/viewmodels/AssetEditorViewModel.cpp
+++ b/src/ui/viewmodels/AssetEditorViewModel.cpp
@@ -122,12 +122,12 @@ void AssetEditorViewModel::SelectBadgeFile()
     SetBadge(ra::Widen(sBadgeName));
 }
 
-void AssetEditorViewModel::LoadAsset(ra::data::models::AssetModelBase* pAsset)
+void AssetEditorViewModel::LoadAsset(ra::data::models::AssetModelBase* pAsset, bool bForce)
 {
     if (m_pAsset == pAsset)
         return;
 
-    if (HasAssetValidationError() && m_pAsset->GetChanges() != ra::data::models::AssetChanges::Deleted)
+    if (!bForce && HasAssetValidationError() && m_pAsset->GetChanges() != ra::data::models::AssetChanges::Deleted)
     {
         if (ra::ui::viewmodels::MessageBoxViewModel::ShowWarningMessage(L"Discard changes?",
             L"The currently loaded asset has an error that cannot be saved. If you switch to another asset, your changes will be lost.",

--- a/src/ui/viewmodels/AssetEditorViewModel.hh
+++ b/src/ui/viewmodels/AssetEditorViewModel.hh
@@ -413,7 +413,7 @@ public:
 
     // ===== Functions =====
 
-    void LoadAsset(ra::data::models::AssetModelBase* pAsset);
+    void LoadAsset(ra::data::models::AssetModelBase* pAsset, bool bForce = false);
     const ra::data::models::AssetModelBase* GetAsset() const noexcept { return m_pAsset; }
 
     void DoFrame();

--- a/tests/ui/viewmodels/AssetEditorViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/AssetEditorViewModel_Tests.cpp
@@ -578,6 +578,38 @@ public:
         Assert::AreEqual(std::wstring(), editor.GetAssetValidationWarning());
     }
 
+    TEST_METHOD(TestLoadAchievementForcedValidationError)
+    {
+        AssetEditorViewModelHarness editor;
+        AchievementModel achievement;
+        achievement.SetName(L"Test Achievement");
+        achievement.SetID(1234U);
+        achievement.SetState(AssetState::Active);
+        achievement.SetDescription(L"Do something cool");
+        achievement.SetCategory(AssetCategory::Unofficial);
+        achievement.SetPoints(10);
+        achievement.SetBadge(L"58329");
+        achievement.SetTrigger("M:0x1234=10");
+        achievement.CreateServerCheckpoint();
+        achievement.CreateLocalCheckpoint();
+
+        editor.LoadAsset(&achievement);
+        editor.SetAssetValidationError(L"Multiple Measured"); // not really, just fake it
+
+        Assert::IsTrue(editor.HasAssetValidationError());
+        Assert::AreEqual(std::wstring(L"Multiple Measured"), editor.GetAssetValidationError());
+
+        Assert::IsFalse(editor.HasAssetValidationWarning());
+        Assert::AreEqual(std::wstring(), editor.GetAssetValidationWarning());
+
+        editor.LoadAsset(nullptr, true);
+        Assert::IsFalse(editor.mockDesktop.WasDialogShown());
+        Assert::IsFalse(editor.HasAssetValidationError());
+        Assert::AreEqual(std::wstring(), editor.GetAssetValidationError());
+        Assert::IsFalse(editor.HasAssetValidationWarning());
+        Assert::AreEqual(std::wstring(), editor.GetAssetValidationWarning());
+    }
+
     TEST_METHOD(TestLoadLeaderboard)
     {
         AssetEditorViewModelHarness editor;


### PR DESCRIPTION
When an invalid asset is being removed from the editor, a prompt is shown to confirm the action. If the user cancels the removal while the application is shutting down, the asset will be left in the editor after the assets have been free'd, then when the editor tries to free itself, it references the free'd asset and crashes.

Ideally, the prompt could abort closing the game, but that requires much larger changes that I didn't want to attempt at this time.