### PR TITLE
prevent loss of custom bookmark descriptions over multiple sessions

### DIFF
--- a/src/ui/viewmodels/MemoryBookmarksViewModel.cpp
+++ b/src/ui/viewmodels/MemoryBookmarksViewModel.cpp
@@ -318,8 +318,18 @@ void MemoryBookmarksViewModel::OnCodeNoteChanged(ra::ByteAddress nAddress, const
     for (gsl::index nIndex = 0; ra::to_unsigned(nIndex) < m_vBookmarks.Count(); ++nIndex)
     {
         auto* pBookmark = m_vBookmarks.GetItemAt(nIndex);
-        if (pBookmark && pBookmark->GetAddress() == nAddress && !pBookmark->IsCustomDescription())
-            pBookmark->SetDescription(sNewNote);
+        if (pBookmark && pBookmark->GetAddress() == nAddress)
+        {
+            if (!pBookmark->IsCustomDescription())
+            {
+                pBookmark->SetDescription(sNewNote);
+            }
+            else
+            {
+                if (pBookmark->GetDescription() == sNewNote)
+                    pBookmark->SetIsCustomDescription(false);
+            }
+        }
     }
 }
 
@@ -403,14 +413,17 @@ void MemoryBookmarksViewModel::LoadBookmarks(ra::services::TextReader& sBookmark
                     vmBookmark->SetAddress(bookmark["Address"].GetUint());
                 }
 
+                const auto* pNote = pGameContext.FindCodeNote(vmBookmark->GetAddress());
+
                 std::wstring sDescription;
                 if (bookmark.HasMember("Description"))
                 {
                     sDescription = ra::Widen(bookmark["Description"].GetString());
+                    vmBookmark->SetIsCustomDescription(!pNote || sDescription != *pNote);
                 }
                 else
                 {
-                    const auto* pNote = pGameContext.FindCodeNote(vmBookmark->GetAddress());
+                    vmBookmark->SetIsCustomDescription(false);
                     if (pNote)
                         sDescription = *pNote;
                 }


### PR DESCRIPTION
When a custom bookmark description was loaded from a previous session, it wasn't being flagged as a custom bookmark description, so it didn't get saved for the next session if any other modifications were made to bookmarks during the session.