### PR TITLE
prevent crash viewing tooltip for address chain when in invalid state

### DIFF
--- a/src/ui/viewmodels/TriggerConditionViewModel.cpp
+++ b/src/ui/viewmodels/TriggerConditionViewModel.cpp
@@ -587,11 +587,19 @@ unsigned int TriggerConditionViewModel::GetIndirectAddress(unsigned int nAddress
     if (pGroup == nullptr)
         return nAddress;
 
+    rc_condition_t* pCondition = nullptr;
+
     const auto* pTrigger = pTriggerViewModel->GetTriggerFromString();
     if (pTrigger != nullptr)
     {
         // if the trigger is managed by the viewmodel (not the runtime) then we need to update the memrefs
         rc_update_memref_values(pTrigger->memrefs, rc_peek_callback, nullptr);
+        pCondition = pTrigger->requirement->conditions;
+    }
+    else
+    {
+        Expects(pGroup->m_pConditionSet != nullptr);
+        pCondition = pGroup->m_pConditionSet->conditions;
     }
 
     bool bIsIndirect = false;
@@ -600,10 +608,7 @@ unsigned int TriggerConditionViewModel::GetIndirectAddress(unsigned int nAddress
     rc_typed_value_t value = {};
     oEvalState.peek = rc_peek_callback;
 
-    Expects(pGroup->m_pConditionSet != nullptr);
-
     gsl::index nConditionIndex = 0;
-    rc_condition_t* pCondition = pGroup->m_pConditionSet->conditions;
     for (; pCondition != nullptr; pCondition = pCondition->next)
     {
         auto* vmCondition = pTriggerViewModel->Conditions().GetItemAt(nConditionIndex++);

--- a/src/ui/viewmodels/TriggerViewModel.cpp
+++ b/src/ui/viewmodels/TriggerViewModel.cpp
@@ -448,6 +448,7 @@ rc_trigger_t* TriggerViewModel::ParseTrigger(const std::string& sTrigger)
             memset(pTrigger, 0, sizeof(rc_trigger_t));
             pTrigger->requirement = pValue->conditions;
             pTrigger->alternative = pValue->conditions->next;
+            pTrigger->memrefs = pValue->memrefs;
             return pTrigger;
         }
     }
@@ -494,6 +495,7 @@ void TriggerViewModel::InitializeFrom(const rc_value_t& pValue)
     memset(m_pTrigger, 0, sizeof(rc_trigger_t));
     m_pTrigger->requirement = pValue.conditions;
     m_pTrigger->alternative = (pValue.conditions) ? pValue.conditions->next : nullptr;
+    m_pTrigger->memrefs = pValue.memrefs;
     InitializeGroups(*m_pTrigger);
 }
 

--- a/tests/ui/viewmodels/TriggerConditionViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/TriggerConditionViewModel_Tests.cpp
@@ -762,6 +762,36 @@ public:
         Assert::AreEqual(std::wstring(L"0x0008 (indirect)\r\n[No code note]"), pCondition3->GetTooltip(TriggerConditionViewModel::SourceValueProperty));
     }
 
+    TEST_METHOD(TestTooltipDoubleIndirectAddressValue)
+    {
+        IndirectAddressTriggerViewModelHarness vmTrigger;
+        vmTrigger.SetIsValue(true);
+        vmTrigger.Parse("I:0xH0001_I:0xH0002_M:0xH0003=4");
+        vmTrigger.mockConfiguration.SetFeatureEnabled(ra::services::Feature::PreferDecimal, true);
+
+        const auto* pCondition1 = vmTrigger.Conditions().GetItemAt(0);
+        Expects(pCondition1 != nullptr);
+        const auto* pCondition2 = vmTrigger.Conditions().GetItemAt(1);
+        Expects(pCondition2 != nullptr);
+        const auto* pCondition3 = vmTrigger.Conditions().GetItemAt(2);
+        Expects(pCondition3 != nullptr);
+
+        Assert::IsFalse(pCondition1->IsIndirect());
+        Assert::IsTrue(pCondition2->IsIndirect());
+        Assert::IsTrue(pCondition3->IsIndirect());
+
+        // $0001 = 1, 1+2 = $0003, $0003 = 3, 3+3 = $0006
+        Assert::AreEqual(std::wstring(L"0x0001\r\n[No code note]"), pCondition1->GetTooltip(TriggerConditionViewModel::SourceValueProperty));
+        Assert::AreEqual(std::wstring(L"0x0003 (indirect)\r\n[No code note]"), pCondition2->GetTooltip(TriggerConditionViewModel::SourceValueProperty));
+        Assert::AreEqual(std::wstring(L"0x0006 (indirect)\r\n[No code note]"), pCondition3->GetTooltip(TriggerConditionViewModel::SourceValueProperty));
+
+        // $0001 = 3, 3+2 = $0005, $0005 = 5, 5+3 = $0008
+        vmTrigger.SetMemory({ 1 }, 3);
+        Assert::AreEqual(std::wstring(L"0x0001\r\n[No code note]"), pCondition1->GetTooltip(TriggerConditionViewModel::SourceValueProperty));
+        Assert::AreEqual(std::wstring(L"0x0005 (indirect)\r\n[No code note]"), pCondition2->GetTooltip(TriggerConditionViewModel::SourceValueProperty));
+        Assert::AreEqual(std::wstring(L"0x0008 (indirect)\r\n[No code note]"), pCondition3->GetTooltip(TriggerConditionViewModel::SourceValueProperty));
+    }
+
     TEST_METHOD(TestIsModifying)
     {
         TriggerConditionViewModelHarness condition;


### PR DESCRIPTION
When the trigger cannot be parsed (having a condition without a flag in the value definition), attempting to evaluate the indirect tooltip was throwing an assertion exception as the unparseable trigger could not be used to evaluate the AddAddress chain.

When the trigger is unparseable, an internal representation for the currently visible trigger is used. This PR modifies the tooltip code to leverage the internal representation when it is available.