### PR TITLE
attempt to prevent deadlock

### DIFF
--- a/src/ui/viewmodels/MemorySearchViewModel.hh
+++ b/src/ui/viewmodels/MemorySearchViewModel.hh
@@ -484,6 +484,7 @@ private:
     std::chrono::steady_clock::time_point m_tLastContinuousFilter;
     bool m_bScrolling = false;
     bool m_bSelectingFilter = false;
+    bool m_bUpdateResultsPending = false;
 
     std::mutex m_oMutex;
 


### PR DESCRIPTION
Extension of #1026.

Data binding events were trying to execute UI code from the non-UI thread. If the UI thread was blocked waiting for the search results to be updated, a deadlock would occur: https://discord.com/channels/310192285306454017/1149693430306447380/1152705143394009262

This attempts to keep the UI thread from being blocked by detecting that the list is being updated and setting a flag so the code that needs the lock on the UI thread can be called after the list finishes updating.