### PR TITLE
add ASCII display to memory viewer

### DIFF
--- a/src/ui/Types.hh
+++ b/src/ui/Types.hh
@@ -71,6 +71,27 @@ union Color {
     } Channel;
 
     static const Color Transparent;
+
+    static const Color Blend(Color nFirst, Color nSecond, float fFirstSaturation = 0.5f) noexcept
+    {
+        unsigned char r = 0, g = 0, b = 0;
+        if (fFirstSaturation == 0.5f)
+        {
+            r = gsl::narrow_cast<unsigned char>((gsl::narrow_cast<int>(nFirst.Channel.R) + nSecond.Channel.R) / 2);
+            g = gsl::narrow_cast<unsigned char>((gsl::narrow_cast<int>(nFirst.Channel.G) + nSecond.Channel.G) / 2);
+            b = gsl::narrow_cast<unsigned char>((gsl::narrow_cast<int>(nFirst.Channel.B) + nSecond.Channel.B) / 2);
+        }
+        else
+        {
+            r = gsl::narrow_cast<unsigned char>(fFirstSaturation * nFirst.Channel.R +
+                                                (1.0f - fFirstSaturation) * nSecond.Channel.R);
+            g = gsl::narrow_cast<unsigned char>(fFirstSaturation * nFirst.Channel.G +
+                                                (1.0f - fFirstSaturation) * nSecond.Channel.G);
+            b = gsl::narrow_cast<unsigned char>(fFirstSaturation * nFirst.Channel.B +
+                                                (1.0f - fFirstSaturation) * nSecond.Channel.B);
+        }
+        return Color(r, g, b);
+    }
 };
 static_assert(sizeof(Color) == sizeof(unsigned int));
 

--- a/src/ui/viewmodels/MemoryViewerViewModel.hh
+++ b/src/ui/viewmodels/MemoryViewerViewModel.hh
@@ -161,7 +161,7 @@ public:
     void SetSize(MemSize value) { SetValue(SizeProperty, ra::etoi(value)); }
 
     void OnClick(int nX, int nY);
-    void OnResized(_UNUSED int nWidth, int nHeight);
+    void OnResized(int nWidth, int nHeight);
     bool OnChar(char c);
     void OnGotFocus();
     void OnLostFocus();
@@ -197,6 +197,8 @@ protected:
     bool m_bReadOnly = true;
     bool m_bAddressFixed = false;
     bool m_bHasFocus = false;
+    bool m_bWideEnoughForASCII = false;
+    bool m_bShowASCII = false;
 
     static constexpr int REDRAW_MEMORY = 1;
     static constexpr int REDRAW_ADDRESSES = 2;
@@ -209,6 +211,7 @@ protected:
 private:
     static const IntModelProperty PendingAddressProperty;
 
+    void ResetSurface() noexcept;
     void BuildFontSurface();
     void RenderAddresses();
     void RenderHeader();
@@ -224,10 +227,13 @@ private:
     int GetSelectedNibbleOffset() const;
     void UpdateSelectedNibble(int nNewNibble);
 
+    void DetermineIfASCIIShouldBeVisible();
+
     std::unique_ptr<uint8_t[]> m_pBuffer;
 
     std::unique_ptr<ra::ui::drawing::ISurface> m_pSurface;
     static std::unique_ptr<ra::ui::drawing::ISurface> s_pFontSurface;
+    static std::unique_ptr<ra::ui::drawing::ISurface> s_pFontASCIISurface;
     static int s_nFont;
 
     class MemoryBookmarkMonitor;

--- a/src/ui/viewmodels/OverlayManager.cpp
+++ b/src/ui/viewmodels/OverlayManager.cpp
@@ -831,8 +831,8 @@ void OverlayManager::ProcessScreenshots()
                 if (pMessage == nullptr)
                 {
                     // popup no longer available, discard request
-                    iter = pScreenshot.vMessages.erase(iter);
                     RA_LOG_INFO("Popup no longer available for %s", iter->second);
+                    iter = pScreenshot.vMessages.erase(iter);
                 }
                 else
                 {


### PR DESCRIPTION
If the memory viewer is in 8-bit mode and the window is sufficiently wide, the ASCII translations of the bytes will also be displayed.

![image](https://github.com/RetroAchievements/RAIntegration/assets/32680403/f0a33f02-3e6f-4490-aa71-d978d9c27a9a)

Note that bytes can be selected by clicking on the ASCII values, but the ASCII values _cannot be directly modified_. Keypresses will still be sent to the cursor on the left side of the viewer.