### PR TITLE
fix race condition integrating local code notes

### DIFF
--- a/src/data/models/CodeNotesModel.cpp
+++ b/src/data/models/CodeNotesModel.cpp
@@ -1006,6 +1006,7 @@ bool CodeNotesModel::Deserialize(ra::Tokenizer& pTokenizer)
     if (!ReadQuoted(pTokenizer, sNote))
         return false;
 
+    ra::NormalizeLineEndings(sNote);
     SetCodeNote(nAddress, sNote);
     return true;
 }

--- a/src/data/models/CodeNotesModel.cpp
+++ b/src/data/models/CodeNotesModel.cpp
@@ -39,6 +39,11 @@ void CodeNotesModel::Refresh(unsigned int nGameId, CodeNoteChangedFunction fCode
     if (callback == nullptr) // unit test workaround to avoid server call
         return;
 
+    {
+        std::unique_lock<std::mutex> lock(m_oMutex);
+        m_bRefreshing = true;
+    }
+
     ra::api::FetchCodeNotes::Request request;
     request.GameId = nGameId;
     request.CallAsync([this, callback](const ra::api::FetchCodeNotes::Response& response)
@@ -66,6 +71,16 @@ void CodeNotesModel::Refresh(unsigned int nGameId, CodeNoteChangedFunction fCode
                 AddCodeNote(pNote.Address, pNote.Author, pNote.Note);
             }
         }
+
+        std::map<ra::ByteAddress, std::wstring> mPendingCodeNotes;
+        {
+            std::unique_lock<std::mutex> lock(m_oMutex);
+            mPendingCodeNotes.swap(m_mPendingCodeNotes);
+            m_bRefreshing = false;
+        }
+
+        for (const auto pNote : mPendingCodeNotes)
+            SetCodeNote(pNote.first, pNote.second);
 
         callback();
     });
@@ -608,6 +623,12 @@ void CodeNotesModel::SetCodeNote(ra::ByteAddress nAddress, const std::wstring& s
 
     {
         std::unique_lock<std::mutex> lock(m_oMutex);
+
+        if (m_bRefreshing)
+        {
+            m_mPendingCodeNotes[nAddress] = sNote;
+            return;
+        }
 
         const auto pIter = m_mCodeNotes.find(nAddress);
         if (pIter != m_mCodeNotes.end())

--- a/src/data/models/CodeNotesModel.hh
+++ b/src/data/models/CodeNotesModel.hh
@@ -220,11 +220,14 @@ protected:
     std::map<ra::ByteAddress, CodeNote> m_mCodeNotes;
     std::map<ra::ByteAddress, std::pair<std::string, std::wstring>> m_mOriginalCodeNotes;
 
+    std::map<ra::ByteAddress, std::wstring> m_mPendingCodeNotes;
+
     const CodeNote* FindCodeNoteInternal(ra::ByteAddress nAddress) const;
     void EnumerateCodeNotes(std::function<bool(ra::ByteAddress nAddress, const CodeNote& pCodeNote)> callback, bool bIncludeDerived) const;
 
     unsigned int m_nGameId = 0;
     bool m_bHasPointers = false;
+    bool m_bRefreshing = false;
 
     CodeNoteChangedFunction m_fCodeNoteChanged;
 

--- a/src/ui/viewmodels/MemoryViewerViewModel.cpp
+++ b/src/ui/viewmodels/MemoryViewerViewModel.cpp
@@ -205,11 +205,13 @@ void MemoryViewerViewModel::UpdateColors()
     if (pCodeNotes != nullptr)
     {
         const auto nStopAddress = nFirstAddress + nVisibleLines * 16;
-        pCodeNotes->EnumerateCodeNotes([nFirstAddress, nStopAddress, this](ra::ByteAddress nAddress, unsigned nBytes, const std::wstring&) {
-            if (nAddress + nBytes <= nFirstAddress)
+        pCodeNotes->EnumerateCodeNotes([nFirstAddress, nStopAddress, this](ra::ByteAddress nAddress, unsigned nBytes, const std::wstring& sNote) {
+            if (nAddress + nBytes <= nFirstAddress) // not to viewing window yet
                 return true;
-            if (nAddress >= nStopAddress)
+            if (nAddress >= nStopAddress) // past viewing window
                 return false;
+            if (sNote.empty()) // ignore deleted notes
+                return true;
 
             uint8_t* pOffset = m_pColor;
             Expects(pOffset != nullptr);

--- a/tests/data/models/CodeNotesModel_Tests.cpp
+++ b/tests/data/models/CodeNotesModel_Tests.cpp
@@ -1059,7 +1059,7 @@ public:
 
         Assert::IsTrue(notes.Deserialize(pTokenizer));
         Assert::AreEqual(AssetChanges::Unpublished, notes.GetChanges());
-        notes.AssertNote(0x1234, std::wstring(L"16-bit pointer\n+2:\t\"a\"\n+4:\tb\n"));
+        notes.AssertNote(0x1234, std::wstring(L"16-bit pointer\r\n+2:\t\"a\"\r\n+4:\tb\r\n"));
     }
 
     TEST_METHOD(TestDeserializeUnchanged)


### PR DESCRIPTION
fixes #997 

There was a race condition where the main thread was trying to merge local code notes into the code notes list while a background thread was populating the list from the server response. If the code notes window or memory inspector was open, the background thread would block, waiting for the UI thread to become available so the UI could be updated. This would result in the server notes response processing thread waiting indefinitely while the game loaded on the main thread, and all local notes read while loading the game on the main thread would be overwritten by the server notes when the background thread was eventually allowed to continue.

Solution: Keep track of when server notes are being fetched and queue up changes until the fetch is complete, then apply the changes.