### PR TITLE
limit 'does not trigger' submission to 5 achievements at a time

### DIFF
--- a/src/ui/viewmodels/BrokenAchievementsViewModel.cpp
+++ b/src/ui/viewmodels/BrokenAchievementsViewModel.cpp
@@ -161,6 +161,13 @@ bool BrokenAchievementsViewModel::Submit()
     switch (request.Problem)
     {
         case ra::api::SubmitTicket::ProblemType::DidNotTrigger:
+            if (request.AchievementIds.size() > 5)
+            {
+                ra::ui::viewmodels::MessageBoxViewModel::ShowErrorMessage(L"Too many achievements selected.",
+                    L"You cannot report more than 5 achievements at a time for not triggering. Please provide separate details for each achievement that did not trigger for you.");
+                return false;
+            }
+
             if (nUnachievedSelected == 0)
             {
                 if (ra::ui::viewmodels::MessageBoxViewModel::ShowWarningMessage(L"Submit anyway?",


### PR DESCRIPTION
Makes it harder for a user to ticket an entire set because they have the wrong ROM, an unsupported core, or an old version of RetroArch.

Does not affect 'triggered at the wrong time' submissions as it's entirely possible that an entire set needs save protection.