### PR TITLE
open editor when pressing New with Rich Presence filter

### DIFF
--- a/src/ui/viewmodels/RichPresenceMonitorViewModel.cpp
+++ b/src/ui/viewmodels/RichPresenceMonitorViewModel.cpp
@@ -44,8 +44,18 @@ void RichPresenceMonitorViewModel::StartMonitoring()
         case MonitorState::None:
             // not monitoring - start doing so.
             m_nState = MonitorState::Active;
-            UpdateDisplayString();
             m_tRichPresenceFileTime = GetRichPresenceModified();
+            if (m_tRichPresenceFileTime)
+            {
+                auto& pGameContext = ra::services::ServiceLocator::GetMutable<ra::data::context::GameContext>();
+                auto* pRichPresence = pGameContext.Assets().FindRichPresence();
+                if (pRichPresence != nullptr)
+                {
+                    pRichPresence->ReloadRichPresenceScript();
+                    pRichPresence->Activate();
+                }
+            }
+            UpdateDisplayString();
             ScheduleUpdateDisplayString();
             break;
 


### PR DESCRIPTION
Prevents assertion failure: https://discord.com/channels/310192285306454017/310195377993416714/972280272047443998

If the filter type is All, the picker dialog still only has Achievement and Leaderboard as choices. Since you can only have one Rich Presence script, I felt that having a button for Rich Presence would just be confusing.