### PR TITLE
fix performance issue using Continuous Filter with Initial Value and large result sets

### DIFF
--- a/src/services/SearchResults.cpp
+++ b/src/services/SearchResults.cpp
@@ -1601,7 +1601,7 @@ void SearchResults::MergeSearchResults(const SearchResults& srMemory, const Sear
     m_nFilterType = srAddresses.m_nFilterType;
     m_nFilterValue = srAddresses.m_nFilterValue;
 
-    for (const auto pSrcBlock : srAddresses.m_vBlocks)
+    for (const auto& pSrcBlock : srAddresses.m_vBlocks)
     {
         // copy the block from the srAddresses collection, then update the memory from the srMemory collection.
         // this creates a new block with the memory from the srMemory collection and the addresses from the
@@ -1611,7 +1611,7 @@ void SearchResults::MergeSearchResults(const SearchResults& srMemory, const Sear
         ra::ByteAddress nAddress = pNewBlock.GetFirstAddress();
         unsigned char* pWrite = pNewBlock.GetBytes();
 
-        for (const auto pMemBlock : srMemory.m_vBlocks)
+        for (const auto& pMemBlock : srMemory.m_vBlocks)
         {
             if (nAddress >= pMemBlock.GetFirstAddress() && nAddress < pMemBlock.GetFirstAddress() + pMemBlock.GetBytesSize())
             {

--- a/src/ui/viewmodels/MemorySearchViewModel.cpp
+++ b/src/ui/viewmodels/MemorySearchViewModel.cpp
@@ -637,13 +637,15 @@ void MemorySearchViewModel::ApplyContinuousFilter()
     // for 10000 results, only filter every 100ms
     // for 50000 results, only filter every 500ms
     // for 100000 results, only filter every second
+    // up to a max of one filter every ten seconds at 1000000 or more results
     const auto nResults = pResult.pResults.MatchingAddressCount();
     if (nResults > 1000)
     {
         const auto tNow = ra::services::ServiceLocator::Get<ra::services::IClock>().UpTime();
         const auto nElapsed = std::chrono::duration_cast<std::chrono::milliseconds>(tNow - m_tLastContinuousFilter);
+        const auto nElapsedMilliseconds = gsl::narrow_cast<size_t>(nElapsed.count());
 
-        if (gsl::narrow_cast<size_t>(nElapsed.count()) < nResults / 100)
+        if (nElapsedMilliseconds < 10000 && nElapsedMilliseconds < nResults / 100)
             return;
 
         m_tLastContinuousFilter = tNow;


### PR DESCRIPTION
When using Continuous Filter, the current memory state is merged into the last result set. In order to find where to do the merge, a linear search is performed. However, due to the abstraction of an `auto`, the linear search was duplicating the data, not just scanning it. This resulted in a very noticeable performance impact. (i.e. taking over a minute instead of fractions of a second when processing the 32MB of memory provided by PSP).

Additionally, this sets an upper limit of 10 seconds on the auto-filter timer. To minimize the performance impact of running the continuous search, the filter is applied less frequently if there are many results. The more results, the less frequently it was applied. There was no upper limit, so if 32 million results remained, the auto-filter would only occur once every five minutes.