### PR TITLE
server reponse for unknown client changed

### DIFF
--- a/src/data/context/EmulatorContext.cpp
+++ b/src/data/context/EmulatorContext.cpp
@@ -265,7 +265,7 @@ bool EmulatorContext::ValidateClientVersion(bool& bHardcore)
         auto response = request.Call();
         if (!response.Succeeded())
         {
-            if (ra::StringStartsWith(response.ErrorMessage, "Unknown client!"))
+            if (ra::StringStartsWith(response.ErrorMessage, "Unknown client"))
             {
                 // if m_nEmulatorID is not recognized by the server, let it through regardless of version.
                 // assume it's a new emulator that hasn't been released yet.

--- a/tests/data/context/EmulatorContext_Tests.cpp
+++ b/tests/data/context/EmulatorContext_Tests.cpp
@@ -498,14 +498,14 @@ public:
         emulator.SetClientVersion("1.0");
         emulator.mockServer.HandleRequest<ra::api::LatestClient>([](const ra::api::LatestClient::Request&, ra::api::LatestClient::Response& response)
         {
-            response.ErrorMessage = "Unknown client! (EmulatorID: 999)";
+            response.ErrorMessage = "Unknown client";
             response.Result = ra::api::ApiResult::Error;
             return true;
         });
         emulator.mockDesktop.ExpectWindow<ra::ui::viewmodels::MessageBoxViewModel>([](ra::ui::viewmodels::MessageBoxViewModel& vmMessageBox)
         {
             Assert::AreEqual(std::wstring(L"Could not retrieve latest client version."), vmMessageBox.GetHeader());
-            Assert::AreEqual(std::wstring(L"Unknown client! (EmulatorID: 999)"), vmMessageBox.GetMessage());
+            Assert::AreEqual(std::wstring(L"Unknown client"), vmMessageBox.GetMessage());
             return ra::ui::DialogResult::OK;
         });
 


### PR DESCRIPTION
apparently, quite some time ago: https://github.com/RetroAchievements/RAWeb/commit/45876ddb50ec08f0a9ca41e35f122a0976599d3e#diff-896548613286480b5affffe474b50b7ce6b838d65c4fa0594a3e7714b59614bfR183