### PR TITLE
recalculate total hits when switching between alts

### DIFF
--- a/src/ui/viewmodels/TriggerViewModel.hh
+++ b/src/ui/viewmodels/TriggerViewModel.hh
@@ -163,6 +163,7 @@ private:
     void InitializeGroups(const rc_trigger_t& pTrigger);
     void UpdateGroups(const rc_trigger_t& pTrigger);
     void UpdateConditions(const GroupViewModel* pGroup);
+    void UpdateTotalHits();
 
     void DeselectAllConditions();
     void UpdateIndicesAndEnsureSelectionVisible();

--- a/tests/ui/viewmodels/TriggerViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/TriggerViewModel_Tests.cpp
@@ -1419,6 +1419,28 @@ public:
         Assert::AreEqual(sTooltip, vmTrigger.GetHitChainTooltip(5)); // non hit modifier
         Assert::AreEqual(sTooltip, vmTrigger.GetHitChainTooltip(6)); // end of hits-chain
     }
+
+    TEST_METHOD(TestAltHitChain)
+    {
+        TriggerViewModelHarness vmTrigger;
+        Parse(vmTrigger, "1=1SC:0xH1234=1_0=1.10.SC:0xH2345=1_0=1.10.");
+        Assert::AreEqual({3U}, vmTrigger.Groups().Count());
+
+        vmTrigger.Groups().GetItemAt(1)->m_pConditionSet->conditions->current_hits = 2;
+        vmTrigger.Groups().GetItemAt(2)->m_pConditionSet->conditions->current_hits = 3;
+
+        vmTrigger.SetSelectedGroupIndex(2);
+        Assert::AreEqual(3U, vmTrigger.Conditions().GetItemAt(0)->GetCurrentHits());
+        Assert::AreEqual(0U, vmTrigger.Conditions().GetItemAt(0)->GetTotalHits());
+        Assert::AreEqual(0U, vmTrigger.Conditions().GetItemAt(1)->GetCurrentHits());
+        Assert::AreEqual(3U, vmTrigger.Conditions().GetItemAt(1)->GetTotalHits());
+
+        vmTrigger.SetSelectedGroupIndex(1);
+        Assert::AreEqual(2U, vmTrigger.Conditions().GetItemAt(0)->GetCurrentHits());
+        Assert::AreEqual(0U, vmTrigger.Conditions().GetItemAt(0)->GetTotalHits());
+        Assert::AreEqual(0U, vmTrigger.Conditions().GetItemAt(1)->GetCurrentHits());
+        Assert::AreEqual(2U, vmTrigger.Conditions().GetItemAt(1)->GetTotalHits());
+    }
 };
 
 } // namespace tests


### PR DESCRIPTION
When switching between alt groups, the total value of an AddHits chain would disappear until the next frame was processed.

https://discord.com/channels/310192285306454017/962817919698501702/1062935418267500554

This forces it to be recalculates when switching groups.