### PR TITLE
allow emulator to provide function for reading chunks of memory

### DIFF
--- a/src/Exports.cpp
+++ b/src/Exports.cpp
@@ -345,6 +345,12 @@ API void CCONV _RA_InstallMemoryBank(int nBankID, void* pReader, void* pWriter, 
         static_cast<ra::data::context::EmulatorContext::MemoryWriteFunction*>(pWriter));
 }
 
+API void CCONV _RA_InstallMemoryBankBlockReader(int nBankID, void* pReader)
+{
+    ra::services::ServiceLocator::GetMutable<ra::data::context::EmulatorContext>().AddMemoryBlockReader(
+        nBankID, static_cast<ra::data::context::EmulatorContext::MemoryReadBlockFunction*>(pReader));
+}
+
 API void CCONV _RA_ClearMemoryBanks()
 {
     ra::services::ServiceLocator::GetMutable<ra::data::context::EmulatorContext>().ClearMemoryBlocks();

--- a/src/Exports.hh
+++ b/src/Exports.hh
@@ -65,9 +65,11 @@ extern "C" {
     API int CCONV _RA_OnLoadNewRom(const BYTE* pROM, unsigned int nROMSize);
 
     // On or immediately after a new ROM is loaded, for each memory bank found
-    //  pReader is typedef unsigned char (_RAMByteReadFn)( size_t nOffset );
-    //  pWriter is typedef void (_RAMByteWriteFn)( unsigned int nOffs, unsigned int nVal );
+    //  pReader is typedef unsigned char (_RAMByteReadFn)( unsigned nOffset );
+    //  pBlockReader is typedef unsigned (_RAMBlockReadFn)( unsigned nOffset, unsigned char* pBuffer, unsigned nCount );
+    //  pWriter is typedef void (_RAMByteWriteFn)( unsigned int nOffs, unsigned char nVal );
     API void CCONV _RA_InstallMemoryBank(int nBankID, void* pReader, void* pWriter, int nBankSize);
+    API void CCONV _RA_InstallMemoryBankBlockReader(int nBankID, void* pBlockReader);
 
     // Call before installing any memory banks
     API void CCONV _RA_ClearMemoryBanks();

--- a/src/data/context/EmulatorContext.hh
+++ b/src/data/context/EmulatorContext.hh
@@ -174,12 +174,18 @@ public:
     const wchar_t* GetCancelButtonText() const noexcept { return m_sCancelButtonText; }
 
     typedef uint8_t(MemoryReadFunction)(uint32_t nAddress);
+    typedef uint32_t(MemoryReadBlockFunction)(uint32_t nAddress, uint8_t* pBuffer, uint32_t nBytes);
     typedef void (MemoryWriteFunction)(uint32_t nAddress, uint8_t nValue);
 
     /// <summary>
     /// Specifies functions to read and write memory in the emulator.
     /// </summary>
     void AddMemoryBlock(gsl::index nIndex, size_t nBytes, MemoryReadFunction* pReader, MemoryWriteFunction* pWriter);
+
+    /// <summary>
+    /// Specifies functions to read chunks of memory in the emulator.
+    /// </summary>
+    void AddMemoryBlockReader(gsl::index nIndex, MemoryReadBlockFunction* pReader);
 
     /// <summary>
     /// Clears all registered memory blocks so they can be rebuilt.
@@ -301,6 +307,7 @@ protected:
         size_t size;
         MemoryReadFunction* read;
         MemoryWriteFunction* write;
+        MemoryReadBlockFunction* readBlock;
     };
 
     std::vector<MemoryBlock> m_vMemoryBlocks;

--- a/src/data/context/GameContext.cpp
+++ b/src/data/context/GameContext.cpp
@@ -96,7 +96,7 @@ void GameContext::LoadGame(unsigned int nGameId, Mode nMode)
         if (pData != nullptr)
         {
             rapidjson::Document pDocument;
-            if (LoadDocument(pDocument, *pData) && pDocument.HasMember("RichPresencePatch"))
+            if (LoadDocument(pDocument, *pData) && pDocument.HasMember("RichPresencePatch") && pDocument["RichPresencePatch"].IsString())
                 sOldRichPresence = pDocument["RichPresencePatch"].GetString();
         }
     }

--- a/src/data/models/AssetModelBase.cpp
+++ b/src/data/models/AssetModelBase.cpp
@@ -42,7 +42,7 @@ static void WriteEscapedString(ra::services::TextWriter& pWriter, const std::bas
     std::basic_string<CharT> sEscaped;
     sEscaped.reserve(sText.length() + nToEscape + 2);
     sEscaped.push_back('"');
-    for (CharT c : sText)
+    for (const CharT c : sText)
     {
         if (c == '"' || c == '\\')
             sEscaped.push_back('\\');

--- a/tests/RA_Interface_Tests.cpp
+++ b/tests/RA_Interface_Tests.cpp
@@ -83,6 +83,7 @@ public:
         Assert::IsNotNull((const void*)_RA_SetConsoleID);
         Assert::IsNotNull((const void*)_RA_ClearMemoryBanks);
         Assert::IsNotNull((const void*)_RA_InstallMemoryBank);
+        Assert::IsNotNull((const void*)_RA_InstallMemoryBankBlockReader);
         Assert::IsNotNull((const void*)_RA_Shutdown);
         Assert::IsNotNull((const void*)_RA_IsOverlayFullyVisible);
         Assert::IsNotNull((const void*)_RA_SetPaused);
@@ -126,6 +127,7 @@ public:
         Assert::IsNull((const void*)_RA_SetConsoleID);
         Assert::IsNull((const void*)_RA_ClearMemoryBanks);
         Assert::IsNull((const void*)_RA_InstallMemoryBank);
+        Assert::IsNull((const void*)_RA_InstallMemoryBankBlockReader);
         Assert::IsNull((const void*)_RA_Shutdown);
         Assert::IsNull((const void*)_RA_IsOverlayFullyVisible);
         Assert::IsNull((const void*)_RA_SetPaused);

--- a/tests/data/context/EmulatorContext_Tests.cpp
+++ b/tests/data/context/EmulatorContext_Tests.cpp
@@ -1296,11 +1296,11 @@ public:
         uint8_t buffer[16];
         emulator.ReadMemory(0U, buffer, sizeof(buffer));
         for (size_t i = 0; i < sizeof(buffer); i++)
-            Assert::AreEqual(buffer[i], memory.at(i));
+            Assert::AreEqual(gsl::at(buffer, i), memory.at(i));
 
         emulator.ReadMemory(4U, buffer, 1);
-        Assert::AreEqual(buffer[0], memory.at(4));
-        Assert::AreEqual(buffer[1], memory.at(1));
+        Assert::AreEqual(gsl::at(buffer, 0), memory.at(4));
+        Assert::AreEqual(gsl::at(buffer, 1), memory.at(1));
     }
 
     TEST_METHOD(TestReadMemoryByteInvalidAddressDisablesAchievement)

--- a/tests/data/context/EmulatorContext_Tests.cpp
+++ b/tests/data/context/EmulatorContext_Tests.cpp
@@ -1255,7 +1255,7 @@ public:
 
     TEST_METHOD(TestReadMemoryBlock)
     {
-        for (int i = 0; i < memory.size(); i++)
+        for (size_t i = 0; i < memory.size(); i++)
             memory.at(i) = gsl::narrow_cast<uint8_t>(i);
 
         memory.at(4) = 0xA8;
@@ -1295,7 +1295,7 @@ public:
         // test the block reader directly
         uint8_t buffer[16];
         emulator.ReadMemory(0U, buffer, sizeof(buffer));
-        for (int i = 0; i < sizeof(buffer); i++)
+        for (size_t i = 0; i < sizeof(buffer); i++)
             Assert::AreEqual(buffer[i], memory.at(i));
 
         emulator.ReadMemory(4U, buffer, 1);

--- a/tests/data/context/GameContext_Tests.cpp
+++ b/tests/data/context/GameContext_Tests.cpp
@@ -488,6 +488,25 @@ public:
         Assert::AreEqual(ra::data::models::AssetChanges::Unpublished, pRichPresence->GetChanges());
     }
 
+    TEST_METHOD(TestLoadGameRichPresenceNotOnServer)
+    {
+        GameContextHarness game;
+        game.mockStorage.MockStoredData(ra::services::StorageItemType::GameData, L"1", "{\"RichPresencePatch\": null}");
+        game.mockServer.HandleRequest<ra::api::FetchGameData>([](const ra::api::FetchGameData::Request&, ra::api::FetchGameData::Response&)
+        {
+            return true;
+        });
+
+        game.LoadGame(1U);
+
+        Assert::IsFalse(game.HasRichPresence());
+        Assert::IsFalse(game.mockStorage.HasStoredData(ra::services::StorageItemType::RichPresence, L"1"));
+        Assert::IsFalse(game.IsRichPresenceFromFile());
+
+        const auto* pRichPresence = game.Assets().FindRichPresence();
+        Assert::IsNull(pRichPresence);
+    }
+
     TEST_METHOD(TestLoadGameNoRichPresence)
     {
         GameContextHarness game;

--- a/tests/mocks/MockServer.hh
+++ b/tests/mocks/MockServer.hh
@@ -34,10 +34,11 @@ public:
             std::string(TApi::Name()),
             [fHandler = std::move(fHandler)](const void* restrict pRequest, void* restrict pResponse) 
         {
-                const gsl::not_null<const typename TApi::Request* const> pTRequest{
-                    gsl::make_not_null(static_cast<const typename TApi::Request*>(pRequest))};
-                const gsl::not_null<typename TApi::Response* const> pTResponse{
-                    gsl::make_not_null(static_cast<typename TApi::Response*>(pResponse))};
+                const auto* pTRequest = static_cast<const typename TApi::Request*>(pRequest);
+                auto* pTResponse = static_cast<typename TApi::Response*>(pResponse);
+                if (!pTRequest || !pTResponse)
+                    return false;
+
                 return fHandler(*pTRequest, *pTResponse);
         });
     }


### PR DESCRIPTION
It's more efficient than reading one byte at a time. Should provide small performance improvements when the memory viewer is open and when performing searches. Still requires the emulator to provide a handler.