### PR TITLE
suppress WM_ERASEBKGND message for memory viewer

### DIFF
--- a/src/ui/win32/bindings/MemoryViewerControlBinding.cpp
+++ b/src/ui/win32/bindings/MemoryViewerControlBinding.cpp
@@ -27,6 +27,10 @@ static LRESULT CALLBACK s_MemoryViewerControlWndProc(HWND hControl, UINT uMsg, W
             pControl->RenderMemViewer();
             return 0;
 
+        case WM_ERASEBKGND:
+            // we'll repaint the entire control area in WM_PAINT, so don't need to clear first.
+            return TRUE;
+
         case WM_MOUSEWHEEL:
             if (GET_WHEEL_DELTA_WPARAM(wParam) > 0)
                 pControl->ScrollUp();


### PR DESCRIPTION
I believe this fixes #972, though I could not reliably reproduce it. I only saw a brief flicker once every 30-40 seconds while moving on and off an address with a note. The problem appears to be that the window is clearing the area before repainting the memory viewer. 

When going to/from a local note, the publish and revert button states are updated. Because of a workaround for running within the SDL framework, this forces the entire Memory Inspector dialog to repaint, including the Memory View. In this situation, the WM_ERASEBKGND message is sent, clearing the area "behind" the memory viewer. This happens almost instantaneously before drawing the control, so I don't know why you're seeing so much flicker (thanks for the video). Since the control is fully pre-rendered offscreen, the background doesn't need to be reset before painting, I've suppressed the WM_ERASEBKGND message, and no longer see any flicker locally. Hopefully it works for you too.

