### PR TITLE
hide all popups and overlay when activating game 0

### DIFF
--- a/src/Exports.cpp
+++ b/src/Exports.cpp
@@ -398,6 +398,14 @@ API unsigned int CCONV _RA_IdentifyHash(const char* sHash)
 API void CCONV _RA_ActivateGame(unsigned int nGameId)
 {
     _RA_SuspendRepaint();
+
+    if (nGameId == 0)
+    {
+        auto& pOverlayManager = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>();
+        pOverlayManager.ClearPopups();
+        pOverlayManager.HideOverlayImmediately();
+    }
+
     ra::services::ServiceLocator::GetMutable<ra::services::GameIdentifier>().ActivateGame(nGameId);
     _RA_ResumeRepaint();
 }

--- a/src/ui/viewmodels/OverlayManager.hh
+++ b/src/ui/viewmodels/OverlayManager.hh
@@ -68,6 +68,14 @@ public:
     }
 
     /// <summary>
+    /// Hides the overlay without animating it.
+    /// </summary>
+    void HideOverlayImmediately()
+    {
+        m_vmOverlay.DeactivateImmediately();
+    }
+
+    /// <summary>
     /// Determines if the overlay is completely covering the emulator screen.
     /// </summary>
     bool IsOverlayFullyVisible() const noexcept

--- a/src/ui/viewmodels/OverlayViewModel.cpp
+++ b/src/ui/viewmodels/OverlayViewModel.cpp
@@ -357,6 +357,18 @@ void OverlayViewModel::Deactivate()
     }
 }
 
+void OverlayViewModel::DeactivateImmediately()
+{
+    if (m_nState != State::Hidden)
+    {
+        // set the state to completely faded out, but not hidden, as it won't repaint once
+        // it's completely hidden.
+        m_nState = State::FadeOut;
+        m_fAnimationProgress = INOUT_TIME;
+        RefreshOverlay();
+    }
+}
+
 void OverlayViewModel::PopulatePages()
 {
     m_vPages.resize(4);

--- a/src/ui/viewmodels/OverlayViewModel.hh
+++ b/src/ui/viewmodels/OverlayViewModel.hh
@@ -63,6 +63,7 @@ public:
 
     void Activate();
     void Deactivate();
+    void DeactivateImmediately();
 
     class PageViewModel : public ViewModelBase
     {

--- a/tests/ui/viewmodels/OverlayManager_Tests.cpp
+++ b/tests/ui/viewmodels/OverlayManager_Tests.cpp
@@ -605,6 +605,33 @@ public:
 
         Assert::IsFalse(overlay.IsOverlayFullyVisible());
     }
+
+    TEST_METHOD(TestHideOverlayImmediately)
+    {
+        OverlayManagerHarness overlay;
+        ra::ui::drawing::mocks::MockSurface mockSurface(800, 600);
+
+        overlay.ShowOverlay();
+
+        // after 0.5 seconds, it should be fully on screen
+        overlay.mockClock.AdvanceTime(std::chrono::milliseconds(500));
+        overlay.ResetRenderRequested();
+        overlay.Render(mockSurface, false);
+        Assert::AreEqual(0, overlay.GetOverlayRenderX());
+        Assert::IsFalse(overlay.WasRenderRequested());
+        Assert::IsTrue(overlay.IsOverlayFullyVisible());
+
+        overlay.HideOverlayImmediately();
+        Assert::IsTrue(overlay.WasRenderRequested());
+        Assert::IsFalse(overlay.IsOverlayFullyVisible());
+
+        overlay.Render(mockSurface, false); // force state change from FadeOut to Hidden
+
+        // it should be fully off screen immediately
+        Assert::AreEqual(-800, overlay.GetOverlayRenderX());
+        Assert::IsTrue(overlay.WasRenderRequested());
+        Assert::IsTrue(overlay.WasHideRequested());
+    }
 };
 
 } // namespace tests


### PR DESCRIPTION
prevents remnants from remaining after the emulator indicates a game has been unloaded