### PR TITLE
allow GB games to be loaded in GBC context

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -16,6 +16,8 @@ jobs:
         submodules: recursive
     - name: Install MSBuild
       uses: microsoft/setup-msbuild@v1.0.2
+      with:
+        vs-version: '[16.11,16.12)'
     - name: Build
       run: msbuild.exe RA_Integration.sln -t:RA_Integration -p:Configuration=Release -p:Platform=Win32
 
@@ -28,6 +30,8 @@ jobs:
         submodules: recursive
     - name: Install MSBuild
       uses: microsoft/setup-msbuild@v1.0.2
+      with:
+        vs-version: '[16.11,16.12)'
     - name: Build
       run: msbuild.exe RA_Integration.sln -t:RA_Integration -p:Configuration=Release -p:Platform=x64
 
@@ -40,6 +44,8 @@ jobs:
         submodules: recursive
     - name: Install MSBuild
       uses: microsoft/setup-msbuild@v1.0.2
+      with:
+        vs-version: '[16.11,16.12)'
     - name: Install VSTest
       uses: Malcolmnixon/Setup-VSTest@v4
     - name: Build
@@ -59,6 +65,8 @@ jobs:
         submodules: recursive
     - name: Install MSBuild
       uses: microsoft/setup-msbuild@v1.0.2
+      with:
+        vs-version: '[16.11,16.12)'
     - name: Install VSTest
       uses: Malcolmnixon/Setup-VSTest@v4
     - name: Build
@@ -77,6 +85,8 @@ jobs:
         submodules: recursive
     - name: Install MSBuild
       uses: microsoft/setup-msbuild@v1.0.2
+      with:
+        vs-version: '[16.11,16.12)'
     - name: Build
       run: msbuild.exe RA_Integration.sln -p:Configuration=Analysis -p:Platform=Win32 /WarnAsError
 
@@ -89,5 +99,7 @@ jobs:
         submodules: recursive
     - name: Install MSBuild
       uses: microsoft/setup-msbuild@v1.0.2
+      with:
+        vs-version: '[16.11,16.12)'
     - name: Build
       run: msbuild.exe RA_Integration.sln -p:Configuration=Analysis -p:Platform=x64 /WarnAsError

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -16,8 +16,6 @@ jobs:
         submodules: recursive
     - name: Install MSBuild
       uses: microsoft/setup-msbuild@v1.0.2
-      with:
-        vs-version: '[16.0,16.99)'
     - name: Build
       run: msbuild.exe RA_Integration.sln -t:RA_Integration -p:Configuration=Release -p:Platform=Win32
 
@@ -30,8 +28,6 @@ jobs:
         submodules: recursive
     - name: Install MSBuild
       uses: microsoft/setup-msbuild@v1.0.2
-      with:
-        vs-version: '[16.0,16.99)'
     - name: Build
       run: msbuild.exe RA_Integration.sln -t:RA_Integration -p:Configuration=Release -p:Platform=x64
 
@@ -44,8 +40,6 @@ jobs:
         submodules: recursive
     - name: Install MSBuild
       uses: microsoft/setup-msbuild@v1.0.2
-      with:
-        vs-version: '[16.0,16.99)'
     - name: Install VSTest
       uses: Malcolmnixon/Setup-VSTest@v4
     - name: Build
@@ -65,8 +59,6 @@ jobs:
         submodules: recursive
     - name: Install MSBuild
       uses: microsoft/setup-msbuild@v1.0.2
-      with:
-        vs-version: '[16.0,16.99)'
     - name: Install VSTest
       uses: Malcolmnixon/Setup-VSTest@v4
     - name: Build
@@ -85,8 +77,6 @@ jobs:
         submodules: recursive
     - name: Install MSBuild
       uses: microsoft/setup-msbuild@v1.0.2
-      with:
-        vs-version: '[16.0,16.99)'
     - name: Build
       run: msbuild.exe RA_Integration.sln -p:Configuration=Analysis -p:Platform=Win32 /WarnAsError
 
@@ -99,7 +89,5 @@ jobs:
         submodules: recursive
     - name: Install MSBuild
       uses: microsoft/setup-msbuild@v1.0.2
-      with:
-        vs-version: '[16.0,16.99)'
     - name: Build
       run: msbuild.exe RA_Integration.sln -p:Configuration=Analysis -p:Platform=x64 /WarnAsError

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install MSBuild
       uses: microsoft/setup-msbuild@v1.0.2
       with:
-        vs-version: '[16.11,16.12)'
+        vs-version: '[16.0,16.99)'
     - name: Build
       run: msbuild.exe RA_Integration.sln -t:RA_Integration -p:Configuration=Release -p:Platform=Win32
 
@@ -31,7 +31,7 @@ jobs:
     - name: Install MSBuild
       uses: microsoft/setup-msbuild@v1.0.2
       with:
-        vs-version: '[16.11,16.12)'
+        vs-version: '[16.0,16.99)'
     - name: Build
       run: msbuild.exe RA_Integration.sln -t:RA_Integration -p:Configuration=Release -p:Platform=x64
 
@@ -45,7 +45,7 @@ jobs:
     - name: Install MSBuild
       uses: microsoft/setup-msbuild@v1.0.2
       with:
-        vs-version: '[16.11,16.12)'
+        vs-version: '[16.0,16.99)'
     - name: Install VSTest
       uses: Malcolmnixon/Setup-VSTest@v4
     - name: Build
@@ -66,7 +66,7 @@ jobs:
     - name: Install MSBuild
       uses: microsoft/setup-msbuild@v1.0.2
       with:
-        vs-version: '[16.11,16.12)'
+        vs-version: '[16.0,16.99)'
     - name: Install VSTest
       uses: Malcolmnixon/Setup-VSTest@v4
     - name: Build
@@ -86,7 +86,7 @@ jobs:
     - name: Install MSBuild
       uses: microsoft/setup-msbuild@v1.0.2
       with:
-        vs-version: '[16.11,16.12)'
+        vs-version: '[16.0,16.99)'
     - name: Build
       run: msbuild.exe RA_Integration.sln -p:Configuration=Analysis -p:Platform=Win32 /WarnAsError
 
@@ -100,6 +100,6 @@ jobs:
     - name: Install MSBuild
       uses: microsoft/setup-msbuild@v1.0.2
       with:
-        vs-version: '[16.11,16.12)'
+        vs-version: '[16.0,16.99)'
     - name: Build
       run: msbuild.exe RA_Integration.sln -p:Configuration=Analysis -p:Platform=x64 /WarnAsError

--- a/tests/data/context/GameContext_Tests.cpp
+++ b/tests/data/context/GameContext_Tests.cpp
@@ -231,6 +231,43 @@ public:
         Assert::AreEqual(std::wstring(L""), game.GameTitle());
     }
 
+    TEST_METHOD(TestLoadGameTitleConsoleMismatchGBvGBC)
+    {
+        GameContextHarness game;
+        game.mockServer.HandleRequest<ra::api::FetchGameData>([](const ra::api::FetchGameData::Request& request, ra::api::FetchGameData::Response& response)
+        {
+            Assert::AreEqual(1U, request.GameId);
+
+            response.Title = L"Game";
+            response.ConsoleId = ra::etoi(ConsoleID::GB);
+            response.ImageIcon = "9743";
+            return true;
+        });
+
+        game.mockConsoleContext.SetId(ConsoleID::GBC);
+        game.mockConsoleContext.SetName(L"GameBoy Color");
+
+        bool bDialogShown = false;
+        game.mockDesktop.ExpectWindow<ra::ui::viewmodels::MessageBoxViewModel>([&bDialogShown](ra::ui::viewmodels::MessageBoxViewModel&)
+        {
+            bDialogShown = true;
+            return ra::ui::DialogResult::OK;
+        });
+
+        game.LoadGame(1U);
+
+        Assert::IsTrue(game.mockAudioSystem.WasAudioFilePlayed(std::wstring(L"Overlay\\info.wav")));
+
+        const auto* pPopup = game.mockOverlayManager.GetMessage(1);
+        Expects(pPopup != nullptr);
+        Assert::IsNotNull(pPopup);
+        Assert::AreEqual(std::wstring(L"Loaded Game"), pPopup->GetTitle());
+        Assert::AreEqual(std::wstring(L"0 achievements, 0 points"), pPopup->GetDescription());
+        Assert::AreEqual(std::string("9743"), pPopup->GetImage().Name());
+
+        Assert::IsFalse(bDialogShown);
+    }
+
     TEST_METHOD(TestLoadGameNotify)
     {
         class NotifyHarness : public GameContext::NotifyTarget


### PR DESCRIPTION
The GB and GBC memory maps are identical, with the exception that GBC games can page different memory into the $D000-$DFFF range. As such, a GB game can run in the GBC context without any penalty, and there are several hacks that leverage this functionality to enhance the 4-color GB games to run in 16-color mode.

As these are cosmetic hacks, we have a couple already linked to the base GB game. VBA-M automatically forces GBC mode when it sees the GBC flag in the header, so we need to allow this particular cross-pollination.