### PR TITLE
add rich presence to asset list

### DIFF
--- a/src/RA_Integration.vcxproj
+++ b/src/RA_Integration.vcxproj
@@ -64,6 +64,7 @@
     <ClCompile Include="data\models\CapturedTriggerHits.cpp" />
     <ClCompile Include="data\models\LeaderboardModel.cpp" />
     <ClCompile Include="data\models\LocalBadgesModel.cpp" />
+    <ClCompile Include="data\models\RichPresenceModel.cpp" />
     <ClCompile Include="data\models\TriggerValidation.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
@@ -217,6 +218,7 @@
     <ClInclude Include="data\models\CapturedTriggerHits.hh" />
     <ClInclude Include="data\models\LeaderboardModel.hh" />
     <ClInclude Include="data\models\LocalBadgesModel.hh" />
+    <ClInclude Include="data\models\RichPresenceModel.hh" />
     <ClInclude Include="data\models\TriggerValidation.hh" />
     <ClInclude Include="data\Types.hh" />
     <ClInclude Include="Exports.hh" />

--- a/src/RA_Integration.vcxproj.filters
+++ b/src/RA_Integration.vcxproj.filters
@@ -387,6 +387,9 @@
     <ClCompile Include="ui\viewmodels\NewAssetViewModel.cpp">
       <Filter>UI\ViewModels</Filter>
     </ClCompile>
+    <ClCompile Include="data\models\RichPresenceModel.cpp">
+      <Filter>Data\Models</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="RA_Resource.h">
@@ -961,6 +964,9 @@
     </ClInclude>
     <ClInclude Include="api\UpdateLeaderboard.hh">
       <Filter>API</Filter>
+    </ClInclude>
+    <ClInclude Include="data\models\RichPresenceModel.hh">
+      <Filter>Data\Models</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/data/context/GameAssets.hh
+++ b/src/data/context/GameAssets.hh
@@ -7,6 +7,7 @@
 
 #include "data\models\AchievementModel.hh"
 #include "data\models\LeaderboardModel.hh"
+#include "data\models\RichPresenceModel.hh"
 
 namespace ra {
 namespace data {
@@ -73,6 +74,22 @@ public:
     /// Creates a new leaderboard asset.
     /// </summary>
     ra::data::models::LeaderboardModel& NewLeaderboard();
+
+    /// <summary>
+    /// Finds the rich presence asset.
+    /// </summary>
+    ra::data::models::RichPresenceModel* FindRichPresence()
+    {
+        return dynamic_cast<ra::data::models::RichPresenceModel*>(FindAsset(ra::data::models::AssetType::RichPresence, 0));
+    }
+
+    /// <summary>
+    /// Finds the rich presence asset.
+    /// </summary>
+    const ra::data::models::RichPresenceModel* FindRichPresence() const
+    {
+        return dynamic_cast<const ra::data::models::RichPresenceModel*>(FindAsset(ra::data::models::AssetType::RichPresence, 0));
+    }
 
     /// <summary>
     /// Determines if any Core assets exist.

--- a/src/data/context/GameContext.hh
+++ b/src/data/context/GameContext.hh
@@ -106,21 +106,11 @@ public:
     /// Gets whether or not the loaded game has a rich presence script.
     /// </summary>
     virtual bool HasRichPresence() const;
-    
-    /// <summary>
-    /// Gets whether or not the loaded game has a rich presence script.
-    /// </summary>
-    bool IsRichPresenceFromFile() const noexcept { return m_bRichPresenceFromFile; }
 
     /// <summary>
     /// Gets the current rich presence display string.
     /// </summary>
     virtual std::wstring GetRichPresenceDisplayString() const;
-    
-    /// <summary>
-    /// Reloads the rich presence script.
-    /// </summary>
-    void ReloadRichPresenceScript();
 
     /// <summary>
     /// Returns the note associated with the specified address.
@@ -266,8 +256,6 @@ private:
 protected:
     void RefreshUnlocks(bool bUnpause, int nPopup);
     void UpdateUnlocks(const std::set<unsigned int>& vUnlockedAchievements, bool bUnpause, int nPopup);
-    void AwardMastery() const;
-    void LoadRichPresenceScript(const std::string& sRichPresenceScript);
     void RefreshCodeNotes();
     void AddCodeNote(ra::ByteAddress nAddress, const std::string& sAuthor, const std::wstring& sNote);
     void ShowSimplifiedScoreboard(ra::LeaderboardID nLeaderboardId, int nScore) const;
@@ -282,8 +270,6 @@ protected:
     std::string m_sGameHash;
     std::string m_sGameImage;
     Mode m_nMode{};
-    std::string m_sServerRichPresenceMD5;
-    bool m_bRichPresenceFromFile = false;
 
     struct CodeNote
     {

--- a/src/data/context/SessionTracker.cpp
+++ b/src/data/context/SessionTracker.cpp
@@ -273,7 +273,8 @@ std::wstring SessionTracker::GetCurrentActivity() const
         return sMessage;
     }
 
-    if (pGameContext.HasRichPresence() && !pGameContext.IsRichPresenceFromFile())
+    if (pGameContext.HasRichPresence() &&
+        pGameContext.Assets().FindRichPresence()->GetChanges() == ra::data::models::AssetChanges::None)
     {
         const auto sRPResponse = pGameContext.GetRichPresenceDisplayString();
         if (!sRPResponse.empty())

--- a/src/data/models/AssetModelBase.hh
+++ b/src/data/models/AssetModelBase.hh
@@ -18,6 +18,7 @@ enum class AssetType
     None = 0,
     Achievement,
     Leaderboard,
+    RichPresence,
     LocalBadges,
 };
 

--- a/src/data/models/RichPresenceModel.cpp
+++ b/src/data/models/RichPresenceModel.cpp
@@ -1,0 +1,158 @@
+#include "RichPresenceModel.hh"
+
+#include "data\context\GameContext.hh"
+
+#include "services\AchievementRuntime.hh"
+#include "services\ILocalStorage.hh"
+#include "services\ServiceLocator.hh"
+
+namespace ra {
+namespace data {
+namespace models {
+
+const IntModelProperty RichPresenceModel::ScriptProperty("RichPresenceModel", "Script", 0);
+
+RichPresenceModel::RichPresenceModel() noexcept
+{
+    GSL_SUPPRESS_F6 SetValue(TypeProperty, ra::etoi(AssetType::RichPresence));
+    GSL_SUPPRESS_F6 SetValue(NameProperty, L"Rich Presence");
+
+    GSL_SUPPRESS_F6 AddAssetDefinition(m_pScript, ScriptProperty);
+}
+
+void RichPresenceModel::Activate()
+{
+    SetState(AssetState::Active);
+}
+
+void RichPresenceModel::Deactivate()
+{
+    SetState(AssetState::Inactive);
+}
+
+void RichPresenceModel::OnValueChanged(const IntModelProperty::ChangeArgs& args)
+{
+    // if we're still loading the asset, ignore the event. we'll get recalled once loading finishes
+    if (!IsUpdating())
+    {
+        if (args.Property == StateProperty || args.Property == ScriptProperty)
+        {
+            auto& pRuntime = ra::services::ServiceLocator::GetMutable<ra::services::AchievementRuntime>();
+
+            if (IsActive())
+            {
+                const std::string sScript = GetScript();
+                pRuntime.ActivateRichPresence(sScript);
+            }
+            else
+            {
+                pRuntime.ActivateRichPresence("");
+            }
+        }
+        else if (args.Property == ChangesProperty && args.tNewValue == 0)
+        {
+            WriteRichPresenceScript();
+        }
+    }
+
+    AssetModelBase::OnValueChanged(args);
+}
+
+void RichPresenceModel::SetScript(const std::string& sScript)
+{
+    bool bIsOnlyWhitespace = true;
+    for (const char c : sScript)
+    {
+        if (!isspace(static_cast<int>(c)))
+        {
+            bIsOnlyWhitespace = false;
+            break;
+        }
+    }
+
+    if (bIsOnlyWhitespace)
+    {
+        SetAssetDefinition(m_pScript, "");
+        return;
+    }
+
+    if (sScript.back() == '\n' && sScript.find('\r') == std::string::npos)
+    {
+        SetAssetDefinition(m_pScript, sScript);
+        return;
+    }
+
+    // normalize (unix line endings, must end with a line ending)
+    std::string sNormalizedScript = sScript;
+    sNormalizedScript.erase(std::remove(sNormalizedScript.begin(), sNormalizedScript.end(), '\r'), sNormalizedScript.end());
+    if (!sNormalizedScript.empty() && sNormalizedScript.back() != '\n')
+        sNormalizedScript.push_back('\n');
+
+    SetAssetDefinition(m_pScript, sNormalizedScript);
+}
+
+void RichPresenceModel::ReloadRichPresenceScript()
+{
+    const auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::context::GameContext>();
+    auto& pLocalStorage = ra::services::ServiceLocator::GetMutable<ra::services::ILocalStorage>();
+    auto pRich = pLocalStorage.ReadText(ra::services::StorageItemType::RichPresence, std::to_wstring(pGameContext.GameId()));
+
+    if (pRich == nullptr)
+    {
+        // file doesn't exist. reset back to the server state
+        RestoreServerCheckpoint();
+
+        // if server state is not empty, flush it to disk
+        if (!GetScript().empty())
+            WriteRichPresenceScript();
+
+        return;
+    }
+
+    std::string sRichPresence;
+    std::string sLine;
+    while (pRich->GetLine(sLine))
+    {
+        sRichPresence.append(sLine);
+        sRichPresence.append("\n");
+    }
+
+    // remove UTF-8 BOM if present
+    if (ra::StringStartsWith(sRichPresence, "\xef\xbb\xbf"))
+        sRichPresence.erase(0, 3);
+
+    SetScript(sRichPresence);
+
+    UpdateLocalCheckpoint();
+
+    // if there's a local script, but no core script, change the category to Local
+    if (GetChanges() == ra::data::models::AssetChanges::Unpublished && m_pScript.m_sCoreDefinition.empty())
+    {
+        SetCategory(ra::data::models::AssetCategory::Local);
+        UpdateLocalCheckpoint();
+    }
+}
+
+void RichPresenceModel::WriteRichPresenceScript()
+{
+    const auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::context::GameContext>();
+    auto& pLocalStorage = ra::services::ServiceLocator::GetMutable<ra::services::ILocalStorage>();
+
+    auto pWriter = pLocalStorage.WriteText(ra::services::StorageItemType::RichPresence,
+                                           std::to_wstring(pGameContext.GameId()));
+    const auto& pScript = GetScript();
+    pWriter->Write(pScript);
+}
+
+void RichPresenceModel::Serialize(ra::services::TextWriter&) const noexcept
+{
+}
+
+bool RichPresenceModel::Deserialize(ra::Tokenizer&) noexcept
+{
+    return false;
+}
+
+} // namespace models
+} // namespace data
+} // namespace ra

--- a/src/data/models/RichPresenceModel.hh
+++ b/src/data/models/RichPresenceModel.hh
@@ -1,0 +1,56 @@
+#ifndef RA_DATA_RICHPRESENCE_MODEL_H
+#define RA_DATA_RICHPRESENCE_MODEL_H
+#pragma once
+
+#include "AssetModelBase.hh"
+
+#include "CapturedTriggerHits.hh"
+
+#include "data\Types.hh"
+
+namespace ra {
+namespace data {
+namespace models {
+
+class RichPresenceModel : public AssetModelBase
+{
+public:
+    RichPresenceModel() noexcept;
+
+    /// <summary>
+    /// The <see cref="ModelProperty" /> for the start trigger version.
+    /// </summary>
+    static const IntModelProperty ScriptProperty;
+
+    /// <summary>
+    /// Gets the start trigger definition.
+    /// </summary>
+    const std::string& GetScript() const { return GetAssetDefinition(m_pScript); }
+
+    /// <summary>
+    /// Sets the start trigger definition.
+    /// </summary>
+    void SetScript(const std::string& sScript);
+
+    void ReloadRichPresenceScript();
+
+    void Activate() override;
+    void Deactivate() override;
+
+    void Serialize(ra::services::TextWriter& pWriter) const noexcept override;
+    bool Deserialize(ra::Tokenizer& pTokenizer) noexcept override;
+
+protected:
+    void OnValueChanged(const IntModelProperty::ChangeArgs& args) override;
+
+private:
+    void WriteRichPresenceScript();
+
+    AssetDefinition m_pScript;
+};
+
+} // namespace models
+} // namespace data
+} // namespace ra
+
+#endif RA_DATA_RICHPRESENCE_MODEL_H

--- a/src/services/AchievementRuntime.cpp
+++ b/src/services/AchievementRuntime.cpp
@@ -157,7 +157,7 @@ int AchievementRuntime::ActivateLeaderboard(unsigned int nId, const std::string&
     return rc_runtime_activate_lboard(&m_pRuntime, nId, sDefinition.c_str(), nullptr, 0);
 }
 
-void AchievementRuntime::ActivateRichPresence(const std::string& sScript)
+bool AchievementRuntime::ActivateRichPresence(const std::string& sScript)
 {
     std::lock_guard<std::mutex> pLock(m_pMutex);
     EnsureInitialized();
@@ -174,6 +174,8 @@ void AchievementRuntime::ActivateRichPresence(const std::string& sScript)
         if (m_nRichPresenceParseResult != RC_OK)
             m_nRichPresenceParseResult = rc_richpresence_size_lines(sScript.c_str(), &m_nRichPresenceErrorLine);
     }
+
+    return (m_nRichPresenceParseResult == RC_OK);
 }
 
 std::wstring AchievementRuntime::GetRichPresenceDisplayString() const

--- a/src/services/AchievementRuntime.hh
+++ b/src/services/AchievementRuntime.hh
@@ -127,7 +127,8 @@ public:
     /// Specifies the rich presence to process each frame.
     /// </summary>
     /// <remarks>Only updates the memrefs each frame (for deltas), the script is not processed here.</remarks>
-    void ActivateRichPresence(const std::string& sScript);
+    /// <returns><c>true</c> if the rich presence was activated, <c>false</c> if there was an error.</returns>
+    bool ActivateRichPresence(const std::string& sScript);
 
     /// <summary>
     /// Gets whether or not the loaded game has a rich presence script.

--- a/src/ui/viewmodels/IntegrationMenuViewModel.cpp
+++ b/src/ui/viewmodels/IntegrationMenuViewModel.cpp
@@ -277,7 +277,9 @@ void IntegrationMenuViewModel::ShowMemoryBookmarks()
 void IntegrationMenuViewModel::ShowRichPresenceMonitor()
 {
     auto& pGameContext = ra::services::ServiceLocator::GetMutable<ra::data::context::GameContext>();
-    pGameContext.ReloadRichPresenceScript();
+    auto* pRichPresence = pGameContext.Assets().FindRichPresence();
+    if (pRichPresence != nullptr)
+        pRichPresence->ReloadRichPresenceScript();
 
     auto& pWindowManager = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::WindowManager>();
     pWindowManager.RichPresenceMonitor.Show();

--- a/src/ui/viewmodels/RichPresenceMonitorViewModel.hh
+++ b/src/ui/viewmodels/RichPresenceMonitorViewModel.hh
@@ -56,6 +56,7 @@ protected:
 
 private:
     void ScheduleUpdateDisplayString();
+    void UpdateWindowTitle();
 
     enum class MonitorState
     {

--- a/src/ui/win32/AssetListDialog.cpp
+++ b/src/ui/win32/AssetListDialog.cpp
@@ -63,6 +63,10 @@ public:
         if (nId >= ra::data::context::GameAssets::FirstLocalId)
             return L"0";
 
+        const auto nType = vmItems.GetItemValue(nIndex, ra::data::models::AssetModelBase::TypeProperty);
+        if (nType == ra::etoi(ra::data::models::AssetType::RichPresence))
+            return L"";
+
         return std::to_wstring(nId);
     }
 };
@@ -111,11 +115,10 @@ public:
             case ra::data::models::AssetType::Leaderboard:
                 return L"\U0001F4CA"; // 1F4CA - Bar Chart
 
-            //case ra::data::models::AssetType::RichPresence:
+            case ra::data::models::AssetType::RichPresence:
             //    return L"\U0001F4C4"; // 1F4C4 - Document
             //    return L"\U0001F4CD"; // 1F4CD - Round Pushpin
-            //    return L"\U0001F4DC"; // 1F4DC - Scroll
-            //    return L"\U0001F522"; // 1F5FA - World Map
+                return L"\U0001F4DC"; // 1F4DC - Scroll
 
             default:
                 return std::to_wstring(ra::etoi(nType));
@@ -132,6 +135,9 @@ public:
 
             case ra::data::models::AssetType::Leaderboard:
                 return L"Leaderboard";
+
+            case ra::data::models::AssetType::RichPresence:
+                return L"Rich Presence";
 
             default:
                 return std::to_wstring(ra::etoi(nType));

--- a/tests/RA_Integration.Tests.vcxproj
+++ b/tests/RA_Integration.Tests.vcxproj
@@ -385,6 +385,7 @@
     <ClCompile Include="..\src\data\models\CapturedTriggerHits.cpp" />
     <ClCompile Include="..\src\data\models\LeaderboardModel.cpp" />
     <ClCompile Include="..\src\data\models\LocalBadgesModel.cpp" />
+    <ClCompile Include="..\src\data\models\RichPresenceModel.cpp" />
     <ClCompile Include="..\src\data\models\TriggerValidation.cpp" />
     <ClCompile Include="..\src\pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
@@ -461,6 +462,7 @@
     <ClCompile Include="data\models\AssetModelBase_Tests.cpp" />
     <ClCompile Include="data\models\LeaderboardModel_Tests.cpp" />
     <ClCompile Include="data\models\LocalBadgesModel_Tests.cpp" />
+    <ClCompile Include="data\models\RichPresenceModel_Tests.cpp" />
     <ClCompile Include="data\models\TriggerValidation_Tests.cpp" />
     <ClCompile Include="Exports_Tests.cpp" />
     <ClCompile Include="services\AchievementRuntime_Tests.cpp" />

--- a/tests/RA_Integration.Tests.vcxproj.filters
+++ b/tests/RA_Integration.Tests.vcxproj.filters
@@ -432,6 +432,12 @@
     <ClCompile Include="..\src\ui\viewmodels\NewAssetViewModel.cpp">
       <Filter>Code</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\data\models\RichPresenceModel.cpp">
+      <Filter>Code</Filter>
+    </ClCompile>
+    <ClCompile Include="data\models\RichPresenceModel_Tests.cpp">
+      <Filter>Tests\Data\Models</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="base.props" />

--- a/tests/data/context/SessionTracker_Tests.cpp
+++ b/tests/data/context/SessionTracker_Tests.cpp
@@ -5,6 +5,7 @@
 #include "tests\RA_UnitTestHelpers.h"
 #include "tests\data\DataAsserts.hh"
 
+#include "tests\mocks\MockAchievementRuntime.hh"
 #include "tests\mocks\MockClock.hh"
 #include "tests\mocks\MockConfiguration.hh"
 #include "tests\mocks\MockGameContext.hh"
@@ -36,6 +37,7 @@ public:
 
         ra::api::mocks::MockServer mockServer;
         ra::data::context::mocks::MockGameContext mockGameContext;
+        ra::services::mocks::MockAchievementRuntime mockRuntime;
         ra::services::mocks::MockClock mockClock;
         ra::services::mocks::MockConfiguration mockConfiguration;
         ra::services::mocks::MockLocalStorage mockStorage;

--- a/tests/data/models/RichPresenceModel_Tests.cpp
+++ b/tests/data/models/RichPresenceModel_Tests.cpp
@@ -1,0 +1,261 @@
+#include "CppUnitTest.h"
+
+#include "data\models\RichPresenceModel.hh"
+
+#include "services\impl\StringTextWriter.hh"
+
+#include "tests\RA_UnitTestHelpers.h"
+#include "tests\data\DataAsserts.hh"
+
+#include "tests\mocks\MockAchievementRuntime.hh"
+#include "tests\mocks\MockGameContext.hh"
+#include "tests\mocks\MockLocalStorage.hh"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace ra {
+namespace data {
+namespace models {
+namespace tests {
+
+TEST_CLASS(RichPresenceModel_Tests)
+{
+private:
+    class RichPresenceModelHarness : public RichPresenceModel
+    {
+    public:
+        ra::data::context::mocks::MockGameContext mockGameContext;
+        ra::services::mocks::MockLocalStorage mockLocalStorage;
+        ra::services::impl::StringTextWriter textWriter;
+        ra::services::mocks::MockAchievementRuntime mockRuntime;
+    };
+
+public:
+    TEST_METHOD(TestInitialValues)
+    {
+        RichPresenceModelHarness richPresence;
+
+        Assert::AreEqual(AssetType::RichPresence, richPresence.GetType());
+        Assert::AreEqual(0U, richPresence.GetID());
+        Assert::AreEqual(std::wstring(L"Rich Presence"), richPresence.GetName());
+        Assert::AreEqual(std::wstring(L""), richPresence.GetDescription());
+        Assert::AreEqual(AssetCategory::Core, richPresence.GetCategory());
+        Assert::AreEqual(AssetState::Inactive, richPresence.GetState());
+        Assert::AreEqual(AssetChanges::None, richPresence.GetChanges());
+        Assert::AreEqual(std::string(""), richPresence.GetScript());
+    }
+
+    TEST_METHOD(TestActivateDeactivate)
+    {
+        RichPresenceModelHarness richPresence;
+        richPresence.SetScript("Display:\nTest\n");
+        richPresence.CreateServerCheckpoint();
+        richPresence.CreateLocalCheckpoint();
+
+        Assert::AreEqual(std::string("Display:\nTest\n"), richPresence.GetScript());
+
+        Assert::AreEqual(AssetState::Inactive, richPresence.GetState());
+        Assert::AreEqual(std::wstring(L"No Rich Presence defined."), richPresence.mockRuntime.GetRichPresenceDisplayString());
+
+        richPresence.Activate();
+
+        Assert::AreEqual(AssetState::Active, richPresence.GetState());
+        Assert::AreEqual(std::wstring(L"Test"), richPresence.mockRuntime.GetRichPresenceDisplayString());
+
+        richPresence.Deactivate();
+
+        Assert::AreEqual(AssetState::Inactive, richPresence.GetState());
+        Assert::AreEqual(std::wstring(L"No Rich Presence defined."), richPresence.mockRuntime.GetRichPresenceDisplayString());
+    }
+
+    TEST_METHOD(TestChangeWhileActive)
+    {
+        RichPresenceModelHarness richPresence;
+        richPresence.SetScript("Display:\nTest\n");
+        richPresence.CreateServerCheckpoint();
+        richPresence.CreateLocalCheckpoint();
+        richPresence.Activate();
+
+        Assert::AreEqual(AssetState::Active, richPresence.GetState());
+        Assert::AreEqual(std::wstring(L"Test"), richPresence.mockRuntime.GetRichPresenceDisplayString());
+
+        richPresence.SetScript("Display:\nNew test\n");
+
+        Assert::AreEqual(AssetState::Active, richPresence.GetState());
+        Assert::AreEqual(std::wstring(L"New test"), richPresence.mockRuntime.GetRichPresenceDisplayString());
+    }
+
+    TEST_METHOD(TestNormalizeScript)
+    {
+        RichPresenceModelHarness richPresence;
+        richPresence.SetScript("Display:\nTest\n");
+        richPresence.CreateServerCheckpoint();
+        richPresence.CreateLocalCheckpoint();
+
+        Assert::AreEqual(AssetChanges::None, richPresence.GetChanges());
+
+        richPresence.SetScript("Display:\r\nTest\r\n");
+        Assert::AreEqual(AssetChanges::None, richPresence.GetChanges());
+
+        richPresence.SetScript("Display:\nTest");
+        Assert::AreEqual(AssetChanges::None, richPresence.GetChanges());
+
+        richPresence.SetScript("Display:\nTest2\n");
+        Assert::AreEqual(AssetChanges::Modified, richPresence.GetChanges());
+    }
+
+    TEST_METHOD(TestNormalizeScriptOnlyWhitespace)
+    {
+        RichPresenceModelHarness richPresence;
+        richPresence.CreateServerCheckpoint();
+        richPresence.CreateLocalCheckpoint();
+
+        Assert::AreEqual(AssetChanges::None, richPresence.GetChanges());
+
+        richPresence.SetScript("\n");
+        Assert::AreEqual(AssetChanges::None, richPresence.GetChanges());
+
+        richPresence.SetScript("     ");
+        Assert::AreEqual(AssetChanges::None, richPresence.GetChanges());
+
+        richPresence.SetScript("\n\nDisplay:\nTest\n");
+        Assert::AreEqual(AssetChanges::Modified, richPresence.GetChanges());
+    }
+
+    TEST_METHOD(TestReloadWritesFile)
+    {
+        RichPresenceModelHarness richPresence;
+        richPresence.mockGameContext.SetGameId(1);
+        richPresence.SetScript("Display:\nTest\n");
+        richPresence.CreateServerCheckpoint();
+        richPresence.CreateLocalCheckpoint();
+
+        Assert::AreEqual(AssetChanges::None, richPresence.GetChanges());
+        Assert::AreEqual(std::string(), richPresence.mockLocalStorage.GetStoredData(ra::services::StorageItemType::RichPresence, L"1"));
+
+        richPresence.ReloadRichPresenceScript();
+        Assert::AreEqual(AssetChanges::None, richPresence.GetChanges());
+        Assert::AreEqual(std::string("Display:\nTest\n"), richPresence.mockLocalStorage.GetStoredData(ra::services::StorageItemType::RichPresence, L"1"));
+    }
+
+    TEST_METHOD(TestReloadReadsFile)
+    {
+        RichPresenceModelHarness richPresence;
+        richPresence.mockGameContext.SetGameId(1);
+        richPresence.mockLocalStorage.MockStoredData(ra::services::StorageItemType::RichPresence, L"1", "Display:\nFrom file\n");
+        richPresence.SetScript("Display:\nTest\n");
+        richPresence.CreateServerCheckpoint();
+        richPresence.CreateLocalCheckpoint();
+
+        Assert::AreEqual(AssetChanges::None, richPresence.GetChanges());
+
+        richPresence.ReloadRichPresenceScript();
+        Assert::AreEqual(std::string("Display:\nFrom file\n"), richPresence.GetScript());
+        Assert::AreEqual(AssetChanges::Unpublished, richPresence.GetChanges());
+        Assert::AreEqual(AssetCategory::Core, richPresence.GetCategory());
+
+        Assert::AreEqual(std::string("Display:\nFrom file\n"), richPresence.mockLocalStorage.GetStoredData(ra::services::StorageItemType::RichPresence, L"1"));
+    }
+
+    TEST_METHOD(TestReloadNormalizesFile)
+    {
+        RichPresenceModelHarness richPresence;
+        richPresence.mockGameContext.SetGameId(1);
+        richPresence.mockLocalStorage.MockStoredData(ra::services::StorageItemType::RichPresence, L"1", "\xef\xbb\xbf\nDisplay:\r\nFrom file\r\n");
+        richPresence.SetScript("Display:\nTest\n");
+        richPresence.CreateServerCheckpoint();
+        richPresence.CreateLocalCheckpoint();
+
+        Assert::AreEqual(AssetChanges::None, richPresence.GetChanges());
+
+        richPresence.ReloadRichPresenceScript();
+        Assert::AreEqual(std::string("\nDisplay:\nFrom file\n"), richPresence.GetScript());
+        Assert::AreEqual(AssetChanges::Unpublished, richPresence.GetChanges());
+        Assert::AreEqual(AssetCategory::Core, richPresence.GetCategory());
+
+        Assert::AreEqual(std::string("\xef\xbb\xbf\nDisplay:\r\nFrom file\r\n"), richPresence.mockLocalStorage.GetStoredData(ra::services::StorageItemType::RichPresence, L"1"));
+    }
+
+    TEST_METHOD(TestReloadReadsFileNoServerData)
+    {
+        RichPresenceModelHarness richPresence;
+        richPresence.mockGameContext.SetGameId(1);
+        richPresence.mockLocalStorage.MockStoredData(ra::services::StorageItemType::RichPresence, L"1", "Display:\nFrom file\n");
+        richPresence.CreateServerCheckpoint();
+        richPresence.CreateLocalCheckpoint();
+
+        Assert::AreEqual(AssetChanges::None, richPresence.GetChanges());
+
+        richPresence.ReloadRichPresenceScript();
+        Assert::AreEqual(std::string("Display:\nFrom file\n"), richPresence.GetScript());
+        Assert::AreEqual(AssetChanges::Unpublished, richPresence.GetChanges());
+        Assert::AreEqual(AssetCategory::Local, richPresence.GetCategory());
+
+        Assert::AreEqual(std::string("Display:\nFrom file\n"), richPresence.mockLocalStorage.GetStoredData(ra::services::StorageItemType::RichPresence, L"1"));
+    }
+
+    TEST_METHOD(TestReloadDiscardsChanges)
+    {
+        RichPresenceModelHarness richPresence;
+        richPresence.mockGameContext.SetGameId(1);
+        richPresence.mockLocalStorage.MockStoredData(ra::services::StorageItemType::RichPresence, L"1", "Display:\nFrom file\n");
+        richPresence.SetScript("Display:\nTest\n");
+        richPresence.CreateServerCheckpoint();
+        richPresence.SetScript("Display:\nLocal\n");
+        richPresence.CreateLocalCheckpoint();
+
+        Assert::AreEqual(AssetChanges::Unpublished, richPresence.GetChanges());
+
+        richPresence.ReloadRichPresenceScript();
+        Assert::AreEqual(std::string("Display:\nFrom file\n"), richPresence.GetScript());
+        Assert::AreEqual(AssetChanges::Unpublished, richPresence.GetChanges());
+        Assert::AreEqual(AssetCategory::Core, richPresence.GetCategory());
+
+        Assert::AreEqual(std::string("Display:\nFrom file\n"), richPresence.mockLocalStorage.GetStoredData(ra::services::StorageItemType::RichPresence, L"1"));
+    }
+
+    TEST_METHOD(TestReloadDiscardsChangesMatchesServer)
+    {
+        RichPresenceModelHarness richPresence;
+        richPresence.mockGameContext.SetGameId(1);
+        richPresence.mockLocalStorage.MockStoredData(ra::services::StorageItemType::RichPresence, L"1", "Display:\nTest\n");
+        richPresence.SetScript("Display:\nTest\n");
+        richPresence.CreateServerCheckpoint();
+        richPresence.SetScript("Display:\nLocal\n");
+        richPresence.CreateLocalCheckpoint();
+
+        Assert::AreEqual(AssetChanges::Unpublished, richPresence.GetChanges());
+
+        richPresence.ReloadRichPresenceScript();
+        Assert::AreEqual(std::string("Display:\nTest\n"), richPresence.GetScript());
+        Assert::AreEqual(AssetChanges::None, richPresence.GetChanges());
+        Assert::AreEqual(AssetCategory::Core, richPresence.GetCategory());
+
+        Assert::AreEqual(std::string("Display:\nTest\n"), richPresence.mockLocalStorage.GetStoredData(ra::services::StorageItemType::RichPresence, L"1"));
+    }
+
+    TEST_METHOD(TestRevertUpdatesFile)
+    {
+        RichPresenceModelHarness richPresence;
+        richPresence.mockGameContext.SetGameId(1);
+        richPresence.mockLocalStorage.MockStoredData(ra::services::StorageItemType::RichPresence, L"1", "Display:\nFrom file\n");
+        richPresence.SetScript("Display:\nTest\n");
+        richPresence.CreateServerCheckpoint();
+        richPresence.SetScript("Display:\nLocal\n");
+        richPresence.CreateLocalCheckpoint();
+
+        Assert::AreEqual(AssetChanges::Unpublished, richPresence.GetChanges());
+
+        richPresence.RestoreServerCheckpoint();
+        Assert::AreEqual(std::string("Display:\nTest\n"), richPresence.GetScript());
+        Assert::AreEqual(AssetChanges::None, richPresence.GetChanges());
+        Assert::AreEqual(AssetCategory::Core, richPresence.GetCategory());
+
+        Assert::AreEqual(std::string("Display:\nTest\n"), richPresence.mockLocalStorage.GetStoredData(ra::services::StorageItemType::RichPresence, L"1"));
+    }
+};
+
+} // namespace tests
+} // namespace models
+} // namespace data
+} // namespace ra

--- a/tests/data/models/RichPresenceModel_Tests.cpp
+++ b/tests/data/models/RichPresenceModel_Tests.cpp
@@ -85,6 +85,29 @@ public:
         Assert::AreEqual(std::wstring(L"New test"), richPresence.mockRuntime.GetRichPresenceDisplayString());
     }
 
+    TEST_METHOD(TestActivateInvalid)
+    {
+        RichPresenceModelHarness richPresence;
+        richPresence.SetScript("Test\n");
+        richPresence.CreateServerCheckpoint();
+        richPresence.CreateLocalCheckpoint();
+
+        Assert::AreEqual(std::string("Test\n"), richPresence.GetScript());
+
+        Assert::AreEqual(AssetState::Inactive, richPresence.GetState());
+        Assert::AreEqual(std::wstring(L"No Rich Presence defined."), richPresence.mockRuntime.GetRichPresenceDisplayString());
+
+        richPresence.Activate();
+
+        Assert::AreEqual(AssetState::Disabled, richPresence.GetState());
+        Assert::AreEqual(std::wstring(L"Parse error -18 (line 1): Missing display string"), richPresence.mockRuntime.GetRichPresenceDisplayString());
+
+        richPresence.SetScript("Display:\nTest\n");
+
+        Assert::AreEqual(AssetState::Active, richPresence.GetState());
+        Assert::AreEqual(std::wstring(L"Test"), richPresence.mockRuntime.GetRichPresenceDisplayString());
+    }
+
     TEST_METHOD(TestNormalizeScript)
     {
         RichPresenceModelHarness richPresence;

--- a/tests/mocks/MockGameContext.hh
+++ b/tests/mocks/MockGameContext.hh
@@ -45,9 +45,31 @@ public:
     /// <summary>
     /// Sets the rich presence display string.
     /// </summary>
-    void SetRichPresenceDisplayString(std::wstring sValue) { m_sRichPresenceDisplayString = sValue; }
+    void SetRichPresenceDisplayString(std::wstring sValue)
+    {
+        if (Assets().FindRichPresence() == nullptr)
+        {
+            auto pRichPresence = std::make_unique<ra::data::models::RichPresenceModel>();
+            pRichPresence->SetScript(ra::StringPrintf("Display:\n%s\n", sValue));
+            pRichPresence->CreateServerCheckpoint();
+            pRichPresence->CreateLocalCheckpoint();
+            Assets().Append(std::move(pRichPresence));
+        }
 
-    void SetRichPresenceFromFile(bool bValue) noexcept { m_bRichPresenceFromFile = bValue; }
+        m_sRichPresenceDisplayString = sValue;
+    }
+
+    void SetRichPresenceFromFile(bool bValue)
+    {
+        auto* pRichPresence = Assets().FindRichPresence();
+        if (pRichPresence)
+        {
+            if (bValue)
+                pRichPresence->SetScript("Display:\nThis differs\n");
+            else
+                pRichPresence->SetScript(ra::StringPrintf("Display:\n%s\n", m_sRichPresenceDisplayString));
+        }
+    }
 
     bool SetCodeNote(ra::ByteAddress nAddress, const std::wstring& sNote) override
     {


### PR DESCRIPTION
Provides minimal functionality. Attempting to open the asset launches the file in the default text editor on the machine. The only available action is "Revert" which will replace the file with the data downloaded from the server. 

The main feature provided by this functionality is that any modifications made to the file will be kept between sessions.

![image](https://user-images.githubusercontent.com/32680403/165642863-c18371f4-7adb-4866-a393-0a314024189e.png)

![image](https://user-images.githubusercontent.com/32680403/165642983-e6caa1bf-c39f-4f99-8e62-f03d0e5e28c1.png)

If there is no rich presence data available on the server, the asset is automatically marked as local, and the "Revert" functionality is also disabled.

![image](https://user-images.githubusercontent.com/32680403/165642924-eecef8eb-bda4-4a30-a3ca-edcddb18c9b4.png)

This does not provide any support for publishing/activating/deactivating the rich presence. Changes to the text file are still only detected while the Rich Presence Monitor is open.