### PR TITLE
don't update app title unless RA_UpdateAppTitle has been previously called

### DIFF
--- a/src/Exports.cpp
+++ b/src/Exports.cpp
@@ -298,7 +298,7 @@ static void HandleLoginResponse(const ra::api::Login::Response& response)
         ra::services::ServiceLocator::Get<ra::data::context::EmulatorContext>().RebuildMenu();
 
         // update the client title-bar to include the user name
-        _RA_UpdateAppTitle();
+        ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::WindowManager>().Emulator.UpdateWindowTitle();
     }
     else if (!response.ErrorMessage.empty())
     {
@@ -408,9 +408,9 @@ API int CCONV _RA_OnLoadNewRom(const BYTE* pROM, unsigned int nROMSize)
 
 API void CCONV _RA_UpdateAppTitle(const char* sMessage)
 {
-    auto sTitle = ra::services::ServiceLocator::Get<ra::data::context::EmulatorContext>().GetAppTitle(sMessage ? sMessage : "");
     auto& vmEmulator = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::WindowManager>().Emulator;
-    vmEmulator.SetWindowTitle(sTitle);
+    vmEmulator.SetAppTitleMessage(sMessage);
+    vmEmulator.UpdateWindowTitle();
 }
 
 API int _RA_IsOverlayFullyVisible()

--- a/src/Exports.cpp
+++ b/src/Exports.cpp
@@ -410,7 +410,6 @@ API void CCONV _RA_UpdateAppTitle(const char* sMessage)
 {
     auto& vmEmulator = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::WindowManager>().Emulator;
     vmEmulator.SetAppTitleMessage(sMessage);
-    vmEmulator.UpdateWindowTitle();
 }
 
 API int _RA_IsOverlayFullyVisible()

--- a/src/RA_Integration.vcxproj
+++ b/src/RA_Integration.vcxproj
@@ -111,6 +111,7 @@
     <ClCompile Include="ui\viewmodels\BrokenAchievementsViewModel.cpp" />
     <ClCompile Include="ui\viewmodels\ChallengeIndicatorViewModel.cpp" />
     <ClCompile Include="ui\viewmodels\CodeNotesViewModel.cpp" />
+    <ClCompile Include="ui\viewmodels\EmulatorViewModel.cpp" />
     <ClCompile Include="ui\viewmodels\FileDialogViewModel.cpp" />
     <ClCompile Include="ui\viewmodels\GameChecksumViewModel.cpp" />
     <ClCompile Include="ui\viewmodels\IntegrationMenuViewModel.cpp" />

--- a/src/RA_Integration.vcxproj.filters
+++ b/src/RA_Integration.vcxproj.filters
@@ -393,6 +393,9 @@
     <ClCompile Include="data\models\CodeNotesModel.cpp">
       <Filter>Data\Models</Filter>
     </ClCompile>
+    <ClCompile Include="ui\viewmodels\EmulatorViewModel.cpp">
+      <Filter>UI\ViewModels</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="RA_Resource.h">

--- a/src/data/context/EmulatorContext.hh
+++ b/src/data/context/EmulatorContext.hh
@@ -100,7 +100,7 @@ public:
     /// </summary>
     /// <param name="sMessage">A custom message provided by the emulator to also display in the title bar.</param>
     std::wstring GetAppTitle(const std::string& sMessage) const;
-    
+
     /// <summary>
     /// Gets the game title from the emulator.
     /// </summary>

--- a/src/data/context/UserContext.cpp
+++ b/src/data/context/UserContext.cpp
@@ -11,6 +11,7 @@
 
 #include "ui\viewmodels\MessageBoxViewModel.hh"
 #include "ui\viewmodels\OverlayManager.hh"
+#include "ui\viewmodels\WindowManager.hh"
 
 namespace ra {
 namespace data {
@@ -35,9 +36,8 @@ void UserContext::Logout()
         pOverlayManager.HideOverlay();
 
         ra::services::ServiceLocator::Get<ra::services::IConfiguration>().Save();
-#ifndef RA_UTEST
-        _RA_UpdateAppTitle();
-#endif
+
+        ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::WindowManager>().Emulator.UpdateWindowTitle();
         ra::services::ServiceLocator::Get<ra::data::context::EmulatorContext>().RebuildMenu();
 
         ra::ui::viewmodels::MessageBoxViewModel::ShowInfoMessage(L"You are now logged out.");

--- a/src/ui/viewmodels/EmulatorViewModel.cpp
+++ b/src/ui/viewmodels/EmulatorViewModel.cpp
@@ -1,0 +1,22 @@
+#include "EmulatorViewModel.hh"
+
+#include "data/context/EmulatorContext.hh"
+
+#include "services/ServiceLocator.hh"
+
+namespace ra {
+namespace ui {
+namespace viewmodels {
+
+void EmulatorViewModel::UpdateWindowTitle()
+{
+    if (!m_bAppTitleManaged)
+        return;
+
+    auto sTitle = ra::services::ServiceLocator::Get<ra::data::context::EmulatorContext>().GetAppTitle(m_sAppTitleMessage);
+    SetWindowTitle(sTitle);
+}
+
+} // namespace viewmodels
+} // namespace ui
+} // namespace ra

--- a/src/ui/viewmodels/EmulatorViewModel.hh
+++ b/src/ui/viewmodels/EmulatorViewModel.hh
@@ -22,6 +22,8 @@ public:
         UpdateWindowTitle();
     }
 
+    bool IsAppTitleManaged() const noexcept { return m_bAppTitleManaged; }
+
     void UpdateWindowTitle();
 
 private:

--- a/src/ui/viewmodels/EmulatorViewModel.hh
+++ b/src/ui/viewmodels/EmulatorViewModel.hh
@@ -10,6 +10,23 @@ namespace viewmodels {
 
 class EmulatorViewModel : public WindowViewModelBase
 {
+public:
+    /// <summary>
+    /// Sets the additional text to display in the application title bar.
+    /// </summary>
+    void SetAppTitleMessage(const std::string& sValue)
+    {
+        m_bAppTitleManaged = true;
+        m_sAppTitleMessage = sValue;
+
+        UpdateWindowTitle();
+    }
+
+    void UpdateWindowTitle();
+
+private:
+    bool m_bAppTitleManaged = false;
+    std::string m_sAppTitleMessage;
 };
 
 } // namespace viewmodels

--- a/src/ui/viewmodels/LoginViewModel.cpp
+++ b/src/ui/viewmodels/LoginViewModel.cpp
@@ -13,6 +13,7 @@
 #include "services\IConfiguration.hh"
 
 #include "ui\viewmodels\MessageBoxViewModel.hh"
+#include "ui\viewmodels\WindowManager.hh"
 
 namespace ra {
 namespace ui {
@@ -79,9 +80,7 @@ bool LoginViewModel::Login() const
         std::wstring(L"Successfully logged in as ") + ra::Widen(response.Username));
 
     ra::services::ServiceLocator::Get<ra::data::context::EmulatorContext>().RebuildMenu();
-#ifndef RA_UTEST
-    _RA_UpdateAppTitle();
-#endif
+    ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::WindowManager>().Emulator.UpdateWindowTitle();
 
     return true;
 }

--- a/src/ui/win32/bindings/WindowBinding.cpp
+++ b/src/ui/win32/bindings/WindowBinding.cpp
@@ -26,7 +26,7 @@ void WindowBinding::SetHWND(DialogBase* pDialog, HWND hWnd)
     if (m_hWnd)
     {
         // immediately push values from the viewmodel to the UI
-        SetWindowTextW(m_hWnd, GetValue(WindowViewModelBase::WindowTitleProperty).c_str());
+        UpdateAppTitle();
 
         for (auto& pIter : m_mLabelBindings)
         {
@@ -93,6 +93,13 @@ void WindowBinding::SetHWND(DialogBase* pDialog, HWND hWnd)
 
         RestoreSizeAndPosition();
     }
+}
+
+void WindowBinding::UpdateAppTitle()
+{
+    const auto& pEmulatorViewModel = ra::services::ServiceLocator::Get<ra::ui::viewmodels::WindowManager>().Emulator;
+    if (pEmulatorViewModel.IsAppTitleManaged())
+        SetWindowTextW(m_hWnd, GetValue(WindowViewModelBase::WindowTitleProperty).c_str());
 }
 
 void WindowBinding::SetInitialPosition(RelativePosition nDefaultHorizontalLocation, RelativePosition nDefaultVerticalLocation, const char* sSizeAndPositionKey)
@@ -278,7 +285,7 @@ void WindowBinding::OnViewModelStringValueChanged(const StringModelProperty::Cha
 {
     if (args.Property == WindowViewModelBase::WindowTitleProperty)
     {
-        SetWindowTextW(m_hWnd, args.tNewValue.c_str());
+        UpdateAppTitle();
         return;
     }
 

--- a/src/ui/win32/bindings/WindowBinding.hh
+++ b/src/ui/win32/bindings/WindowBinding.hh
@@ -132,6 +132,7 @@ protected:
     GSL_SUPPRESS_F6 void OnViewModelBoolValueChanged(const BoolModelProperty::ChangeArgs& args) noexcept override;
 
     void RestoreSizeAndPosition();
+    void UpdateAppTitle();
 
 private:
     std::unordered_map<int, int> m_mLabelBindings;

--- a/tests/RA_Integration.Tests.vcxproj
+++ b/tests/RA_Integration.Tests.vcxproj
@@ -418,6 +418,7 @@
     <ClCompile Include="..\src\ui\viewmodels\BrokenAchievementsViewModel.cpp" />
     <ClCompile Include="..\src\ui\viewmodels\ChallengeIndicatorViewModel.cpp" />
     <ClCompile Include="..\src\ui\viewmodels\CodeNotesViewModel.cpp" />
+    <ClCompile Include="..\src\ui\viewmodels\EmulatorViewModel.cpp" />
     <ClCompile Include="..\src\ui\viewmodels\FileDialogViewModel.cpp" />
     <ClCompile Include="..\src\ui\viewmodels\IntegrationMenuViewModel.cpp" />
     <ClCompile Include="..\src\ui\viewmodels\LookupItemViewModel.cpp" />

--- a/tests/RA_Integration.Tests.vcxproj.filters
+++ b/tests/RA_Integration.Tests.vcxproj.filters
@@ -444,6 +444,9 @@
     <ClCompile Include="..\src\data\models\CodeNotesModel.cpp">
       <Filter>Code</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\ui\viewmodels\EmulatorViewModel.cpp">
+      <Filter>Code</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="base.props" />


### PR DESCRIPTION
Prevents overwriting the application window title for integrations that want to manage their own title bar.