### PR TITLE
add ASCII bookmark size

### DIFF
--- a/src/services/SearchResults.cpp
+++ b/src/services/SearchResults.cpp
@@ -1122,7 +1122,7 @@ public:
 
     std::wstring GetFormattedValue(const SearchResults& pResults, ra::ByteAddress nAddress, MemSize) const override
     {
-        std::array<unsigned char, 16> pBuffer;
+        std::array<unsigned char, 16> pBuffer = {0};
         pResults.GetBytes(nAddress, &pBuffer.at(0), pBuffer.size());
 
         std::wstring sText;
@@ -1524,8 +1524,11 @@ void SearchResults::Initialize(ra::ByteAddress nAddress, size_t nBytes, SearchTy
     m_nType = nType;
 
     const auto& pEmulatorContext = ra::services::ServiceLocator::Get<ra::data::context::EmulatorContext>();
-    if (nBytes + nAddress > pEmulatorContext.TotalMemorySize())
-        nBytes = pEmulatorContext.TotalMemorySize() - nAddress;
+    const auto nTotalMemorySize = pEmulatorContext.TotalMemorySize();
+    if (nAddress > nTotalMemorySize)
+        nAddress = 0;
+    if (nBytes + nAddress > nTotalMemorySize)
+        nBytes = nTotalMemorySize - nAddress;
 
     switch (nType)
     {

--- a/src/ui/viewmodels/MemorySearchViewModel.cpp
+++ b/src/ui/viewmodels/MemorySearchViewModel.cpp
@@ -1070,12 +1070,6 @@ void MemorySearchViewModel::BookmarkSelected()
         return;
 
     const MemSize nSize = m_vSearchResults.back().pResults.GetSize();
-    if (nSize == MemSize::Text)
-    {
-        ra::ui::viewmodels::MessageBoxViewModel::ShowInfoMessage(L"Text bookmarks are not supported");
-        return;
-    }
-
     auto& vmBookmarks = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::WindowManager>().MemoryBookmarks;
     if (!vmBookmarks.IsVisible())
         vmBookmarks.Show();

--- a/src/ui/win32/MemoryBookmarksDialog.cpp
+++ b/src/ui/win32/MemoryBookmarksDialog.cpp
@@ -91,7 +91,7 @@ public:
     HWND CreateInPlaceEditor(HWND hParent, InPlaceEditorInfo& pInfo) override
     {
         const auto& vmItems = static_cast<ra::ui::win32::bindings::GridBinding*>(pInfo.pGridBinding)->GetItems();
-        if (vmItems.GetItemValue(pInfo.nColumnIndex, MemoryBookmarksViewModel::MemoryBookmarkViewModel::ReadOnlyProperty))
+        if (vmItems.GetItemValue(pInfo.nItemIndex, MemoryBookmarksViewModel::MemoryBookmarkViewModel::ReadOnlyProperty))
             return nullptr;
 
         return ra::ui::win32::bindings::GridTextColumnBinding::CreateInPlaceEditor(hParent, pInfo);
@@ -159,6 +159,7 @@ private:
         {
             case MemSize::Float:
             case MemSize::MBF32:
+            case MemSize::Text:
                 return true;
 
             default:

--- a/tests/services/SearchResults_Tests.cpp
+++ b/tests/services/SearchResults_Tests.cpp
@@ -2046,6 +2046,19 @@ public:
         Assert::IsTrue(results2.MatchesFilter(results1, result2));  // 18 >= 18 (18) ?
         Assert::IsTrue(results2.MatchesFilter(results1, result3));  // 24 >= 18 (24) ?
     }
+
+    TEST_METHOD(TestInitializeFromMemoryAsciiEmpty)
+    {
+        ra::data::context::mocks::MockEmulatorContext mockEmulatorContext;
+        Assert::AreEqual({0U}, mockEmulatorContext.TotalMemorySize());
+
+        SearchResults results;
+        results.Initialize(0U, 16, ra::services::SearchType::AsciiText);
+
+        Assert::AreEqual({0U}, results.MatchingAddressCount());
+
+        Assert::AreEqual(std::wstring(), results.GetFormattedValue(0U, MemSize::Text));
+    }
 };
 
 } // namespace tests

--- a/tests/ui/viewmodels/MemorySearchViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/MemorySearchViewModel_Tests.cpp
@@ -1276,21 +1276,13 @@ public:
         Assert::AreEqual({ 1U }, search.Results().Count());
         search.Results().GetItemAt(0)->SetSelected(true);
 
-        bool bSawDialog = false;
-        search.mockDesktop.ExpectWindow<ra::ui::viewmodels::MessageBoxViewModel>([&bSawDialog](ra::ui::viewmodels::MessageBoxViewModel& vmMessageBox)
-        {
-            bSawDialog = true;
-            Assert::AreEqual(std::wstring(L"Text bookmarks are not supported"), vmMessageBox.GetMessage());
-            return ra::ui::DialogResult::OK;
-        });
-
         search.BookmarkSelected();
-        Assert::IsTrue(bSawDialog);
         Assert::AreEqual({ 1U }, search.Results().Count());
 
         const auto& pBookmarks = search.mockWindowManager.MemoryBookmarks.Bookmarks();
-        Assert::AreEqual({ 0U }, pBookmarks.Count());
-
+        Assert::AreEqual({ 1U }, pBookmarks.Count());
+        Assert::AreEqual({ 8U }, pBookmarks.GetItemAt(0)->GetAddress());
+        Assert::AreEqual(MemSize::Text, pBookmarks.GetItemAt(0)->GetSize());
         Assert::IsTrue(search.Results().GetItemAt(0)->IsSelected());
     }
 


### PR DESCRIPTION
Bookmarks created from an ASCII Text search result will automatically be set to ASCII. Bookmarks created from the current memory address or code notes will default to a byte-size, but can be switched to ASCII.

ASCII Bookmarks are read-only. You cannot change the ASCII text using the bookmark. Freezing an ASCII bookmark has no effect. 

ASCII Bookmarks only show the first 8 characters of the string due to the limited width of the column. Pause on Change functionality still works, but only if the change is in the first 8 bytes. Multiple bookmarks can be used for longer strings.

![image](https://user-images.githubusercontent.com/32680403/192107106-79467f75-61ba-481c-9ae6-c406c1b03b15.png)
