### PR TITLE
show error when hash cannot be generated

### DIFF
--- a/src/services/GameIdentifier.cpp
+++ b/src/services/GameIdentifier.cpp
@@ -47,7 +47,13 @@ unsigned int GameIdentifier::IdentifyGame(const BYTE* pROM, size_t nROMSize)
     }
 
     char hash[33];
-    rc_hash_generate_from_buffer(hash, nConsoleId, pROM, nROMSize);
+    if (!rc_hash_generate_from_buffer(hash, nConsoleId, pROM, nROMSize))
+    {
+        ra::ui::viewmodels::MessageBoxViewModel::ShowErrorMessage(
+            L"Could not identify game.",
+            L"No hash was generated for the provided content.");
+        return 0U;
+    }
 
     return IdentifyHash(hash);
 }

--- a/tests/services/GameIdentifier_Tests.cpp
+++ b/tests/services/GameIdentifier_Tests.cpp
@@ -164,6 +164,24 @@ public:
         Assert::IsTrue(bDialogShown);
     }
 
+    TEST_METHOD(TestIdentifyGameUnhashable)
+    {
+        GameIdentifierHarness identifier;
+        ra::data::context::mocks::MockConsoleContext n64Context(N64, L"N64");
+
+        bool bDialogShown = false;
+        identifier.mockDesktop.ExpectWindow<ra::ui::viewmodels::MessageBoxViewModel>([&bDialogShown](ra::ui::viewmodels::MessageBoxViewModel& vmMessageBox)
+        {
+            Assert::AreEqual(std::wstring(L"Could not identify game."), vmMessageBox.GetHeader());
+            Assert::AreEqual(std::wstring(L"No hash was generated for the provided content."), vmMessageBox.GetMessage());
+            bDialogShown = true;
+            return ra::ui::DialogResult::OK;
+        });
+
+        Assert::AreEqual(0U, identifier.IdentifyGame(&ROM.at(0), ROM.size()));
+        Assert::IsTrue(bDialogShown);
+    }
+
     TEST_METHOD(TestIdentifyGameNotLoggedIn)
     {
         GameIdentifierHarness identifier;
@@ -179,6 +197,7 @@ public:
         });
 
         Assert::AreEqual(0U, identifier.IdentifyGame(&ROM.at(0), ROM.size()));
+        Assert::IsTrue(bDialogShown);
     }
 
     TEST_METHOD(TestIdentifyGameNoConsole)
@@ -196,6 +215,7 @@ public:
         });
 
         Assert::AreEqual(0U, identifier.IdentifyGame(&ROM.at(0), ROM.size()));
+        Assert::IsTrue(bDialogShown);
     }
 
     TEST_METHOD(TestIdentifyGameHashChange)


### PR DESCRIPTION
Shows a "No hash was generated" error instead of showing garbage (uninitialized memory) for the hash in the unknown game dialog.