### PR TITLE
give priority to actual note over indirect note for note edit field

### DIFF
--- a/src/ui/viewmodels/MemoryInspectorViewModel.hh
+++ b/src/ui/viewmodels/MemoryInspectorViewModel.hh
@@ -178,6 +178,7 @@ private:
     unsigned m_nGameId = 0;
     bool m_bSyncingAddress = false;
     bool m_bSyncingCodeNote = false;
+    bool m_bNoteIsIndirect = false;
     ra::ByteAddress m_nSavedNoteAddress = 0xFFFFFFFF;
     std::wstring m_sSavedNote;
 };

--- a/src/ui/win32/bindings/GridBinding.cpp
+++ b/src/ui/win32/bindings/GridBinding.cpp
@@ -348,6 +348,9 @@ void GridBinding::OnViewModelIntValueChanged(gsl::index nIndex, const IntModelPr
             m_bForceRepaintItems = true;
         }
     }
+
+    if (!m_vmItems->IsUpdating())
+        OnEndViewModelCollectionUpdate();
 }
 
 void GridBinding::OnViewModelBoolValueChanged(gsl::index nIndex, const BoolModelProperty::ChangeArgs& args)

--- a/tests/ui/viewmodels/MemoryInspectorViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/MemoryInspectorViewModel_Tests.cpp
@@ -13,6 +13,7 @@
 #include "tests\mocks\MockDesktop.hh"
 #include "tests\mocks\MockEmulatorContext.hh"
 #include "tests\mocks\MockGameContext.hh"
+#include "tests\mocks\MockLocalStorage.hh"
 #include "tests\mocks\MockUserContext.hh"
 #include "tests\mocks\MockServer.hh"
 #include "tests\mocks\MockThreadPool.hh"
@@ -37,6 +38,7 @@ private:
         ra::data::context::mocks::MockGameContext mockGameContext;
         ra::data::context::mocks::MockUserContext mockUserContext;
         ra::services::mocks::MockConfiguration mockConfiguration;
+        ra::services::mocks::MockLocalStorage mockLocalStorage;
         ra::services::mocks::MockThreadPool mockThreadPool;
         ra::ui::mocks::MockDesktop mockDesktop;
         ra::ui::viewmodels::mocks::MockWindowManager mockWindowManager;
@@ -132,12 +134,18 @@ public:
     TEST_METHOD(TestSetCurrentAddress)
     {
         MemoryInspectorViewModelHarness inspector;
+        inspector.mockGameContext.SetGameId(1);
+        inspector.mockGameContext.NotifyActiveGameChanged(); // enable note support
+
         inspector.SetCurrentAddress({ 3U });
 
         Assert::AreEqual({ 3U }, inspector.GetCurrentAddress());
         Assert::AreEqual(std::wstring(L"0x0003"), inspector.GetCurrentAddressText());
         Assert::AreEqual(std::wstring(), inspector.GetCurrentAddressNote());
         Assert::AreEqual(std::wstring(L"0 0 0 0 0 0 1 1"), inspector.GetCurrentAddressBits());
+        Assert::IsTrue(inspector.CanEditCurrentAddressNote());
+        Assert::IsFalse(inspector.CanPublishCurrentAddressNote());
+        Assert::IsFalse(inspector.CanRevertCurrentAddressNote());
 
         Assert::AreEqual({ 3U }, inspector.Viewer().GetAddress());
     }
@@ -145,14 +153,97 @@ public:
     TEST_METHOD(TestSetCurrentAddressText)
     {
         MemoryInspectorViewModelHarness inspector;
+        inspector.mockGameContext.SetGameId(1);
+        inspector.mockGameContext.NotifyActiveGameChanged(); // enable note support
+
         inspector.SetCurrentAddressText(L"3");
 
         Assert::AreEqual({ 3U }, inspector.GetCurrentAddress());
         Assert::AreEqual(std::wstring(L"3"), inspector.GetCurrentAddressText()); /* don't update text when user types in partial address */
         Assert::AreEqual(std::wstring(), inspector.GetCurrentAddressNote());
         Assert::AreEqual(std::wstring(L"0 0 0 0 0 0 1 1"), inspector.GetCurrentAddressBits());
+        Assert::IsTrue(inspector.CanEditCurrentAddressNote());
+        Assert::IsFalse(inspector.CanPublishCurrentAddressNote());
+        Assert::IsFalse(inspector.CanRevertCurrentAddressNote());
 
         Assert::AreEqual({ 3U }, inspector.Viewer().GetAddress());
+    }
+
+    TEST_METHOD(TestSetCurrentAddressWithNote)
+    {
+        MemoryInspectorViewModelHarness inspector;
+        inspector.mockGameContext.SetGameId(1);
+        inspector.mockGameContext.NotifyActiveGameChanged(); // enable note support
+
+        inspector.SetCurrentAddress({ 3U });
+        inspector.mockGameContext.Assets().FindCodeNotes()->SetServerCodeNote({3U}, L"Note on 3");
+        inspector.mockGameContext.Assets().FindCodeNotes()->SetCodeNote({3U}, L"Note on 3");
+
+        Assert::AreEqual({ 3U }, inspector.GetCurrentAddress());
+        Assert::AreEqual(std::wstring(L"0x0003"), inspector.GetCurrentAddressText());
+        Assert::AreEqual(std::wstring(L"Note on 3"), inspector.GetCurrentAddressNote());
+        Assert::AreEqual(std::wstring(L"0 0 0 0 0 0 1 1"), inspector.GetCurrentAddressBits());
+        Assert::IsTrue(inspector.CanEditCurrentAddressNote());
+        Assert::IsFalse(inspector.CanPublishCurrentAddressNote());
+        Assert::IsFalse(inspector.CanRevertCurrentAddressNote());
+
+        // update note directly as SetCurrentNoteAddress doesn't cause UpdateNoteButtons to be called
+        inspector.mockGameContext.Assets().FindCodeNotes()->SetCodeNote({3U}, L"Modified Note on 3");
+
+        Assert::IsTrue(inspector.CanEditCurrentAddressNote());
+        Assert::IsTrue(inspector.CanPublishCurrentAddressNote());
+        Assert::IsTrue(inspector.CanRevertCurrentAddressNote());
+    }
+
+    TEST_METHOD(TestSetCurrentAddressWithNoteIndirect)
+    {
+        MemoryInspectorViewModelHarness inspector;
+        inspector.mockGameContext.SetGameId(1);
+        inspector.mockGameContext.NotifyActiveGameChanged(); // enable note support
+        inspector.mockGameContext.Assets().FindCodeNotes()->SetServerCodeNote({3U}, L"[8-bit Pointer]\n+1 Test");
+
+        inspector.SetCurrentAddress({ 3U });
+
+        Assert::AreEqual({ 3U }, inspector.GetCurrentAddress());
+        Assert::AreEqual(std::wstring(L"0x0003"), inspector.GetCurrentAddressText());
+        Assert::AreEqual(std::wstring(L"[8-bit Pointer]\n+1 Test"), inspector.GetCurrentAddressNote());
+        Assert::AreEqual(std::wstring(L"0 0 0 0 0 0 1 1"), inspector.GetCurrentAddressBits());
+        Assert::IsTrue(inspector.CanEditCurrentAddressNote());
+        Assert::IsFalse(inspector.CanPublishCurrentAddressNote());
+        Assert::IsFalse(inspector.CanRevertCurrentAddressNote());
+
+        inspector.SetCurrentAddress({ 4U });
+
+        Assert::AreEqual({ 4U }, inspector.GetCurrentAddress());
+        Assert::AreEqual(std::wstring(L"0x0004"), inspector.GetCurrentAddressText());
+        Assert::AreEqual(std::wstring(L"[Indirect from 0x0003]\r\nTest"), inspector.GetCurrentAddressNote());
+        Assert::AreEqual(std::wstring(L"0 0 0 0 0 1 0 0"), inspector.GetCurrentAddressBits());
+        Assert::IsFalse(inspector.CanEditCurrentAddressNote());
+        Assert::IsFalse(inspector.CanPublishCurrentAddressNote());
+        Assert::IsFalse(inspector.CanRevertCurrentAddressNote());
+
+        inspector.mockEmulatorContext.WriteMemoryByte({3U}, 2);
+        inspector.mockGameContext.Assets().FindCodeNotes()->DoFrame();
+        
+        Assert::AreEqual({ 4U }, inspector.GetCurrentAddress());
+        Assert::AreEqual(std::wstring(L"0x0004"), inspector.GetCurrentAddressText());
+        Assert::AreEqual(std::wstring(), inspector.GetCurrentAddressNote());
+        Assert::AreEqual(std::wstring(L"0 0 0 0 0 1 0 0"), inspector.GetCurrentAddressBits());
+        Assert::IsTrue(inspector.CanEditCurrentAddressNote());
+        Assert::IsFalse(inspector.CanPublishCurrentAddressNote());
+        Assert::IsFalse(inspector.CanRevertCurrentAddressNote());
+
+        // $3 = 2 + 1 = 3, so 3 is currently indirectly pointing it itself
+        // expect to find the original note, not the indirect one
+        inspector.SetCurrentAddress({ 3U });
+
+        Assert::AreEqual({ 3U }, inspector.GetCurrentAddress());
+        Assert::AreEqual(std::wstring(L"0x0003"), inspector.GetCurrentAddressText());
+        Assert::AreEqual(std::wstring(L"[8-bit Pointer]\n+1 Test"), inspector.GetCurrentAddressNote());
+        Assert::AreEqual(std::wstring(L"0 0 0 0 0 0 1 0"), inspector.GetCurrentAddressBits());
+        Assert::IsTrue(inspector.CanEditCurrentAddressNote());
+        Assert::IsFalse(inspector.CanPublishCurrentAddressNote());
+        Assert::IsFalse(inspector.CanRevertCurrentAddressNote());
     }
 
     TEST_METHOD(TestSetViewerAddress)


### PR DESCRIPTION
prevents making the edit field readonly if an indirect note occurs at a valid address for a real note