### PR TITLE
prevent exception if progress tracker updated on background thread

### DIFF
--- a/src/ui/viewmodels/ProgressTrackerViewModel.cpp
+++ b/src/ui/viewmodels/ProgressTrackerViewModel.cpp
@@ -39,7 +39,7 @@ bool ProgressTrackerViewModel::UpdateRenderImage(double fElapsed)
 
     bool bUpdated = false;
 
-    if (m_pSurface == nullptr)
+    if (m_pSurface == nullptr || m_bRegenerate)
     {
         const auto& pTheme = ra::services::ServiceLocator::Get<ra::ui::OverlayTheme>();
         const auto nShadowOffset = pTheme.ShadowOffset();
@@ -79,6 +79,7 @@ bool ProgressTrackerViewModel::UpdateRenderImage(double fElapsed)
         pSurface->WriteText(nX + 2, nY + 2, nFontSubtitle, pOverlayTheme.ColorTextShadow(), m_sProgress);
         pSurface->WriteText(nX, nY, nFontSubtitle, pOverlayTheme.ColorDetail(), m_sProgress);
 
+        m_bRegenerate = false;
         m_pSurface = std::move(pSurface);
 
         bUpdated = true;

--- a/src/ui/viewmodels/ProgressTrackerViewModel.hh
+++ b/src/ui/viewmodels/ProgressTrackerViewModel.hh
@@ -19,7 +19,7 @@ public:
     void SetImage(ra::ui::ImageType nImageType, const std::string& sImageName)
     {
         m_hImage.ChangeReference(nImageType, sImageName);
-        m_pSurface.reset();
+        m_bRegenerate = true;
         SetRenderLocationY(-1); // force redraw when position calculated
     }
 
@@ -54,6 +54,7 @@ public:
 private:
     ra::ui::ImageReference m_hImage;
     std::wstring m_sProgress;
+    bool m_bRegenerate = false;
 
     double m_fAnimationProgress = TOTAL_ANIMATION_TIME;
 


### PR DESCRIPTION
PCSX2 does achievement processing on a thread other than the one managing the Windows message queue. As a result, there's a situation where the achievement code can update the progress tracker while the UI thread is trying to render it.

Instead of immediately destroying the old image, I've added a flag indicating that the image is stale and needs to be replaced. This way, the code that generates the image can swap out the new image for the old without ever leaving the image undefined.