### PR TITLE
allow Invert for non-value logic

### DIFF
--- a/src/ui/viewmodels/TriggerConditionViewModel.cpp
+++ b/src/ui/viewmodels/TriggerConditionViewModel.cpp
@@ -757,24 +757,6 @@ bool TriggerConditionViewModel::IsAddressType(TriggerOperandType nType) noexcept
     }
 }
 
-
-bool TriggerConditionViewModel::IsOperandTypeVisible(const ViewModelBase& vmItem, int nValue) noexcept
-{
-    const auto* vmCondition = dynamic_cast<const TriggerConditionViewModel*>(&vmItem);
-    if (vmCondition == nullptr)
-        return false;
-
-    const auto nOperandType = ra::itoe<TriggerOperandType>(nValue);
-    switch (nOperandType)
-    {
-        case TriggerOperandType::Inverted:
-            return vmCondition->IsForValue();
-
-        default:
-            return true;
-    }
-}
-
 bool TriggerConditionViewModel::IsComparisonVisible(const ViewModelBase& vmItem, int nValue)
 {
     const auto* vmCondition = dynamic_cast<const TriggerConditionViewModel*>(&vmItem);

--- a/src/ui/viewmodels/TriggerConditionViewModel.hh
+++ b/src/ui/viewmodels/TriggerConditionViewModel.hh
@@ -137,7 +137,6 @@ public:
     bool IsModifying() const { return IsModifying(GetType()); }
 
     static bool IsComparisonVisible(const ViewModelBase& vmItem, int nValue);
-    static bool IsOperandTypeVisible(const ViewModelBase& vmItem, int nValue) noexcept;
     static std::wstring FormatValue(unsigned nValue, TriggerOperandType nType);
     static std::wstring FormatValue(float fValue, TriggerOperandType nType);
 

--- a/src/ui/win32/AssetEditorDialog.cpp
+++ b/src/ui/win32/AssetEditorDialog.cpp
@@ -824,7 +824,6 @@ AssetEditorDialog::AssetEditorDialog(AssetEditorViewModel& vmAssetEditor)
         TriggerConditionViewModel::SourceTypeProperty, vmAssetEditor.Trigger().OperandTypes());
     pSourceTypeColumn->SetHeader(L"Type");
     pSourceTypeColumn->SetWidth(ra::ui::win32::bindings::GridColumnBinding::WidthType::Pixels, COLUMN_WIDTH_TYPE);
-    pSourceTypeColumn->SetVisibilityFilter(TriggerConditionViewModel::IsOperandTypeVisible);
     pSourceTypeColumn->SetReadOnly(false);
     m_bindConditions.BindColumn(2, std::move(pSourceTypeColumn));
 
@@ -854,7 +853,6 @@ AssetEditorDialog::AssetEditorDialog(AssetEditorViewModel& vmAssetEditor)
         TriggerConditionViewModel::HasTargetProperty, vmAssetEditor.Trigger().OperandTypes());
     pTargetTypeColumn->SetHeader(L"Type");
     pTargetTypeColumn->SetWidth(ra::ui::win32::bindings::GridColumnBinding::WidthType::Pixels, COLUMN_WIDTH_TYPE);
-    pTargetTypeColumn->SetVisibilityFilter(TriggerConditionViewModel::IsOperandTypeVisible);
     pTargetTypeColumn->SetReadOnly(false);
     m_bindConditions.BindColumn(6, std::move(pTargetTypeColumn));
 


### PR DESCRIPTION
Invert is used to toggle all the bits of a value.  It's been supported in values for a very long time.

It's been excluded from logic because it's better to invert the logic than the value read from memory. I wanted to eliminate it entirely, as it was originally added as a way ignore values when certain bits were set (`0xX1234*~0xN2345` would evaluate to 0 if bit1 of $2345 was 1). A better solution for that is to use MeasuredIf. 

Unfortunately, there are at least a couple games that are using it in a way that's not easily replaceable with alternate syntax, so I haven't been able to deprecate it.

As it's just as effectively useful in logic as BCD, I've removed the restriction limiting its use to values.
