### PR TITLE
use AddAddress chain for determining indirect tooltip in asset editor

### DIFF
--- a/src/data/context/ConsoleContext.cpp
+++ b/src/data/context/ConsoleContext.cpp
@@ -78,7 +78,7 @@ const ConsoleContext::MemoryRegion* ConsoleContext::GetMemoryRegion(ra::ByteAddr
     return nullptr;
 }
 
-ra::ByteAddress ConsoleContext::ByteAddressFromRealAddress(ra::ByteAddress nRealAddress) const
+ra::ByteAddress ConsoleContext::ByteAddressFromRealAddress(ra::ByteAddress nRealAddress) const noexcept
 {
     for (const auto& pRegion : m_vRegions)
     {

--- a/src/data/context/ConsoleContext.cpp
+++ b/src/data/context/ConsoleContext.cpp
@@ -24,6 +24,7 @@ ConsoleContext::ConsoleContext(ConsoleID nId) noexcept
             auto& pMemoryRegion = m_vRegions.emplace_back();
             pMemoryRegion.StartAddress = pRegion.start_address;
             pMemoryRegion.EndAddress = pRegion.end_address;
+            pMemoryRegion.RealAddress = pRegion.real_address;
             pMemoryRegion.Description = pRegion.description;
 
             switch (pRegion.type)
@@ -76,6 +77,22 @@ const ConsoleContext::MemoryRegion* ConsoleContext::GetMemoryRegion(ra::ByteAddr
 
     return nullptr;
 }
+
+ra::ByteAddress ConsoleContext::ByteAddressFromRealAddress(ra::ByteAddress nRealAddress) const
+{
+    for (const auto& pRegion : m_vRegions)
+    {
+        if (pRegion.RealAddress < nRealAddress)
+        {
+            const auto nRegionSize = pRegion.EndAddress - pRegion.StartAddress;
+            if (nRealAddress < pRegion.RealAddress + nRegionSize)
+                return (nRealAddress - pRegion.RealAddress) + pRegion.StartAddress;
+        }
+    }
+
+    return 0xFFFFFFFF;
+}
+
 
 } // namespace context
 } // namespace data

--- a/src/data/context/ConsoleContext.hh
+++ b/src/data/context/ConsoleContext.hh
@@ -79,6 +79,7 @@ public:
     {
         ra::ByteAddress StartAddress = 0U;
         ra::ByteAddress EndAddress = 0U;
+        ra::ByteAddress RealAddress = 0U;
         AddressType Type = AddressType::Unknown;
         std::string Description;
     };
@@ -93,6 +94,12 @@ public:
     /// </summary>
     /// <returns>Matching <see cref="MemoryRegion"/>, <c>nullptr</c> if not found.
     const MemoryRegion* GetMemoryRegion(ra::ByteAddress nAddress) const;
+
+    /// <summary>
+    /// Converts a real address into the "RetroAchievements" address where the data should be.
+    /// </summary>
+    /// <returns>Converted address, or <c>0xFFFFFFFF</c> if conversion could not be completed.
+    ra::ByteAddress ByteAddressFromRealAddress(ra::ByteAddress nRealAddress) const;
 
 protected:
     ConsoleID m_nId{};

--- a/src/data/context/ConsoleContext.hh
+++ b/src/data/context/ConsoleContext.hh
@@ -99,7 +99,7 @@ public:
     /// Converts a real address into the "RetroAchievements" address where the data should be.
     /// </summary>
     /// <returns>Converted address, or <c>0xFFFFFFFF</c> if conversion could not be completed.
-    ra::ByteAddress ByteAddressFromRealAddress(ra::ByteAddress nRealAddress) const;
+    ra::ByteAddress ByteAddressFromRealAddress(ra::ByteAddress nRealAddress) const noexcept;
 
 protected:
     ConsoleID m_nId{};

--- a/src/data/models/CodeNotesModel.cpp
+++ b/src/data/models/CodeNotesModel.cpp
@@ -309,7 +309,7 @@ static unsigned ReadPointer(const ra::data::context::EmulatorContext& pEmulatorC
 {
     auto nAddress = pEmulatorContext.ReadMemory(nPointerAddress, nSize);
 
-    // assume anything annotated as a 32-bit pointer is proving a real (non-translated) address and
+    // assume anything annotated as a 32-bit pointer is providing a real (non-translated) address and
     // attempt to do the translation ourself.
     if (nSize == MemSize::ThirtyTwoBit)
     {
@@ -690,7 +690,7 @@ const CodeNotesModel::CodeNote* CodeNotesModel::FindCodeNoteInternal(ra::ByteAdd
     return nullptr;
 }
 
-const std::wstring* CodeNotesModel::FindIndirectCodeNote(ra::ByteAddress nAddress, unsigned nOffset) const
+const std::wstring* CodeNotesModel::FindIndirectCodeNote(ra::ByteAddress nAddress, unsigned nOffset) const noexcept
 {
     if (!m_bHasPointers)
         return nullptr;
@@ -874,7 +874,7 @@ void CodeNotesModel::DoFrame()
         if (!pNote.second.PointerData)
             continue;
 
-        auto nNewAddress = ReadPointer(pEmulatorContext, pNote.first, pNote.second.MemSize);
+        const auto nNewAddress = ReadPointer(pEmulatorContext, pNote.first, pNote.second.MemSize);
 
         const auto nOldAddress = pNote.second.PointerData->PointerValue;
         if (nNewAddress == nOldAddress)

--- a/src/data/models/CodeNotesModel.hh
+++ b/src/data/models/CodeNotesModel.hh
@@ -72,7 +72,7 @@ public:
     /// Returns the note associated with the specified address.
     /// </summary>
     /// <returns>The note associated to the address, <c>nullptr</c> if no note is associated to the address.</returns>
-    const std::wstring* FindIndirectCodeNote(ra::ByteAddress nAddress, unsigned nOffset) const;
+    const std::wstring* FindIndirectCodeNote(ra::ByteAddress nAddress, unsigned nOffset) const noexcept;
 
     /// <summary>
     /// Returns the number of bytes associated to the code note at the specified address.

--- a/src/data/models/CodeNotesModel.hh
+++ b/src/data/models/CodeNotesModel.hh
@@ -69,6 +69,12 @@ public:
     const std::wstring* FindCodeNote(ra::ByteAddress nAddress, _Inout_ std::string& sAuthor) const;
 
     /// <summary>
+    /// Returns the note associated with the specified address.
+    /// </summary>
+    /// <returns>The note associated to the address, <c>nullptr</c> if no note is associated to the address.</returns>
+    const std::wstring* FindIndirectCodeNote(ra::ByteAddress nAddress, unsigned nOffset) const;
+
+    /// <summary>
     /// Returns the number of bytes associated to the code note at the specified address.
     /// </summary>
     /// <param name="nAddress">Address to query.</param>

--- a/src/ui/viewmodels/TriggerConditionViewModel.cpp
+++ b/src/ui/viewmodels/TriggerConditionViewModel.cpp
@@ -553,7 +553,7 @@ std::wstring TriggerConditionViewModel::GetTooltip(const StringModelProperty& nP
 
         if (IsIndirect())
         {
-            ra::ByteAddress nPointerAddress;
+            ra::ByteAddress nPointerAddress = 0;
             const auto nOffset = GetSourceAddress();
             const auto nIndirectAddress = GetIndirectAddress(nOffset, &nPointerAddress);
             return GetAddressTooltip(nIndirectAddress, nPointerAddress, nOffset);
@@ -573,7 +573,7 @@ std::wstring TriggerConditionViewModel::GetTooltip(const StringModelProperty& nP
 
         if (IsIndirect())
         {
-            ra::ByteAddress nPointerAddress;
+            ra::ByteAddress nPointerAddress = 0;
             const auto nOffset = GetTargetAddress();
             const auto nIndirectAddress = GetIndirectAddress(nOffset, &nPointerAddress);
             return GetAddressTooltip(nIndirectAddress, nPointerAddress, nOffset);
@@ -721,7 +721,6 @@ std::wstring TriggerConditionViewModel::GetAddressTooltip(ra::ByteAddress nAddre
 
     if (nOffset)
     {
-        const auto nStartAddress = nAddress - nOffset;
         sAddress = ra::StringPrintf(L"%s (indirect)", ra::ByteAddressToString(nAddress));
 
         if (nPointerAddress != 0xFFFFFFFF)

--- a/src/ui/viewmodels/TriggerConditionViewModel.cpp
+++ b/src/ui/viewmodels/TriggerConditionViewModel.cpp
@@ -552,9 +552,14 @@ std::wstring TriggerConditionViewModel::GetTooltip(const StringModelProperty& nP
             return L"";
 
         if (IsIndirect())
-            return GetAddressTooltip(GetIndirectAddress(GetSourceAddress()), true);
+        {
+            ra::ByteAddress nPointerAddress;
+            const auto nOffset = GetSourceAddress();
+            const auto nIndirectAddress = GetIndirectAddress(nOffset, &nPointerAddress);
+            return GetAddressTooltip(nIndirectAddress, nPointerAddress, nOffset);
+        }
 
-        return GetAddressTooltip(GetSourceAddress(), false);
+        return GetAddressTooltip(GetSourceAddress(), 0, 0);
     }
 
     if (nProperty == TargetValueProperty)
@@ -567,9 +572,14 @@ std::wstring TriggerConditionViewModel::GetTooltip(const StringModelProperty& nP
             return L"";
 
         if (IsIndirect())
-            return GetAddressTooltip(GetIndirectAddress(GetTargetAddress()), true);
+        {
+            ra::ByteAddress nPointerAddress;
+            const auto nOffset = GetTargetAddress();
+            const auto nIndirectAddress = GetIndirectAddress(nOffset, &nPointerAddress);
+            return GetAddressTooltip(nIndirectAddress, nPointerAddress, nOffset);
+        }
 
-        return GetAddressTooltip(GetTargetAddress(), false);
+        return GetAddressTooltip(GetTargetAddress(), 0, 0);
     }
 
     return L"";
@@ -589,8 +599,11 @@ static bool IsIndirectMemref(const rc_operand_t& operand) noexcept
     return rc_operand_is_memref(&operand) && operand.value.memref->value.is_indirect;
 }
 
-unsigned int TriggerConditionViewModel::GetIndirectAddress(unsigned int nAddress) const
+ra::ByteAddress TriggerConditionViewModel::GetIndirectAddress(ra::ByteAddress nAddress, ra::ByteAddress* pPointerAddress) const
 {
+    if (pPointerAddress != nullptr)
+        *pPointerAddress = 0xFFFFFFFF;
+
     const auto* pTriggerViewModel = dynamic_cast<const TriggerViewModel*>(m_pTriggerViewModel);
     if (pTriggerViewModel == nullptr)
         return nAddress;
@@ -678,6 +691,10 @@ unsigned int TriggerConditionViewModel::GetIndirectAddress(unsigned int nAddress
                 rc_evaluate_condition_value(&value, pCondition, &oEvalState);
                 rc_typed_value_convert(&value, RC_VALUE_TYPE_UNSIGNED);
                 oEvalState.add_address = value.value.u32;
+
+                if (pPointerAddress != nullptr && rc_operand_is_memref(&pCondition->operand1))
+                    *pPointerAddress = (bIsIndirect) ? 0xFFFFFFFF : pCondition->operand1.value.memref->address;
+
                 bIsIndirect = true;
             }
         }
@@ -691,29 +708,47 @@ unsigned int TriggerConditionViewModel::GetIndirectAddress(unsigned int nAddress
     return nAddress;
 }
 
-std::wstring TriggerConditionViewModel::GetAddressTooltip(unsigned int nAddress, bool bIsIndirect)
+std::wstring TriggerConditionViewModel::GetAddressTooltip(ra::ByteAddress nAddress,
+    ra::ByteAddress nPointerAddress, ra::ByteAddress nOffset)
 {
     const auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::context::GameContext>();
     const auto* pCodeNotes = pGameContext.Assets().FindCodeNotes();
+    const std::wstring* pNote = nullptr;
     std::wstring sAddress;
 
-    const auto nStartAddress = (pCodeNotes != nullptr) ? pCodeNotes->FindCodeNoteStart(nAddress) : 0xFFFFFFFF;
-    if (nStartAddress != nAddress && nStartAddress != 0xFFFFFFFF)
+    if (pCodeNotes == nullptr)
+        return ra::StringPrintf(L"%s%s\r\n[No code note]", ra::ByteAddressToString(nAddress), nOffset ? L" (indirect)" : L"");
+
+    if (nOffset)
     {
-        sAddress = ra::StringPrintf(L"%s [%s+%d]", ra::ByteAddressToString(nAddress),
-            ra::ByteAddressToString(nStartAddress), nAddress - nStartAddress);
+        const auto nStartAddress = nAddress - nOffset;
+        sAddress = ra::StringPrintf(L"%s (indirect)", ra::ByteAddressToString(nAddress));
+
+        if (nPointerAddress != 0xFFFFFFFF)
+            pNote = pCodeNotes->FindIndirectCodeNote(nPointerAddress, nOffset);
+        else
+            pNote = pCodeNotes->FindCodeNote(nAddress);
     }
     else
     {
         sAddress = ra::Widen(ra::ByteAddressToString(nAddress));
+        pNote = pCodeNotes->FindCodeNote(nAddress);
     }
 
-    if (bIsIndirect)
-        sAddress.append(L" (indirect)");
-
-    const auto* pNote = (nStartAddress != 0xFFFFFFFF) ? pCodeNotes->FindCodeNote(nStartAddress) : nullptr;
     if (!pNote)
-        return ra::StringPrintf(L"%s\r\n[No code note]", sAddress);
+    {
+        const auto nStartAddress = (pCodeNotes != nullptr) ? pCodeNotes->FindCodeNoteStart(nAddress) : 0xFFFFFFFF;
+        if (nStartAddress != nAddress && nStartAddress != 0xFFFFFFFF)
+        {
+            sAddress = ra::StringPrintf(L"%s [%s+%d]%s", ra::ByteAddressToString(nAddress),
+                                        ra::ByteAddressToString(nStartAddress), nAddress - nStartAddress,
+                                        nOffset ? L" (indirect)" : L"");
+            pNote = pCodeNotes->FindCodeNote(nStartAddress);
+        }
+
+        if (!pNote)
+            return ra::StringPrintf(L"%s\r\n[No code note]", sAddress);
+    }
 
     // limit the tooltip to the first 20 lines of the code note
     size_t nLines = 0;

--- a/src/ui/viewmodels/TriggerConditionViewModel.hh
+++ b/src/ui/viewmodels/TriggerConditionViewModel.hh
@@ -120,7 +120,7 @@ public:
     static const BoolModelProperty IsIndirectProperty;
     bool IsIndirect() const { return GetValue(IsIndirectProperty); }
     void SetIndirect(bool bValue) { SetValue(IsIndirectProperty, bValue); }
-    unsigned int GetIndirectAddress(unsigned int nAddress) const;
+    ra::ByteAddress GetIndirectAddress(ra::ByteAddress nAddress, ra::ByteAddress* pPointerAddress) const;
 
     static const BoolModelProperty IsSelectedProperty;
     bool IsSelected() const { return GetValue(IsSelectedProperty); }
@@ -152,7 +152,7 @@ private:
     void SerializeAppendOperand(std::string& sBuffer, TriggerOperandType nType, MemSize nSize, const std::wstring& nValue) const;
 
     static std::wstring GetValueTooltip(unsigned int nValue);
-    static std::wstring GetAddressTooltip(unsigned int nAddress, bool bIsIndirect);
+    static std::wstring GetAddressTooltip(ra::ByteAddress nAddress, ra::ByteAddress nPointerAddress, ra::ByteAddress nOffset);
     ra::ByteAddress GetSourceAddress() const;
     ra::ByteAddress GetTargetAddress() const;
     void SetOperand(const IntModelProperty& pTypeProperty, const IntModelProperty& pSizeProperty,

--- a/src/ui/win32/AssetEditorDialog.cpp
+++ b/src/ui/win32/AssetEditorDialog.cpp
@@ -232,7 +232,7 @@ public:
             {
                 const auto* pConditionViewModel = dynamic_cast<const TriggerConditionViewModel*>(vmItems.GetViewModelAt(nIndex));
                 Expects(pConditionViewModel != nullptr);
-                nAddress = pConditionViewModel->GetIndirectAddress(nAddress);
+                nAddress = pConditionViewModel->GetIndirectAddress(nAddress, nullptr);
             }
 
             auto& pMemoryInspector = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::WindowManager>().MemoryInspector;

--- a/tests/RA_Integration.Tests.vcxproj
+++ b/tests/RA_Integration.Tests.vcxproj
@@ -453,6 +453,7 @@
     <ClCompile Include="..\src\ui\viewmodels\MessageBoxViewModel.cpp" />
     <ClCompile Include="..\src\ui\viewmodels\RichPresenceMonitorViewModel.cpp" />
     <ClCompile Include="..\src\ui\WindowViewModelBase.cpp" />
+    <ClCompile Include="data\context\ConsoleContext_Tests.cpp" />
     <ClCompile Include="data\context\EmulatorContext_Tests.cpp" />
     <ClCompile Include="data\context\GameAssets_Tests.cpp" />
     <ClCompile Include="data\context\GameContext_Tests.cpp" />

--- a/tests/RA_Integration.Tests.vcxproj.filters
+++ b/tests/RA_Integration.Tests.vcxproj.filters
@@ -447,6 +447,9 @@
     <ClCompile Include="..\src\ui\viewmodels\EmulatorViewModel.cpp">
       <Filter>Code</Filter>
     </ClCompile>
+    <ClCompile Include="data\context\ConsoleContext_Tests.cpp">
+      <Filter>Tests\Data\Context</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="base.props" />

--- a/tests/data/context/ConsoleContext_Tests.cpp
+++ b/tests/data/context/ConsoleContext_Tests.cpp
@@ -1,0 +1,118 @@
+#include "CppUnitTest.h"
+
+#include "data\context\ConsoleContext.hh"
+
+#include "tests\data\DataAsserts.hh"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace ra {
+namespace data {
+namespace context {
+namespace tests {
+
+TEST_CLASS(ConsoleContext_Tests)
+{
+private:
+    static void AssertRegion(const ConsoleContext& context, ra::ByteAddress nAddress,
+        const ConsoleContext::MemoryRegion* pExpectedRegion)
+    {
+        const auto* pFoundRegion = context.GetMemoryRegion(nAddress);
+        if (pFoundRegion != pExpectedRegion)
+        {
+            if (pExpectedRegion == nullptr)
+                Assert::Fail(ra::StringPrintf(L"Found region for address %08x", nAddress).c_str());
+            else if (pFoundRegion == nullptr)
+                Assert::Fail(ra::StringPrintf(L"Did not find region for address %08x", nAddress).c_str());
+            else
+                Assert::Fail(ra::StringPrintf(L"Found wrong region for address %08x", nAddress).c_str());
+        }
+    }
+
+public:
+    TEST_METHOD(TestAtari2600)
+    {
+        ConsoleContext context(ConsoleID::Atari2600);
+
+        Assert::AreEqual(25, (int)context.Id());
+        Assert::AreEqual(std::wstring(L"Atari 2600"), context.Name());
+
+        const auto& vRegions = context.MemoryRegions();
+        Assert::AreEqual({1}, vRegions.size());
+        Assert::AreEqual(0x00U, vRegions.at(0).StartAddress);
+        Assert::AreEqual(0x7FU, vRegions.at(0).EndAddress);
+        Assert::AreEqual(0x80U, vRegions.at(0).RealAddress);
+        Assert::AreEqual((int)ConsoleContext::AddressType::SystemRAM, (int)vRegions.at(0).Type);
+        Assert::AreEqual(std::string("System RAM"), vRegions.at(0).Description);
+
+        AssertRegion(context, 0x00U, &vRegions.at(0));
+        AssertRegion(context, 0x7FU, &vRegions.at(0));
+        AssertRegion(context, 0x80U, nullptr);
+
+        Assert::AreEqual(0x14U, context.ByteAddressFromRealAddress(0x94U));
+        Assert::AreEqual(0xFFFFFFFFU, context.ByteAddressFromRealAddress(0x14U));
+    }
+
+    TEST_METHOD(TestGameboyAdvance)
+    {
+        ConsoleContext context(ConsoleID::GBA);
+
+        Assert::AreEqual(5, (int)context.Id());
+        Assert::AreEqual(std::wstring(L"GameBoy Advance"), context.Name());
+
+        const auto& vRegions = context.MemoryRegions();
+        Assert::AreEqual({2}, vRegions.size());
+        Assert::AreEqual(0x00000000U, vRegions.at(0).StartAddress);
+        Assert::AreEqual(0x00007FFFU, vRegions.at(0).EndAddress);
+        Assert::AreEqual(0x03000000U, vRegions.at(0).RealAddress);
+        Assert::AreEqual((int)ConsoleContext::AddressType::SaveRAM, (int)vRegions.at(0).Type);
+        Assert::AreEqual(std::string("Cartridge RAM"), vRegions.at(0).Description);
+        Assert::AreEqual(0x00008000U, vRegions.at(1).StartAddress);
+        Assert::AreEqual(0x00047FFFU, vRegions.at(1).EndAddress);
+        Assert::AreEqual(0x02000000U, vRegions.at(1).RealAddress);
+        Assert::AreEqual((int)ConsoleContext::AddressType::SystemRAM, (int)vRegions.at(1).Type);
+        Assert::AreEqual(std::string("System RAM"), vRegions.at(1).Description);
+
+        AssertRegion(context, 0x00000000U, &vRegions.at(0));
+        AssertRegion(context, 0x00007FFFU, &vRegions.at(0));
+        AssertRegion(context, 0x00008000U, &vRegions.at(1));
+        AssertRegion(context, 0x00047FFFU, &vRegions.at(1));
+        AssertRegion(context, 0x00048000U, nullptr);
+
+        Assert::AreEqual(0x00019234U, context.ByteAddressFromRealAddress(0x02011234U));
+    }
+
+    TEST_METHOD(TestPlayStationPortable)
+    {
+        ConsoleContext context(ConsoleID::PSP);
+
+        Assert::AreEqual(41, (int)context.Id());
+        Assert::AreEqual(std::wstring(L"PlayStation Portable"), context.Name());
+
+        const auto& vRegions = context.MemoryRegions();
+        Assert::AreEqual({2}, vRegions.size());
+        Assert::AreEqual(0x00000000U, vRegions.at(0).StartAddress);
+        Assert::AreEqual(0x007FFFFFU, vRegions.at(0).EndAddress);
+        Assert::AreEqual(0x08000000U, vRegions.at(0).RealAddress);
+        Assert::AreEqual((int)ConsoleContext::AddressType::SystemRAM, (int)vRegions.at(0).Type);
+        Assert::AreEqual(std::string("Kernel RAM"), vRegions.at(0).Description);
+        Assert::AreEqual(0x00800000U, vRegions.at(1).StartAddress);
+        Assert::AreEqual(0x01FFFFFFU, vRegions.at(1).EndAddress);
+        Assert::AreEqual(0x08800000U, vRegions.at(1).RealAddress);
+        Assert::AreEqual((int)ConsoleContext::AddressType::SystemRAM, (int)vRegions.at(1).Type);
+        Assert::AreEqual(std::string("System RAM"), vRegions.at(1).Description);
+
+        AssertRegion(context, 0x00000000U, &vRegions.at(0));
+        AssertRegion(context, 0x007FFFFFU, &vRegions.at(0));
+        AssertRegion(context, 0x00800000U, &vRegions.at(1));
+        AssertRegion(context, 0x01FFFFFFU, &vRegions.at(1));
+        AssertRegion(context, 0x02000000U, nullptr);
+
+        Assert::AreEqual(0x01123456U, context.ByteAddressFromRealAddress(0x09123456U));
+    }
+};
+
+} // namespace tests
+} // namespace context
+} // namespace data
+} // namespace ra

--- a/tests/mocks/MockConsoleContext.hh
+++ b/tests/mocks/MockConsoleContext.hh
@@ -31,11 +31,19 @@ public:
 
     void ResetMemoryRegions() noexcept { m_vRegions.clear(); }
 
-    void AddMemoryRegion(ra::ByteAddress nStartAddress, ra::ByteAddress nEndAddress, AddressType nAddressType, const std::string& sDescription = "")
+    void AddMemoryRegion(ra::ByteAddress nStartAddress, ra::ByteAddress nEndAddress, 
+        AddressType nAddressType, const std::string& sDescription = "")
+    { 
+        AddMemoryRegion(nStartAddress, nEndAddress, nAddressType, nStartAddress, sDescription);
+    }
+
+    void AddMemoryRegion(ra::ByteAddress nStartAddress, ra::ByteAddress nEndAddress, 
+        AddressType nAddressType, ra::ByteAddress nRealAddress, const std::string& sDescription = "")
     { 
         auto& pRegion = m_vRegions.emplace_back();
         pRegion.StartAddress = nStartAddress;
         pRegion.EndAddress = nEndAddress;
+        pRegion.RealAddress = nRealAddress;
         pRegion.Type = nAddressType;
         pRegion.Description = sDescription;
     }

--- a/tests/ui/viewmodels/TriggerConditionViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/TriggerConditionViewModel_Tests.cpp
@@ -6,6 +6,7 @@
 
 #include "tests\RA_UnitTestHelpers.h"
 #include "tests\mocks\MockConfiguration.hh"
+#include "tests\mocks\MockConsoleContext.hh"
 #include "tests\mocks\MockEmulatorContext.hh"
 #include "tests\mocks\MockGameContext.hh"
 #include "tests\mocks\MockUserContext.hh"
@@ -637,7 +638,7 @@ public:
         IndirectAddressTriggerViewModelHarness vmTrigger;
         vmTrigger.Parse("I:0xH0001_0xH0002=3");
         vmTrigger.mockConfiguration.SetFeatureEnabled(ra::services::Feature::PreferDecimal, true);
-        vmTrigger.mockGameContext.SetCodeNote({ 3U }, L"This is a note.");
+        vmTrigger.mockGameContext.SetCodeNote({ 1U }, L"[8-bit pointer]\n+2=This is a note.");
 
         const auto* pCondition = vmTrigger.Conditions().GetItemAt(1);
         Expects(pCondition != nullptr);
@@ -648,7 +649,7 @@ public:
 
         // $0001 = 3, 3+2 = $0005
         vmTrigger.SetMemory({ 1 }, 3);
-        Assert::AreEqual(std::wstring(L"0x0005 (indirect)\r\n[No code note]"), pCondition->GetTooltip(TriggerConditionViewModel::SourceValueProperty));
+        Assert::AreEqual(std::wstring(L"0x0005 (indirect)\r\nThis is a note."), pCondition->GetTooltip(TriggerConditionViewModel::SourceValueProperty));
     }
 
     TEST_METHOD(TestTooltipIndirectAddressMultiNote)
@@ -656,8 +657,7 @@ public:
         IndirectAddressTriggerViewModelHarness vmTrigger;
         vmTrigger.Parse("I:0xH0001_0xH0002=0xH0004");
         vmTrigger.mockConfiguration.SetFeatureEnabled(ra::services::Feature::PreferDecimal, true);
-        vmTrigger.mockGameContext.SetCodeNote({ 3U }, L"This is a note.");
-        vmTrigger.mockGameContext.SetCodeNote({ 5U }, L"This is another note.");
+        vmTrigger.mockGameContext.SetCodeNote({ 1U }, L"[8-bit pointer]\n+2=This is a note.\n+4=This is another note.");
 
         const auto* pCondition = vmTrigger.Conditions().GetItemAt(1);
         Expects(pCondition != nullptr);
@@ -669,24 +669,24 @@ public:
 
         // $0001 = 3, 3+2 = $0005, 3+4 = $0007
         vmTrigger.SetMemory({ 1 }, 3);
-        Assert::AreEqual(std::wstring(L"0x0005 (indirect)\r\nThis is another note."), pCondition->GetTooltip(TriggerConditionViewModel::SourceValueProperty));
-        Assert::AreEqual(std::wstring(L"0x0007 (indirect)\r\n[No code note]"), pCondition->GetTooltip(TriggerConditionViewModel::TargetValueProperty));
+        Assert::AreEqual(std::wstring(L"0x0005 (indirect)\r\nThis is a note."), pCondition->GetTooltip(TriggerConditionViewModel::SourceValueProperty));
+        Assert::AreEqual(std::wstring(L"0x0007 (indirect)\r\nThis is another note."), pCondition->GetTooltip(TriggerConditionViewModel::TargetValueProperty));
     }
 
     TEST_METHOD(TestTooltipIndirectAddressMultiByteNote)
     {
         IndirectAddressTriggerViewModelHarness vmTrigger;
-        vmTrigger.Parse("I:0xH0001_0xH0002=0xH0004");
+        vmTrigger.Parse("I:0xH0001_0xH0002=0xH0005");
         vmTrigger.mockConfiguration.SetFeatureEnabled(ra::services::Feature::PreferDecimal, true);
-        vmTrigger.mockGameContext.SetCodeNote({ 4U }, L"[8 bytes] This is a note.");
+        vmTrigger.mockGameContext.SetCodeNote({ 1U }, L"[8-bit pointer]\n+4=[8 bytes] This is a note.");
 
         const auto* pCondition = vmTrigger.Conditions().GetItemAt(1);
         Expects(pCondition != nullptr);
         Assert::IsTrue(pCondition->IsIndirect());
 
-        // $0001 = 1, 1+2 = $0003, 1+4 = $0005
+        // $0001 = 1, 1+2 = $0003, 1+5 = $0006
         Assert::AreEqual(std::wstring(L"0x0003 (indirect)\r\n[No code note]"), pCondition->GetTooltip(TriggerConditionViewModel::SourceValueProperty));
-        Assert::AreEqual(std::wstring(L"0x0005 [0x0004+1] (indirect)\r\n[8 bytes] This is a note."), pCondition->GetTooltip(TriggerConditionViewModel::TargetValueProperty));
+        Assert::AreEqual(std::wstring(L"0x0006 [0x0005+1] (indirect)\r\n[8 bytes] This is a note."), pCondition->GetTooltip(TriggerConditionViewModel::TargetValueProperty));
     }
 
     TEST_METHOD(TestTooltipIndirectAddressMultiplyNoCodeNote)
@@ -712,7 +712,7 @@ public:
         IndirectAddressTriggerViewModelHarness vmTrigger;
         vmTrigger.Parse("I:0xH0001_0xH0002=3S0=0S1=1");
         vmTrigger.mockConfiguration.SetFeatureEnabled(ra::services::Feature::PreferDecimal, true);
-        vmTrigger.mockGameContext.SetCodeNote({ 3U }, L"This is a note.");
+        vmTrigger.mockGameContext.SetCodeNote({ 1U }, L"[8-bit pointer]\n+2=This is a note.");
 
         const auto* pCondition = vmTrigger.Conditions().GetItemAt(1);
         Expects(pCondition != nullptr);
@@ -723,7 +723,7 @@ public:
 
         // $0001 = 3, 3+2 = $0005
         vmTrigger.SetMemory({ 1 }, 3);
-        Assert::AreEqual(std::wstring(L"0x0005 (indirect)\r\n[No code note]"), pCondition->GetTooltip(TriggerConditionViewModel::SourceValueProperty));
+        Assert::AreEqual(std::wstring(L"0x0005 (indirect)\r\nThis is a note."), pCondition->GetTooltip(TriggerConditionViewModel::SourceValueProperty));
     }
 
     TEST_METHOD(TestTooltipIndirectAddressInAlt1CodeNote)
@@ -731,7 +731,7 @@ public:
         IndirectAddressTriggerViewModelHarness vmTrigger;
         vmTrigger.Parse("0=0SI:0xH0001_0xH0002=3S1=1");
         vmTrigger.mockConfiguration.SetFeatureEnabled(ra::services::Feature::PreferDecimal, true);
-        vmTrigger.mockGameContext.SetCodeNote({ 3U }, L"This is a note.");
+        vmTrigger.mockGameContext.SetCodeNote({ 1U }, L"[8-bit pointer]\n+2=This is a note.");
         vmTrigger.SetSelectedGroupIndex(1);
 
         const auto* pCondition = vmTrigger.Conditions().GetItemAt(1);
@@ -743,7 +743,7 @@ public:
 
         // $0001 = 3, 3+2 = $0005
         vmTrigger.SetMemory({ 1 }, 3);
-        Assert::AreEqual(std::wstring(L"0x0005 (indirect)\r\n[No code note]"), pCondition->GetTooltip(TriggerConditionViewModel::SourceValueProperty));
+        Assert::AreEqual(std::wstring(L"0x0005 (indirect)\r\nThis is a note."), pCondition->GetTooltip(TriggerConditionViewModel::SourceValueProperty));
     }
 
     TEST_METHOD(TestTooltipIndirectAddressInAlt2CodeNote)
@@ -751,7 +751,7 @@ public:
         IndirectAddressTriggerViewModelHarness vmTrigger;
         vmTrigger.Parse("0=0S1=1SI:0xH0001_0xH0002=3");
         vmTrigger.mockConfiguration.SetFeatureEnabled(ra::services::Feature::PreferDecimal, true);
-        vmTrigger.mockGameContext.SetCodeNote({ 3U }, L"This is a note.");
+        vmTrigger.mockGameContext.SetCodeNote({ 1U }, L"[8-bit pointer]\n+2=This is a note.");
         vmTrigger.SetSelectedGroupIndex(2);
 
         const auto* pCondition = vmTrigger.Conditions().GetItemAt(1);
@@ -763,7 +763,7 @@ public:
 
         // $0001 = 3, 3+2 = $0005
         vmTrigger.SetMemory({ 1 }, 3);
-        Assert::AreEqual(std::wstring(L"0x0005 (indirect)\r\n[No code note]"), pCondition->GetTooltip(TriggerConditionViewModel::SourceValueProperty));
+        Assert::AreEqual(std::wstring(L"0x0005 (indirect)\r\nThis is a note."), pCondition->GetTooltip(TriggerConditionViewModel::SourceValueProperty));
     }
 
     TEST_METHOD(TestTooltipDoubleIndirectAddress)


### PR DESCRIPTION
Fixes issue where indirect tooltips were not being shown in the achievement editor if the achievement logic only uses a portion of the pointer (i.e. 24-bit read on 32-bit pointer). If the note was annotated with "[32-bit pointer]", it would assign the indirect note to the real address, not the address associated to the RetroAchievements mapping.

This modifies the tooltip logic to use the AddAddress from the achievement definition to find the indirect tooltip. The actual note panel will not show the indirect note as it still assumes the note is associated to the real address.