### PR TITLE
automatically change asset category filter when loading game

### DIFF
--- a/src/data/context/GameAssets.hh
+++ b/src/data/context/GameAssets.hh
@@ -111,7 +111,16 @@ public:
     /// <summary>
     /// Determines if any Core assets exist.
     /// </summary>
-    bool HasCoreAssets() const;
+    bool HasCoreAssets() const
+    {
+        return (MostPublishedAssetCategory() == ra::data::models::AssetCategory::Core);
+    }
+
+    /// <summary>
+    /// Determines the most published asset category.
+    /// </summary>
+    /// <remarks>Core > Unpublished > Local > None</remarks>
+    ra::data::models::AssetCategory MostPublishedAssetCategory() const;
 
     /// <summary>
     /// Writes the local assets files.

--- a/src/data/models/AssetModelBase.hh
+++ b/src/data/models/AssetModelBase.hh
@@ -25,6 +25,7 @@ enum class AssetType
 
 enum class AssetCategory
 {
+    None = -1,
     Local = 0,
     Core = 3,
     Unofficial = 5,

--- a/src/ui/viewmodels/AssetListViewModel.cpp
+++ b/src/ui/viewmodels/AssetListViewModel.cpp
@@ -102,6 +102,21 @@ void AssetListViewModel::OnActiveGameChanged()
 {
     const auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::context::GameContext>();
     SetGameId(pGameContext.GameId());
+
+    switch (pGameContext.Assets().MostPublishedAssetCategory())
+    {
+        case ra::data::models::AssetCategory::Core:
+            SetFilterCategory(ra::ui::viewmodels::AssetListViewModel::FilterCategory::Core);
+            break;
+
+        case ra::data::models::AssetCategory::Unofficial:
+            SetFilterCategory(ra::ui::viewmodels::AssetListViewModel::FilterCategory::Unofficial);
+            break;
+
+        case ra::data::models::AssetCategory::Local:
+            SetFilterCategory(ra::ui::viewmodels::AssetListViewModel::FilterCategory::Local);
+            break;
+    }
 }
 
 void AssetListViewModel::OnDataModelStringValueChanged(gsl::index nIndex, const StringModelProperty::ChangeArgs& args)

--- a/tests/ui/viewmodels/AssetListViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/AssetListViewModel_Tests.cpp
@@ -637,6 +637,54 @@ public:
         Assert::AreEqual(std::wstring(L"Deleted"), vmAssetList.Changes().GetItemAt(4)->GetLabel());
     }
 
+    TEST_METHOD(TestLoadGameNoAchievements)
+    {
+        AssetListViewModelHarness vmAssetList;
+        vmAssetList.MockGameId(1U);
+
+        Assert::AreEqual(1U, vmAssetList.GetGameId());
+        Assert::AreEqual(AssetListViewModel::FilterCategory::Core, vmAssetList.GetFilterCategory());
+        Assert::AreEqual({0U}, vmAssetList.FilteredAssets().Count());
+
+        vmAssetList.SetFilterCategory(AssetListViewModel::FilterCategory::Local);
+        vmAssetList.MockGameId(2U);
+        Assert::AreEqual(AssetListViewModel::FilterCategory::Local, vmAssetList.GetFilterCategory());
+        Assert::AreEqual({0U}, vmAssetList.FilteredAssets().Count());
+    }
+
+    TEST_METHOD(TestLoadGameCoreAchievements)
+    {
+        AssetListViewModelHarness vmAssetList;
+        vmAssetList.AddAchievement(AssetCategory::Core, 10, L"Ach1");
+        vmAssetList.MockGameId(1U);
+
+        Assert::AreEqual(1U, vmAssetList.GetGameId());
+        Assert::AreEqual(AssetListViewModel::FilterCategory::Core, vmAssetList.GetFilterCategory());
+        Assert::AreEqual({1U}, vmAssetList.FilteredAssets().Count());
+    }
+
+    TEST_METHOD(TestLoadGameUnofficialAchievements)
+    {
+        AssetListViewModelHarness vmAssetList;
+        vmAssetList.AddAchievement(AssetCategory::Unofficial, 10, L"Ach1");
+        vmAssetList.MockGameId(1U);
+
+        Assert::AreEqual(1U, vmAssetList.GetGameId());
+        Assert::AreEqual(AssetListViewModel::FilterCategory::Unofficial, vmAssetList.GetFilterCategory());
+        Assert::AreEqual({1U}, vmAssetList.FilteredAssets().Count());
+    }
+
+    TEST_METHOD(TestLoadGameLocalAchievements)
+    {
+        AssetListViewModelHarness vmAssetList;
+        vmAssetList.AddAchievement(AssetCategory::Local, 10, L"Ach1");
+        vmAssetList.MockGameId(1U);
+
+        Assert::AreEqual(1U, vmAssetList.GetGameId());
+        Assert::AreEqual(AssetListViewModel::FilterCategory::Local, vmAssetList.GetFilterCategory());
+        Assert::AreEqual({1U}, vmAssetList.FilteredAssets().Count());
+    }
+
     TEST_METHOD(TestAddRemoveCoreAchievement)
     {
         AssetListViewModelHarness vmAssetList;


### PR DESCRIPTION
When loading a game with local achievements, but no published achievements, switches the asset filter to Local