### PR TITLE
Ability to edit local achievements without an internet connection

### DIFF
--- a/src/Exports.cpp
+++ b/src/Exports.cpp
@@ -5,7 +5,9 @@
 #include "RA_Log.h"
 #include "RA_Resource.h"
 
+#include "api\IServer.hh"
 #include "api\Login.hh"
+#include "api\impl\OfflineServer.hh"
 
 #include "data\context\ConsoleContext.hh"
 #include "data\context\EmulatorContext.hh"
@@ -113,6 +115,8 @@ static BOOL InitCommon([[maybe_unused]] HWND hMainHWND, [[maybe_unused]] int nEm
         ra::services::ServiceLocator::GetMutable<ra::services::IConfiguration>()
             .SetFeatureEnabled(ra::services::Feature::Offline, true);
         ra::services::ServiceLocator::GetMutable<ra::data::context::UserContext>().DisableLogin();
+
+        ra::services::ServiceLocator::Provide<ra::api::IServer>(std::make_unique<ra::api::impl::OfflineServer>());
     }
     else
     {

--- a/src/Exports.cpp
+++ b/src/Exports.cpp
@@ -104,17 +104,18 @@ static BOOL InitCommon([[maybe_unused]] HWND hMainHWND, [[maybe_unused]] int nEm
     }
 #endif
 
+    // Set the client version and User-Agent string
+    ra::services::ServiceLocator::GetMutable<ra::data::context::EmulatorContext>().SetClientVersion(sClientVer);
+
     if (bOffline)
     {
+        RA_LOG_INFO("Initializing offline mode");
         ra::services::ServiceLocator::GetMutable<ra::services::IConfiguration>()
             .SetFeatureEnabled(ra::services::Feature::Offline, true);
         ra::services::ServiceLocator::GetMutable<ra::data::context::UserContext>().DisableLogin();
     }
     else
     {
-        // Set the client version and User-Agent string
-        ra::services::ServiceLocator::GetMutable<ra::data::context::EmulatorContext>().SetClientVersion(sClientVer);
-
         // validate version (async call)
         ra::services::ServiceLocator::GetMutable<ra::services::IThreadPool>().RunAsync([]
         {

--- a/src/Exports.cpp
+++ b/src/Exports.cpp
@@ -106,6 +106,8 @@ static BOOL InitCommon([[maybe_unused]] HWND hMainHWND, [[maybe_unused]] int nEm
 
     if (bOffline)
     {
+        ra::services::ServiceLocator::GetMutable<ra::services::IConfiguration>()
+            .SetFeatureEnabled(ra::services::Feature::Offline, true);
         ra::services::ServiceLocator::GetMutable<ra::data::context::UserContext>().DisableLogin();
     }
     else

--- a/src/RA_Core.cpp
+++ b/src/RA_Core.cpp
@@ -7,6 +7,7 @@
 #include "data\context\SessionTracker.hh"
 
 #include "services\AchievementRuntime.hh"
+#include "services\GameIdentifier.hh"
 #include "services\IConfiguration.hh"
 #include "services\IThreadPool.hh"
 #include "services\Initialization.hh"
@@ -104,6 +105,12 @@ API int CCONV _RA_Shutdown()
 
         // notify the background threads as soon as possible so they start to wind down
         ra::services::ServiceLocator::GetMutable<ra::services::IThreadPool>().Shutdown(false);
+
+        if (!ra::services::ServiceLocator::Get<ra::services::IConfiguration>()
+            .IsFeatureEnabled(ra::services::Feature::Offline))
+        {
+            ra::services::ServiceLocator::Get<ra::services::GameIdentifier>().SaveKnownHashes();
+        }
 
         ra::services::ServiceLocator::Get<ra::services::IConfiguration>().Save();
 

--- a/src/api/impl/OfflineServer.cpp
+++ b/src/api/impl/OfflineServer.cpp
@@ -29,6 +29,22 @@ Logout::Response OfflineServer::Logout(const Logout::Request&) noexcept
     return response;
 }
 
+AwardAchievement::Response OfflineServer::AwardAchievement(const AwardAchievement::Request&) noexcept
+{
+    AwardAchievement::Response response;
+    response.Result = ApiResult::Failed;
+    response.ErrorMessage = "Achievements are not actually unlocked in offline mode";
+    return response;
+}
+
+SubmitLeaderboardEntry::Response OfflineServer::SubmitLeaderboardEntry(const SubmitLeaderboardEntry::Request&) noexcept
+{
+    SubmitLeaderboardEntry::Response response;
+    response.Result = ApiResult::Failed;
+    response.ErrorMessage = "Leaderboard entries are not actually submitted in offline mode";
+    return response;
+}
+
 FetchGameData::Response OfflineServer::FetchGameData(const FetchGameData::Request& request)
 {
     FetchGameData::Response response;
@@ -100,7 +116,7 @@ FetchCodeNotes::Response OfflineServer::FetchCodeNotes(const FetchCodeNotes::Req
     return response;
 }
 
-LatestClient::Response OfflineServer::LatestClient(const LatestClient::Request& request)
+LatestClient::Response OfflineServer::LatestClient(const LatestClient::Request&)
 {
     // all versions are newer than 0.0.0.0, and are therefore valid/allowed
     LatestClient::Response response;

--- a/src/api/impl/OfflineServer.cpp
+++ b/src/api/impl/OfflineServer.cpp
@@ -29,7 +29,7 @@ Logout::Response OfflineServer::Logout(const Logout::Request&) noexcept
     return response;
 }
 
-AwardAchievement::Response OfflineServer::AwardAchievement(const AwardAchievement::Request&) noexcept
+AwardAchievement::Response OfflineServer::AwardAchievement(const AwardAchievement::Request&)
 {
     AwardAchievement::Response response;
     response.Result = ApiResult::Failed;
@@ -37,7 +37,7 @@ AwardAchievement::Response OfflineServer::AwardAchievement(const AwardAchievemen
     return response;
 }
 
-SubmitLeaderboardEntry::Response OfflineServer::SubmitLeaderboardEntry(const SubmitLeaderboardEntry::Request&) noexcept
+SubmitLeaderboardEntry::Response OfflineServer::SubmitLeaderboardEntry(const SubmitLeaderboardEntry::Request&)
 {
     SubmitLeaderboardEntry::Response response;
     response.Result = ApiResult::Failed;

--- a/src/api/impl/OfflineServer.cpp
+++ b/src/api/impl/OfflineServer.cpp
@@ -100,6 +100,15 @@ FetchCodeNotes::Response OfflineServer::FetchCodeNotes(const FetchCodeNotes::Req
     return response;
 }
 
+LatestClient::Response OfflineServer::LatestClient(const LatestClient::Request& request)
+{
+    // all versions are newer than 0.0.0.0, and are therefore valid/allowed
+    LatestClient::Response response;
+    response.LatestVersion = response.MinimumVersion = "0.0.0.0";
+    response.Result = ApiResult::Success;
+    return response;
+}
+
 } // namespace impl
 } // namespace api
 } // namespace ra

--- a/src/api/impl/OfflineServer.hh
+++ b/src/api/impl/OfflineServer.hh
@@ -13,6 +13,8 @@ public:
 
     Login::Response Login(const Login::Request& request) override;
     Logout::Response Logout(const Logout::Request&) noexcept override;
+    AwardAchievement::Response AwardAchievement(const AwardAchievement::Request&) noexcept override;
+    SubmitLeaderboardEntry::Response SubmitLeaderboardEntry(const SubmitLeaderboardEntry::Request&) noexcept override;
 
     FetchGameData::Response FetchGameData(const FetchGameData::Request& request) override;
     FetchCodeNotes::Response FetchCodeNotes(const FetchCodeNotes::Request& request) override;

--- a/src/api/impl/OfflineServer.hh
+++ b/src/api/impl/OfflineServer.hh
@@ -13,8 +13,8 @@ public:
 
     Login::Response Login(const Login::Request& request) override;
     Logout::Response Logout(const Logout::Request&) noexcept override;
-    AwardAchievement::Response AwardAchievement(const AwardAchievement::Request&) noexcept override;
-    SubmitLeaderboardEntry::Response SubmitLeaderboardEntry(const SubmitLeaderboardEntry::Request&) noexcept override;
+    AwardAchievement::Response AwardAchievement(const AwardAchievement::Request&) override;
+    SubmitLeaderboardEntry::Response SubmitLeaderboardEntry(const SubmitLeaderboardEntry::Request&) override;
 
     FetchGameData::Response FetchGameData(const FetchGameData::Request& request) override;
     FetchCodeNotes::Response FetchCodeNotes(const FetchCodeNotes::Request& request) override;

--- a/src/api/impl/OfflineServer.hh
+++ b/src/api/impl/OfflineServer.hh
@@ -16,6 +16,8 @@ public:
 
     FetchGameData::Response FetchGameData(const FetchGameData::Request& request) override;
     FetchCodeNotes::Response FetchCodeNotes(const FetchCodeNotes::Request& request) override;
+
+    LatestClient::Response LatestClient(const LatestClient::Request& request) override;
 };
 
 } // namespace impl

--- a/src/data/context/EmulatorContext.cpp
+++ b/src/data/context/EmulatorContext.cpp
@@ -555,10 +555,11 @@ std::wstring EmulatorContext::GetAppTitle(const std::string& sMessage) const
     }
 
     const auto& pUserContext = ra::services::ServiceLocator::Get<ra::data::context::UserContext>();
-    if (pUserContext.IsLoggedIn())
+    const auto& sDisplayName = pUserContext.GetDisplayName();
+    if (!sDisplayName.empty())
     {
         builder.Append(" - ");
-        builder.Append(pUserContext.GetDisplayName());
+        builder.Append(sDisplayName);
     }
 
     const auto& pConfiguration = ra::services::ServiceLocator::Get<ra::services::IConfiguration>();

--- a/src/data/context/EmulatorContext.cpp
+++ b/src/data/context/EmulatorContext.cpp
@@ -561,7 +561,9 @@ std::wstring EmulatorContext::GetAppTitle(const std::string& sMessage) const
         builder.Append(pUserContext.GetDisplayName());
     }
 
-    const auto& sHostName = ra::services::ServiceLocator::Get<ra::services::IConfiguration>().GetHostName();
+    const auto& pConfiguration = ra::services::ServiceLocator::Get<ra::services::IConfiguration>();
+    const auto& sHostName =
+        pConfiguration.IsFeatureEnabled(ra::services::Feature::Offline) ? "OFFLINE": pConfiguration.GetHostName();
     if (sHostName != "retroachievements.org")
     {
         builder.Append(" [");

--- a/src/data/context/GameAssets.cpp
+++ b/src/data/context/GameAssets.cpp
@@ -399,6 +399,9 @@ void GameAssets::SaveAssets(const std::vector<ra::data::models::AssetModelBase*>
             case ra::data::models::AssetType::Leaderboard:
                 pData->Write("L");
                 break;
+
+            case ra::data::models::AssetType::RichPresence:
+                continue;
         }
 
         pData->Write(std::to_string(pItem->GetID()));

--- a/src/data/context/GameAssets.cpp
+++ b/src/data/context/GameAssets.cpp
@@ -77,10 +77,20 @@ bool GameAssets::HasCoreAssets() const
 
                 default:
                     // Core, Bonus, or something else that's been published
-                    if (pAsset->GetType() == ra::data::models::AssetType::RichPresence)
-                        break;
 
-                    return true;
+                    // we really only care about published achievements and
+                    // leaderboards. if a set only has published rich presence
+                    // or code notes, don't consider it a published set.
+                    switch (pAsset->GetType())
+                    {
+                        case ra::data::models::AssetType::Achievement:
+                        case ra::data::models::AssetType::Leaderboard:
+                            return true;
+
+                        default:
+                            break;
+                    }
+                    break;
             }
         }
     }

--- a/src/data/context/GameContext.cpp
+++ b/src/data/context/GameContext.cpp
@@ -528,6 +528,12 @@ void GameContext::AwardAchievement(ra::AchievementID nAchievementId)
         bSubmit = false;
     }
 
+    if (bSubmit && pConfiguration.IsFeatureEnabled(ra::services::Feature::Offline))
+    {
+        vmPopup->SetTitle(L"Offline Achievement Unlocked");
+        bSubmit = false;
+    }
+
     int nPopupId = -1;
 
     ra::services::ServiceLocator::Get<ra::services::IAudioSystem>().PlayAudioFile(
@@ -777,6 +783,11 @@ void GameContext::SubmitLeaderboardEntry(ra::LeaderboardID nLeaderboardId, int n
         else if (pEmulatorContext.IsMemoryInsecure())
         {
             vmPopup->SetErrorDetail(L"Error: RAM insecure");
+            bSubmit = false;
+        }
+        else if (pConfiguration.IsFeatureEnabled(ra::services::Feature::Offline))
+        {
+            vmPopup->SetDetail(L"Leaderboards are not submitted in offline mode.");
             bSubmit = false;
         }
     }

--- a/src/data/context/UserContext.cpp
+++ b/src/data/context/UserContext.cpp
@@ -26,6 +26,7 @@ void UserContext::Logout()
     if (response.Succeeded())
     {
         m_sUsername.clear();
+        m_sDisplayName.clear();
         m_sApiToken.clear();
         m_nScore = 0U;
 

--- a/src/services/AchievementRuntime.cpp
+++ b/src/services/AchievementRuntime.cpp
@@ -813,10 +813,6 @@ bool AchievementRuntime::LoadProgressFromFile(const char* sLoadStateFilename)
     if (sLoadStateFilename == nullptr)
         return false;
 
-    const auto& pUserContext = ra::services::ServiceLocator::Get<ra::data::context::UserContext>();
-    if (!pUserContext.IsLoggedIn())
-        return false;
-
     std::wstring sAchievementStateFile = ra::Widen(sLoadStateFilename) + L".rap";
     const auto& pFileSystem = ra::services::ServiceLocator::Get<ra::services::IFileSystem>();
     auto pFile = pFileSystem.OpenTextFile(sAchievementStateFile);
@@ -888,10 +884,6 @@ bool AchievementRuntime::LoadProgressFromBuffer(const char* pBuffer)
     // reset the runtime state, then apply state from file
     rc_runtime_reset(&m_pRuntime);
 
-    const auto& pUserContext = ra::services::ServiceLocator::Get<ra::data::context::UserContext>();
-    if (!pUserContext.IsLoggedIn())
-        return false;
-
     const unsigned char* pBytes;
     GSL_SUPPRESS_TYPE1 pBytes = reinterpret_cast<const unsigned char*>(pBuffer);
     if (rc_runtime_deserialize_progress(&m_pRuntime, pBytes, nullptr) == RC_OK)
@@ -907,8 +899,7 @@ void AchievementRuntime::SaveProgressToFile(const char* sSaveStateFilename) cons
     if (sSaveStateFilename == nullptr)
         return;
 
-    const auto& pUserContext = ra::services::ServiceLocator::Get<ra::data::context::UserContext>();
-    if (!pUserContext.IsLoggedIn())
+    if (!m_bInitialized)
         return;
 
     std::wstring sAchievementStateFile = ra::Widen(sSaveStateFilename) + L".rap";
@@ -932,8 +923,7 @@ void AchievementRuntime::SaveProgressToFile(const char* sSaveStateFilename) cons
 
 int AchievementRuntime::SaveProgressToBuffer(char* pBuffer, int nBufferSize) const
 {
-    const auto& pUserContext = ra::services::ServiceLocator::Get<ra::data::context::UserContext>();
-    if (!pUserContext.IsLoggedIn())
+    if (!m_bInitialized)
         return 0;
 
     std::lock_guard<std::mutex> pLock(m_pMutex);

--- a/src/services/AchievementRuntime.cpp
+++ b/src/services/AchievementRuntime.cpp
@@ -37,7 +37,8 @@ void AchievementRuntime::ResetRuntime() noexcept
     }
 }
 
-void AchievementRuntime::ResetActiveAchievements() noexcept
+GSL_SUPPRESS_F6
+void AchievementRuntime::ResetActiveAchievements()
 {
     if (m_bInitialized)
     {

--- a/src/services/AchievementRuntime.cpp
+++ b/src/services/AchievementRuntime.cpp
@@ -37,6 +37,15 @@ void AchievementRuntime::ResetRuntime() noexcept
     }
 }
 
+void AchievementRuntime::ResetActiveAchievements() noexcept
+{
+    if (m_bInitialized)
+    {
+        rc_runtime_reset(&m_pRuntime);
+        RA_LOG_INFO("Runtime reset");
+    }
+}
+
 int AchievementRuntime::ActivateAchievement(ra::AchievementID nId, const std::string& sTrigger)
 {
     std::lock_guard<std::mutex> pLock(m_pMutex);

--- a/src/services/AchievementRuntime.hh
+++ b/src/services/AchievementRuntime.hh
@@ -239,11 +239,7 @@ public:
     /// <summary>
     /// Resets any active achievements and disables them until their triggers are false.
     /// </summary>
-    void ResetActiveAchievements() noexcept
-    {
-        if (m_bInitialized)
-            rc_runtime_reset(&m_pRuntime);
-    }
+    void ResetActiveAchievements() noexcept;
 
     void InvalidateAddress(ra::ByteAddress nAddress) noexcept;
 

--- a/src/services/AchievementRuntime.hh
+++ b/src/services/AchievementRuntime.hh
@@ -239,7 +239,7 @@ public:
     /// <summary>
     /// Resets any active achievements and disables them until their triggers are false.
     /// </summary>
-    void ResetActiveAchievements() noexcept;
+    void ResetActiveAchievements();
 
     void InvalidateAddress(ra::ByteAddress nAddress) noexcept;
 

--- a/src/services/GameIdentifier.cpp
+++ b/src/services/GameIdentifier.cpp
@@ -56,8 +56,8 @@ unsigned int GameIdentifier::IdentifyHash(const std::string& sHash)
 {
     if (!ra::services::ServiceLocator::Get<ra::data::context::UserContext>().IsLoggedIn())
     {
-        if (ra::services::ServiceLocator::Get<ra::services::IConfiguration>().IsFeatureEnabled(
-                ra::services::Feature::Offline))
+        if (ra::services::ServiceLocator::Get<ra::services::IConfiguration>().
+                IsFeatureEnabled(ra::services::Feature::Offline))
         {
             LoadKnownHashes(m_mKnownHashes);
 
@@ -158,8 +158,8 @@ void GameIdentifier::ActivateGame(unsigned int nGameId)
     {
         if (!ra::services::ServiceLocator::Get<ra::data::context::UserContext>().IsLoggedIn())
         {
-            if (!ra::services::ServiceLocator::Get<ra::services::IConfiguration>().IsFeatureEnabled(
-                    ra::services::Feature::Offline))
+            if (!ra::services::ServiceLocator::Get<ra::services::IConfiguration>().
+                    IsFeatureEnabled(ra::services::Feature::Offline))
             {
                 ra::ui::viewmodels::MessageBoxViewModel::ShowErrorMessage(
                     L"Cannot load achievements",

--- a/src/services/GameIdentifier.hh
+++ b/src/services/GameIdentifier.hh
@@ -36,7 +36,15 @@ public:
     /// <param name="nGameId">Unique identifier of the game to activate.</param>
     void ActivateGame(unsigned int nGameId);
 
+    /// <summary>
+    /// Flushes the known hashes to disk.
+    /// </summary>
+    void SaveKnownHashes() const;
+
 private:
+    static void LoadKnownHashes(std::map<std::string, unsigned>& mHashes);
+    static void SaveKnownHashes(std::map<std::string, unsigned>& mHashes);
+
     std::string m_sPendingHash;
     unsigned int m_nPendingGameId{};
     ra::data::context::GameContext::Mode m_nPendingMode{};

--- a/src/services/IConfiguration.hh
+++ b/src/services/IConfiguration.hh
@@ -17,6 +17,7 @@ enum class Feature
     NonHardcoreWarning,
     AchievementTriggeredScreenshot,
     MasteryNotificationScreenshot,
+    Offline,
 };
 
 

--- a/src/ui/drawing/gdi/ImageRepository.cpp
+++ b/src/ui/drawing/gdi/ImageRepository.cpp
@@ -173,8 +173,11 @@ void ImageRepository::FetchImage(ImageType nType, const std::string& sName)
         m_vRequestedImages.emplace(sFilename);
     }
 
-    // fetch it
     const auto& pConfiguration = ra::services::ServiceLocator::Get<ra::services::IConfiguration>();
+    if (pConfiguration.IsFeatureEnabled(ra::services::Feature::Offline))
+        return;
+
+    // fetch it
     std::string sUrl;
     switch (nType)
     {

--- a/src/ui/viewmodels/AssetListViewModel.cpp
+++ b/src/ui/viewmodels/AssetListViewModel.cpp
@@ -635,6 +635,9 @@ void AssetListViewModel::DoUpdateButtons()
     gsl::index nRichPresenceSelectionIndex = -1;
     bool bHasNonRichPresenceSelection = false;
 
+    const bool bOffline = ra::services::ServiceLocator::Get<ra::services::IConfiguration>().
+        IsFeatureEnabled(ra::services::Feature::Offline);
+
     const bool bGameLoaded = (GetGameId() != 0);
     if (!bGameLoaded)
     {
@@ -788,17 +791,17 @@ void AssetListViewModel::DoUpdateButtons()
     else if (bHasUnpublishedSelection)
     {
         SetValue(SaveButtonTextProperty, L"Publi&sh");
-        SetValue(CanSaveProperty, true);
+        SetValue(CanSaveProperty, !bOffline);
     }
     else if (bHasUnofficialSelection)
     {
         SetValue(SaveButtonTextProperty, L"Pro&mote");
-        SetValue(CanSaveProperty, true);
+        SetValue(CanSaveProperty, !bOffline);
     }
     else if (bHasCoreSelection)
     {
         SetValue(SaveButtonTextProperty, L"De&mote");
-        SetValue(CanSaveProperty, true);
+        SetValue(CanSaveProperty, !bOffline);
     }
     else if (bHasSelection)
     {
@@ -813,12 +816,12 @@ void AssetListViewModel::DoUpdateButtons()
     else if (bHasUnpublished)
     {
         SetValue(SaveButtonTextProperty, L"Publi&sh All");
-        SetValue(CanSaveProperty, true);
+        SetValue(CanSaveProperty, !bOffline);
     }
     else if (bHasUnofficial)
     {
         SetValue(SaveButtonTextProperty, L"Pro&mote All");
-        SetValue(CanSaveProperty, true);
+        SetValue(CanSaveProperty, !bOffline);
     }
     else
     {

--- a/src/ui/viewmodels/IntegrationMenuViewModel.cpp
+++ b/src/ui/viewmodels/IntegrationMenuViewModel.cpp
@@ -26,26 +26,48 @@ namespace viewmodels {
 
 void IntegrationMenuViewModel::BuildMenu(LookupItemViewModelCollection& vmMenu)
 {
-    if (ra::services::ServiceLocator::Get<ra::data::context::UserContext>().IsLoggedIn())
+    const auto& pUserContext = ra::services::ServiceLocator::Get<ra::data::context::UserContext>();
+    if (pUserContext.IsLoggedIn())
         BuildMenuLoggedIn(vmMenu);
-    else
+    else if (ra::services::ServiceLocator::Get<ra::services::IConfiguration>().IsFeatureEnabled(ra::services::Feature::Offline))
+        BuildMenuOffline(vmMenu);
+    else if (!pUserContext.IsLoginDisabled())
         BuildMenuLoggedOut(vmMenu);
+    else
+        BuildMenuOffline(vmMenu);
 }
 
 void IntegrationMenuViewModel::BuildMenuLoggedOut(LookupItemViewModelCollection& vmMenu)
 {
     vmMenu.Add(IDM_RA_FILES_LOGIN, L"&Login");
+    vmMenu.Add(0, L"-----");
+    AddCommonMenuItems(vmMenu);
 }
 
 void IntegrationMenuViewModel::BuildMenuLoggedIn(LookupItemViewModelCollection& vmMenu)
 {
-    const auto& pConfiguration = ra::services::ServiceLocator::Get<ra::services::IConfiguration>();
-
     vmMenu.Add(IDM_RA_FILES_LOGOUT, L"Log&out");
     vmMenu.Add(0, L"-----");
     vmMenu.Add(IDM_RA_OPENUSERPAGE, L"Open my &User Page");
     vmMenu.Add(IDM_RA_OPENGAMEPAGE, L"Open this &Game's Page");
     vmMenu.Add(0, L"-----");
+    AddCommonMenuItems(vmMenu);
+    vmMenu.Add(0, L"-----");
+    vmMenu.Add(IDM_RA_REPORTBROKENACHIEVEMENTS, L"&Report Achievement Problem");
+    vmMenu.Add(IDM_RA_GETROMCHECKSUM, L"View Game H&ash");
+}
+
+void IntegrationMenuViewModel::BuildMenuOffline(LookupItemViewModelCollection& vmMenu)
+{
+    AddCommonMenuItems(vmMenu);
+    vmMenu.Add(0, L"-----");
+    vmMenu.Add(IDM_RA_GETROMCHECKSUM, L"View Game H&ash");
+}
+
+void IntegrationMenuViewModel::AddCommonMenuItems(LookupItemViewModelCollection& vmMenu)
+{
+    const auto& pConfiguration = ra::services::ServiceLocator::Get<ra::services::IConfiguration>();
+
     vmMenu.Add(IDM_RA_HARDCORE_MODE, L"&Hardcore Mode").SetSelected(pConfiguration.IsFeatureEnabled(ra::services::Feature::Hardcore));
     vmMenu.Add(IDM_RA_NON_HARDCORE_WARNING, L"Non-Hardcore &Warning").SetSelected(pConfiguration.IsFeatureEnabled(ra::services::Feature::NonHardcoreWarning));
     vmMenu.Add(0, L"-----");
@@ -57,9 +79,6 @@ void IntegrationMenuViewModel::BuildMenuLoggedIn(LookupItemViewModelCollection& 
     vmMenu.Add(IDM_RA_FILES_MEMORYFINDER, L"&Memory Inspector");
     vmMenu.Add(IDM_RA_FILES_MEMORYBOOKMARKS, L"Memory &Bookmarks");
     vmMenu.Add(IDM_RA_PARSERICHPRESENCE, L"Rich &Presence Monitor");
-    vmMenu.Add(0, L"-----");
-    vmMenu.Add(IDM_RA_REPORTBROKENACHIEVEMENTS, L"&Report Achievement Problem");
-    vmMenu.Add(IDM_RA_GETROMCHECKSUM, L"View Game H&ash");
 }
 
 void IntegrationMenuViewModel::ActivateMenuItem(int nMenuItemId)

--- a/src/ui/viewmodels/IntegrationMenuViewModel.hh
+++ b/src/ui/viewmodels/IntegrationMenuViewModel.hh
@@ -18,6 +18,8 @@ public:
 private:
     static void BuildMenuLoggedIn(LookupItemViewModelCollection& vmMenu);
     static void BuildMenuLoggedOut(LookupItemViewModelCollection& vmMenu);
+    static void BuildMenuOffline(LookupItemViewModelCollection& vmMenu);
+    static void AddCommonMenuItems(LookupItemViewModelCollection& vmMenu);
 
     static void Login();
     static void Logout();

--- a/src/ui/viewmodels/MemoryInspectorViewModel.cpp
+++ b/src/ui/viewmodels/MemoryInspectorViewModel.cpp
@@ -6,6 +6,7 @@
 #include "data\context\GameContext.hh"
 
 #include "services\IAudioSystem.hh"
+#include "services\IConfiguration.hh"
 #include "services\ServiceLocator.hh"
 
 #include "ui\viewmodels\MessageBoxViewModel.hh"
@@ -339,15 +340,16 @@ void MemoryInspectorViewModel::OnActiveGameChanged()
         SetWindowTitle(L"Memory Inspector [no game loaded]");
         SetValue(CanModifyNotesProperty, false);
     }
-    else if (pGameContext.GetMode() == ra::data::context::GameContext::Mode::CompatibilityTest)
-    {
-        SetWindowTitle(L"Memory Inspector [compatibility mode]");
-        SetValue(CanModifyNotesProperty, true);
-    }
     else
     {
-        SetWindowTitle(L"Memory Inspector");
-        SetValue(CanModifyNotesProperty, true);
+        if (pGameContext.GetMode() == ra::data::context::GameContext::Mode::CompatibilityTest)
+            SetWindowTitle(L"Memory Inspector [compatibility mode]");
+        else
+            SetWindowTitle(L"Memory Inspector");
+
+        const bool bOffline = ra::services::ServiceLocator::Get<ra::services::IConfiguration>().
+            IsFeatureEnabled(ra::services::Feature::Offline);
+        SetValue(CanModifyNotesProperty, !bOffline);
     }
 
     SetValue(IsCurrentAddressNoteEditableProperty, CanModifyNotes());

--- a/src/ui/win32/bindings/GridBinding.hh
+++ b/src/ui/win32/bindings/GridBinding.hh
@@ -74,6 +74,7 @@ public:
     virtual void EnsureVisible(gsl::index nIndex) noexcept(false);
 
 protected:
+    void SuspendRedraw() noexcept;
     void UpdateLayout();
     virtual void UpdateAllItems();
     virtual void UpdateItems(gsl::index nColumn);
@@ -109,7 +110,6 @@ protected:
 private:
     void UpdateRow(gsl::index nIndex, bool bExisting);
     void UpdateSelectedItemStates();
-    void SuspendRedraw() noexcept;
 
     bool m_bShowGridLines = false;
     bool m_bHasScrollbar = false;

--- a/src/ui/win32/bindings/ImageBinding.hh
+++ b/src/ui/win32/bindings/ImageBinding.hh
@@ -66,12 +66,12 @@ private:
     {
         if (m_hWnd)
         {
+            // load the image or placeholder
+            UpdateImage();
+
+            // if it's the placeholder, request the actual image
             auto& pImageRepository = ra::services::ServiceLocator::GetMutable<ra::ui::IImageRepository>();
-            if (pImageRepository.IsImageAvailable(m_pImageReference.Type(), m_pImageReference.Name()))
-            {
-                UpdateImage();
-            }
-            else
+            if (!pImageRepository.IsImageAvailable(m_pImageReference.Type(), m_pImageReference.Name()))
             {
                 pImageRepository.AddNotifyTarget(*this);
                 pImageRepository.FetchImage(m_pImageReference.Type(), m_pImageReference.Name());

--- a/src/ui/win32/bindings/MultiLineGridBinding.cpp
+++ b/src/ui/win32/bindings/MultiLineGridBinding.cpp
@@ -58,6 +58,8 @@ void MultiLineGridBinding::OnViewModelAdded(gsl::index nIndex)
 
     if (!m_vmItems->IsUpdating())
         OnEndViewModelCollectionUpdate();
+    else
+        SuspendRedraw();
 }
 
 void MultiLineGridBinding::OnViewModelRemoved(gsl::index nIndex)
@@ -66,6 +68,8 @@ void MultiLineGridBinding::OnViewModelRemoved(gsl::index nIndex)
 
     if (!m_vmItems->IsUpdating())
         OnEndViewModelCollectionUpdate();
+    else
+        SuspendRedraw();
 }
 
 void MultiLineGridBinding::OnViewModelStringValueChanged(gsl::index nIndex, const StringModelProperty::ChangeArgs& args)

--- a/tests/Exports_Tests.cpp
+++ b/tests/Exports_Tests.cpp
@@ -971,8 +971,20 @@ private:
         ra::data::context::mocks::MockUserContext mockUserContext;
 
         RA_MenuItem menu[32];
-        Assert::AreEqual(1, _RA_GetPopupMenuItems(menu));
+        Assert::AreEqual(13, _RA_GetPopupMenuItems(menu));
         AssertMenuItem(&menu[0], IDM_RA_FILES_LOGIN, L"&Login");
+        AssertMenuItem(&menu[1], 0, nullptr);
+        AssertMenuItem(&menu[2], IDM_RA_HARDCORE_MODE, L"&Hardcore Mode");
+        AssertMenuItem(&menu[3], IDM_RA_NON_HARDCORE_WARNING, L"Non-Hardcore &Warning");
+        AssertMenuItem(&menu[4], 0, nullptr);
+        AssertMenuItem(&menu[5], IDM_RA_TOGGLELEADERBOARDS, L"Enable &Leaderboards");
+        AssertMenuItem(&menu[6], IDM_RA_OVERLAYSETTINGS, L"O&verlay Settings");
+        AssertMenuItem(&menu[7], 0, nullptr);
+        AssertMenuItem(&menu[8], IDM_RA_FILES_ACHIEVEMENTS, L"Assets Li&st");
+        AssertMenuItem(&menu[9], IDM_RA_FILES_ACHIEVEMENTEDITOR, L"Assets &Editor");
+        AssertMenuItem(&menu[10], IDM_RA_FILES_MEMORYFINDER, L"&Memory Inspector");
+        AssertMenuItem(&menu[11], IDM_RA_FILES_MEMORYBOOKMARKS, L"Memory &Bookmarks");
+        AssertMenuItem(&menu[12], IDM_RA_PARSERICHPRESENCE, L"Rich &Presence Monitor");
     }
 
     TEST_METHOD(TestGetPopupMenuItemsLoggedIn)

--- a/tests/data/context/GameContext_Tests.cpp
+++ b/tests/data/context/GameContext_Tests.cpp
@@ -1765,6 +1765,31 @@ public:
         game.mockThreadPool.ExecuteNextTask();
     }
 
+    TEST_METHOD(TestAwardAchievementOffline)
+    {
+        GameContextHarness game;
+        game.mockConfiguration.SetPopupLocation(ra::ui::viewmodels::Popup::AchievementTriggered, ra::ui::viewmodels::PopupLocation::BottomLeft);
+        game.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, true);
+        game.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Offline, true);
+        game.mockServer.ExpectUncalled<ra::api::AwardAchievement>();
+
+        game.MockAchievement();
+        game.AwardAchievement(1U);
+
+        Assert::IsTrue(game.mockAudioSystem.WasAudioFilePlayed(L"Overlay\\unlock.wav"));
+        const auto* pPopup = game.mockOverlayManager.GetMessage(1);
+        Expects(pPopup != nullptr);
+        Assert::IsNotNull(pPopup);
+        Assert::AreEqual(std::wstring(L"Offline Achievement Unlocked"), pPopup->GetTitle());
+        Assert::AreEqual(std::wstring(L"AchievementTitle (5)"), pPopup->GetDescription());
+        Assert::AreEqual(std::wstring(L"AchievementDescription"), pPopup->GetDetail());
+        Assert::IsFalse(pPopup->IsDetailError());
+        Assert::AreEqual(std::string("12345"), pPopup->GetImage().Name());
+
+        // AwardAchievement API call is async, try to execute it - expect no tasks queued
+        game.mockThreadPool.ExecuteNextTask();
+    }
+
     TEST_METHOD(TestAwardAchievementDuplicate)
     {
         GameContextHarness game;
@@ -2653,6 +2678,50 @@ public:
         Assert::AreEqual(std::wstring(L"LeaderboardTitle"), pPopup->GetDescription());
         Assert::AreEqual(std::wstring(L"Error: RAM insecure"), pPopup->GetDetail());
         Assert::IsTrue(pPopup->IsDetailError());
+
+        // empty leaderboard should be displayed with the non-submitted score
+        const auto* vmScoreboard = game.mockOverlayManager.GetScoreboard(1U);
+        Assert::IsNotNull(vmScoreboard);
+        Ensures(vmScoreboard != nullptr);
+        Assert::AreEqual(std::wstring(L"LeaderboardTitle"), vmScoreboard->GetHeaderText());
+        Assert::AreEqual({ 1U }, vmScoreboard->Entries().Count());
+
+        const auto* vmEntry = vmScoreboard->Entries().GetItemAt(0);
+        Assert::IsNotNull(vmEntry);
+        Ensures(vmEntry != nullptr);
+        Assert::AreEqual(0, vmEntry->GetRank());
+        Assert::AreEqual(std::wstring(L"Player"), vmEntry->GetUserName());
+        Assert::AreEqual(std::wstring(L"1234"), vmEntry->GetScore());
+        Assert::IsTrue(vmEntry->IsHighlighted());
+    }
+
+    TEST_METHOD(TestSubmitLeaderboardEntryOffline)
+    {
+        GameContextHarness game;
+        game.mockConfiguration.SetPopupLocation(ra::ui::viewmodels::Popup::LeaderboardScoreboard, ra::ui::viewmodels::PopupLocation::BottomRight);
+        game.mockUser.Initialize("player", "Player", "");
+        game.SetGameHash("hash");
+        game.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, true);
+        game.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Offline, true);
+
+        game.mockServer.ExpectUncalled<ra::api::SubmitLeaderboardEntry>();
+
+        game.MockLeaderboard();
+        game.SubmitLeaderboardEntry(1U, 1234U);
+
+        // SubmitLeaderboardEntry API call is async, try to execute it - expect no tasks queued
+        game.mockThreadPool.ExecuteNextTask();
+
+        Assert::IsTrue(game.mockAudioSystem.WasAudioFilePlayed(L"Overlay\\info.wav"));
+
+        // error message should be reported
+        const auto* pPopup = game.mockOverlayManager.GetMessage(1);
+        Expects(pPopup != nullptr);
+        Assert::IsNotNull(pPopup);
+        Assert::AreEqual(std::wstring(L"Leaderboard NOT Submitted"), pPopup->GetTitle());
+        Assert::AreEqual(std::wstring(L"LeaderboardTitle"), pPopup->GetDescription());
+        Assert::AreEqual(std::wstring(L"Leaderboards are not submitted in offline mode."), pPopup->GetDetail());
+        Assert::IsFalse(pPopup->IsDetailError());
 
         // empty leaderboard should be displayed with the non-submitted score
         const auto* vmScoreboard = game.mockOverlayManager.GetScoreboard(1U);

--- a/tests/mocks/MockUserContext.hh
+++ b/tests/mocks/MockUserContext.hh
@@ -33,6 +33,7 @@ public:
     void Logout() noexcept override
     {
         m_sUsername.clear();
+        m_sDisplayName.clear();
         m_sApiToken.clear();
         m_nScore = 0U;
     }

--- a/tests/services/GameIdentifier_Tests.cpp
+++ b/tests/services/GameIdentifier_Tests.cpp
@@ -670,7 +670,7 @@ public:
         identifier.SaveKnownHashes();
 
         Assert::IsTrue(identifier.mockLocalStorage.HasStoredData(ra::services::StorageItemType::HashMapping, KNOWN_HASHES_KEY));
-        Assert::AreEqual(ra::StringPrintf("%s=%u|%s\n", ROM_HASH, 32U, "NW"),
+        Assert::AreEqual(ra::StringPrintf("%s=%u\n", ROM_HASH, 32U),
             identifier.mockLocalStorage.GetStoredData(ra::services::StorageItemType::HashMapping, KNOWN_HASHES_KEY));
     }
 
@@ -678,7 +678,7 @@ public:
     {
         GameIdentifierHarness identifier;
         identifier.mockUserContext.Initialize("User", "ApiToken");
-        const auto sFileContents = ra::StringPrintf("%s=%u|%s\ninvalid=0|X\n", ROM_HASH, 32U, "NW");
+        const auto sFileContents = ra::StringPrintf("%s=%u\ninvalid=0\n", ROM_HASH, 32U);
         identifier.mockLocalStorage.MockStoredData(ra::services::StorageItemType::HashMapping, KNOWN_HASHES_KEY, sFileContents);
                             
         identifier.mockServer.HandleRequest<ra::api::ResolveHash>(
@@ -701,7 +701,7 @@ public:
     {
         GameIdentifierHarness identifier;
         identifier.mockUserContext.Initialize("User", "ApiToken");
-        const auto sFileContents = ra::StringPrintf("%s=%u|%s\ninvalid=0|X\n", ROM_HASH, 32U, "NW");
+        const auto sFileContents = ra::StringPrintf("%s=%u\ninvalid=0\n", ROM_HASH, 32U);
         identifier.mockLocalStorage.MockStoredData(
             ra::services::StorageItemType::HashMapping, KNOWN_HASHES_KEY, sFileContents);
 
@@ -718,7 +718,7 @@ public:
 
         // invalid entry will be discarded
         Assert::AreEqual(
-            ra::StringPrintf("%s=%u|%s\n", ROM_HASH, 35U, "YS"),
+            ra::StringPrintf("%s=%u\n", ROM_HASH, 35U),
             identifier.mockLocalStorage.GetStoredData(ra::services::StorageItemType::HashMapping, KNOWN_HASHES_KEY));
     }
 
@@ -727,7 +727,7 @@ public:
         GameIdentifierHarness identifier;
         const std::string sAlternateHash = "abcdef01234567899876543210fedcba";
         identifier.mockUserContext.Initialize("User", "ApiToken");
-        const auto sFileContents = ra::StringPrintf("%s=%u|%s\ninvalid=0|X\n", sAlternateHash, 32U, "IF");
+        const auto sFileContents = ra::StringPrintf("%s=%u\ninvalid=0\n", sAlternateHash, 32U);
         identifier.mockLocalStorage.MockStoredData(
             ra::services::StorageItemType::HashMapping, KNOWN_HASHES_KEY, sFileContents);
 
@@ -744,7 +744,7 @@ public:
 
         // invalid entry will be discarded
         Assert::AreEqual(
-            ra::StringPrintf("%s=%u|%s\n%s=%u|%s\n", ROM_HASH, 35U, "YS", sAlternateHash, 32U, "IF"),
+            ra::StringPrintf("%s=%u\n%s=%u\n", ROM_HASH, 35U, sAlternateHash, 32U),
             identifier.mockLocalStorage.GetStoredData(ra::services::StorageItemType::HashMapping, KNOWN_HASHES_KEY));
     }
 
@@ -774,7 +774,7 @@ public:
         identifier.mockUserContext.Logout();
         identifier.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Offline, true);
 
-        const auto sFileContents = ra::StringPrintf("%s=%u|%s\n", ROM_HASH, 32U, "NW");
+        const auto sFileContents = ra::StringPrintf("%s=%u\n", ROM_HASH, 32U);
         identifier.mockLocalStorage.MockStoredData(ra::services::StorageItemType::HashMapping, KNOWN_HASHES_KEY, sFileContents);
 
         Assert::AreEqual(32U, identifier.IdentifyGame(&ROM.at(0), ROM.size()));
@@ -787,7 +787,7 @@ public:
         identifier.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, true);
         identifier.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Offline, true);
 
-        const auto sFileContents = ra::StringPrintf("%s=%u|%s\n", ROM_HASH, 32U, "NW");
+        const auto sFileContents = ra::StringPrintf("%s=%u\n", ROM_HASH, 32U);
         identifier.mockLocalStorage.MockStoredData(
             ra::services::StorageItemType::HashMapping, KNOWN_HASHES_KEY, sFileContents);
 

--- a/tests/services/GameIdentifier_Tests.cpp
+++ b/tests/services/GameIdentifier_Tests.cpp
@@ -29,6 +29,7 @@ namespace tests {
 static std::array<BYTE, 16> ROM = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
 static std::array<BYTE, 16> ROM2 = { 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
 static std::string ROM_HASH = "190c4c105786a2121d85018939108a6c";
+static std::wstring KNOWN_HASHES_KEY = L"Hashes";
 
 class GameIdentifierHarness : public GameIdentifier
 {
@@ -80,11 +81,11 @@ public:
     ra::ui::mocks::MockDesktop mockDesktop;
     ra::ui::viewmodels::mocks::MockOverlayManager mockOverlayManager;
     ra::ui::viewmodels::mocks::MockWindowManager mockWindowManager;
+    ra::services::mocks::MockLocalStorage mockLocalStorage;
 
 private:
     ra::services::mocks::MockAudioSystem mockAudioSystem;
     ra::services::mocks::MockClock mockClock;
-    ra::services::mocks::MockLocalStorage mockLocalStorage;
     ra::services::mocks::MockThreadPool mockThreadPool;
 };
 
@@ -643,6 +644,164 @@ public:
         // it should still be reloaded.
         Assert::IsTrue(identifier.mockGameContext.WasLoaded());
     }
+
+    TEST_METHOD(TestSaveKnownHashesNone)
+    {
+        GameIdentifierHarness identifier;
+        identifier.SaveKnownHashes();
+
+        Assert::IsFalse(identifier.mockLocalStorage.HasStoredData(ra::services::StorageItemType::HashMapping, KNOWN_HASHES_KEY));
+    }
+
+    TEST_METHOD(TestSaveKnownHashesNew)
+    {
+        GameIdentifierHarness identifier;
+        identifier.mockUserContext.Initialize("User", "ApiToken");
+
+        identifier.mockServer.HandleRequest<ra::api::ResolveHash>(
+            [](const ra::api::ResolveHash::Request&, ra::api::ResolveHash::Response& response)
+        {
+            response.Result = ra::api::ApiResult::Success;
+            response.GameId = 32U;
+            return true;
+        });
+        Assert::AreEqual(32U, identifier.IdentifyHash(ROM_HASH));
+
+        identifier.SaveKnownHashes();
+
+        Assert::IsTrue(identifier.mockLocalStorage.HasStoredData(ra::services::StorageItemType::HashMapping, KNOWN_HASHES_KEY));
+        Assert::AreEqual(ra::StringPrintf("%s=%u|%s\n", ROM_HASH, 32U, "NW"),
+            identifier.mockLocalStorage.GetStoredData(ra::services::StorageItemType::HashMapping, KNOWN_HASHES_KEY));
+    }
+
+    TEST_METHOD(TestSaveKnownHashesUnchanged)
+    {
+        GameIdentifierHarness identifier;
+        identifier.mockUserContext.Initialize("User", "ApiToken");
+        const auto sFileContents = ra::StringPrintf("%s=%u|%s\ninvalid=0|X\n", ROM_HASH, 32U, "NW");
+        identifier.mockLocalStorage.MockStoredData(ra::services::StorageItemType::HashMapping, KNOWN_HASHES_KEY, sFileContents);
+                            
+        identifier.mockServer.HandleRequest<ra::api::ResolveHash>(
+            [](const ra::api::ResolveHash::Request&, ra::api::ResolveHash::Response& response)
+        {
+            response.Result = ra::api::ApiResult::Success;
+            response.GameId = 32U;
+            return true;
+        });
+        Assert::AreEqual(32U, identifier.IdentifyHash(ROM_HASH));
+
+        identifier.SaveKnownHashes();
+
+        // invalid entry would be removed if the file were updated
+        Assert::AreEqual(sFileContents,
+            identifier.mockLocalStorage.GetStoredData(ra::services::StorageItemType::HashMapping, KNOWN_HASHES_KEY));
+    }
+
+    TEST_METHOD(TestSaveKnownHashesIDChanged)
+    {
+        GameIdentifierHarness identifier;
+        identifier.mockUserContext.Initialize("User", "ApiToken");
+        const auto sFileContents = ra::StringPrintf("%s=%u|%s\ninvalid=0|X\n", ROM_HASH, 32U, "NW");
+        identifier.mockLocalStorage.MockStoredData(
+            ra::services::StorageItemType::HashMapping, KNOWN_HASHES_KEY, sFileContents);
+
+        identifier.mockServer.HandleRequest<ra::api::ResolveHash>(
+            [](const ra::api::ResolveHash::Request&, ra::api::ResolveHash::Response& response)
+        {
+            response.Result = ra::api::ApiResult::Success;
+            response.GameId = 35U;
+            return true;
+        });
+        Assert::AreEqual(35U, identifier.IdentifyHash(ROM_HASH));
+
+        identifier.SaveKnownHashes();
+
+        // invalid entry will be discarded
+        Assert::AreEqual(
+            ra::StringPrintf("%s=%u|%s\n", ROM_HASH, 35U, "YS"),
+            identifier.mockLocalStorage.GetStoredData(ra::services::StorageItemType::HashMapping, KNOWN_HASHES_KEY));
+    }
+
+    TEST_METHOD(TestSaveKnownHashesAdded)
+    {
+        GameIdentifierHarness identifier;
+        const std::string sAlternateHash = "abcdef01234567899876543210fedcba";
+        identifier.mockUserContext.Initialize("User", "ApiToken");
+        const auto sFileContents = ra::StringPrintf("%s=%u|%s\ninvalid=0|X\n", sAlternateHash, 32U, "IF");
+        identifier.mockLocalStorage.MockStoredData(
+            ra::services::StorageItemType::HashMapping, KNOWN_HASHES_KEY, sFileContents);
+
+        identifier.mockServer.HandleRequest<ra::api::ResolveHash>(
+            [](const ra::api::ResolveHash::Request&, ra::api::ResolveHash::Response& response)
+        {
+            response.Result = ra::api::ApiResult::Success;
+            response.GameId = 35U;
+            return true;
+        });
+        Assert::AreEqual(35U, identifier.IdentifyHash(ROM_HASH));
+
+        identifier.SaveKnownHashes();
+
+        // invalid entry will be discarded
+        Assert::AreEqual(
+            ra::StringPrintf("%s=%u|%s\n%s=%u|%s\n", ROM_HASH, 35U, "YS", sAlternateHash, 32U, "IF"),
+            identifier.mockLocalStorage.GetStoredData(ra::services::StorageItemType::HashMapping, KNOWN_HASHES_KEY));
+    }
+
+    TEST_METHOD(TestIdentifyGameOfflineUnknown)
+    {
+        GameIdentifierHarness identifier;
+        identifier.mockUserContext.Logout();
+        identifier.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Offline, true);
+
+        bool bDialogShown = false;
+        identifier.mockDesktop.ExpectWindow<ra::ui::viewmodels::MessageBoxViewModel>(
+            [&bDialogShown](ra::ui::viewmodels::MessageBoxViewModel& vmMessageBox)
+        {
+            Assert::AreEqual(std::wstring(L"Cannot load achievements"), vmMessageBox.GetHeader());
+            Assert::AreEqual(std::wstring(L"This game was not previously identified and requires a connection to identify it."),
+                vmMessageBox.GetMessage());
+            bDialogShown = true;
+            return ra::ui::DialogResult::OK;
+        });
+
+        Assert::AreEqual(0U, identifier.IdentifyGame(&ROM.at(0), ROM.size()));
+    }
+
+    TEST_METHOD(TestIdentifyGameOffline)
+    {
+        GameIdentifierHarness identifier;
+        identifier.mockUserContext.Logout();
+        identifier.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Offline, true);
+
+        const auto sFileContents = ra::StringPrintf("%s=%u|%s\n", ROM_HASH, 32U, "NW");
+        identifier.mockLocalStorage.MockStoredData(ra::services::StorageItemType::HashMapping, KNOWN_HASHES_KEY, sFileContents);
+
+        Assert::AreEqual(32U, identifier.IdentifyGame(&ROM.at(0), ROM.size()));
+        Assert::IsFalse(identifier.mockDesktop.WasDialogShown());
+    }
+
+    TEST_METHOD(TestActivateGamePendingOffline)
+    {
+        GameIdentifierHarness identifier;
+        identifier.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, true);
+        identifier.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Offline, true);
+
+        const auto sFileContents = ra::StringPrintf("%s=%u|%s\n", ROM_HASH, 32U, "NW");
+        identifier.mockLocalStorage.MockStoredData(
+            ra::services::StorageItemType::HashMapping, KNOWN_HASHES_KEY, sFileContents);
+
+        Assert::AreEqual(32U, identifier.IdentifyGame(&ROM.at(0), ROM.size()));
+        identifier.ActivateGame(32U);
+
+        Assert::AreEqual(32U, identifier.mockGameContext.GameId());
+        Assert::AreEqual(ROM_HASH, identifier.mockGameContext.GameHash());
+        Assert::AreEqual(ra::data::context::GameContext::Mode::Normal, identifier.mockGameContext.GetMode());
+        Assert::AreEqual(32U, identifier.mockSessionTracker.CurrentSessionGameId());
+        Assert::IsNull(identifier.mockOverlayManager.GetMessage(1U));
+        Assert::IsTrue(identifier.mockGameContext.WasLoaded());
+    }
+
 };
 
 } // namespace tests

--- a/tests/ui/viewmodels/IntegrationMenuViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/IntegrationMenuViewModel_Tests.cpp
@@ -128,8 +128,20 @@ public:
 
         menu.BuildMenu();
 
-        menu.AssertMenuSize(1);
+        menu.AssertMenuSize(13);
         menu.AssertMenuItem(0, IDM_RA_FILES_LOGIN, L"&Login");
+        menu.AssertMenuSeparator(1);
+        menu.AssertMenuItem(2, IDM_RA_HARDCORE_MODE, L"&Hardcore Mode");
+        menu.AssertMenuItem(3, IDM_RA_NON_HARDCORE_WARNING, L"Non-Hardcore &Warning");
+        menu.AssertMenuSeparator(4);
+        menu.AssertMenuItem(5, IDM_RA_TOGGLELEADERBOARDS, L"Enable &Leaderboards");
+        menu.AssertMenuItem(6, IDM_RA_OVERLAYSETTINGS, L"O&verlay Settings");
+        menu.AssertMenuSeparator(7);
+        menu.AssertMenuItem(8, IDM_RA_FILES_ACHIEVEMENTS, L"Assets Li&st");
+        menu.AssertMenuItem(9, IDM_RA_FILES_ACHIEVEMENTEDITOR, L"Assets &Editor");
+        menu.AssertMenuItem(10, IDM_RA_FILES_MEMORYFINDER, L"&Memory Inspector");
+        menu.AssertMenuItem(11, IDM_RA_FILES_MEMORYBOOKMARKS, L"Memory &Bookmarks");
+        menu.AssertMenuItem(12, IDM_RA_PARSERICHPRESENCE, L"Rich &Presence Monitor");
     }
 
     TEST_METHOD(TestBuildMenuLoggedIn)
@@ -159,6 +171,29 @@ public:
         menu.AssertMenuSeparator(16);
         menu.AssertMenuItem(17, IDM_RA_REPORTBROKENACHIEVEMENTS, L"&Report Achievement Problem");
         menu.AssertMenuItem(18, IDM_RA_GETROMCHECKSUM, L"View Game H&ash");
+    }
+
+    TEST_METHOD(TestBuildMenuOffline)
+    {
+        IntegrationMenuViewModelHarness menu;
+        menu.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Offline, true);
+
+        menu.BuildMenu();
+
+        menu.AssertMenuSize(13);
+        menu.AssertMenuItem(0, IDM_RA_HARDCORE_MODE, L"&Hardcore Mode");
+        menu.AssertMenuItem(1, IDM_RA_NON_HARDCORE_WARNING, L"Non-Hardcore &Warning");
+        menu.AssertMenuSeparator(2);
+        menu.AssertMenuItem(3, IDM_RA_TOGGLELEADERBOARDS, L"Enable &Leaderboards");
+        menu.AssertMenuItem(4, IDM_RA_OVERLAYSETTINGS, L"O&verlay Settings");
+        menu.AssertMenuSeparator(5);
+        menu.AssertMenuItem(6, IDM_RA_FILES_ACHIEVEMENTS, L"Assets Li&st");
+        menu.AssertMenuItem(7, IDM_RA_FILES_ACHIEVEMENTEDITOR, L"Assets &Editor");
+        menu.AssertMenuItem(8, IDM_RA_FILES_MEMORYFINDER, L"&Memory Inspector");
+        menu.AssertMenuItem(9, IDM_RA_FILES_MEMORYBOOKMARKS, L"Memory &Bookmarks");
+        menu.AssertMenuItem(10, IDM_RA_PARSERICHPRESENCE, L"Rich &Presence Monitor");
+        menu.AssertMenuSeparator(11);
+        menu.AssertMenuItem(12, IDM_RA_GETROMCHECKSUM, L"View Game H&ash");
     }
 
     TEST_METHOD(TestLoginHardcoreValidClient)

--- a/tests/ui/viewmodels/MemoryInspectorViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/MemoryInspectorViewModel_Tests.cpp
@@ -477,6 +477,30 @@ public:
         Assert::IsTrue(inspector.CanModifyCodeNotes());
     }
 
+    TEST_METHOD(TestActiveGameChangedOffline)
+    {
+        MemoryInspectorViewModelHarness inspector;
+        inspector.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Offline, true);
+        Assert::AreEqual(std::wstring(L"Memory Inspector [no game loaded]"), inspector.GetWindowTitle());
+        Assert::IsFalse(inspector.CanModifyCodeNotes());
+
+        inspector.mockGameContext.SetGameId({3});
+        inspector.mockGameContext.NotifyActiveGameChanged();
+        Assert::AreEqual(std::wstring(L"Memory Inspector"), inspector.GetWindowTitle());
+        Assert::IsFalse(inspector.CanModifyCodeNotes());
+
+        inspector.mockGameContext.SetGameId({0});
+        inspector.mockGameContext.NotifyActiveGameChanged();
+        Assert::AreEqual(std::wstring(L"Memory Inspector [no game loaded]"), inspector.GetWindowTitle());
+        Assert::IsFalse(inspector.CanModifyCodeNotes());
+
+        inspector.mockGameContext.SetGameId({5});
+        inspector.mockGameContext.SetMode(ra::data::context::GameContext::Mode::CompatibilityTest);
+        inspector.mockGameContext.NotifyActiveGameChanged();
+        Assert::AreEqual(std::wstring(L"Memory Inspector [compatibility mode]"), inspector.GetWindowTitle());
+        Assert::IsFalse(inspector.CanModifyCodeNotes());
+    }
+
     TEST_METHOD(TestActiveGameChangedClearsSearchResults)
     {
         MemoryInspectorViewModelHarness inspector;


### PR DESCRIPTION
Initial support for #770. Pretty much everything is functional, except code notes are read only.

If you open an emulator without an internet connection, you'll get an error indicating that you're being dropped into "offline mode". 
![image](https://user-images.githubusercontent.com/32680403/184559801-51ba812d-98f0-4cda-b772-22944d78c5cd.png)

The title bar indicates the user is "[OFFLINE]" and the menu is simplified:
![image](https://user-images.githubusercontent.com/32680403/184559764-af0938b1-c3e2-46ac-b354-f03e7121ed6c.png)

When a game is loaded while _online_, assets are downloaded and stored in the RACache directory. When a game is loaded while _offline_, only those assets are available to be used. As such, the user must still first load their game in online mode before entering offline mode. Attempting to load a game not already in the cache results in an error indicating a connection is required.

Because there's no online connection, all Core achievements will automatically be activated as if the player had not earned them. Unlocking the achievements shows a modified popup indicating the achievements are Offline achievements. **These will not be synced to the server at a later time. Offline unlocks are local only!**

![image](https://user-images.githubusercontent.com/32680403/184559956-aee80aa5-e136-45f8-bbfd-6b88c2ceb920.png)

Achievement progress is still maintained in the overlay, though the player's score is not updated. Also, any achievements that the player had previously unlocked such that the locked image is not in the cache will appear without an icon. The unlocked icon will be available in the cache and will show up in the unlock popups.

![image](https://user-images.githubusercontent.com/32680403/184560006-9c92158d-261c-4873-8956-93727c5eaa78.png)

Leaderboards are also supported in a similar manner. 

![image](https://user-images.githubusercontent.com/32680403/184560018-0aeb4f3e-9404-464e-90a3-c3fd269ee7e5.png)

All of the developer tools work the same. Memory can be searched, bookmarked, edited, and frozen. Local modifications to achievements and leaderboards can be saved to be published later. The rich presence file can be externally modified and picked up by the emulator. Existing notes will be present and are searchable. I'm pretty sure that the only thing that doesn't work in offline mode is editing code notes as those are written directly to the server. Supporting that is a much larger project and may or may not happen before this feature is released.



