### PR TITLE
use correct address for notification event when not on first memory block

### DIFF
--- a/src/data/context/EmulatorContext.cpp
+++ b/src/data/context/EmulatorContext.cpp
@@ -790,14 +790,15 @@ uint32_t EmulatorContext::ReadMemory(ra::ByteAddress nAddress, MemSize nSize) co
 
 void EmulatorContext::WriteMemoryByte(ra::ByteAddress nAddress, uint8_t nValue) const
 {
+    auto nBlockAddress = nAddress;
     for (const auto& pBlock : m_vMemoryBlocks)
     {
-        if (nAddress < pBlock.size)
+        if (nBlockAddress < pBlock.size)
         {
             if (!pBlock.write)
                 return;
 
-            pBlock.write(nAddress, nValue);
+            pBlock.write(nBlockAddress, nValue);
             m_bMemoryModified = true;
 
             // create a copy of the list of pointers in case it's modified by one of the callbacks
@@ -811,7 +812,7 @@ void EmulatorContext::WriteMemoryByte(ra::ByteAddress nAddress, uint8_t nValue) 
             return;
         }
 
-        nAddress -= gsl::narrow_cast<ra::ByteAddress>(pBlock.size);
+        nBlockAddress -= gsl::narrow_cast<ra::ByteAddress>(pBlock.size);
     }
 }
 

--- a/tests/data/context/EmulatorContext_Tests.cpp
+++ b/tests/data/context/EmulatorContext_Tests.cpp
@@ -85,7 +85,7 @@ private:
     class EmulatorContextNotifyHarness : public EmulatorContext::NotifyTarget
     {
     public:
-        void OnByteWritten(ra::ByteAddress nAddress, uint8_t nValue)
+        void OnByteWritten(ra::ByteAddress nAddress, uint8_t nValue) noexcept override
         {
             nLastByteWrittenAddress = nAddress;
             nLastByteWritten = nValue;

--- a/tests/data/context/EmulatorContext_Tests.cpp
+++ b/tests/data/context/EmulatorContext_Tests.cpp
@@ -82,6 +82,19 @@ private:
         }
     };
 
+    class EmulatorContextNotifyHarness : public EmulatorContext::NotifyTarget
+    {
+    public:
+        void OnByteWritten(ra::ByteAddress nAddress, uint8_t nValue)
+        {
+            nLastByteWrittenAddress = nAddress;
+            nLastByteWritten = nValue;
+        }
+
+        ra::ByteAddress nLastByteWrittenAddress = 0xFFFFFFFFU;
+        uint8_t nLastByteWritten = 0xFF;
+    };
+
 public:
     TEST_METHOD(TestClientName)
     {
@@ -1340,6 +1353,42 @@ public:
         // the others should have their original values
         for (uint8_t i = gsl::narrow_cast<uint8_t>(emulator.TotalMemorySize()); i < memory.size(); ++i)
             Assert::AreEqual(i, memory.at(i));
+    }
+
+    TEST_METHOD(TestWriteMemoryByteEvents)
+    {
+        InitializeMemory();
+
+        EmulatorContextHarness emulator;
+        emulator.AddMemoryBlock(0, 20, &ReadMemory0, &WriteMemory0);
+        emulator.AddMemoryBlock(1, 10, &ReadMemory2, &WriteMemory2);
+        Assert::AreEqual({ 30U }, emulator.TotalMemorySize());
+
+        EmulatorContextNotifyHarness notify;
+        emulator.AddNotifyTarget(notify);
+
+        // write to first block
+        uint8_t nByte = 0xCE;
+        emulator.WriteMemoryByte(6U, nByte);
+        Assert::AreEqual(6U, notify.nLastByteWrittenAddress);
+        Assert::AreEqual(nByte, notify.nLastByteWritten);
+
+        // write to second block
+        nByte = 0xEE;
+        emulator.WriteMemoryByte(26U, nByte);
+        Assert::AreEqual(26U, notify.nLastByteWrittenAddress);
+        Assert::AreEqual(nByte, notify.nLastByteWritten);
+
+        // write to invalid address
+        emulator.WriteMemoryByte(36U, nByte + 3);
+        Assert::AreEqual(26U, notify.nLastByteWrittenAddress);
+        Assert::AreEqual(nByte, notify.nLastByteWritten);
+
+        // write partial value
+        nByte = 0xC4;
+        emulator.WriteMemory(6U, MemSize::Nibble_Lower, 0x04);
+        Assert::AreEqual(6U, notify.nLastByteWrittenAddress);
+        Assert::AreEqual(nByte, notify.nLastByteWritten);
     }
 
     TEST_METHOD(TestWriteMemory)


### PR DESCRIPTION
Fixes issue where a frozen memory address on a memory block other than the first (usually labelled as something other than System RAM) could not be modified.

The address being modified was mutated to reflect the offset within the appropriate block. This was then passed as the modified address to the event handlers, which were expecting the original address. As a result, the bookmark was not immediately updated and the frozen value was written back into memory on the next frame.