### PR TITLE
explicitly force first condition added to a Value to be Measured

### DIFF
--- a/tests/ui/viewmodels/TriggerViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/TriggerViewModel_Tests.cpp
@@ -949,6 +949,38 @@ public:
             vmTrigger.Conditions().GetItemAt(2)->GetTooltip(TriggerConditionViewModel::SourceValueProperty));
     }
 
+    TEST_METHOD(TestNewConditionValue)
+    {
+        std::array<uint8_t, 10> pMemory = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+        TriggerViewModelHarness vmTrigger;
+        vmTrigger.SetIsValue(true);
+        vmTrigger.AddGroup();
+        Assert::AreEqual({ 0U }, vmTrigger.Conditions().Count());
+
+        vmTrigger.InitializeMemory(&pMemory.at(0), pMemory.size());
+        vmTrigger.mockWindowManager.MemoryInspector.Viewer().SetAddress(8);
+        vmTrigger.mockWindowManager.MemoryInspector.Viewer().SetSize(MemSize::EightBit);
+        vmTrigger.NewCondition();
+
+        // first condition added to a value should be Measured without an operator
+        Assert::AreEqual({ 1U }, vmTrigger.Conditions().Count());
+        Assert::IsTrue(vmTrigger.Conditions().GetItemAt(0)->IsSelected());
+        Assert::AreEqual(std::string("M:0xH0008"), vmTrigger.Serialize());
+
+        // second condition should be added normally (as a comparison)
+        vmTrigger.mockWindowManager.MemoryInspector.Viewer().SetAddress(4);
+        vmTrigger.mockWindowManager.MemoryInspector.Viewer().SetSize(MemSize::SixteenBit);
+        vmTrigger.NewCondition();
+
+        Assert::AreEqual({ 2U }, vmTrigger.Conditions().Count());
+
+        // new condition should be selected, any previously selected items should be deselected
+        Assert::IsFalse(vmTrigger.Conditions().GetItemAt(0)->IsSelected());
+        Assert::IsTrue(vmTrigger.Conditions().GetItemAt(1)->IsSelected());
+
+        Assert::AreEqual(std::string("M:0xH0008_0x 0004=1284"), vmTrigger.Serialize());
+    }
+
     TEST_METHOD(TestAddGroupNoAlts)
     {
         TriggerViewModelHarness vmTrigger;


### PR DESCRIPTION
When a new condition is added, the current value is captured and included as an equality check (i.e. `0xH1234=8`). When this is processed as a value, the "=8" is discarded, and the type is changed to Measured, but the underlying serialized value is still `0xH1234=8`, which can be saved to the local file or published to the server.

This PR modifies the New Condition behavior to generate the normalized condition (`M:0xH1234`) immediately, instead of when processed.

See also https://discord.com/channels/310192285306454017/936655398725902356/1070810810957447278