### PR TITLE
remove queue for achievements activated while runtime paused

### DIFF
--- a/src/services/AchievementRuntime.hh
+++ b/src/services/AchievementRuntime.hh
@@ -233,7 +233,7 @@ public:
     /// <summary>
     /// Sets whether achievement processing should be temporarily suspended.
     /// </summary>
-    void SetPaused(bool bValue) { m_bPaused = bValue; }
+    void SetPaused(bool bValue) noexcept { m_bPaused = bValue; }
 
     /// <summary>
     /// Resets any active achievements and disables them until their triggers are false.

--- a/src/services/AchievementRuntime.hh
+++ b/src/services/AchievementRuntime.hh
@@ -233,7 +233,7 @@ public:
     /// <summary>
     /// Sets whether achievement processing should be temporarily suspended.
     /// </summary>
-    void SetPaused(bool bValue);
+    void SetPaused(bool bValue) { m_bPaused = bValue; }
 
     /// <summary>
     /// Resets any active achievements and disables them until their triggers are false.
@@ -262,7 +262,6 @@ private:
 
     void EnsureInitialized() noexcept;
 
-    std::map<unsigned int, std::string> m_vQueuedAchievements;
     int m_nRichPresenceParseResult = RC_OK;
     int m_nRichPresenceErrorLine = 0;
     bool m_bInitialized = false;


### PR DESCRIPTION
Way back in 0.75, achievements loaded into the runtime were queued up while the runtime was paused to prevent them from being processed until we knew if the user had unlocked them. Some time later, the initialization logic was changed such that achievements were not loaded into the runtime until a later point where we knew whether or not the achievements had been earned by the user. As a result, the queue is no longer necessary. If we decide to load something into the runtime it should be loaded into the runtime immediately.

This also fixes an oddity when activating achievements while the runtime is paused (Processing Active is unchecked). Because an activation was queued while the runtime was paused, attempting to manually activate an achievement while the runtime was paused would cause the achievement to automatically appear Inactive in the next time a frame was processed as the achievement hadn't actually been reactivated yet.

NOTE: While this does allow the achievement the be activated in a paused runtime, it will be forever Waiting as the runtime cannot determine that the achievement is not true while it is paused, and therefore cannot promote it to Active.