### PR TITLE
report 'Inspecting Memory' if no local or core assets exist

### DIFF
--- a/src/data/context/SessionTracker.cpp
+++ b/src/data/context/SessionTracker.cpp
@@ -244,16 +244,33 @@ std::wstring SessionTracker::GetCurrentActivity() const
 
     if (IsInspectingMemory())
     {
-        if (!pGameContext.Assets().HasCoreAssets())
-            return L"Developing Achievements";
-
         if (pGameContext.GetMode() == ra::data::context::GameContext::Mode::CompatibilityTest)
             return L"Testing Compatibility";
 
         if (_RA_HardcoreModeIsActive())
             return L"Inspecting Memory in Hardcore mode";
 
-        return L"Fixing Achievements";
+        std::wstring sMessage = L"Inspecting Memory";
+        for (gsl::index i = 0; i < gsl::narrow_cast<gsl::index>(pGameContext.Assets().Count()); ++i)
+        {
+            const auto* pAsset = pGameContext.Assets().GetItemAt(i);
+            if (pAsset)
+            {
+                if (pAsset->GetType() == ra::data::models::AssetType::LocalBadges)
+                    continue;
+
+                if (pAsset->GetCategory() == ra::data::models::AssetCategory::Local)
+                {
+                    sMessage = L"Developing Achievements";
+                    break;
+                }
+
+                if (pAsset->GetChanges() != ra::data::models::AssetChanges::None)
+                    sMessage = L"Fixing Achievements";
+            }
+        }
+
+        return sMessage;
     }
 
     if (pGameContext.HasRichPresence() && !pGameContext.IsRichPresenceFromFile())


### PR DESCRIPTION
Previously it would report 'Developing Achievements'. Now at least one local asset must exist for that message to be displayed. Similarly, 'Fixing Achievements' will only be reported if one or more published assets is modified and no local assets exist.