### PR TITLE
static_assert<false> always fails in newest version of VS2022

### DIFF
--- a/src/RA_StringUtils.h
+++ b/src/RA_StringUtils.h
@@ -62,7 +62,7 @@ _NODISCARD inline const std::string ToString(_In_ const T& value)
     }
     else
     {
-        static_assert(false, "No ToString implementation for type");
+        static_assert(std::is_arithmetic_v<T>, "No ToString implementation for type");
         return std::string();
     }
 }
@@ -132,7 +132,7 @@ _NODISCARD inline const std::wstring ToWString(_In_ const T& value)
     }
     else
     {
-        static_assert(false, "No ToWString implementation for type");
+        static_assert(std::is_arithmetic_v<T>, "No ToWString implementation for type");
         return std::wstring();
     }
 }
@@ -585,7 +585,7 @@ _NODISCARD inline auto StringPrintf(_In_z_ _Printf_format_string_ const CharT* c
     }
     else
     {
-        static_assert(false, "unsupported character type");
+        static_assert(std::is_same_v<CharT, char>, "unsupported character type");
         return std::string();
     }
 }


### PR DESCRIPTION
see https://docs.microsoft.com/en-us/cpp/overview/cpp-conformance-improvements?view=msvc-170#error-on-a-non-dependent-static_assert

solution: replace `static_assert<false>` with a static_assert that will always be false due to being handled in previous branches of the logic.