### PR TITLE
don't show hidden leaderboards in overlay

### DIFF
--- a/src/api/FetchGameData.hh
+++ b/src/api/FetchGameData.hh
@@ -42,6 +42,7 @@ public:
             std::string Definition;
             int Format{ 0 };
             bool LowerIsBetter{ false };
+            bool Hidden{ false };
         };
         std::vector<Leaderboard> Leaderboards;
     };

--- a/src/api/impl/ConnectedServer.cpp
+++ b/src/api/impl/ConnectedServer.cpp
@@ -867,6 +867,7 @@ void ConnectedServer::ProcessGamePatchData(ra::api::FetchGameData::Response &res
             pLeaderboard.Definition = pSrcLeaderboard->definition;
             pLeaderboard.Format = pSrcLeaderboard->format;
             pLeaderboard.LowerIsBetter = pSrcLeaderboard->lower_is_better;
+            pLeaderboard.Hidden = pSrcLeaderboard->hidden;
         }
     }
 

--- a/src/data/context/GameContext.cpp
+++ b/src/data/context/GameContext.cpp
@@ -201,6 +201,7 @@ void GameContext::LoadGame(unsigned int nGameId, Mode nMode)
         vmLeaderboard->SetCategory(ra::data::models::AssetCategory::Core);
         vmLeaderboard->SetValueFormat(ra::itoe<ValueFormat>(pLeaderboardData.Format));
         vmLeaderboard->SetLowerIsBetter(pLeaderboardData.LowerIsBetter);
+        vmLeaderboard->SetHidden(pLeaderboardData.Hidden);
         vmLeaderboard->SetDefinition(pLeaderboardData.Definition);
         vmLeaderboard->CreateServerCheckpoint();
         vmLeaderboard->CreateLocalCheckpoint();

--- a/src/data/models/LeaderboardModel.cpp
+++ b/src/data/models/LeaderboardModel.cpp
@@ -19,6 +19,7 @@ const IntModelProperty LeaderboardModel::ValueFormatProperty("LeaderboardModel",
 const IntModelProperty LeaderboardModel::PauseOnResetProperty("LeaderboardModel", "PauseOnReset", ra::etoi(LeaderboardModel::LeaderboardParts::None));
 const IntModelProperty LeaderboardModel::PauseOnTriggerProperty("LeaderboardModel", "PauseOnTrigger", ra::etoi(LeaderboardModel::LeaderboardParts::None));
 const BoolModelProperty LeaderboardModel::LowerIsBetterProperty("LeaderboardModel", "LowerIsBetter", false);
+const BoolModelProperty LeaderboardModel::IsHiddenProperty("LeaderboardModel", "Hidden", false);
 
 LeaderboardModel::LeaderboardModel() noexcept
 {

--- a/src/data/models/LeaderboardModel.hh
+++ b/src/data/models/LeaderboardModel.hh
@@ -152,6 +152,21 @@ public:
     void SetLowerIsBetter(bool nValue) { SetValue(LowerIsBetterProperty, nValue); }
 
     /// <summary>
+    /// The <see cref="ModelProperty" /> for whether or not the leaderboard should not be displayed in the overlay.
+    /// </summary>
+    static const BoolModelProperty IsHiddenProperty;
+
+    /// <summary>
+    /// Gets whether or not the leaderboard should not be displayed in the overlay.
+    /// </summary>
+    bool IsHidden() const { return GetValue(IsHiddenProperty); }
+
+    /// <summary>
+    /// Sets whether or not the leaderboard should not be displayed in the overlay.
+    /// </summary>
+    void SetHidden(bool nValue) { SetValue(IsHiddenProperty, nValue); }
+
+    /// <summary>
     /// Populates the start/submit/cancel/value fields from a compound definition.
     /// </summary>
     void SetDefinition(const std::string& sDefinition);

--- a/src/ui/viewmodels/OverlayAchievementsPageViewModel.cpp
+++ b/src/ui/viewmodels/OverlayAchievementsPageViewModel.cpp
@@ -25,32 +25,6 @@ const StringModelProperty OverlayAchievementsPageViewModel::AchievementViewModel
 const StringModelProperty OverlayAchievementsPageViewModel::AchievementViewModel::ModifiedDateProperty("AchievementViewModel", "ModifiedDate", L"");
 const StringModelProperty OverlayAchievementsPageViewModel::AchievementViewModel::WonByProperty("AchievementViewModel", "WonBy", L"");
 
-OverlayListPageViewModel::ItemViewModel& OverlayAchievementsPageViewModel::GetNextItem(size_t* nIndex)
-{
-    Expects(nIndex != nullptr);
-
-    ItemViewModel* pvmAchievement = m_vItems.GetItemAt((*nIndex)++);
-    if (pvmAchievement == nullptr)
-    {
-        pvmAchievement = &m_vItems.Add();
-        Ensures(pvmAchievement != nullptr);
-    }
-
-    return *pvmAchievement;
-}
-
-static void SetHeader(OverlayListPageViewModel::ItemViewModel& vmItem, const std::wstring& sHeader)
-{
-    vmItem.SetId(0);
-    vmItem.SetLabel(sHeader);
-    vmItem.SetDetail(L"");
-    vmItem.SetDisabled(false);
-    vmItem.Image.ChangeReference(ra::ui::ImageType::None, "");
-    vmItem.SetProgressValue(0U);
-    vmItem.SetProgressMaximum(0U);
-    vmItem.SetProgressPercentage(true);
-}
-
 static void SetAchievement(OverlayListPageViewModel::ItemViewModel& vmItem, const ra::data::models::AchievementModel& vmAchievement)
 {
     vmItem.SetId(vmAchievement.GetID());
@@ -103,22 +77,6 @@ static void SetAchievement(OverlayListPageViewModel::ItemViewModel& vmItem, cons
         vmItem.SetProgressMaximum(0U);
         vmItem.SetProgressPercentage(false);
     }
-}
-
-static bool AppearsInFilter(const ra::data::models::AchievementModel* vmAchievement)
-{
-    Expects(vmAchievement != nullptr);
-
-    const auto nId = ra::to_signed(vmAchievement->GetID());
-    const auto& vFilteredAssets = ra::services::ServiceLocator::Get<ra::ui::viewmodels::WindowManager>().AssetList.FilteredAssets();
-    for (gsl::index nIndex = 0; nIndex < ra::to_signed(vFilteredAssets.Count()); ++nIndex)
-    {
-        const auto* pAsset = vFilteredAssets.GetItemAt(nIndex);
-        if (pAsset && pAsset->GetId() == nId && pAsset->GetType() == ra::data::models::AssetType::Achievement)
-            return true;
-    }
-
-    return false;
 }
 
 void OverlayAchievementsPageViewModel::Refresh()
@@ -204,12 +162,12 @@ void OverlayAchievementsPageViewModel::Refresh()
         switch (vmAchievement->GetCategory())
         {
             case ra::data::models::AssetCategory::Local:
-                if (AppearsInFilter(vmAchievement))
+                if (AssetAppearsInFilter(*vmAchievement))
                     vLocalAchievements.push_back(vmAchievement);
                 break;
 
             case ra::data::models::AssetCategory::Unofficial:
-                if (AppearsInFilter(vmAchievement))
+                if (AssetAppearsInFilter(*vmAchievement))
                     vUnofficialAchievements.push_back(vmAchievement);
                 break;
 

--- a/src/ui/viewmodels/OverlayAchievementsPageViewModel.hh
+++ b/src/ui/viewmodels/OverlayAchievementsPageViewModel.hh
@@ -86,8 +86,6 @@ protected:
     std::map<ra::AchievementID, AchievementViewModel> m_vAchievementDetails;
 
 private:
-    ItemViewModel& GetNextItem(size_t* nIndex);
-
     void RenderDetail(ra::ui::drawing::ISurface& pSurface, int nX, int nY, _UNUSED int nWidth, int nHeight) const override;
 
     std::wstring m_sSummary;

--- a/src/ui/viewmodels/OverlayListPageViewModel.cpp
+++ b/src/ui/viewmodels/OverlayListPageViewModel.cpp
@@ -7,6 +7,7 @@
 
 #include "ui\OverlayTheme.hh"
 #include "ui\viewmodels\OverlayManager.hh"
+#include "ui\viewmodels\WindowManager.hh"
 
 namespace ra {
 namespace ui {
@@ -27,6 +28,49 @@ void OverlayListPageViewModel::Refresh()
     m_bDetail = false;
     SetTitle(m_sTitle);
     m_nImagesPending = 99;
+}
+
+bool OverlayListPageViewModel::AssetAppearsInFilter(const ra::data::models::AssetModelBase& pAsset)
+{
+    const auto nType = pAsset.GetType();
+    const auto nId = ra::to_signed(pAsset.GetID());
+
+    const auto& pAssetList = ra::services::ServiceLocator::Get<ra::ui::viewmodels::WindowManager>().AssetList;
+    const auto& vFilteredAssets = pAssetList.FilteredAssets();
+    for (gsl::index nIndex = 0; nIndex < ra::to_signed(vFilteredAssets.Count()); ++nIndex)
+    {
+        const auto* vmAsset = vFilteredAssets.GetItemAt(nIndex);
+        if (vmAsset && vmAsset->GetId() == nId && vmAsset->GetType() == nType)
+            return true;
+    }
+
+    return false;
+}
+
+OverlayListPageViewModel::ItemViewModel& OverlayListPageViewModel::GetNextItem(size_t* nIndex)
+{
+    Expects(nIndex != nullptr);
+
+    ItemViewModel* pvmItem = m_vItems.GetItemAt((*nIndex)++);
+    if (pvmItem == nullptr)
+    {
+        pvmItem = &m_vItems.Add();
+        Ensures(pvmItem != nullptr);
+    }
+
+    return *pvmItem;
+}
+
+void OverlayListPageViewModel::SetHeader(OverlayListPageViewModel::ItemViewModel& vmItem, const std::wstring& sHeader)
+{
+    vmItem.SetId(0);
+    vmItem.SetLabel(sHeader);
+    vmItem.SetDetail(L"");
+    vmItem.SetDisabled(false);
+    vmItem.Image.ChangeReference(ra::ui::ImageType::None, "");
+    vmItem.SetProgressValue(0U);
+    vmItem.SetProgressMaximum(0U);
+    vmItem.SetProgressPercentage(true);
 }
 
 void OverlayListPageViewModel::EnsureSelectedItemIndexValid()

--- a/src/ui/viewmodels/OverlayListPageViewModel.hh
+++ b/src/ui/viewmodels/OverlayListPageViewModel.hh
@@ -3,6 +3,8 @@
 
 #include "OverlayViewModel.hh"
 
+#include "data\models\AssetModelBase.hh"
+
 #include "ui\ViewModelCollection.hh"
 #include "ui\viewmodels\LookupItemViewModel.hh"
 
@@ -161,6 +163,10 @@ protected:
     bool m_bDetail = false;
     std::wstring m_sTitle;
     std::wstring m_sDetailTitle;
+
+    ItemViewModel& GetNextItem(size_t* nIndex);
+    static void SetHeader(OverlayListPageViewModel::ItemViewModel& vmItem, const std::wstring& sHeader);
+    static bool AssetAppearsInFilter(const ra::data::models::AssetModelBase& pAsset);
 
     ra::ui::ViewModelCollection<ItemViewModel> m_vItems;
 

--- a/tests/ui/viewmodels/OverlayLeaderboardsPageViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/OverlayLeaderboardsPageViewModel_Tests.cpp
@@ -8,6 +8,7 @@
 #include "tests\mocks\MockServer.hh"
 #include "tests\mocks\MockThreadPool.hh"
 #include "tests\mocks\MockUserContext.hh"
+#include "tests\mocks\MockWindowManager.hh"
 #include "tests\RA_UnitTestHelpers.h"
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
@@ -29,6 +30,7 @@ private:
         ra::services::mocks::MockThreadPool mockThreadPool;
         ra::ui::mocks::MockImageRepository mockImageRepository;
         ra::ui::viewmodels::mocks::MockOverlayManager mockOverlayManager;
+        ra::ui::viewmodels::mocks::MockWindowManager mockWindowManager;
 
         ItemViewModel* GetItem(gsl::index nIndex) { return m_vItems.GetItemAt(nIndex); }
 
@@ -47,6 +49,13 @@ private:
 
             return nullptr;
         }
+
+        void SetAssetFilter(ra::ui::viewmodels::AssetListViewModel::FilterCategory nCategory)
+        {
+            auto& pAssetList = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::WindowManager>().AssetList;
+            pAssetList.SetAssetTypeFilter(ra::data::models::AssetType::Leaderboard);
+            pAssetList.SetFilterCategory(nCategory);
+        }
     };
 
 public:
@@ -62,6 +71,7 @@ public:
     TEST_METHOD(TestRefreshLeaderboards)
     {
         OverlayLeaderboardsPageViewModelHarness leaderboardsPage;
+        leaderboardsPage.SetAssetFilter(ra::ui::viewmodels::AssetListViewModel::FilterCategory::All);
         auto& pLB1 = leaderboardsPage.mockGameContext.Assets().NewLeaderboard();
         pLB1.SetID(1U);
         pLB1.SetName(L"LeaderboardTitle");
@@ -86,6 +96,295 @@ public:
         Assert::AreEqual(2, pItem->GetId());
         Assert::AreEqual(std::wstring(L"LeaderboardTitle2"), pItem->GetLabel());
         Assert::AreEqual(std::wstring(L"Trigger this too"), pItem->GetDetail());
+    }
+
+    TEST_METHOD(TestRefreshCoreOnly)
+    {
+        OverlayLeaderboardsPageViewModelHarness leaderboardsPage;
+        auto& pLB1 = leaderboardsPage.mockGameContext.Assets().NewLeaderboard();
+        pLB1.SetID(1U);
+        pLB1.SetName(L"LeaderboardTitle");
+        pLB1.SetDescription(L"Capture this");
+        auto& pLB2 = leaderboardsPage.mockGameContext.Assets().NewLeaderboard();
+        pLB2.SetID(2U);
+        pLB2.SetName(L"LeaderboardTitle2");
+        pLB2.SetDescription(L"Local Leaderboard");
+        pLB2.SetCategory(ra::data::models::AssetCategory::Local);
+        auto& pLB3 = leaderboardsPage.mockGameContext.Assets().NewLeaderboard();
+        pLB3.SetID(3U);
+        pLB3.SetName(L"LeaderboardTitle3");
+        pLB3.SetDescription(L"Capture this too");
+        leaderboardsPage.Refresh();
+
+        Assert::AreEqual(std::wstring(L"Leaderboards"), leaderboardsPage.GetTitle());
+        Assert::AreEqual(std::wstring(L"2 leaderboards present"), leaderboardsPage.GetSummary());
+
+        // only 1 and 3 will be visible - 2 is not core, and filtered out by asset list
+        auto* pItem = leaderboardsPage.GetItem(0);
+        Expects(pItem != nullptr);
+        Assert::AreEqual(1, pItem->GetId());
+        Assert::AreEqual(std::wstring(L"LeaderboardTitle"), pItem->GetLabel());
+        Assert::AreEqual(std::wstring(L"Capture this"), pItem->GetDetail());
+
+        pItem = leaderboardsPage.GetItem(1);
+        Expects(pItem != nullptr);
+        Assert::AreEqual(3, pItem->GetId());
+        Assert::AreEqual(std::wstring(L"LeaderboardTitle3"), pItem->GetLabel());
+        Assert::AreEqual(std::wstring(L"Capture this too"), pItem->GetDetail());
+
+        Assert::IsNull(leaderboardsPage.GetItem(3));
+    }
+
+    TEST_METHOD(TestRefreshCoreAndLocal)
+    {
+        OverlayLeaderboardsPageViewModelHarness leaderboardsPage;
+        auto& pLB1 = leaderboardsPage.mockGameContext.Assets().NewLeaderboard();
+        pLB1.SetID(1U);
+        pLB1.SetName(L"LeaderboardTitle");
+        pLB1.SetDescription(L"Capture this");
+        auto& pLB2 = leaderboardsPage.mockGameContext.Assets().NewLeaderboard();
+        pLB2.SetID(2U);
+        pLB2.SetName(L"LeaderboardTitle2");
+        pLB2.SetDescription(L"Local Leaderboard");
+        pLB2.SetCategory(ra::data::models::AssetCategory::Local);
+        auto& pLB3 = leaderboardsPage.mockGameContext.Assets().NewLeaderboard();
+        pLB3.SetID(3U);
+        pLB3.SetName(L"LeaderboardTitle3");
+        pLB3.SetDescription(L"Capture this too");
+        leaderboardsPage.mockWindowManager.AssetList.SetAssetTypeFilter(ra::data::models::AssetType::Leaderboard);
+        leaderboardsPage.mockWindowManager.AssetList.SetFilterCategory(ra::ui::viewmodels::AssetListViewModel::FilterCategory::All);
+        leaderboardsPage.Refresh();
+
+        Assert::AreEqual(std::wstring(L"Leaderboards"), leaderboardsPage.GetTitle());
+        Assert::AreEqual(std::wstring(L"3 leaderboards present"), leaderboardsPage.GetSummary());
+
+        auto* pItem = leaderboardsPage.GetItem(0);
+        Expects(pItem != nullptr);
+        Assert::IsTrue(pItem->IsHeader());
+        Assert::AreEqual(std::wstring(L"Inactive Local Leaderboards"), pItem->GetLabel());
+        Assert::IsFalse(pItem->IsDisabled());
+
+        pItem = leaderboardsPage.GetItem(1);
+        Expects(pItem != nullptr);
+        Assert::AreEqual(2, pItem->GetId());
+        Assert::AreEqual(std::wstring(L"LeaderboardTitle2"), pItem->GetLabel());
+        Assert::AreEqual(std::wstring(L"Local Leaderboard"), pItem->GetDetail());
+
+        pItem = leaderboardsPage.GetItem(2);
+        Expects(pItem != nullptr);
+        Assert::IsTrue(pItem->IsHeader());
+        Assert::AreEqual(std::wstring(L"Inactive Leaderboards"), pItem->GetLabel());
+        Assert::IsFalse(pItem->IsDisabled());
+
+        pItem = leaderboardsPage.GetItem(3);
+        Expects(pItem != nullptr);
+        Assert::AreEqual(1, pItem->GetId());
+        Assert::AreEqual(std::wstring(L"LeaderboardTitle"), pItem->GetLabel());
+        Assert::AreEqual(std::wstring(L"Capture this"), pItem->GetDetail());
+
+        pItem = leaderboardsPage.GetItem(4);
+        Expects(pItem != nullptr);
+        Assert::AreEqual(3, pItem->GetId());
+        Assert::AreEqual(std::wstring(L"LeaderboardTitle3"), pItem->GetLabel());
+        Assert::AreEqual(std::wstring(L"Capture this too"), pItem->GetDetail());
+
+        Assert::IsNull(leaderboardsPage.GetItem(5));
+    }
+
+    TEST_METHOD(TestRefreshWithHidden)
+    {
+        OverlayLeaderboardsPageViewModelHarness leaderboardsPage;
+        auto& pLB1 = leaderboardsPage.mockGameContext.Assets().NewLeaderboard();
+        pLB1.SetID(1U);
+        pLB1.SetName(L"LeaderboardTitle");
+        pLB1.SetDescription(L"Capture this");
+        auto& pLB2 = leaderboardsPage.mockGameContext.Assets().NewLeaderboard();
+        pLB2.SetID(2U);
+        pLB2.SetName(L"LeaderboardTitle2");
+        pLB2.SetDescription(L"Hidden Leaderboard");
+        pLB2.SetHidden(true);
+        auto& pLB3 = leaderboardsPage.mockGameContext.Assets().NewLeaderboard();
+        pLB3.SetID(3U);
+        pLB3.SetName(L"LeaderboardTitle3");
+        pLB3.SetDescription(L"Capture this too");
+        leaderboardsPage.Refresh();
+
+        Assert::AreEqual(std::wstring(L"Leaderboards"), leaderboardsPage.GetTitle());
+        Assert::AreEqual(std::wstring(L"2 leaderboards present"), leaderboardsPage.GetSummary());
+
+        // only 1 and 3 will be visible - 2 is not core, and filtered out by asset list
+        auto* pItem = leaderboardsPage.GetItem(0);
+        Expects(pItem != nullptr);
+        Assert::AreEqual(1, pItem->GetId());
+        Assert::AreEqual(std::wstring(L"LeaderboardTitle"), pItem->GetLabel());
+        Assert::AreEqual(std::wstring(L"Capture this"), pItem->GetDetail());
+
+        pItem = leaderboardsPage.GetItem(1);
+        Expects(pItem != nullptr);
+        Assert::AreEqual(3, pItem->GetId());
+        Assert::AreEqual(std::wstring(L"LeaderboardTitle3"), pItem->GetLabel());
+        Assert::AreEqual(std::wstring(L"Capture this too"), pItem->GetDetail());
+
+        Assert::IsNull(leaderboardsPage.GetItem(3));
+    }
+
+    TEST_METHOD(TestRefreshWithActive)
+    {
+        OverlayLeaderboardsPageViewModelHarness leaderboardsPage;
+        auto& pLB1 = leaderboardsPage.mockGameContext.Assets().NewLeaderboard();
+        pLB1.SetID(1U);
+        pLB1.SetName(L"LeaderboardTitle");
+        pLB1.SetDescription(L"Capture this");
+        auto& pLB2 = leaderboardsPage.mockGameContext.Assets().NewLeaderboard();
+        pLB2.SetID(2U);
+        pLB2.SetName(L"LeaderboardTitle2");
+        pLB2.SetDescription(L"Another Capture");
+        pLB2.SetState(ra::data::models::AssetState::Primed);
+        auto& pLB3 = leaderboardsPage.mockGameContext.Assets().NewLeaderboard();
+        pLB3.SetID(3U);
+        pLB3.SetName(L"LeaderboardTitle3");
+        pLB3.SetDescription(L"Capture this too");
+        pLB3.SetState(ra::data::models::AssetState::Primed);
+        leaderboardsPage.Refresh();
+
+        Assert::AreEqual(std::wstring(L"Leaderboards"), leaderboardsPage.GetTitle());
+        Assert::AreEqual(std::wstring(L"3 leaderboards present"), leaderboardsPage.GetSummary());
+
+        auto* pItem = leaderboardsPage.GetItem(0);
+        Expects(pItem != nullptr);
+        Assert::IsTrue(pItem->IsHeader());
+        Assert::AreEqual(std::wstring(L"Active Leaderboards"), pItem->GetLabel());
+        Assert::IsFalse(pItem->IsDisabled());
+
+        pItem = leaderboardsPage.GetItem(1);
+        Expects(pItem != nullptr);
+        Assert::AreEqual(2, pItem->GetId());
+        Assert::AreEqual(std::wstring(L"LeaderboardTitle2"), pItem->GetLabel());
+        Assert::AreEqual(std::wstring(L"Another Capture"), pItem->GetDetail());
+
+        pItem = leaderboardsPage.GetItem(2);
+        Expects(pItem != nullptr);
+        Assert::AreEqual(3, pItem->GetId());
+        Assert::AreEqual(std::wstring(L"LeaderboardTitle3"), pItem->GetLabel());
+        Assert::AreEqual(std::wstring(L"Capture this too"), pItem->GetDetail());
+
+        pItem = leaderboardsPage.GetItem(3);
+        Expects(pItem != nullptr);
+        Assert::IsTrue(pItem->IsHeader());
+        Assert::AreEqual(std::wstring(L"Inactive Leaderboards"), pItem->GetLabel());
+        Assert::IsFalse(pItem->IsDisabled());
+
+        pItem = leaderboardsPage.GetItem(4);
+        Expects(pItem != nullptr);
+        Assert::AreEqual(1, pItem->GetId());
+        Assert::AreEqual(std::wstring(L"LeaderboardTitle"), pItem->GetLabel());
+        Assert::AreEqual(std::wstring(L"Capture this"), pItem->GetDetail());
+
+        Assert::IsNull(leaderboardsPage.GetItem(5));
+    }
+
+    TEST_METHOD(TestRefreshWithHiddenActive)
+    {
+        OverlayLeaderboardsPageViewModelHarness leaderboardsPage;
+        auto& pLB1 = leaderboardsPage.mockGameContext.Assets().NewLeaderboard();
+        pLB1.SetID(1U);
+        pLB1.SetName(L"LeaderboardTitle");
+        pLB1.SetDescription(L"Capture this");
+        auto& pLB2 = leaderboardsPage.mockGameContext.Assets().NewLeaderboard();
+        pLB2.SetID(2U);
+        pLB2.SetName(L"LeaderboardTitle2");
+        pLB2.SetDescription(L"Another Capture");
+        pLB2.SetState(ra::data::models::AssetState::Primed);
+        pLB2.SetHidden(true);
+        auto& pLB3 = leaderboardsPage.mockGameContext.Assets().NewLeaderboard();
+        pLB3.SetID(3U);
+        pLB3.SetName(L"LeaderboardTitle3");
+        pLB3.SetDescription(L"Capture this too");
+        pLB3.SetState(ra::data::models::AssetState::Primed);
+        leaderboardsPage.Refresh();
+
+        Assert::AreEqual(std::wstring(L"Leaderboards"), leaderboardsPage.GetTitle());
+        Assert::AreEqual(std::wstring(L"2 leaderboards present"), leaderboardsPage.GetSummary());
+
+        auto* pItem = leaderboardsPage.GetItem(0);
+        Expects(pItem != nullptr);
+        Assert::IsTrue(pItem->IsHeader());
+        Assert::AreEqual(std::wstring(L"Active Leaderboards"), pItem->GetLabel());
+        Assert::IsFalse(pItem->IsDisabled());
+
+        pItem = leaderboardsPage.GetItem(1);
+        Expects(pItem != nullptr);
+        Assert::AreEqual(3, pItem->GetId());
+        Assert::AreEqual(std::wstring(L"LeaderboardTitle3"), pItem->GetLabel());
+        Assert::AreEqual(std::wstring(L"Capture this too"), pItem->GetDetail());
+
+        pItem = leaderboardsPage.GetItem(2);
+        Expects(pItem != nullptr);
+        Assert::IsTrue(pItem->IsHeader());
+        Assert::AreEqual(std::wstring(L"Inactive Leaderboards"), pItem->GetLabel());
+        Assert::IsFalse(pItem->IsDisabled());
+
+        pItem = leaderboardsPage.GetItem(3);
+        Expects(pItem != nullptr);
+        Assert::AreEqual(1, pItem->GetId());
+        Assert::AreEqual(std::wstring(L"LeaderboardTitle"), pItem->GetLabel());
+        Assert::AreEqual(std::wstring(L"Capture this"), pItem->GetDetail());
+
+        Assert::IsNull(leaderboardsPage.GetItem(4));
+    }
+
+    TEST_METHOD(TestRefreshWithDisabled)
+    {
+        OverlayLeaderboardsPageViewModelHarness leaderboardsPage;
+        auto& pLB1 = leaderboardsPage.mockGameContext.Assets().NewLeaderboard();
+        pLB1.SetID(1U);
+        pLB1.SetName(L"LeaderboardTitle");
+        pLB1.SetDescription(L"Capture this");
+        auto& pLB2 = leaderboardsPage.mockGameContext.Assets().NewLeaderboard();
+        pLB2.SetID(2U);
+        pLB2.SetName(L"LeaderboardTitle2");
+        pLB2.SetDescription(L"Disabled Leaderboard");
+        pLB2.SetState(ra::data::models::AssetState::Disabled);
+        auto& pLB3 = leaderboardsPage.mockGameContext.Assets().NewLeaderboard();
+        pLB3.SetID(3U);
+        pLB3.SetName(L"LeaderboardTitle3");
+        pLB3.SetDescription(L"Capture this too");
+        leaderboardsPage.Refresh();
+
+        Assert::AreEqual(std::wstring(L"Leaderboards"), leaderboardsPage.GetTitle());
+        Assert::AreEqual(std::wstring(L"3 leaderboards present"), leaderboardsPage.GetSummary());
+
+        auto* pItem = leaderboardsPage.GetItem(0);
+        Expects(pItem != nullptr);
+        Assert::IsTrue(pItem->IsHeader());
+        Assert::AreEqual(std::wstring(L"Inactive Leaderboards"), pItem->GetLabel());
+        Assert::IsFalse(pItem->IsDisabled());
+
+        pItem = leaderboardsPage.GetItem(1);
+        Expects(pItem != nullptr);
+        Assert::AreEqual(1, pItem->GetId());
+        Assert::AreEqual(std::wstring(L"LeaderboardTitle"), pItem->GetLabel());
+        Assert::AreEqual(std::wstring(L"Capture this"), pItem->GetDetail());
+
+        pItem = leaderboardsPage.GetItem(2);
+        Expects(pItem != nullptr);
+        Assert::AreEqual(3, pItem->GetId());
+        Assert::AreEqual(std::wstring(L"LeaderboardTitle3"), pItem->GetLabel());
+        Assert::AreEqual(std::wstring(L"Capture this too"), pItem->GetDetail());
+
+        pItem = leaderboardsPage.GetItem(3);
+        Expects(pItem != nullptr);
+        Assert::IsTrue(pItem->IsHeader());
+        Assert::AreEqual(std::wstring(L"Unsupported Leaderboards"), pItem->GetLabel());
+        Assert::IsFalse(pItem->IsDisabled());
+
+        pItem = leaderboardsPage.GetItem(4);
+        Expects(pItem != nullptr);
+        Assert::AreEqual(2, pItem->GetId());
+        Assert::AreEqual(std::wstring(L"LeaderboardTitle2"), pItem->GetLabel());
+        Assert::AreEqual(std::wstring(L"Disabled Leaderboard"), pItem->GetDetail());
+
+        Assert::IsNull(leaderboardsPage.GetItem(5));
     }
 
     TEST_METHOD(TestFetchItemDetail)


### PR DESCRIPTION
also prioritizes active leaderboards at the top of the list.