### PR TITLE
prevent crash viewing tooltip for address chain after modification

### DIFF
--- a/src/ui/viewmodels/TriggerViewModel.cpp
+++ b/src/ui/viewmodels/TriggerViewModel.cpp
@@ -639,12 +639,43 @@ void TriggerViewModel::ConditionsMonitor::OnEndViewModelCollectionUpdate()
 
 void TriggerViewModel::ConditionsMonitor::UpdateCurrentGroup()
 {
+    if (m_nUpdateCount > 0)
+    {
+        m_bUpdatePending = true;
+        return;
+    }
+
     auto* pGroup = m_vmTrigger->m_vGroups.GetItemAt(m_vmTrigger->GetSelectedGroupIndex());
     if (pGroup)
     {
         if (pGroup->UpdateSerialized(m_vmTrigger->m_vConditions))
             m_vmTrigger->UpdateVersion();
     }
+}
+
+void TriggerViewModel::ConditionsMonitor::EndUpdate()
+{
+    if (m_nUpdateCount > 0)
+    {
+        if (--m_nUpdateCount == 0)
+        {
+            if (m_bUpdatePending)
+            {
+                m_bUpdatePending = false;
+                UpdateCurrentGroup();
+            }
+        }
+    }
+}
+
+void TriggerViewModel::SuspendConditionMonitor() const noexcept
+{
+    m_pConditionsMonitor.BeginUpdate();
+}
+
+void TriggerViewModel::ResumeConditionMonitor() const
+{
+    m_pConditionsMonitor.EndUpdate();
 }
 
 void TriggerViewModel::UpdateVersion()

--- a/src/ui/viewmodels/TriggerViewModel.hh
+++ b/src/ui/viewmodels/TriggerViewModel.hh
@@ -92,6 +92,9 @@ public:
     void InitializeFrom(const rc_value_t& pValue);
     void UpdateFrom(const rc_value_t& pValue);
 
+    void SuspendConditionMonitor() const noexcept;
+    void ResumeConditionMonitor() const;
+
     void CopyToClipboard();
 
     void RemoveSelectedConditions();
@@ -180,6 +183,9 @@ private:
             m_vmTrigger = &vmTrigger;
         }
 
+        void BeginUpdate() noexcept { ++m_nUpdateCount; }
+        void EndUpdate();
+
     protected:
         void OnViewModelIntValueChanged(gsl::index nIndex, const IntModelProperty::ChangeArgs& args) override;
         void OnViewModelStringValueChanged(gsl::index nIndex, const StringModelProperty::ChangeArgs& args) override;
@@ -190,9 +196,12 @@ private:
         void UpdateCurrentGroup();
 
         TriggerViewModel* m_vmTrigger;
+
+        int m_nUpdateCount = 0;
+        bool m_bUpdatePending = false;
     };
 
-    ConditionsMonitor m_pConditionsMonitor;
+    mutable ConditionsMonitor m_pConditionsMonitor;
 
     LookupItemViewModelCollection m_vConditionTypes;
     LookupItemViewModelCollection m_vOperandTypes;

--- a/tests/ui/viewmodels/AssetEditorViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/AssetEditorViewModel_Tests.cpp
@@ -2,6 +2,7 @@
 
 #include "ui\EditorTheme.hh"
 
+#include "ui\BindingBase.hh"
 #include "ui\viewmodels\AssetEditorViewModel.hh"
 #include "ui\viewmodels\FileDialogViewModel.hh"
 #include "ui\viewmodels\MessageBoxViewModel.hh"
@@ -80,8 +81,24 @@ private:
             SetValue(AssetValidationErrorProperty, sValue);
         }
 
+        int GetTriggerVersion()
+        {
+            TriggerVersionBinding binding(Trigger());
+            return binding.GetVersion();
+        }
+
     private:
         ra::services::ServiceLocator::ServiceOverride<ra::ui::EditorTheme> m_pMockThemeOverride;
+
+        class TriggerVersionBinding : public ui::BindingBase
+        {
+        public:
+            TriggerVersionBinding(TriggerViewModel& vmTrigger) noexcept : ui::BindingBase(vmTrigger)
+            {
+            }
+
+            int GetVersion() const { return GetValue(TriggerViewModel::VersionProperty); }
+        };
     };
 
 
@@ -1477,6 +1494,41 @@ public:
         Expects(pCondition != nullptr);
         Assert::AreEqual(TriggerConditionType::Measured, pCondition->GetType());
         Assert::AreEqual(2U, pCondition->GetRequiredHits());
+    }
+
+    TEST_METHOD(TestTriggerUpdatedValueToDelta)
+    {
+        // When a condition changes from value to delta, two properties are changed (type and size)
+        // Expect a single change notification and make sure the condition is referenced by the updated condition
+
+        AssetEditorViewModelHarness editor;
+        editor.mockConfiguration.SetFeatureEnabled(ra::services::Feature::PreferDecimal, true);
+        AchievementModel achievement;
+        achievement.SetID(1234U);
+        achievement.SetTrigger("0xH1234=1");
+        achievement.CreateServerCheckpoint();
+        achievement.CreateLocalCheckpoint();
+        achievement.Activate();
+
+        editor.LoadAsset(&achievement);
+
+        editor.Trigger().SetSelectedGroupIndex(0);
+        auto& condition = *editor.Trigger().Conditions().GetItemAt(0);
+        auto& group = *editor.Trigger().Groups().GetItemAt(0);
+        const auto initialVersion = editor.GetTriggerVersion();
+        Assert::IsNotNull(group.m_pConditionSet);
+
+        // change to address switches size to match source
+        condition.SetTargetType(TriggerOperandType::Delta);
+        Assert::AreEqual(std::string("0xH1234=d0xH0001"), achievement.GetTrigger());
+        Assert::AreEqual(initialVersion + 1, editor.GetTriggerVersion());
+        Assert::IsNotNull(group.m_pConditionSet);
+
+        // change to value sets size back to 32-bit
+        condition.SetTargetType(TriggerOperandType::Value);
+        Assert::AreEqual(std::string("0xH1234=1"), achievement.GetTrigger());
+        Assert::AreEqual(initialVersion + 2, editor.GetTriggerVersion());
+        Assert::IsNotNull(group.m_pConditionSet);
     }
 
     TEST_METHOD(TestValueUpdated)

--- a/tests/ui/viewmodels/TriggerConditionViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/TriggerConditionViewModel_Tests.cpp
@@ -844,6 +844,28 @@ public:
         Assert::IsFalse(condition.IsModifying());
     }
 
+    TEST_METHOD(TestSwitchBetweenValueAndAddress)
+    {
+        TriggerConditionViewModelHarness condition;
+        condition.SetSourceValue(0x1234U);
+        condition.SetOperator(TriggerOperatorType::NotEquals);
+        condition.SetTargetValue(8U);
+        Assert::AreEqual(std::string("0xH1234!=8"), condition.Serialize());
+        Assert::IsFalse(condition.HasTargetSize());
+
+        // change to address switches size to match source
+        condition.SetTargetType(TriggerOperandType::Delta);
+        Assert::IsTrue(condition.HasTargetSize());
+        Assert::AreEqual(MemSize::EightBit, condition.GetTargetSize());
+        Assert::AreEqual(std::string("0xH1234!=d0xH0008"), condition.Serialize());
+
+        // change to value sets size back to 32-bit
+        condition.SetTargetType(TriggerOperandType::Value);
+        Assert::IsFalse(condition.HasTargetSize());
+        Assert::AreEqual(MemSize::ThirtyTwoBit, condition.GetTargetSize());
+        Assert::AreEqual(std::string("0xH1234!=8"), condition.Serialize());
+    }
+
     TEST_METHOD(TestChangeOperand)
     {
         TriggerConditionViewModelHarness condition;


### PR DESCRIPTION
Ensures only one change event is raised when multiple properties of a condition change at the same time.

When changing a field from Value to a memory type, the size field is updated as well as the Type field. This generates two events for the trigger changing, but the serialized form did not actually change on the second event, leaving the backing data uninitialized. When trying to view the Indirect tooltip without backing data, the application would crash.