### PR TITLE
better error message for 429 error

### DIFF
--- a/src/api/impl/ConnectedServer.cpp
+++ b/src/api/impl/ConnectedServer.cpp
@@ -279,7 +279,11 @@ static bool DoRequestWithoutLog(const rc_api_request_t& api_request, _UNUSED con
     switch (pHttpResponse.Content().at(0))
     {
         case '{': // JSON, expected
+            break;
+
         case '<': // HTML, not expected
+            if (HandleHttpError(pHttpResponse.StatusCode(), pResponse))
+                return false;
             break;
 
         default:

--- a/src/services/Http.hh
+++ b/src/services/Http.hh
@@ -16,6 +16,7 @@ public:
         Unauthorized = 401,
         Forbidden = 403,
         NotFound = 404,
+        TooManyRequests = 429,
     };
 
     class Response

--- a/src/services/impl/WindowsHttpRequester.cpp
+++ b/src/services/impl/WindowsHttpRequester.cpp
@@ -348,6 +348,7 @@ std::string WindowsHttpRequester::GetStatusCodeText(unsigned int nStatusCode) co
             case HTTP_STATUS_NOT_SUPPORTED: message = "Not Implemented"; break;
             case HTTP_STATUS_BAD_GATEWAY: message = "Bad Gateway"; break;
             case HTTP_STATUS_SERVICE_UNAVAIL: message = "Service Unavailable"; break;
+            case 429: message = "Too Many Requests"; break;
         }
     }
 


### PR DESCRIPTION
https://discord.com/channels/310192285306454017/310195377993416714/1094895782223675434

Should now report "HTTP error code: 429 (Too Many Requests)" instead of "JSON Parse Error: Invalid JSON".