### PR TITLE
maintain extension when attaching non-png badges to achievements

### DIFF
--- a/src/ui/drawing/gdi/ImageRepository.cpp
+++ b/src/ui/drawing/gdi/ImageRepository.cpp
@@ -234,8 +234,11 @@ std::string ImageRepository::StoreImage(ImageType nType, const std::wstring& sPa
     if (!pFileSystem.DirectoryExists(sDirectory))
         pFileSystem.CreateDirectory(sDirectory);
 
+    auto sExtension = pFileSystem.GetExtension(sPath);
+    ra::StringMakeLowercase(sExtension);
+
     const auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::context::GameContext>();
-    sFileMD5 = ra::StringPrintf("local\\%u-%s", pGameContext.GameId(), sFileMD5);
+    sFileMD5 = ra::StringPrintf("local\\%u-%s.%s", pGameContext.GameId(), sFileMD5, sExtension);
 
     std::wstring sFilename = GetFilename(nType, sFileMD5);
 


### PR DESCRIPTION
Fixes an issue where trying to publish an achievement with a non-png badge would simply generate a "500 Internal Server Error".

https://discord.com/channels/310192285306454017/310195377993416714/966537071860789278

The files were being incorrectly queued as PNGs, so when they were uploaded to the server, the server couldn't decode them and threw an exception. Server changes to return a more appropriate error message are here: https://github.com/RetroAchievements/RAWeb/pull/961