### PR TITLE
reset rich presence monitor when game changes

### DIFF
--- a/src/ui/viewmodels/RichPresenceMonitorViewModel.cpp
+++ b/src/ui/viewmodels/RichPresenceMonitorViewModel.cpp
@@ -202,8 +202,8 @@ void RichPresenceMonitorViewModel::OnActiveGameChanged()
 {
     if (IsVisible())
     {
-        UpdateWindowTitle();
-        UpdateDisplayString();
+        m_nState = MonitorState::None;
+        StartMonitoring();
     }
 }
 

--- a/tests/data/context/GameContext_Tests.cpp
+++ b/tests/data/context/GameContext_Tests.cpp
@@ -447,6 +447,8 @@ public:
         Ensures(pRichPresence != nullptr);
         Assert::AreEqual(ra::data::models::AssetCategory::Core, pRichPresence->GetCategory());
         Assert::AreEqual(ra::data::models::AssetChanges::Unpublished, pRichPresence->GetChanges());
+
+        // modified rich presence should not be active unless monitor is opened
         Assert::IsFalse(pRichPresence->IsActive());
     }
 

--- a/tests/ui/viewmodels/RichPresenceMonitorViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/RichPresenceMonitorViewModel_Tests.cpp
@@ -211,8 +211,8 @@ TEST_CLASS(RichPresenceMonitorViewModel_Tests)
     {
         RichPresenceMonitorViewModelHarness vmRichPresence;
 
-        auto tNow = std::chrono::system_clock::now();
-        auto tThen = tNow - std::chrono::minutes(5);
+        const auto tNow = std::chrono::system_clock::now();
+        const auto tThen = tNow - std::chrono::minutes(5);
         vmRichPresence.mockLocalStorage.MockStoredData(ra::services::StorageItemType::RichPresence, L"1", "Display:\nHello, world!\n");
         vmRichPresence.mockLocalStorage.MockLastModified(ra::services::StorageItemType::RichPresence, L"1", tThen);
         vmRichPresence.mockGameContext.SetRichPresenceDisplayString(L"Server");
@@ -221,7 +221,7 @@ TEST_CLASS(RichPresenceMonitorViewModel_Tests)
         vmRichPresence.SetIsVisible(true);
         Assert::AreEqual(std::wstring(L"No game loaded."), vmRichPresence.GetDisplayString());
         Assert::AreEqual({ 0U }, vmRichPresence.mockThreadPool.PendingTasks());
-        auto* pRichPresence = vmRichPresence.mockGameContext.Assets().FindRichPresence();
+        const auto* pRichPresence = vmRichPresence.mockGameContext.Assets().FindRichPresence();
         Expects(pRichPresence != nullptr);
 
         // without a callback, display string is not automatically updated


### PR DESCRIPTION
fixes issue where "Rich Presence not active" remains shown when loading a game with local rich presence and the monitor already open