### PR TITLE
normalize code note line endings

### DIFF
--- a/src/RA_StringUtils.cpp
+++ b/src/RA_StringUtils.cpp
@@ -210,6 +210,25 @@ std::wstring& Trim(std::wstring& str)
 }
 
 _Use_decl_annotations_
+std::wstring& NormalizeLineEndings(std::wstring& str)
+{
+    size_t nIndex = 0;
+    do
+    {
+        nIndex = str.find('\n', nIndex);
+        if (nIndex == std::wstring::npos)
+            break;
+
+        if (nIndex == 0 || str.at(nIndex - 1) != '\r')
+            str.insert(str.begin() + nIndex++, '\r');
+
+        ++nIndex;
+    } while (true);
+
+    return str;
+}
+
+_Use_decl_annotations_
 const std::string FormatDateTime(time_t when)
 {
     struct tm tm;

--- a/src/RA_StringUtils.h
+++ b/src/RA_StringUtils.h
@@ -36,6 +36,12 @@ std::string& TrimLineEnding(_Inout_ std::string& str) noexcept;
 /// <returns>Reference to <paramref name="str" /> for chaining.</returns>
 std::wstring& Trim(_Inout_ std::wstring& str);
 
+/// <summary>
+/// Converts all "\n"s in a string to "\r\n".
+/// </summary>
+/// <returns>Reference to <paramref name="str" /> for chaining.</returns>
+std::wstring& NormalizeLineEndings(_Inout_ std::wstring& str);
+
 // ----- ToString -----
 
 template<typename T>

--- a/src/api/impl/ConnectedServer.cpp
+++ b/src/api/impl/ConnectedServer.cpp
@@ -943,6 +943,8 @@ void ConnectedServer::ProcessCodeNotes(FetchCodeNotes::Response& response, const
         pNote.Author = note->author;
         pNote.Address = note->address;
         pNote.Note = ra::Widen(note->note);
+
+        ra::NormalizeLineEndings(pNote.Note);
     }
 }
 #pragma warning(pop)

--- a/src/ui/viewmodels/AssetListViewModel.cpp
+++ b/src/ui/viewmodels/AssetListViewModel.cpp
@@ -1178,7 +1178,7 @@ static std::wstring ValidateCondSet(const rc_condset_t* pCondSet)
     for (const auto* pCondition = pCondSet->conditions; pCondition != nullptr; pCondition = pCondition->next)
     {
         /* rc_condition_t validation goes here */
-#if RA_INTEGRATION_VERSION_LESS_THAN(1,2,0)
+#if RA_INTEGRATION_VERSION_LESS_THAN(1,2,1)
 #define VALIDATE_PRERELEASE_FUNCTIONALITY
 //        if (pCondition->operand1.size == RC_MEMSIZE_MBF32_LE || pCondition->operand2.size == RC_MEMSIZE_MBF32_LE)
 //            return L"MBF32 LE size is pre-release functionality";


### PR DESCRIPTION
Fixes a display issue if the database note contains Linux line feeds instead of Windows line feeds.

Server:
![image](https://user-images.githubusercontent.com/32680403/235168236-b9592c94-5646-465f-b102-5d3281938bc1.png)

Before:
![image](https://user-images.githubusercontent.com/32680403/235167983-fadcb4ae-84b5-451c-90a9-abcab786c159.png)

After:
![image](https://user-images.githubusercontent.com/32680403/235168068-b3e49c24-2b07-42bb-afc0-945da8483cc8.png)
