### PR TITLE
use expected memory map for address validation instead of provided memory blocks

### DIFF
--- a/src/data/context/ConsoleContext.cpp
+++ b/src/data/context/ConsoleContext.cpp
@@ -13,6 +13,7 @@ ConsoleContext::ConsoleContext(ConsoleID nId) noexcept
 {
     m_nId = nId;
     m_sName = ra::Widen(rc_console_name(ra::etoi(nId)));
+    m_nMaxAddress = 0;
 
     const auto* pRegions = rc_console_memory_regions(ra::etoi(nId));
     if (pRegions)
@@ -54,6 +55,8 @@ ConsoleContext::ConsoleContext(ConsoleID nId) noexcept
                     pMemoryRegion.Type = AddressType::Unknown;
                     break;
             }
+
+            m_nMaxAddress = std::max(m_nMaxAddress, pRegion.end_address);
         }
     }
 }

--- a/src/data/context/ConsoleContext.hh
+++ b/src/data/context/ConsoleContext.hh
@@ -101,11 +101,17 @@ public:
     /// <returns>Converted address, or <c>0xFFFFFFFF</c> if conversion could not be completed.
     ra::ByteAddress ByteAddressFromRealAddress(ra::ByteAddress nRealAddress) const noexcept;
 
+    /// <summary>
+    /// Gets the maximum valid address for the console.
+    /// </summary>
+    ra::ByteAddress MaxAddress() const noexcept { return m_nMaxAddress; }
+
 protected:
     ConsoleID m_nId{};
     std::wstring m_sName;
 
     std::vector<MemoryRegion> m_vRegions;
+    ra::ByteAddress m_nMaxAddress = 0;
 };
 
 } // namespace context

--- a/src/data/models/TriggerValidation.cpp
+++ b/src/data/models/TriggerValidation.cpp
@@ -2,7 +2,7 @@
 
 #include "RA_StringUtils.h"
 
-#include "data/context/EmulatorContext.hh"
+#include "data/context/ConsoleContext.hh"
 
 #include "services/ServiceLocator.hh"
 
@@ -99,10 +99,10 @@ bool TriggerValidation::Validate(const std::string& sTrigger, std::wstring& sErr
     const auto* pTrigger = rc_parse_trigger(sTriggerBuffer.data(), sTrigger.c_str(), nullptr, 0);
 
     unsigned nMaxAddress = ra::to_unsigned(-1);
-    if (ra::services::ServiceLocator::Exists<ra::data::context::EmulatorContext>())
+    if (ra::services::ServiceLocator::Exists<ra::data::context::ConsoleContext>())
     {
-        const auto& pEmulatorContext = ra::services::ServiceLocator::Get<ra::data::context::EmulatorContext>();
-        nMaxAddress = gsl::narrow_cast<unsigned>(pEmulatorContext.TotalMemorySize()) - 1;
+        const auto& pConsoleContext = ra::services::ServiceLocator::Get<ra::data::context::ConsoleContext>();
+        nMaxAddress = pConsoleContext.MaxAddress();
     }
 
     char sErrorBuffer[256];

--- a/tests/data/context/ConsoleContext_Tests.cpp
+++ b/tests/data/context/ConsoleContext_Tests.cpp
@@ -36,6 +36,7 @@ public:
 
         Assert::AreEqual(25, (int)context.Id());
         Assert::AreEqual(std::wstring(L"Atari 2600"), context.Name());
+        Assert::AreEqual(0x7FU, context.MaxAddress());
 
         const auto& vRegions = context.MemoryRegions();
         Assert::AreEqual({1}, vRegions.size());
@@ -59,6 +60,7 @@ public:
 
         Assert::AreEqual(5, (int)context.Id());
         Assert::AreEqual(std::wstring(L"GameBoy Advance"), context.Name());
+        Assert::AreEqual(0x00047FFFU, context.MaxAddress());
 
         const auto& vRegions = context.MemoryRegions();
         Assert::AreEqual({2}, vRegions.size());
@@ -88,6 +90,7 @@ public:
 
         Assert::AreEqual(41, (int)context.Id());
         Assert::AreEqual(std::wstring(L"PlayStation Portable"), context.Name());
+        Assert::AreEqual(0x01FFFFFFU, context.MaxAddress());
 
         const auto& vRegions = context.MemoryRegions();
         Assert::AreEqual({2}, vRegions.size());

--- a/tests/services/AchievementRuntime_Tests.cpp
+++ b/tests/services/AchievementRuntime_Tests.cpp
@@ -2,6 +2,7 @@
 
 #include "tests\RA_UnitTestHelpers.h"
 #include "tests\data\DataAsserts.hh"
+#include "tests\mocks\MockConsoleContext.hh"
 #include "tests\mocks\MockEmulatorContext.hh"
 #include "tests\mocks\MockFileSystem.hh"
 #include "tests\mocks\MockGameContext.hh"
@@ -1281,7 +1282,9 @@ public:
 
     TEST_METHOD(TestDetectUnsupportedAchievements)
     {
-        std::array<unsigned char, 2> memory{ 0x00, 0x00 };
+        ra::data::context::mocks::MockConsoleContext mockConsoleContext(Atari2600, L"Atari 2600");
+        Assert::AreEqual(0x7FU, mockConsoleContext.MaxAddress());
+        std::array<unsigned char, 128> memory{};
 
         AchievementRuntimeHarness runtime;
         auto& pAch1 = runtime.mockGameContext.Assets().NewAchievement();
@@ -1289,11 +1292,11 @@ public:
         pAch1.UpdateLocalCheckpoint();
         pAch1.Activate();
         auto& pAch2 = runtime.mockGameContext.Assets().NewAchievement();
-        pAch2.SetTrigger("0xH0002=1");
+        pAch2.SetTrigger("0xH0100=1");
         pAch1.UpdateLocalCheckpoint();
         pAch2.Activate();
         auto& pAch3 = runtime.mockGameContext.Assets().NewAchievement();
-        pAch3.SetTrigger("0xH0002=1");
+        pAch3.SetTrigger("0xH0100=1");
         pAch1.UpdateLocalCheckpoint();
 
         Assert::AreEqual(ra::data::models::AssetState::Waiting, pAch1.GetState());
@@ -1331,9 +1334,9 @@ public:
         Assert::AreEqual(ra::data::models::AssetState::Active, pAch1.GetState());
         Assert::AreEqual(std::wstring(), pAch1.GetValidationError());
         Assert::AreEqual(ra::data::models::AssetState::Disabled, pAch2.GetState());
-        Assert::AreEqual(std::wstring(L"Condition 1: Address 0002 out of range (max 0001)"), pAch2.GetValidationError());
+        Assert::AreEqual(std::wstring(L"Condition 1: Address 0100 out of range (max 007F)"), pAch2.GetValidationError());
         Assert::AreEqual(ra::data::models::AssetState::Inactive, pAch3.GetState());
-        Assert::AreEqual(std::wstring(L"Condition 1: Address 0002 out of range (max 0001)"), pAch3.GetValidationError());
+        Assert::AreEqual(std::wstring(L"Condition 1: Address 0100 out of range (max 007F)"), pAch3.GetValidationError());
     }
 };
 


### PR DESCRIPTION
Ensures memory range validation matches expectations, rather than what's provided by the emulator. Also fixes an issue where published achievements weren't reporting invalid memory addresses if they were validated before the emulator registered it's memory regions.

https://discord.com/channels/310192285306454017/493200466222776342/1052293030650052618