### PR TITLE
provide separate theme colors for modified/unmodified code notes

### DIFF
--- a/data/editor_theme.json
+++ b/data/editor_theme.json
@@ -15,11 +15,17 @@
       "HeaderSelected": "#FF8080"
     }
   },
+  "CodeNotes": {
+    "Colors": {
+      "Normal": "#000000",
+      "Modified": "#C04040"
+    }
+  },
   "TriggerColors": {
     "IsTrue": "#C0FFC0",
     "WasTrue": "#C0C0FF",
     "BecomingTrue": "#C0FFFF",
     "ResetTrue": "#FFFFC0",
-    "PauseTrue": "#FFC0C0",
+    "PauseTrue": "#FFC0C0"
   }
 }

--- a/src/ui/EditorTheme.hh
+++ b/src/ui/EditorTheme.hh
@@ -37,7 +37,8 @@ public:
     Color ColorHeaderSelected() const noexcept { return m_colorHeaderSelected; }
 
     // ===== code notes =====
-    Color ColorModified() const noexcept { return m_colorModified; }
+    Color ColorNoteNormal() const noexcept { return m_colorNoteNormal; }
+    Color ColorNoteModified() const noexcept { return m_colorNoteModified; }
 
     // ===== triggers =====
 
@@ -67,7 +68,8 @@ private:
     Color m_colorHeader{ 255, 128, 128, 128 };
     Color m_colorHeaderSelected{ 255, 255, 96, 96 };
 
-    Color m_colorModified { 255, 192, 64, 64 };
+    Color m_colorNoteNormal{ 255, 0, 0, 0 };
+    Color m_colorNoteModified { 255, 192, 64, 64 };
 
     Color m_colorTriggerIsTrue{ 255, 192, 255, 192 };
     Color m_colorTriggerWasTrue{ 255, 192, 192, 255 };

--- a/src/ui/Theme.cpp
+++ b/src/ui/Theme.cpp
@@ -199,7 +199,8 @@ void EditorTheme::LoadFromFile()
         {
             const rapidjson::Value& colors = codeNotes["Colors"];
 
-            ReadColor(m_colorModified, colors, "Modified");
+            ReadColor(m_colorNoteNormal, colors, "Normal");
+            ReadColor(m_colorNoteModified, colors, "Modified");
         }
     }
 

--- a/src/ui/viewmodels/CodeNotesViewModel.cpp
+++ b/src/ui/viewmodels/CodeNotesViewModel.cpp
@@ -26,7 +26,7 @@ const IntModelProperty CodeNotesViewModel::CodeNoteViewModel::BookmarkColorPrope
 void CodeNotesViewModel::CodeNoteViewModel::SetModified(bool bValue)
 {
     const auto& pEditorTheme = ra::services::ServiceLocator::Get<ra::ui::EditorTheme>();
-    SetBookmarkColor(bValue ? pEditorTheme.ColorModified() : pEditorTheme.ColorNormal());
+    SetBookmarkColor(bValue ? pEditorTheme.ColorNoteModified() : pEditorTheme.ColorNoteNormal());
 }
 
 CodeNotesViewModel::CodeNotesViewModel() noexcept


### PR DESCRIPTION
since we aren't managing the background of the code notes window, the memory viewer colors may not look good used there