### PR TITLE
update invalid regions when memory map is updated

### DIFF
--- a/src/ui/viewmodels/MemoryViewerViewModel.hh
+++ b/src/ui/viewmodels/MemoryViewerViewModel.hh
@@ -219,6 +219,7 @@ private:
 
     void UpdateColor(ra::ByteAddress nAddress);
     void UpdateColors();
+    void UpdateInvalidRegions();
     void UpdateHighlight(ra::ByteAddress nAddress, int nNewLength, int nOldLength);
 
     int NibblesPerWord() const;


### PR DESCRIPTION
Fixes an issue where unprovided memory (-- -- -- --) does not appear or disappear correctly when switching between games.