### PR TITLE
include LowerIsBetter in serialized leaderboard data

### DIFF
--- a/src/data/models/LeaderboardModel.cpp
+++ b/src/data/models/LeaderboardModel.cpp
@@ -258,6 +258,7 @@ void LeaderboardModel::Serialize(ra::services::TextWriter& pWriter) const
 
     WritePossiblyQuoted(pWriter, GetLocalValue(NameProperty));
     WritePossiblyQuoted(pWriter, GetLocalValue(DescriptionProperty));
+    WriteNumber(pWriter, IsLowerBetter() ? 1 : 0);
 }
 
 bool LeaderboardModel::Deserialize(ra::Tokenizer& pTokenizer)
@@ -297,6 +298,11 @@ bool LeaderboardModel::Deserialize(ra::Tokenizer& pTokenizer)
     if (!pTokenizer.EndOfString() && !ReadPossiblyQuoted(pTokenizer, sDescription))
         return false;
 
+    // field 9: lower is better
+    uint32_t nLowerIsBetter = 0;
+    if (!pTokenizer.EndOfString() && !ReadNumber(pTokenizer, nLowerIsBetter))
+        return false;
+
     // line is valid
     SetName(ra::Widen(sTitle));
     SetDescription(ra::Widen(sDescription));
@@ -304,6 +310,7 @@ bool LeaderboardModel::Deserialize(ra::Tokenizer& pTokenizer)
     SetSubmitTrigger(sSubmitTrigger);
     SetCancelTrigger(sCancelTrigger);
     SetValueDefinition(sValueDefinition);
+    SetLowerIsBetter(nLowerIsBetter != 0);
 
     if (sFormat == "VALUE")
         SetValueFormat(ValueFormat::Value);

--- a/tests/data/context/GameAssets_Tests.cpp
+++ b/tests/data/context/GameAssets_Tests.cpp
@@ -622,7 +622,7 @@ public:
 
         gameAssets.SaveAllAssets();
 
-        const auto& sExpected = ra::StringPrintf("0.0.0.0\nGameName\nL%u:\"0xH2234=1\":\"0xH2234=2\":\"0xH2234=3\":\"M:0xH2235\":MINUTES:LB2:Desc2\n", GameAssets::FirstLocalId + 1);
+        const auto& sExpected = ra::StringPrintf("0.0.0.0\nGameName\nL%u:\"0xH2234=1\":\"0xH2234=2\":\"0xH2234=3\":\"M:0xH2235\":MINUTES:LB2:Desc2:0\n", GameAssets::FirstLocalId + 1);
         Assert::AreEqual(sExpected, gameAssets.GetUserFile());
     }
 

--- a/tests/data/models/LeaderboardModel_Tests.cpp
+++ b/tests/data/models/LeaderboardModel_Tests.cpp
@@ -196,6 +196,46 @@ public:
     {
         LeaderboardModelHarness leaderboard;
 
+        const std::string sSerialized = ":\"0xH1234=1\":\"0xH1234=2\":\"0xH1234=3\":\"0xH1234\":FRAMES:Title:Desc:0";
+        ra::Tokenizer pTokenizer(sSerialized);
+        pTokenizer.Consume(':');
+
+        Assert::IsTrue(leaderboard.Deserialize(pTokenizer));
+
+        Assert::AreEqual(std::string("0xH1234=1"), leaderboard.GetStartTrigger());
+        Assert::AreEqual(std::string("0xH1234=2"), leaderboard.GetCancelTrigger());
+        Assert::AreEqual(std::string("0xH1234=3"), leaderboard.GetSubmitTrigger());
+        Assert::AreEqual(std::string("0xH1234"), leaderboard.GetValueDefinition());
+        Assert::AreEqual(ValueFormat::Frames, leaderboard.GetValueFormat());
+        Assert::AreEqual(std::wstring(L"Title"), leaderboard.GetName());
+        Assert::AreEqual(std::wstring(L"Desc"), leaderboard.GetDescription());
+        Assert::IsFalse(leaderboard.IsLowerBetter());
+    }
+
+    TEST_METHOD(TestDeserializeAlternateValues)
+    {
+        LeaderboardModelHarness leaderboard;
+
+        const std::string sSerialized = ":\"0xH1234=1_P:0xH2345=2\":\"0xH1234<2\":\"0xH1234>3\":\"M:0xH1234\":MILLISECS:\"My Title\":\"My Desc\":1";
+        ra::Tokenizer pTokenizer(sSerialized);
+        pTokenizer.Consume(':');
+
+        Assert::IsTrue(leaderboard.Deserialize(pTokenizer));
+
+        Assert::AreEqual(std::string("0xH1234=1_P:0xH2345=2"), leaderboard.GetStartTrigger());
+        Assert::AreEqual(std::string("0xH1234<2"), leaderboard.GetCancelTrigger());
+        Assert::AreEqual(std::string("0xH1234>3"), leaderboard.GetSubmitTrigger());
+        Assert::AreEqual(std::string("M:0xH1234"), leaderboard.GetValueDefinition());
+        Assert::AreEqual(ValueFormat::Centiseconds, leaderboard.GetValueFormat());
+        Assert::AreEqual(std::wstring(L"My Title"), leaderboard.GetName());
+        Assert::AreEqual(std::wstring(L"My Desc"), leaderboard.GetDescription());
+        Assert::IsTrue(leaderboard.IsLowerBetter());
+    }
+
+    TEST_METHOD(TestDeserializeNoLower)
+    {
+        LeaderboardModelHarness leaderboard;
+
         const std::string sSerialized = ":\"0xH1234=1\":\"0xH1234=2\":\"0xH1234=3\":\"0xH1234\":FRAMES:Title:Desc";
         ra::Tokenizer pTokenizer(sSerialized);
         pTokenizer.Consume(':');
@@ -209,6 +249,7 @@ public:
         Assert::AreEqual(ValueFormat::Frames, leaderboard.GetValueFormat());
         Assert::AreEqual(std::wstring(L"Title"), leaderboard.GetName());
         Assert::AreEqual(std::wstring(L"Desc"), leaderboard.GetDescription());
+        Assert::IsFalse(leaderboard.IsLowerBetter());
     }
 
     TEST_METHOD(TestDeserializeEmpty)
@@ -228,6 +269,7 @@ public:
         Assert::AreEqual(ValueFormat::Value, leaderboard.GetValueFormat());
         Assert::AreEqual(std::wstring(), leaderboard.GetName());
         Assert::AreEqual(std::wstring(), leaderboard.GetDescription());
+        Assert::IsFalse(leaderboard.IsLowerBetter());
     }
 
     void TestSerializeValueFormat(ValueFormat nFormat, const std::string& sFormat)
@@ -245,7 +287,7 @@ public:
         ra::services::impl::StringTextWriter pTextWriter(sSerialized);
         leaderboard.Serialize(pTextWriter);
 
-        std::string sExpected = ":\"0xH1234=1\":\"0xH1234=2\":\"0xH1234=3\":\"0xH1234\":" + sFormat + ":Title:Desc";
+        std::string sExpected = ":\"0xH1234=1\":\"0xH1234=2\":\"0xH1234=3\":\"0xH1234\":" + sFormat + ":Title:Desc:0";
         Assert::AreEqual(sExpected, sSerialized);
 
         ra::Tokenizer pTokenizer(sSerialized);


### PR DESCRIPTION
fixes "lower is better" not being remembered for local leaderboards between sessions