### PR TITLE
prevent note from being changed while confirming overwrite

### DIFF
--- a/src/ui/viewmodels/MemoryInspectorViewModel.cpp
+++ b/src/ui/viewmodels/MemoryInspectorViewModel.cpp
@@ -142,7 +142,9 @@ static std::wstring ShortenNote(const std::wstring& sNote)
 
 void MemoryInspectorViewModel::SaveCurrentAddressNote()
 {
-    const auto& sNewNote = GetCurrentAddressNote();
+    // create a copy of the note. it's less efficient, but using a reference allows the value to be
+    // changed out from under us while the confirmation dialog is open.
+    const std::wstring sNewNote = GetCurrentAddressNote();
     const auto nAddress = GetCurrentAddress();
 
     std::string sAuthor;


### PR DESCRIPTION
Fixes an issue where clicking on another note while being asked to confirm overwriting a note will send the newly selected note's data to the server instead of the original data. Depending on the new note's length compared to the original note, it might also result in a crash.