### PR TITLE
use correct group for indirect tooltip when achievement is not active

### DIFF
--- a/src/ui/viewmodels/TriggerConditionViewModel.cpp
+++ b/src/ui/viewmodels/TriggerConditionViewModel.cpp
@@ -588,7 +588,8 @@ unsigned int TriggerConditionViewModel::GetIndirectAddress(unsigned int nAddress
     if (pTriggerViewModel == nullptr)
         return nAddress;
 
-    const auto* pGroup = pTriggerViewModel->Groups().GetItemAt(pTriggerViewModel->GetSelectedGroupIndex());
+    const auto nIndex = pTriggerViewModel->GetSelectedGroupIndex();
+    const auto* pGroup = pTriggerViewModel->Groups().GetItemAt(nIndex);
     if (pGroup == nullptr)
         return nAddress;
 
@@ -599,7 +600,23 @@ unsigned int TriggerConditionViewModel::GetIndirectAddress(unsigned int nAddress
     {
         // if the trigger is managed by the viewmodel (not the runtime) then we need to update the memrefs
         rc_update_memref_values(pTrigger->memrefs, rc_peek_callback, nullptr);
-        pCondition = pTrigger->requirement->conditions;
+
+        // find the condset associated to the selected group
+        if (nIndex == 0)
+        {
+            pCondition = pTrigger->requirement->conditions;
+        }
+        else
+        {
+            rc_condset_t* pAlt = pTrigger->alternative;
+            for (int i = 1; pAlt && i < nIndex; ++i)
+                pAlt = pAlt->next;
+
+            if (!pAlt)
+                return nAddress;
+
+            pCondition = pAlt->conditions;
+        }
     }
     else
     {

--- a/tests/ui/viewmodels/TriggerConditionViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/TriggerConditionViewModel_Tests.cpp
@@ -702,6 +702,65 @@ public:
         Assert::AreEqual(std::wstring(L"0x000b (indirect)\r\n[No code note]"), pCondition->GetTooltip(TriggerConditionViewModel::SourceValueProperty));
     }
 
+    TEST_METHOD(TestTooltipIndirectAddressWithAltCodeNote)
+    {
+        IndirectAddressTriggerViewModelHarness vmTrigger;
+        vmTrigger.Parse("I:0xH0001_0xH0002=3S0=0S1=1");
+        vmTrigger.mockConfiguration.SetFeatureEnabled(ra::services::Feature::PreferDecimal, true);
+        vmTrigger.mockGameContext.SetCodeNote({ 3U }, L"This is a note.");
+
+        const auto* pCondition = vmTrigger.Conditions().GetItemAt(1);
+        Expects(pCondition != nullptr);
+        Assert::IsTrue(pCondition->IsIndirect());
+
+        // $0001 = 1, 1+2 = $0003
+        Assert::AreEqual(std::wstring(L"0x0003 (indirect)\r\nThis is a note."), pCondition->GetTooltip(TriggerConditionViewModel::SourceValueProperty));
+
+        // $0001 = 3, 3+2 = $0005
+        vmTrigger.SetMemory({ 1 }, 3);
+        Assert::AreEqual(std::wstring(L"0x0005 (indirect)\r\n[No code note]"), pCondition->GetTooltip(TriggerConditionViewModel::SourceValueProperty));
+    }
+
+    TEST_METHOD(TestTooltipIndirectAddressInAlt1CodeNote)
+    {
+        IndirectAddressTriggerViewModelHarness vmTrigger;
+        vmTrigger.Parse("0=0SI:0xH0001_0xH0002=3S1=1");
+        vmTrigger.mockConfiguration.SetFeatureEnabled(ra::services::Feature::PreferDecimal, true);
+        vmTrigger.mockGameContext.SetCodeNote({ 3U }, L"This is a note.");
+        vmTrigger.SetSelectedGroupIndex(1);
+
+        const auto* pCondition = vmTrigger.Conditions().GetItemAt(1);
+        Expects(pCondition != nullptr);
+        Assert::IsTrue(pCondition->IsIndirect());
+
+        // $0001 = 1, 1+2 = $0003
+        Assert::AreEqual(std::wstring(L"0x0003 (indirect)\r\nThis is a note."), pCondition->GetTooltip(TriggerConditionViewModel::SourceValueProperty));
+
+        // $0001 = 3, 3+2 = $0005
+        vmTrigger.SetMemory({ 1 }, 3);
+        Assert::AreEqual(std::wstring(L"0x0005 (indirect)\r\n[No code note]"), pCondition->GetTooltip(TriggerConditionViewModel::SourceValueProperty));
+    }
+
+    TEST_METHOD(TestTooltipIndirectAddressInAlt2CodeNote)
+    {
+        IndirectAddressTriggerViewModelHarness vmTrigger;
+        vmTrigger.Parse("0=0S1=1SI:0xH0001_0xH0002=3");
+        vmTrigger.mockConfiguration.SetFeatureEnabled(ra::services::Feature::PreferDecimal, true);
+        vmTrigger.mockGameContext.SetCodeNote({ 3U }, L"This is a note.");
+        vmTrigger.SetSelectedGroupIndex(2);
+
+        const auto* pCondition = vmTrigger.Conditions().GetItemAt(1);
+        Expects(pCondition != nullptr);
+        Assert::IsTrue(pCondition->IsIndirect());
+
+        // $0001 = 1, 1+2 = $0003
+        Assert::AreEqual(std::wstring(L"0x0003 (indirect)\r\nThis is a note."), pCondition->GetTooltip(TriggerConditionViewModel::SourceValueProperty));
+
+        // $0001 = 3, 3+2 = $0005
+        vmTrigger.SetMemory({ 1 }, 3);
+        Assert::AreEqual(std::wstring(L"0x0005 (indirect)\r\n[No code note]"), pCondition->GetTooltip(TriggerConditionViewModel::SourceValueProperty));
+    }
+
     TEST_METHOD(TestTooltipDoubleIndirectAddress)
     {
         IndirectAddressTriggerViewModelHarness vmTrigger;


### PR DESCRIPTION
fixes incorrect tooltips showing for indirect addresses in alt groups, and a crash if the core group is empty.