### PR TITLE
only show one tracker when multiple active leaderboards have same value definition

### DIFF
--- a/src/data/models/LeaderboardModel.hh
+++ b/src/data/models/LeaderboardModel.hh
@@ -117,6 +117,11 @@ public:
     void SetValueDefinition(const std::string& sTrigger) { SetAssetDefinition(m_pValueDefinition, sTrigger); }
 
     /// <summary>
+    /// Gets the calculated hash for the value definition.
+    /// </summary>
+    const int GetValueDefinitionHash() const { return GetValue(ValueDefinitionProperty); }
+
+    /// <summary>
     /// The <see cref="ModelProperty" /> for the value format.
     /// </summary>
     static const IntModelProperty ValueFormatProperty;

--- a/src/services/GameIdentifier.cpp
+++ b/src/services/GameIdentifier.cpp
@@ -214,6 +214,9 @@ void GameIdentifier::ActivateGame(unsigned int nGameId)
 
         ra::services::ServiceLocator::GetMutable<ra::data::context::SessionTracker>().EndSession();
 
+        auto& pOverlayManager = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>();
+        pOverlayManager.ClearPopups();
+
         auto& pGameContext = ra::services::ServiceLocator::GetMutable<ra::data::context::GameContext>();
         pGameContext.LoadGame(0U, m_nPendingMode);
         pGameContext.SetGameHash((m_nPendingGameId == 0) ? m_sPendingHash : "");


### PR DESCRIPTION
implements #880

Only collapses trackers with the _exact_ same Value definition (case matters if manually entered via website).
Does not collapse trackers _showing_ the same value as they may diverge at some point.

Before:
![image](https://user-images.githubusercontent.com/32680403/218266711-888423fb-3661-4792-af0e-f961ddd6d027.png)

After:
![image](https://user-images.githubusercontent.com/32680403/218266833-468ad7c0-33ec-44eb-bc94-d99e431e5482.png)

Note: the leaderboards for this game have been designed to not all appear at the same time (despite what is shown in #880). I modified them to replicate the reported behavior.