### PR TITLE
update overlay header/footer

### DIFF
--- a/src/services/AchievementRuntime.cpp
+++ b/src/services/AchievementRuntime.cpp
@@ -585,6 +585,22 @@ rc_trigger_t* AchievementRuntime::GetAchievementTrigger(ra::AchievementID nId) c
     return (achievement != nullptr) ? achievement->trigger : nullptr;
 }
 
+std::string AchievementRuntime::GetAchievementBadge(const rc_client_achievement_t& pAchievement)
+{
+    std::string sBadgeName = pAchievement.badge_name;
+
+    if (!sBadgeName.empty() && sBadgeName.front() == 'L')
+    {
+        // local image, get from model
+        const auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::context::GameContext>();
+        auto* vmLocalAchievement = pGameContext.Assets().FindAchievement(pAchievement.id);
+        if (vmLocalAchievement != nullptr)
+            sBadgeName = ra::Narrow(vmLocalAchievement->GetBadge());
+    }
+
+    return sBadgeName;
+}
+
 static rc_client_leaderboard_info_t* GetLeaderboardInfo(rc_client_t* pClient, ra::LeaderboardID nId) noexcept
 {
     rc_client_subset_info_t* subset = pClient->game->subsets;
@@ -1111,7 +1127,7 @@ static void HandleAchievementTriggeredEvent(const rc_client_achievement_t& pAchi
     std::unique_ptr<ra::ui::viewmodels::PopupMessageViewModel> vmPopup(new ra::ui::viewmodels::PopupMessageViewModel);
     vmPopup->SetDescription(ra::StringPrintf(L"%s (%u)", pAchievement.title, pAchievement.points));
     vmPopup->SetDetail(ra::Widen(pAchievement.description));
-    vmPopup->SetImage(ra::ui::ImageType::Badge, pAchievement.badge_name);
+    vmPopup->SetImage(ra::ui::ImageType::Badge, AchievementRuntime::GetAchievementBadge(pAchievement));
     vmPopup->SetPopupType(ra::ui::viewmodels::Popup::AchievementTriggered);
 
     switch (vmAchievement->GetCategory())

--- a/src/services/AchievementRuntime.hh
+++ b/src/services/AchievementRuntime.hh
@@ -69,6 +69,8 @@ public:
     /// </summary>
     rc_trigger_t* GetAchievementTrigger(ra::AchievementID nId) const noexcept;
 
+    static std::string GetAchievementBadge(const rc_client_achievement_t& pAchievement);
+
     /// <summary>
     /// Gets the raw definition for the leaderboard.
     /// </summary>

--- a/src/ui/OverlayTheme.hh
+++ b/src/ui/OverlayTheme.hh
@@ -51,6 +51,7 @@ public:
     int FontSizeOverlayTitle() const noexcept { return m_nFontSizeOverlayTitle; }
     int FontSizeOverlayHeader() const noexcept { return m_nFontSizeOverlayHeader; }
     int FontSizeOverlaySummary() const noexcept { return m_nFontSizeOverlaySummary; }
+    int FontSizeOverlayDetail() const noexcept { return m_nFontSizeOverlayDetail; }
 
     Color ColorOverlayPanel() const noexcept { return m_colorOverlayPanel; }
     Color ColorOverlayText() const noexcept { return m_colorOverlayText; }
@@ -96,6 +97,7 @@ private:
     int m_nFontSizeOverlayTitle = 32;
     int m_nFontSizeOverlayHeader = 26;
     int m_nFontSizeOverlaySummary = 22;
+    int m_nFontSizeOverlayDetail = 14;
 
     Color m_colorOverlayPanel{ 255, 32, 32, 32 };
     Color m_colorOverlayText{ 255, 17, 102, 221 };

--- a/src/ui/Theme.cpp
+++ b/src/ui/Theme.cpp
@@ -122,6 +122,7 @@ void OverlayTheme::LoadFromFile()
             ReadSize(m_nFontSizeOverlayTitle, sizes, "Title");
             ReadSize(m_nFontSizeOverlayHeader, sizes, "Header");
             ReadSize(m_nFontSizeOverlaySummary, sizes, "Summary");
+            ReadSize(m_nFontSizeOverlayDetail, sizes, "Detail");
         }
 
         if (overlay.HasMember("Colors"))

--- a/src/ui/viewmodels/OverlayAchievementsPageViewModel.cpp
+++ b/src/ui/viewmodels/OverlayAchievementsPageViewModel.cpp
@@ -270,7 +270,7 @@ bool OverlayAchievementsPageViewModel::OnHeaderClicked(ItemViewModel& vmItem)
     return false;
 }
 
-const wchar_t* OverlayAchievementsPageViewModel::GetPrevButtonText() const
+const wchar_t* OverlayAchievementsPageViewModel::GetPrevButtonText() const noexcept
 {
     if (m_bDetail)
         return L"";
@@ -278,7 +278,7 @@ const wchar_t* OverlayAchievementsPageViewModel::GetPrevButtonText() const
     return L"Recent Games";
 }
 
-const wchar_t* OverlayAchievementsPageViewModel::GetNextButtonText() const
+const wchar_t* OverlayAchievementsPageViewModel::GetNextButtonText() const noexcept
 {
     if (m_bDetail)
         return L"";

--- a/src/ui/viewmodels/OverlayAchievementsPageViewModel.cpp
+++ b/src/ui/viewmodels/OverlayAchievementsPageViewModel.cpp
@@ -95,13 +95,16 @@ static void SetAchievement(OverlayListPageViewModel::ItemViewModel& vmItem,
 
 void OverlayAchievementsPageViewModel::Refresh()
 {
-    m_sTitle = L"Achievements";
-    m_sDetailTitle = L"Achievement Info";
     OverlayListPageViewModel::Refresh();
 
     // title
     const auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::context::GameContext>();
-    SetListTitle(pGameContext.GameTitle());
+    const auto& sTitle = pGameContext.GameTitle();
+    if (sTitle.empty())
+        SetTitle(L"No Game Loaded");
+    else
+        SetTitle(pGameContext.GameTitle());
+    m_bHasDetail = true;
 
     // achievement list
     const auto& pClient = ra::services::ServiceLocator::Get<ra::services::AchievementRuntime>().GetClient();
@@ -200,24 +203,31 @@ void OverlayAchievementsPageViewModel::Refresh()
     rc_client_user_game_summary_t summary;
     rc_client_get_user_game_summary(pClient, &summary);
     if (nNumberOfAchievements == 0)
-        m_sSummary = L"No achievements present";
+    {
+        SetSubTitle(L"No achievements present");
+    }
     else if (summary.num_core_achievements > 0)
-        m_sSummary = ra::StringPrintf(L"%u of %u won (%u/%u)",
-            summary.num_unlocked_achievements, summary.num_core_achievements,
-            summary.points_unlocked, summary.points_core);
+    {
+        SetSubTitle(ra::StringPrintf(L"%u of %u achievements",
+            summary.num_unlocked_achievements, summary.num_core_achievements));
+
+        m_sSummary = ra::StringPrintf(L"%d of %d points", summary.points_unlocked, summary.points_core);
+    }
     else
-        m_sSummary = ra::StringPrintf(L"%u achievements present", nNumberOfAchievements);
+    {
+        SetSubTitle(ra::StringPrintf(L"%u achievements present", nNumberOfAchievements));
+    }
 
     // playtime
     if (pGameContext.GameId() == 0)
     {
-        SetSummary(m_sSummary);
+        SetTitleDetail(m_sSummary);
     }
     else
     {
         const auto nPlayTimeSeconds = ra::services::ServiceLocator::Get<ra::data::context::SessionTracker>().GetTotalPlaytime(pGameContext.GameId());
         const auto nPlayTimeMinutes = std::chrono::duration_cast<std::chrono::minutes>(nPlayTimeSeconds).count();
-        SetSummary(ra::StringPrintf(L"%s - %dh%02dm", m_sSummary, nPlayTimeMinutes / 60, nPlayTimeMinutes % 60));
+        SetTitleDetail(ra::StringPrintf(L"%s - %dh%02dm", m_sSummary, nPlayTimeMinutes / 60, nPlayTimeMinutes % 60));
         m_fElapsed = static_cast<double>(nPlayTimeSeconds.count() % 60);
     }
 
@@ -234,7 +244,7 @@ bool OverlayAchievementsPageViewModel::Update(double fElapsed)
     const auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::context::GameContext>();
     const auto nPlayTimeSeconds = ra::services::ServiceLocator::Get<ra::data::context::SessionTracker>().GetTotalPlaytime(pGameContext.GameId());
     const auto nPlayTimeMinutes = std::chrono::duration_cast<std::chrono::minutes>(nPlayTimeSeconds).count();
-    SetSummary(ra::StringPrintf(L"%s - %dh%02dm", m_sSummary, nPlayTimeMinutes / 60, nPlayTimeMinutes % 60));
+    SetTitleDetail(ra::StringPrintf(L"%s - %dh%02dm", m_sSummary, nPlayTimeMinutes / 60, nPlayTimeMinutes % 60));
 
     do
     {
@@ -260,6 +270,22 @@ bool OverlayAchievementsPageViewModel::OnHeaderClicked(ItemViewModel& vmItem)
     return false;
 }
 
+const wchar_t* OverlayAchievementsPageViewModel::GetPrevButtonText() const
+{
+    if (m_bDetail)
+        return L"";
+
+    return L"Recent Games";
+}
+
+const wchar_t* OverlayAchievementsPageViewModel::GetNextButtonText() const
+{
+    if (m_bDetail)
+        return L"";
+
+    return L"Leaderboards";
+}
+
 void OverlayAchievementsPageViewModel::RenderDetail(ra::ui::drawing::ISurface& pSurface, int nX, int nY, _UNUSED int nWidth, int nHeight) const
 {
     const auto* pAchievement = m_vItems.GetItemAt(GetSelectedItemIndex());
@@ -269,6 +295,7 @@ void OverlayAchievementsPageViewModel::RenderDetail(ra::ui::drawing::ISurface& p
     const auto& pTheme = ra::services::ServiceLocator::Get<ra::ui::OverlayTheme>();
     const auto nFont = pSurface.LoadFont(pTheme.FontOverlay(), pTheme.FontSizeOverlayHeader(), ra::ui::FontStyles::Normal);
     const auto nSubFont = pSurface.LoadFont(pTheme.FontOverlay(), pTheme.FontSizeOverlaySummary(), ra::ui::FontStyles::Normal);
+    const auto nDetailFont = pSurface.LoadFont(pTheme.FontOverlay(), pTheme.FontSizeOverlayDetail(), ra::ui::FontStyles::Normal);
     constexpr auto nAchievementSize = 64;
 
     pSurface.DrawImage(nX, nY, nAchievementSize, nAchievementSize, pAchievement->Image);
@@ -281,9 +308,11 @@ void OverlayAchievementsPageViewModel::RenderDetail(ra::ui::drawing::ISurface& p
     if (pDetail == m_vAchievementDetails.end())
         return;
 
-    pSurface.WriteText(nX, nY, nSubFont, pTheme.ColorOverlaySubText(), L"Created: " + pDetail->second.GetCreatedDate());
-    pSurface.WriteText(nX, nY + 26, nSubFont, pTheme.ColorOverlaySubText(), L"Modified: " + pDetail->second.GetModifiedDate());
-    nY += 60;
+    const auto szDetail = pSurface.MeasureText(nDetailFont, L"M");
+    pSurface.WriteText(nX, nY, nDetailFont, pTheme.ColorOverlaySubText(), L"Created: " + pDetail->second.GetCreatedDate());
+    nY += szDetail.Height;
+    pSurface.WriteText(nX, nY, nDetailFont, pTheme.ColorOverlaySubText(), L"Modified: " + pDetail->second.GetModifiedDate());
+    nY += szDetail.Height + 8;
 
     const auto sWonBy = pDetail->second.GetWonBy();
     if (sWonBy.empty())

--- a/src/ui/viewmodels/OverlayAchievementsPageViewModel.cpp
+++ b/src/ui/viewmodels/OverlayAchievementsPageViewModel.cpp
@@ -52,15 +52,7 @@ static void SetAchievement(OverlayListPageViewModel::ItemViewModel& vmItem,
     vmItem.SetDetail(ra::Widen(pAchievement.description));
     vmItem.SetCollapsed(false);
 
-    std::string sBadgeName = pAchievement.badge_name;
-    if (!sBadgeName.empty() && sBadgeName.front() == 'L')
-    {
-        // local image, get from model
-        const auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::context::GameContext>();
-        auto* vmLocalAchievement = pGameContext.Assets().FindAchievement(vmItem.GetId());
-        if (vmLocalAchievement != nullptr)
-            sBadgeName = ra::Narrow(vmLocalAchievement->GetBadge());
-    }
+    std::string sBadgeName = ra::services::AchievementRuntime::GetAchievementBadge(pAchievement);
 
     switch (pAchievement.state)
     {

--- a/src/ui/viewmodels/OverlayAchievementsPageViewModel.hh
+++ b/src/ui/viewmodels/OverlayAchievementsPageViewModel.hh
@@ -30,6 +30,9 @@ public:
     void Refresh() override;
     bool Update(double fElapsed) override;
 
+    const wchar_t* GetPrevButtonText() const override;
+    const wchar_t* GetNextButtonText() const override;
+
     class AchievementViewModel : public ViewModelBase
     {
     public:

--- a/src/ui/viewmodels/OverlayAchievementsPageViewModel.hh
+++ b/src/ui/viewmodels/OverlayAchievementsPageViewModel.hh
@@ -30,8 +30,8 @@ public:
     void Refresh() override;
     bool Update(double fElapsed) override;
 
-    const wchar_t* GetPrevButtonText() const override;
-    const wchar_t* GetNextButtonText() const override;
+    const wchar_t* GetPrevButtonText() const noexcept override;
+    const wchar_t* GetNextButtonText() const noexcept override;
 
     class AchievementViewModel : public ViewModelBase
     {

--- a/src/ui/viewmodels/OverlayFriendsPageViewModel.cpp
+++ b/src/ui/viewmodels/OverlayFriendsPageViewModel.cpp
@@ -12,7 +12,7 @@ namespace viewmodels {
 
 void OverlayFriendsPageViewModel::Refresh()
 {
-    m_sTitle = L"Following";
+    SetTitle(L"Following");
     OverlayListPageViewModel::Refresh();
 
     const auto& pClock = ra::services::ServiceLocator::Get<ra::services::IClock>();
@@ -26,7 +26,7 @@ void OverlayFriendsPageViewModel::Refresh()
         {
             if (response.Failed())
             {
-                SetSummary(ra::Widen(response.ErrorMessage));
+                SetSubTitle(ra::Widen(response.ErrorMessage));
                 return;
             }
 

--- a/src/ui/viewmodels/OverlayFriendsPageViewModel.hh
+++ b/src/ui/viewmodels/OverlayFriendsPageViewModel.hh
@@ -14,9 +14,9 @@ class OverlayFriendsPageViewModel : public OverlayListPageViewModel
 public:
     void Refresh() override;
 
-    const wchar_t* GetPrevButtonText() const override { return L"Leaderboards"; }
-    const wchar_t* GetNextButtonText() const override { return L"Recent Games"; }
-    const wchar_t* GetAcceptButtonText() const override { return L""; }
+    const wchar_t* GetPrevButtonText() const noexcept override { return L"Leaderboards"; }
+    const wchar_t* GetNextButtonText() const noexcept override { return L"Recent Games"; }
+    const wchar_t* GetAcceptButtonText() const noexcept override { return L""; }
 
 private:
     std::chrono::time_point<std::chrono::steady_clock> m_tLastUpdated;

--- a/src/ui/viewmodels/OverlayFriendsPageViewModel.hh
+++ b/src/ui/viewmodels/OverlayFriendsPageViewModel.hh
@@ -14,6 +14,10 @@ class OverlayFriendsPageViewModel : public OverlayListPageViewModel
 public:
     void Refresh() override;
 
+    const wchar_t* GetPrevButtonText() const override { return L"Leaderboards"; }
+    const wchar_t* GetNextButtonText() const override { return L"Recent Games"; }
+    const wchar_t* GetAcceptButtonText() const override { return L""; }
+
 private:
     std::chrono::time_point<std::chrono::steady_clock> m_tLastUpdated;
 };

--- a/src/ui/viewmodels/OverlayLeaderboardsPageViewModel.cpp
+++ b/src/ui/viewmodels/OverlayLeaderboardsPageViewModel.cpp
@@ -57,13 +57,12 @@ static void SetLeaderboard(OverlayListPageViewModel::ItemViewModel& vmItem,
 
 void OverlayLeaderboardsPageViewModel::Refresh()
 {
-    m_sTitle = L"Leaderboards";
-    m_sDetailTitle = L"Leaderboard Info";
     OverlayListPageViewModel::Refresh();
 
     // title
     const auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::context::GameContext>();
-    SetListTitle(pGameContext.GameTitle());
+    SetTitle(pGameContext.GameTitle());
+    m_bHasDetail = true;
 
     // leaderboard list
     const auto& pClient = ra::services::ServiceLocator::Get<ra::services::AchievementRuntime>().GetClient();
@@ -142,9 +141,9 @@ void OverlayLeaderboardsPageViewModel::Refresh()
 
     // summary
     if (nNumberOfLeaderboards == 0)
-        SetSummary(L"No leaderboards present");
+        SetSubTitle(L"No leaderboards present");
     else
-        SetSummary(ra::StringPrintf(L"%u leaderboards present", nNumberOfLeaderboards));
+        SetSubTitle(ra::StringPrintf(L"%u leaderboards present", nNumberOfLeaderboards));
 }
 
 bool OverlayLeaderboardsPageViewModel::OnHeaderClicked(ItemViewModel& vmItem)
@@ -161,6 +160,22 @@ bool OverlayLeaderboardsPageViewModel::OnHeaderClicked(ItemViewModel& vmItem)
     }
 
     return false;
+}
+
+const wchar_t* OverlayLeaderboardsPageViewModel::GetPrevButtonText() const
+{
+    if (m_bDetail)
+        return L"";
+
+    return L"Achievements";
+}
+
+const wchar_t* OverlayLeaderboardsPageViewModel::GetNextButtonText() const
+{
+    if (m_bDetail)
+        return L"";
+
+    return L"Following";
 }
 
 void OverlayLeaderboardsPageViewModel::RenderDetail(ra::ui::drawing::ISurface& pSurface, int nX, int nY, _UNUSED int nWidth, int nHeight) const

--- a/src/ui/viewmodels/OverlayLeaderboardsPageViewModel.cpp
+++ b/src/ui/viewmodels/OverlayLeaderboardsPageViewModel.cpp
@@ -162,7 +162,7 @@ bool OverlayLeaderboardsPageViewModel::OnHeaderClicked(ItemViewModel& vmItem)
     return false;
 }
 
-const wchar_t* OverlayLeaderboardsPageViewModel::GetPrevButtonText() const
+const wchar_t* OverlayLeaderboardsPageViewModel::GetPrevButtonText() const noexcept
 {
     if (m_bDetail)
         return L"";
@@ -170,7 +170,7 @@ const wchar_t* OverlayLeaderboardsPageViewModel::GetPrevButtonText() const
     return L"Achievements";
 }
 
-const wchar_t* OverlayLeaderboardsPageViewModel::GetNextButtonText() const
+const wchar_t* OverlayLeaderboardsPageViewModel::GetNextButtonText() const noexcept
 {
     if (m_bDetail)
         return L"";

--- a/src/ui/viewmodels/OverlayLeaderboardsPageViewModel.hh
+++ b/src/ui/viewmodels/OverlayLeaderboardsPageViewModel.hh
@@ -16,6 +16,9 @@ class OverlayLeaderboardsPageViewModel : public OverlayListPageViewModel
 public:
     void Refresh() override;
 
+    const wchar_t* GetPrevButtonText() const override;
+    const wchar_t* GetNextButtonText() const override;
+
 protected:
     bool OnHeaderClicked(ItemViewModel& vmItem) override;
     void FetchItemDetail(ItemViewModel& vmItem) override;

--- a/src/ui/viewmodels/OverlayLeaderboardsPageViewModel.hh
+++ b/src/ui/viewmodels/OverlayLeaderboardsPageViewModel.hh
@@ -16,8 +16,8 @@ class OverlayLeaderboardsPageViewModel : public OverlayListPageViewModel
 public:
     void Refresh() override;
 
-    const wchar_t* GetPrevButtonText() const override;
-    const wchar_t* GetNextButtonText() const override;
+    const wchar_t* GetPrevButtonText() const noexcept override;
+    const wchar_t* GetNextButtonText() const noexcept override;
 
 protected:
     bool OnHeaderClicked(ItemViewModel& vmItem) override;

--- a/src/ui/viewmodels/OverlayListPageViewModel.cpp
+++ b/src/ui/viewmodels/OverlayListPageViewModel.cpp
@@ -276,7 +276,7 @@ bool OverlayListPageViewModel::ProcessInput(const ControllerInput& pInput)
         size_t nSelectedItemIndex = gsl::narrow_cast<size_t>(GetSelectedItemIndex());
         if (nSelectedItemIndex < m_vItems.Count() - 1)
         {
-            ItemViewModel* vmItem;
+            ItemViewModel* vmItem = nullptr;
             do
             {
                 ++nSelectedItemIndex;
@@ -301,7 +301,7 @@ bool OverlayListPageViewModel::ProcessInput(const ControllerInput& pInput)
         auto nSelectedItemIndex = GetSelectedItemIndex();
         if (nSelectedItemIndex > 0)
         {
-            ItemViewModel* vmItem;
+            ItemViewModel* vmItem = nullptr;
             do
             {
                 vmItem = m_vItems.GetItemAt(gsl::narrow_cast<size_t>(--nSelectedItemIndex));

--- a/src/ui/viewmodels/OverlayListPageViewModel.hh
+++ b/src/ui/viewmodels/OverlayListPageViewModel.hh
@@ -16,36 +16,6 @@ class OverlayListPageViewModel : public OverlayViewModel::PageViewModel
 {
 public:
     /// <summary>
-    /// The <see cref="ModelProperty" /> for the list title.
-    /// </summary>
-    static const StringModelProperty ListTitleProperty;
-
-    /// <summary>
-    /// Gets the list title.
-    /// </summary>
-    const std::wstring& GetListTitle() const { return GetValue(ListTitleProperty); }
-
-    /// <summary>
-    /// Sets the list title.
-    /// </summary>
-    void SetListTitle(const std::wstring& sValue) { SetValue(ListTitleProperty, sValue); }
-
-    /// <summary>
-    /// The <see cref="ModelProperty" /> for the summary information.
-    /// </summary>
-    static const StringModelProperty SummaryProperty;
-
-    /// <summary>
-    /// Gets the summary information.
-    /// </summary>
-    const std::wstring& GetSummary() const { return GetValue(SummaryProperty); }
-
-    /// <summary>
-    /// Sets the summary information.
-    /// </summary>
-    void SetSummary(const std::wstring& sValue) { SetValue(SummaryProperty, sValue); }
-
-    /// <summary>
     /// The <see cref="ModelProperty" /> for whether or not headers can be collapsed.
     /// </summary>
     static const BoolModelProperty CanCollapseHeadersProperty;
@@ -80,6 +50,9 @@ public:
     void Render(ra::ui::drawing::ISurface& pSurface, int nX, int nY, int nWidth, int nHeight) const override;
     bool ProcessInput(const ControllerInput& pInput) override;
     const wchar_t* GetAcceptButtonText() const override;
+    const wchar_t* GetCancelButtonText() const override;
+    const wchar_t* GetPrevButtonText() const override;
+    const wchar_t* GetNextButtonText() const override;
 
     class ItemViewModel : public LookupItemViewModel
     {
@@ -178,8 +151,7 @@ protected:
     mutable unsigned int m_nVisibleItems = 0;
     double m_fElapsed = 0.0;
     bool m_bDetail = false;
-    std::wstring m_sTitle;
-    std::wstring m_sDetailTitle;
+    bool m_bHasDetail = false;
 
     ItemViewModel& GetNextItem(size_t* nIndex);
     static void SetHeader(OverlayListPageViewModel::ItemViewModel& vmItem, const std::wstring& sHeader);

--- a/src/ui/viewmodels/OverlayListPageViewModel.hh
+++ b/src/ui/viewmodels/OverlayListPageViewModel.hh
@@ -45,7 +45,7 @@ public:
     /// </summary>
     void SetSelectedItemIndex(int nValue) { SetValue(SelectedItemIndexProperty, nValue); }
 
-    void Refresh() override;
+    void Refresh() noexcept(false) override;
     bool Update(double fElapsed) override;
     void Render(ra::ui::drawing::ISurface& pSurface, int nX, int nY, int nWidth, int nHeight) const override;
     bool ProcessInput(const ControllerInput& pInput) override;

--- a/src/ui/viewmodels/OverlayRecentGamesPageViewModel.cpp
+++ b/src/ui/viewmodels/OverlayRecentGamesPageViewModel.cpp
@@ -21,7 +21,7 @@ namespace viewmodels {
 
 void OverlayRecentGamesPageViewModel::Refresh()
 {
-    m_sTitle = L"Recent Games";
+    SetTitle(L"Recent Games");
     OverlayListPageViewModel::Refresh();
 
     for (gsl::index nIndex = m_vItems.Count() - 1; nIndex >= 0; --nIndex)

--- a/src/ui/viewmodels/OverlayRecentGamesPageViewModel.hh
+++ b/src/ui/viewmodels/OverlayRecentGamesPageViewModel.hh
@@ -12,9 +12,9 @@ class OverlayRecentGamesPageViewModel : public OverlayListPageViewModel
 public:
     void Refresh() override;
 
-    const wchar_t* GetPrevButtonText() const override { return L"Following"; }
-    const wchar_t* GetNextButtonText() const override { return L"Achievements"; }
-    const wchar_t* GetAcceptButtonText() const override { return L""; }
+    const wchar_t* GetPrevButtonText() const noexcept override { return L"Following"; }
+    const wchar_t* GetNextButtonText() const noexcept override { return L"Achievements"; }
+    const wchar_t* GetAcceptButtonText() const noexcept override { return L""; }
 
 protected:
     void UpdateGameEntry(ItemViewModel& pvmItem, const std::wstring& sGameName, const std::string& sGameBadge,

--- a/src/ui/viewmodels/OverlayRecentGamesPageViewModel.hh
+++ b/src/ui/viewmodels/OverlayRecentGamesPageViewModel.hh
@@ -12,6 +12,10 @@ class OverlayRecentGamesPageViewModel : public OverlayListPageViewModel
 public:
     void Refresh() override;
 
+    const wchar_t* GetPrevButtonText() const override { return L"Following"; }
+    const wchar_t* GetNextButtonText() const override { return L"Achievements"; }
+    const wchar_t* GetAcceptButtonText() const override { return L""; }
+
 protected:
     void UpdateGameEntry(ItemViewModel& pvmItem, const std::wstring& sGameName, const std::string& sGameBadge,
                          std::chrono::seconds nPlaytimeSeconds);

--- a/src/ui/viewmodels/OverlayViewModel.cpp
+++ b/src/ui/viewmodels/OverlayViewModel.cpp
@@ -233,7 +233,7 @@ void OverlayViewModel::CreateRenderImage()
     const auto szSelect = bHasSelect ? m_pSurface->MeasureText(nDetailFont, sSelect) : ra::ui::Size();
     const auto szCancel = m_pSurface->MeasureText(nDetailFont, sCancel);
 
-    const int nNavPadding = 2;
+    constexpr int nNavPadding = 2;
     const int nCancelX = nWidth - nMargin - nNavPadding - szCancel.Width;
     const int nSelectX = nCancelX - (bHasSelect ? nMargin * 2 : 0) - szSelect.Width;
     const int nNextX = nSelectX - (bHasNext ? nMargin * 2 : 0) - szNext.Width;

--- a/src/ui/viewmodels/OverlayViewModel.hh
+++ b/src/ui/viewmodels/OverlayViewModel.hh
@@ -83,7 +83,40 @@ public:
         /// </summary>
         void SetTitle(const std::wstring& sValue) { SetValue(TitleProperty, sValue); }
 
+        /// <summary>
+        /// The <see cref="ModelProperty" /> for the page subtitle.
+        /// </summary>
+        static const StringModelProperty SubTitleProperty;
+
+        /// <summary>
+        /// Gets the page subtitle to display.
+        /// </summary>
+        const std::wstring& GetSubTitle() const { return GetValue(SubTitleProperty); }
+
+        /// <summary>
+        /// Sets the page subtitle to display.
+        /// </summary>
+        void SetSubTitle(const std::wstring& sValue) { SetValue(SubTitleProperty, sValue); }
+
+        /// <summary>
+        /// The <see cref="ModelProperty" /> for the page title detail.
+        /// </summary>
+        static const StringModelProperty TitleDetailProperty;
+
+        /// <summary>
+        /// Gets the page title detail to display.
+        /// </summary>
+        const std::wstring& GetTitleDetail() const { return GetValue(TitleDetailProperty); }
+
+        /// <summary>
+        /// Sets the page title detail to display.
+        /// </summary>
+        void SetTitleDetail(const std::wstring& sValue) { SetValue(TitleDetailProperty, sValue); }
+
         virtual const wchar_t* GetAcceptButtonText() const noexcept(false) { return L"Select"; }
+        virtual const wchar_t* GetCancelButtonText() const noexcept(false) { return L"Close"; }
+        virtual const wchar_t* GetPrevButtonText() const noexcept(false) { return L"Prev"; }
+        virtual const wchar_t* GetNextButtonText() const noexcept(false) { return L"Next"; }
 
         virtual void Refresh() = 0;
 

--- a/tests/ui/viewmodels/OverlayAchievementsPageViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/OverlayAchievementsPageViewModel_Tests.cpp
@@ -44,6 +44,8 @@ private:
         OverlayAchievementsPageViewModelHarness() noexcept
         {
             GSL_SUPPRESS_F6 mockWindowManager.AssetList.InitializeNotifyTargets();
+
+            mockGameContext.SetGameTitle(L"Game Title");
         }
 
         ItemViewModel* GetItem(gsl::index nIndex) { return m_vItems.GetItemAt(nIndex); }
@@ -150,8 +152,22 @@ public:
         achievementsPage.SetCanCollapseHeaders(false);
         achievementsPage.Refresh();
 
-        Assert::AreEqual(std::wstring(L"Achievements"), achievementsPage.GetTitle());
-        Assert::AreEqual(std::wstring(L"No achievements present"), achievementsPage.GetSummary());
+        Assert::AreEqual(std::wstring(L"Game Title"), achievementsPage.GetTitle());
+        Assert::AreEqual(std::wstring(L"No achievements present"), achievementsPage.GetSubTitle());
+        Assert::AreEqual(std::wstring(L""), achievementsPage.GetTitleDetail());
+        Assert::IsNull(achievementsPage.GetItem(0));
+    }
+
+    TEST_METHOD(TestRefreshNoGameLoaded)
+    {
+        OverlayAchievementsPageViewModelHarness achievementsPage;
+        achievementsPage.mockGameContext.SetGameTitle(L"");
+        achievementsPage.SetCanCollapseHeaders(false);
+        achievementsPage.Refresh();
+
+        Assert::AreEqual(std::wstring(L"No Game Loaded"), achievementsPage.GetTitle());
+        Assert::AreEqual(std::wstring(L"No achievements present"), achievementsPage.GetSubTitle());
+        Assert::AreEqual(std::wstring(L""), achievementsPage.GetTitleDetail());
         Assert::IsNull(achievementsPage.GetItem(0));
     }
 
@@ -170,8 +186,9 @@ public:
         achievementsPage.SetCanCollapseHeaders(false);
         achievementsPage.Refresh();
 
-        Assert::AreEqual(std::wstring(L"Achievements"), achievementsPage.GetTitle());
-        Assert::AreEqual(std::wstring(L"1 of 1 won (5/5)"), achievementsPage.GetSummary());
+        Assert::AreEqual(std::wstring(L"Game Title"), achievementsPage.GetTitle());
+        Assert::AreEqual(std::wstring(L"1 of 1 achievements"), achievementsPage.GetSubTitle());
+        Assert::AreEqual(std::wstring(L"5 of 5 points"), achievementsPage.GetTitleDetail());
 
         achievementsPage.AssertHeader(0, L"Unlocked");
         achievementsPage.AssertUnlockedAchievement(1, pAch1);
@@ -191,8 +208,9 @@ public:
         achievementsPage.SetCanCollapseHeaders(false);
         achievementsPage.Refresh();
 
-        Assert::AreEqual(std::wstring(L"Achievements"), achievementsPage.GetTitle());
-        Assert::AreEqual(std::wstring(L"0 of 1 won (0/5)"), achievementsPage.GetSummary());
+        Assert::AreEqual(std::wstring(L"Game Title"), achievementsPage.GetTitle());
+        Assert::AreEqual(std::wstring(L"0 of 1 achievements"), achievementsPage.GetSubTitle());
+        Assert::AreEqual(std::wstring(L"0 of 5 points"), achievementsPage.GetTitleDetail());
 
         achievementsPage.AssertHeader(0, L"Locked");
         achievementsPage.AssertLockedAchievement(1, pAch1);
@@ -213,8 +231,9 @@ public:
         achievementsPage.SetCanCollapseHeaders(false);
         achievementsPage.Refresh();
 
-        Assert::AreEqual(std::wstring(L"Achievements"), achievementsPage.GetTitle());
-        Assert::AreEqual(std::wstring(L"0 of 1 won (0/1)"), achievementsPage.GetSummary());
+        Assert::AreEqual(std::wstring(L"Game Title"), achievementsPage.GetTitle());
+        Assert::AreEqual(std::wstring(L"0 of 1 achievements"), achievementsPage.GetSubTitle());
+        Assert::AreEqual(std::wstring(L"0 of 1 points"), achievementsPage.GetTitleDetail());
 
         achievementsPage.AssertHeader(0, L"Locked");
         achievementsPage.AssertLockedAchievement(1, pAch1);
@@ -251,8 +270,9 @@ public:
         achievementsPage.SetCanCollapseHeaders(false);
         achievementsPage.Refresh();
 
-        Assert::AreEqual(std::wstring(L"Achievements"), achievementsPage.GetTitle());
-        Assert::AreEqual(std::wstring(L"1 of 4 won (4/10)"), achievementsPage.GetSummary());
+        Assert::AreEqual(std::wstring(L"Game Title"), achievementsPage.GetTitle());
+        Assert::AreEqual(std::wstring(L"1 of 4 achievements"), achievementsPage.GetSubTitle());
+        Assert::AreEqual(std::wstring(L"4 of 10 points"), achievementsPage.GetTitleDetail());
 
         achievementsPage.AssertHeader(0, L"Locked");
         achievementsPage.AssertLockedAchievement(1, pAch1);
@@ -290,8 +310,9 @@ public:
         achievementsPage.SetCanCollapseHeaders(false);
         achievementsPage.Refresh();
 
-        Assert::AreEqual(std::wstring(L"Achievements"), achievementsPage.GetTitle());
-        Assert::AreEqual(std::wstring(L"1 of 4 won (4/10)"), achievementsPage.GetSummary());
+        Assert::AreEqual(std::wstring(L"Game Title"), achievementsPage.GetTitle());
+        Assert::AreEqual(std::wstring(L"1 of 4 achievements"), achievementsPage.GetSubTitle());
+        Assert::AreEqual(std::wstring(L"4 of 10 points"), achievementsPage.GetTitleDetail());
 
         auto* pItem = achievementsPage.GetItem(0);
         Expects(pItem != nullptr);
@@ -362,8 +383,9 @@ public:
         achievementsPage.SetCanCollapseHeaders(false);
         achievementsPage.Refresh();
 
-        Assert::AreEqual(std::wstring(L"Achievements"), achievementsPage.GetTitle());
-        Assert::AreEqual(std::wstring(L"2 of 4 won (7/10)"), achievementsPage.GetSummary());
+        Assert::AreEqual(std::wstring(L"Game Title"), achievementsPage.GetTitle());
+        Assert::AreEqual(std::wstring(L"2 of 4 achievements"), achievementsPage.GetSubTitle());
+        Assert::AreEqual(std::wstring(L"7 of 10 points"), achievementsPage.GetTitleDetail());
 
         achievementsPage.AssertHeader(0, L"Locked");
         achievementsPage.AssertLockedAchievement(1, pAch1);
@@ -403,8 +425,9 @@ public:
         achievementsPage.SetCanCollapseHeaders(true);
         achievementsPage.Refresh();
 
-        Assert::AreEqual(std::wstring(L"Achievements"), achievementsPage.GetTitle());
-        Assert::AreEqual(std::wstring(L"2 of 4 won (7/10)"), achievementsPage.GetSummary());
+        Assert::AreEqual(std::wstring(L"Game Title"), achievementsPage.GetTitle());
+        Assert::AreEqual(std::wstring(L"2 of 4 achievements"), achievementsPage.GetSubTitle());
+        Assert::AreEqual(std::wstring(L"7 of 10 points"), achievementsPage.GetTitleDetail());
 
         achievementsPage.AssertHeader(0, L"Locked");
         achievementsPage.AssertLockedAchievement(1, pAch1);
@@ -436,8 +459,9 @@ public:
         achievementsPage.SetCanCollapseHeaders(false);
         achievementsPage.Refresh();
 
-        Assert::AreEqual(std::wstring(L"Achievements"), achievementsPage.GetTitle());
-        Assert::AreEqual(std::wstring(L"0 of 3 won (0/6)"), achievementsPage.GetSummary());
+        Assert::AreEqual(std::wstring(L"Game Title"), achievementsPage.GetTitle());
+        Assert::AreEqual(std::wstring(L"0 of 3 achievements"), achievementsPage.GetSubTitle());
+        Assert::AreEqual(std::wstring(L"0 of 6 points"), achievementsPage.GetTitleDetail());
 
         achievementsPage.AssertHeader(0, L"Active Challenges");
         achievementsPage.AssertLockedAchievement(1, pAch2);
@@ -474,8 +498,9 @@ public:
         achievementsPage.SetCanCollapseHeaders(false);
         achievementsPage.Refresh();
 
-        Assert::AreEqual(std::wstring(L"Achievements"), achievementsPage.GetTitle());
-        Assert::AreEqual(std::wstring(L"1 of 2 won (4/5)"), achievementsPage.GetSummary());
+        Assert::AreEqual(std::wstring(L"Game Title"), achievementsPage.GetTitle());
+        Assert::AreEqual(std::wstring(L"1 of 2 achievements"), achievementsPage.GetSubTitle());
+        Assert::AreEqual(std::wstring(L"4 of 5 points"), achievementsPage.GetTitleDetail());
 
         // only 1 and 4 will be visible - 2 and 3 are not core, and will be filtered out
         achievementsPage.AssertHeader(0, L"Locked");
@@ -517,8 +542,9 @@ public:
         achievementsPage.SetCanCollapseHeaders(false);
         achievementsPage.Refresh();
 
-        Assert::AreEqual(std::wstring(L"Achievements"), achievementsPage.GetTitle());
-        Assert::AreEqual(std::wstring(L"1 of 2 won (4/5)"), achievementsPage.GetSummary());
+        Assert::AreEqual(std::wstring(L"Game Title"), achievementsPage.GetTitle());
+        Assert::AreEqual(std::wstring(L"1 of 2 achievements"), achievementsPage.GetSubTitle());
+        Assert::AreEqual(std::wstring(L"4 of 5 points"), achievementsPage.GetTitleDetail());
 
         achievementsPage.AssertHeader(0, L"Game Title - Locked");
         achievementsPage.AssertLockedAchievement(1, pAch1);
@@ -571,8 +597,9 @@ public:
         achievementsPage.SetCanCollapseHeaders(false);
         achievementsPage.Refresh();
 
-        Assert::AreEqual(std::wstring(L"Achievements"), achievementsPage.GetTitle());
-        Assert::AreEqual(std::wstring(L"1 of 4 won (4/10)"), achievementsPage.GetSummary());
+        Assert::AreEqual(std::wstring(L"Game Title"), achievementsPage.GetTitle());
+        Assert::AreEqual(std::wstring(L"1 of 4 achievements"), achievementsPage.GetSubTitle());
+        Assert::AreEqual(std::wstring(L"4 of 10 points"), achievementsPage.GetTitleDetail());
 
         achievementsPage.AssertHeader(0, L"Locked");
         achievementsPage.AssertProgressAchievement(1, pAch1, 0.0, L"");
@@ -620,8 +647,9 @@ public:
         achievementsPage.SetCanCollapseHeaders(false);
         achievementsPage.Refresh();
 
-        Assert::AreEqual(std::wstring(L"Achievements"), achievementsPage.GetTitle());
-        Assert::AreEqual(std::wstring(L"1 of 4 won (2/10)"), achievementsPage.GetSummary());
+        Assert::AreEqual(std::wstring(L"Game Title"), achievementsPage.GetTitle());
+        Assert::AreEqual(std::wstring(L"1 of 4 achievements"), achievementsPage.GetSubTitle());
+        Assert::AreEqual(std::wstring(L"2 of 10 points"), achievementsPage.GetTitleDetail());
 
         achievementsPage.AssertHeader(0, L"Almost There");
         achievementsPage.AssertProgressAchievement(1, pAch3, 90.0, L"9/10");
@@ -671,8 +699,9 @@ public:
         achievementsPage.SetCanCollapseHeaders(false);
         achievementsPage.Refresh();
 
-        Assert::AreEqual(std::wstring(L"Achievements"), achievementsPage.GetTitle());
-        Assert::AreEqual(std::wstring(L"0 of 4 won (0/10)"), achievementsPage.GetSummary());
+        Assert::AreEqual(std::wstring(L"Game Title"), achievementsPage.GetTitle());
+        Assert::AreEqual(std::wstring(L"0 of 4 achievements"), achievementsPage.GetSubTitle());
+        Assert::AreEqual(std::wstring(L"0 of 10 points"), achievementsPage.GetTitleDetail());
 
         achievementsPage.AssertHeader(0, L"Almost There");
         achievementsPage.AssertProgressAchievement(1, pAch3, 95.0, L"95/100");
@@ -695,8 +724,9 @@ public:
 
         achievementsPage.Refresh();
 
-        Assert::AreEqual(std::wstring(L"Achievements"), achievementsPage.GetTitle());
-        Assert::AreEqual(std::wstring(L"1 of 1 won (5/5) - 5h47m"), achievementsPage.GetSummary());
+        Assert::AreEqual(std::wstring(L"Game Title"), achievementsPage.GetTitle());
+        Assert::AreEqual(std::wstring(L"1 of 1 achievements"), achievementsPage.GetSubTitle());
+        Assert::AreEqual(std::wstring(L"5 of 5 points - 5h47m"), achievementsPage.GetTitleDetail());
     }
 
     TEST_METHOD(TestUpdateSession)
@@ -713,18 +743,22 @@ public:
         achievementsPage.Refresh();
 
         achievementsPage.mockSessionTracker.MockSession(1U, 1234567879, std::chrono::minutes(1));
-        Assert::AreEqual(std::wstring(L"Achievements"), achievementsPage.GetTitle());
-        Assert::AreEqual(std::wstring(L"1 of 1 won (5/5) - 0h17m"), achievementsPage.GetSummary());
+        Assert::AreEqual(std::wstring(L"Game Title"), achievementsPage.GetTitle());
+        Assert::AreEqual(std::wstring(L"1 of 1 achievements"), achievementsPage.GetSubTitle());
+        Assert::AreEqual(std::wstring(L"5 of 5 points - 0h17m"), achievementsPage.GetTitleDetail());
 
         // Refresh() called at 12 seconds into session, text shouldn't update until 60 seconds in
         achievementsPage.Update(40.0); // 12 -> 52
-        Assert::AreEqual(std::wstring(L"1 of 1 won (5/5) - 0h17m"), achievementsPage.GetSummary());
+        Assert::AreEqual(std::wstring(L"1 of 1 achievements"), achievementsPage.GetSubTitle());
+        Assert::AreEqual(std::wstring(L"5 of 5 points - 0h17m"), achievementsPage.GetTitleDetail());
 
         Assert::IsFalse(achievementsPage.Update(7.9)); // 52 -> 59.9
-        Assert::AreEqual(std::wstring(L"1 of 1 won (5/5) - 0h17m"), achievementsPage.GetSummary());
+        Assert::AreEqual(std::wstring(L"1 of 1 achievements"), achievementsPage.GetSubTitle());
+        Assert::AreEqual(std::wstring(L"5 of 5 points - 0h17m"), achievementsPage.GetTitleDetail());
 
         Assert::IsTrue(achievementsPage.Update(0.2)); // 59.9 -> 60.1
-        Assert::AreEqual(std::wstring(L"1 of 1 won (5/5) - 0h18m"), achievementsPage.GetSummary());
+        Assert::AreEqual(std::wstring(L"1 of 1 achievements"), achievementsPage.GetSubTitle());
+        Assert::AreEqual(std::wstring(L"5 of 5 points - 0h18m"), achievementsPage.GetTitleDetail());
     }
 
     TEST_METHOD(TestFetchItemDetailLocal)

--- a/tests/ui/viewmodels/OverlayFriendsPageViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/OverlayFriendsPageViewModel_Tests.cpp
@@ -41,6 +41,15 @@ private:
     };
 
 public:
+    TEST_METHOD(TestNavigationLabels)
+    {
+        OverlayFriendsPageViewModelHarness friendsPage;
+        Assert::AreEqual(L"", friendsPage.GetAcceptButtonText());
+        Assert::AreEqual(L"Close", friendsPage.GetCancelButtonText());
+        Assert::AreEqual(L"Leaderboards", friendsPage.GetPrevButtonText());
+        Assert::AreEqual(L"Recent Games", friendsPage.GetNextButtonText());
+    }
+
     TEST_METHOD(TestRefreshNoFriends)
     {
         OverlayFriendsPageViewModelHarness friendsPage;
@@ -54,12 +63,14 @@ public:
         friendsPage.Refresh();
 
         Assert::AreEqual(std::wstring(L"Following"), friendsPage.GetTitle());
-        Assert::AreEqual(std::wstring(), friendsPage.GetSummary());
+        Assert::AreEqual(std::wstring(), friendsPage.GetSubTitle());
+        Assert::AreEqual(std::wstring(), friendsPage.GetTitleDetail());
 
         friendsPage.mockTheadPool.ExecuteNextTask(); // fetch friends list is async
 
-        Assert::AreEqual(std::wstring(), friendsPage.GetSummary());
-        Assert::AreEqual({ 0U }, friendsPage.GetItemCount());
+        Assert::AreEqual(std::wstring(), friendsPage.GetSubTitle());
+        Assert::AreEqual(std::wstring(), friendsPage.GetTitleDetail());
+        Assert::AreEqual({0U}, friendsPage.GetItemCount());
     }
 
     TEST_METHOD(TestRefreshSeveralFriends)
@@ -78,11 +89,13 @@ public:
         friendsPage.Refresh();
 
         Assert::AreEqual(std::wstring(L"Following"), friendsPage.GetTitle());
-        Assert::AreEqual(std::wstring(), friendsPage.GetSummary());
+        Assert::AreEqual(std::wstring(), friendsPage.GetSubTitle());
+        Assert::AreEqual(std::wstring(), friendsPage.GetTitleDetail());
 
         friendsPage.mockTheadPool.ExecuteNextTask(); // fetch friends list is async
 
-        Assert::AreEqual(std::wstring(), friendsPage.GetSummary());
+        Assert::AreEqual(std::wstring(), friendsPage.GetSubTitle());
+        Assert::AreEqual(std::wstring(), friendsPage.GetTitleDetail());
 
         const auto* pFriend1 = friendsPage.GetItem(0);
         Assert::IsNotNull(pFriend1);
@@ -120,12 +133,14 @@ public:
         friendsPage.Refresh();
 
         Assert::AreEqual(std::wstring(L"Following"), friendsPage.GetTitle());
-        Assert::AreEqual(std::wstring(), friendsPage.GetSummary());
+        Assert::AreEqual(std::wstring(), friendsPage.GetSubTitle());
+        Assert::AreEqual(std::wstring(), friendsPage.GetTitleDetail());
 
         friendsPage.mockTheadPool.ExecuteNextTask(); // fetch friends list is async
 
-        Assert::AreEqual(std::wstring(L"Failed to find friends"), friendsPage.GetSummary());
-        Assert::AreEqual({ 0U }, friendsPage.GetItemCount());
+        Assert::AreEqual(std::wstring(L"Failed to find friends"), friendsPage.GetSubTitle());
+        Assert::AreEqual(std::wstring(), friendsPage.GetTitleDetail());
+        Assert::AreEqual({0U}, friendsPage.GetItemCount());
     }
 
     TEST_METHOD(TestRefreshTimer)
@@ -144,7 +159,8 @@ public:
         friendsPage.Refresh();
 
         Assert::AreEqual(std::wstring(L"Following"), friendsPage.GetTitle());
-        Assert::AreEqual(std::wstring(), friendsPage.GetSummary());
+        Assert::AreEqual(std::wstring(), friendsPage.GetSubTitle());
+        Assert::AreEqual(std::wstring(), friendsPage.GetTitleDetail());
 
         friendsPage.mockTheadPool.ExecuteNextTask(); // fetch friends list is async
         Assert::AreEqual({ 3U }, friendsPage.GetItemCount());

--- a/tests/ui/viewmodels/OverlayLeaderboardsPageViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/OverlayLeaderboardsPageViewModel_Tests.cpp
@@ -34,6 +34,11 @@ private:
         ra::ui::viewmodels::mocks::MockOverlayManager mockOverlayManager;
         ra::ui::viewmodels::mocks::MockWindowManager mockWindowManager;
 
+        OverlayLeaderboardsPageViewModelHarness()
+        {
+            mockGameContext.SetGameTitle(L"Game Title");
+        }
+
         ItemViewModel* GetItem(gsl::index nIndex) { return m_vItems.GetItemAt(nIndex); }
 
         void TestFetchItemDetail(gsl::index nIndex)
@@ -94,8 +99,9 @@ public:
         leaderboardsPage.SetCanCollapseHeaders(false);
         leaderboardsPage.Refresh();
 
-        Assert::AreEqual(std::wstring(L"Leaderboards"), leaderboardsPage.GetTitle());
-        Assert::AreEqual(std::wstring(L"No leaderboards present"), leaderboardsPage.GetSummary());
+        Assert::AreEqual(std::wstring(L"Game Title"), leaderboardsPage.GetTitle());
+        Assert::AreEqual(std::wstring(L"No leaderboards present"), leaderboardsPage.GetSubTitle());
+        Assert::AreEqual(std::wstring(), leaderboardsPage.GetTitleDetail());
         Assert::IsNull(leaderboardsPage.GetItem(0));
     }
 
@@ -110,8 +116,9 @@ public:
         leaderboardsPage.SetCanCollapseHeaders(false);
         leaderboardsPage.Refresh();
 
-        Assert::AreEqual(std::wstring(L"Leaderboards"), leaderboardsPage.GetTitle());
-        Assert::AreEqual(std::wstring(L"2 leaderboards present"), leaderboardsPage.GetSummary());
+        Assert::AreEqual(std::wstring(L"Game Title"), leaderboardsPage.GetTitle());
+        Assert::AreEqual(std::wstring(L"2 leaderboards present"), leaderboardsPage.GetSubTitle());
+        Assert::AreEqual(std::wstring(), leaderboardsPage.GetTitleDetail());
 
         leaderboardsPage.AssertHeader(0, L"Inactive");
         leaderboardsPage.AssertLeaderboard(1, pLbd1);
@@ -131,8 +138,9 @@ public:
         leaderboardsPage.SetCanCollapseHeaders(false);
         leaderboardsPage.Refresh();
 
-        Assert::AreEqual(std::wstring(L"Leaderboards"), leaderboardsPage.GetTitle());
-        Assert::AreEqual(std::wstring(L"2 leaderboards present"), leaderboardsPage.GetSummary());
+        Assert::AreEqual(std::wstring(L"Game Title"), leaderboardsPage.GetTitle());
+        Assert::AreEqual(std::wstring(L"2 leaderboards present"), leaderboardsPage.GetSubTitle());
+        Assert::AreEqual(std::wstring(), leaderboardsPage.GetTitleDetail());
 
         leaderboardsPage.AssertHeader(0, L"Inactive");
         leaderboardsPage.AssertLeaderboard(1, pLbd1);
@@ -153,8 +161,9 @@ public:
         leaderboardsPage.SetCanCollapseHeaders(false);
         leaderboardsPage.Refresh();
 
-        Assert::AreEqual(std::wstring(L"Leaderboards"), leaderboardsPage.GetTitle());
-        Assert::AreEqual(std::wstring(L"3 leaderboards present"), leaderboardsPage.GetSummary());
+        Assert::AreEqual(std::wstring(L"Game Title"), leaderboardsPage.GetTitle());
+        Assert::AreEqual(std::wstring(L"3 leaderboards present"), leaderboardsPage.GetSubTitle());
+        Assert::AreEqual(std::wstring(), leaderboardsPage.GetTitleDetail());
 
         leaderboardsPage.AssertHeader(0, L"Game Title - Inactive");
         leaderboardsPage.AssertLeaderboard(1, pLbd1);
@@ -178,8 +187,9 @@ public:
         leaderboardsPage.SetCanCollapseHeaders(false);
         leaderboardsPage.Refresh();
 
-        Assert::AreEqual(std::wstring(L"Leaderboards"), leaderboardsPage.GetTitle());
-        Assert::AreEqual(std::wstring(L"2 leaderboards present"), leaderboardsPage.GetSummary());
+        Assert::AreEqual(std::wstring(L"Game Title"), leaderboardsPage.GetTitle());
+        Assert::AreEqual(std::wstring(L"2 leaderboards present"), leaderboardsPage.GetSubTitle());
+        Assert::AreEqual(std::wstring(), leaderboardsPage.GetTitleDetail());
 
         leaderboardsPage.AssertHeader(0, L"Inactive");
         leaderboardsPage.AssertLeaderboard(1, pLbd1);
@@ -201,8 +211,9 @@ public:
         leaderboardsPage.SetCanCollapseHeaders(false);
         leaderboardsPage.Refresh();
 
-        Assert::AreEqual(std::wstring(L"Leaderboards"), leaderboardsPage.GetTitle());
-        Assert::AreEqual(std::wstring(L"3 leaderboards present"), leaderboardsPage.GetSummary());
+        Assert::AreEqual(std::wstring(L"Game Title"), leaderboardsPage.GetTitle());
+        Assert::AreEqual(std::wstring(L"3 leaderboards present"), leaderboardsPage.GetSubTitle());
+        Assert::AreEqual(std::wstring(), leaderboardsPage.GetTitleDetail());
 
         leaderboardsPage.AssertHeader(0, L"Active");
         leaderboardsPage.AssertLeaderboard(1, pLbd2, L"1:23.00");
@@ -228,8 +239,9 @@ public:
         leaderboardsPage.SetCanCollapseHeaders(false);
         leaderboardsPage.Refresh();
 
-        Assert::AreEqual(std::wstring(L"Leaderboards"), leaderboardsPage.GetTitle());
-        Assert::AreEqual(std::wstring(L"2 leaderboards present"), leaderboardsPage.GetSummary());
+        Assert::AreEqual(std::wstring(L"Game Title"), leaderboardsPage.GetTitle());
+        Assert::AreEqual(std::wstring(L"2 leaderboards present"), leaderboardsPage.GetSubTitle());
+        Assert::AreEqual(std::wstring(), leaderboardsPage.GetTitleDetail());
 
         leaderboardsPage.AssertHeader(0, L"Inactive");
         leaderboardsPage.AssertLeaderboard(1, pLbd1);
@@ -251,8 +263,9 @@ public:
         leaderboardsPage.SetCanCollapseHeaders(false);
         leaderboardsPage.Refresh();
 
-        Assert::AreEqual(std::wstring(L"Leaderboards"), leaderboardsPage.GetTitle());
-        Assert::AreEqual(std::wstring(L"3 leaderboards present"), leaderboardsPage.GetSummary());
+        Assert::AreEqual(std::wstring(L"Game Title"), leaderboardsPage.GetTitle());
+        Assert::AreEqual(std::wstring(L"3 leaderboards present"), leaderboardsPage.GetSubTitle());
+        Assert::AreEqual(std::wstring(), leaderboardsPage.GetTitleDetail());
 
         leaderboardsPage.AssertHeader(0, L"Inactive");
         leaderboardsPage.AssertLeaderboard(1, pLbd1);

--- a/tests/ui/viewmodels/OverlayListPageViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/OverlayListPageViewModel_Tests.cpp
@@ -24,9 +24,8 @@ private:
 
         void Refresh() override
         {
-            m_sTitle = L"Title";
-            m_sDetailTitle = L"Detail Title";
             OverlayListPageViewModel::Refresh();
+            m_bHasDetail = true;
 
             AddItem(1, L"One");
             AddItem(2, L"Two");
@@ -46,9 +45,8 @@ private:
 
         void RefreshWithHeader()
         {
-            m_sTitle = L"Title";
-            m_sDetailTitle = L"Detail Title";
             OverlayListPageViewModel::Refresh();
+            m_bHasDetail = true;
 
             m_vItems.Clear();
             AddItem(0, L"Header 1");
@@ -102,8 +100,8 @@ public:
         Assert::AreEqual({ 0U }, vmListPage.GetItemCount());
         Assert::IsFalse(vmListPage.IsDetail());
         Assert::AreEqual(std::wstring(), vmListPage.GetTitle());
-        Assert::AreEqual(std::wstring(), vmListPage.GetListTitle());
-        Assert::AreEqual(std::wstring(), vmListPage.GetSummary());
+        Assert::AreEqual(std::wstring(), vmListPage.GetSubTitle());
+        Assert::AreEqual(std::wstring(), vmListPage.GetTitleDetail());
     }
 
     TEST_METHOD(TestRefresh)
@@ -115,9 +113,9 @@ public:
         Assert::AreEqual(0, vmListPage.GetSelectedItemIndex());
         Assert::AreEqual({ 12U }, vmListPage.GetItemCount());
         Assert::IsFalse(vmListPage.IsDetail());
-        Assert::AreEqual(std::wstring(L"Title"), vmListPage.GetTitle());
-        Assert::AreEqual(std::wstring(), vmListPage.GetListTitle());
-        Assert::AreEqual(std::wstring(), vmListPage.GetSummary());
+        Assert::AreEqual(std::wstring(), vmListPage.GetTitle());
+        Assert::AreEqual(std::wstring(), vmListPage.GetSubTitle());
+        Assert::AreEqual(std::wstring(), vmListPage.GetTitleDetail());
     }
 
     TEST_METHOD(TestUpdateEmpty)
@@ -344,13 +342,13 @@ public:
         ControllerInput pInputConfirm{};
         pInputConfirm.m_bConfirmPressed = true;
         Assert::IsTrue(vmListPage.ProcessInput(pInputConfirm));
-        Assert::AreEqual(std::wstring(L"Detail Title"), vmListPage.GetTitle());
+        Assert::AreEqual(std::wstring(), vmListPage.GetTitle());
         Assert::AreEqual(0, vmListPage.GetSelectedItemIndex());
         Assert::AreEqual(1, vmListPage.vmDetail->GetId());
 
         // pressing confirm on the detail page does nothing
-        Assert::IsFalse(vmListPage.ProcessInput(pInputConfirm));
-        Assert::AreEqual(std::wstring(L"Detail Title"), vmListPage.GetTitle());
+        Assert::IsTrue(vmListPage.ProcessInput(pInputConfirm));
+        Assert::AreEqual(std::wstring(), vmListPage.GetTitle());
         Assert::AreEqual(0, vmListPage.GetSelectedItemIndex());
         Assert::AreEqual(1, vmListPage.vmDetail->GetId());
 
@@ -358,12 +356,12 @@ public:
         ControllerInput pInputDown{};
         pInputDown.m_bDownPressed = true;
         Assert::IsTrue(vmListPage.ProcessInput(pInputDown));
-        Assert::AreEqual(std::wstring(L"Detail Title"), vmListPage.GetTitle());
+        Assert::AreEqual(std::wstring(), vmListPage.GetTitle());
         Assert::AreEqual(1, vmListPage.GetSelectedItemIndex());
         Assert::AreEqual(2, vmListPage.vmDetail->GetId());
 
         Assert::IsTrue(vmListPage.ProcessInput(pInputDown));
-        Assert::AreEqual(std::wstring(L"Detail Title"), vmListPage.GetTitle());
+        Assert::AreEqual(std::wstring(), vmListPage.GetTitle());
         Assert::AreEqual(2, vmListPage.GetSelectedItemIndex());
         Assert::AreEqual(3, vmListPage.vmDetail->GetId());
 
@@ -372,13 +370,13 @@ public:
         ControllerInput pInputCancel{};
         pInputCancel.m_bCancelPressed = true;
         Assert::IsTrue(vmListPage.ProcessInput(pInputCancel));
-        Assert::AreEqual(std::wstring(L"Title"), vmListPage.GetTitle());
+        Assert::AreEqual(std::wstring(), vmListPage.GetTitle());
         Assert::AreEqual(2, vmListPage.GetSelectedItemIndex());
         Assert::IsNull(vmListPage.vmDetail);
 
         // pressing confirm reopens the detail page
         Assert::IsTrue(vmListPage.ProcessInput(pInputConfirm));
-        Assert::AreEqual(std::wstring(L"Detail Title"), vmListPage.GetTitle());
+        Assert::AreEqual(std::wstring(), vmListPage.GetTitle());
         Assert::AreEqual(2, vmListPage.GetSelectedItemIndex());
         Assert::AreEqual(3, vmListPage.vmDetail->GetId());
     }

--- a/tests/ui/viewmodels/OverlayRecentGamesPageViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/OverlayRecentGamesPageViewModel_Tests.cpp
@@ -47,6 +47,15 @@ private:
     };
 
 public:
+    TEST_METHOD(TestNavigationLabels)
+    {
+        OverlayRecentGamesPageViewModelHarness gamesPage;
+        Assert::AreEqual(L"", gamesPage.GetAcceptButtonText());
+        Assert::AreEqual(L"Close", gamesPage.GetCancelButtonText());
+        Assert::AreEqual(L"Following", gamesPage.GetPrevButtonText());
+        Assert::AreEqual(L"Achievements", gamesPage.GetNextButtonText());
+    }
+
     TEST_METHOD(TestRefreshNoGames)
     {
         OverlayRecentGamesPageViewModelHarness gamesPage;
@@ -54,7 +63,8 @@ public:
         gamesPage.Refresh();
 
         Assert::AreEqual(std::wstring(L"Recent Games"), gamesPage.GetTitle());
-        Assert::AreEqual(std::wstring(), gamesPage.GetSummary());
+        Assert::AreEqual(std::wstring(), gamesPage.GetSubTitle());
+        Assert::AreEqual(std::wstring(), gamesPage.GetTitleDetail());
         Assert::AreEqual({ 0U }, gamesPage.GetItemCount());
     }
 
@@ -67,8 +77,9 @@ public:
         gamesPage.Refresh();
 
         Assert::AreEqual(std::wstring(L"Recent Games"), gamesPage.GetTitle());
-        Assert::AreEqual(std::wstring(), gamesPage.GetSummary());
-        Assert::AreEqual({ 1U }, gamesPage.GetItemCount());
+        Assert::AreEqual(std::wstring(), gamesPage.GetSubTitle());
+        Assert::AreEqual(std::wstring(), gamesPage.GetTitleDetail());
+        Assert::AreEqual({1U}, gamesPage.GetItemCount());
 
         const auto* pItem1 = gamesPage.GetItem(0);
         Assert::IsNotNull(pItem1);
@@ -102,8 +113,9 @@ public:
         gamesPage.Refresh();
 
         Assert::AreEqual(std::wstring(L"Recent Games"), gamesPage.GetTitle());
-        Assert::AreEqual(std::wstring(), gamesPage.GetSummary());
-        Assert::AreEqual({ 1U }, gamesPage.GetItemCount());
+        Assert::AreEqual(std::wstring(), gamesPage.GetSubTitle());
+        Assert::AreEqual(std::wstring(), gamesPage.GetTitleDetail());
+        Assert::AreEqual({1U}, gamesPage.GetItemCount());
 
         // data is not initially available
         auto* pItem1 = gamesPage.GetItem(0);
@@ -158,8 +170,9 @@ public:
         gamesPage.Refresh();
 
         Assert::AreEqual(std::wstring(L"Recent Games"), gamesPage.GetTitle());
-        Assert::AreEqual(std::wstring(), gamesPage.GetSummary());
-        Assert::AreEqual({ 1U }, gamesPage.GetItemCount());
+        Assert::AreEqual(std::wstring(), gamesPage.GetSubTitle());
+        Assert::AreEqual(std::wstring(), gamesPage.GetTitleDetail());
+        Assert::AreEqual({1U}, gamesPage.GetItemCount());
 
         // data is not initially available
         auto* pItem1 = gamesPage.GetItem(0);


### PR DESCRIPTION
Compacts the overlay header/footer to allow a bit more room for content. Enhances the footer to better notate available actions.

Before:
![image](https://github.com/RetroAchievements/RAIntegration/assets/32680403/1af9ffbe-313e-47b1-a909-313b56ebc348)

After:
![image](https://github.com/RetroAchievements/RAIntegration/assets/32680403/9d6a8041-e94f-410e-88d2-1e086fee5b38)
