### PR TITLE
ensure rc_client_idle is called periodically

### DIFF
--- a/src/data/models/RichPresenceModel.cpp
+++ b/src/data/models/RichPresenceModel.cpp
@@ -3,6 +3,7 @@
 #include "data\context\GameContext.hh"
 
 #include "services\AchievementRuntime.hh"
+#include "services\IConfiguration.hh"
 #include "services\ILocalStorage.hh"
 #include "services\ServiceLocator.hh"
 
@@ -145,6 +146,13 @@ void RichPresenceModel::ReloadRichPresenceScript()
     {
         SetCategory(ra::data::models::AssetCategory::Local);
         UpdateLocalCheckpoint();
+    }
+
+    if (GetChanges() != ra::data::models::AssetChanges::None && IsActive() &&
+        ra::services::ServiceLocator::Get<ra::services::IConfiguration>().IsFeatureEnabled(ra::services::Feature::Hardcore))
+    {
+        // ignore modified rich presence in hardcore
+        Deactivate();
     }
 
     EndUpdate();

--- a/src/services/AchievementRuntime.cpp
+++ b/src/services/AchievementRuntime.cpp
@@ -732,7 +732,11 @@ std::wstring AchievementRuntime::GetRichPresenceDisplayString() const
 bool AchievementRuntime::ActivateRichPresence(const std::string& sScript)
 {
     auto* game = GetClient()->game;
-    Expects(game != nullptr);
+    if (!game)
+    {
+        // game still loading - assume success
+        return true;
+    }
     auto* runtime = &game->runtime;
     Expects(runtime != nullptr);
 
@@ -1170,6 +1174,11 @@ void AchievementRuntime::DoFrame()
         RaisePauseOnChangeEvents(vAchievementsWithHits, vActiveAchievements);
     if (!mLeaderboardsWithHits.empty() || !mActiveLeaderboards.empty())
         RaisePauseOnChangeEvents(mLeaderboardsWithHits, mActiveLeaderboards);
+}
+
+void AchievementRuntime::Idle()
+{
+    rc_client_idle(GetClient());
 }
 
 void AchievementRuntime::InvalidateAddress(ra::ByteAddress nAddress) noexcept

--- a/src/services/AchievementRuntime.cpp
+++ b/src/services/AchievementRuntime.cpp
@@ -1947,7 +1947,7 @@ _NODISCARD static char ComparisonSizeFromPrefix(_In_ char cPrefix) noexcept
     const char* ptr = buffer;
     buffer[2] = cPrefix;
 
-    char size = RC_MEMSIZE_16_BITS;
+    uint8_t size = RC_MEMSIZE_16_BITS;
     unsigned address = 0;
     rc_parse_memref(&ptr, &size, &address);
     return size;

--- a/src/services/AchievementRuntime.cpp
+++ b/src/services/AchievementRuntime.cpp
@@ -1176,7 +1176,7 @@ void AchievementRuntime::DoFrame()
         RaisePauseOnChangeEvents(mLeaderboardsWithHits, mActiveLeaderboards);
 }
 
-void AchievementRuntime::Idle()
+void AchievementRuntime::Idle() noexcept
 {
     rc_client_idle(GetClient());
 }

--- a/src/services/AchievementRuntime.hh
+++ b/src/services/AchievementRuntime.hh
@@ -101,6 +101,11 @@ public:
     void DoFrame();
 
     /// <summary>
+    /// Processes stuff not related to a frame.
+    /// </summary>
+    void Idle();
+
+    /// <summary>
     /// Loads HitCount data for active achievements from a save state file.
     /// </summary>
     /// <param name="sLoadStateFilename">The name of the save state file.</param>

--- a/src/services/AchievementRuntime.hh
+++ b/src/services/AchievementRuntime.hh
@@ -103,7 +103,7 @@ public:
     /// <summary>
     /// Processes stuff not related to a frame.
     /// </summary>
-    void Idle();
+    void Idle() noexcept;
 
     /// <summary>
     /// Loads HitCount data for active achievements from a save state file.

--- a/src/ui/viewmodels/MemoryBookmarksViewModel.cpp
+++ b/src/ui/viewmodels/MemoryBookmarksViewModel.cpp
@@ -401,7 +401,7 @@ void MemoryBookmarksViewModel::LoadBookmarks(ra::services::TextReader& sBookmark
                 if (bookmark.HasMember("MemAddr"))
                 {
                     // third bookmark format uses the memref serializer
-                    char size = 0;
+                    uint8_t size = 0;
                     unsigned address = 0;
                     const char* memaddr = bookmark["MemAddr"].GetString();
                     if (rc_parse_memref(&memaddr, &size, &address) == RC_OK)

--- a/src/ui/viewmodels/RichPresenceMonitorViewModel.cpp
+++ b/src/ui/viewmodels/RichPresenceMonitorViewModel.cpp
@@ -7,7 +7,6 @@
 #include "services\AchievementRuntime.hh"
 #include "services\IConfiguration.hh"
 #include "services\ILocalStorage.hh"
-#include "services\IThreadPool.hh"
 #include "services\ServiceLocator.hh"
 
 namespace ra {
@@ -27,165 +26,77 @@ void RichPresenceMonitorViewModel::InitializeNotifyTargets()
     pGameContext.AddNotifyTarget(*this);
 }
 
-static time_t GetRichPresenceModified()
-{
-    const auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::context::GameContext>();
-    auto& pLocalStorage = ra::services::ServiceLocator::GetMutable<ra::services::ILocalStorage>();
-    const auto tLastModified = pLocalStorage.GetLastModified(ra::services::StorageItemType::RichPresence,
-                                                             std::to_wstring(pGameContext.GameId()));
-    return std::chrono::system_clock::to_time_t(tLastModified);
-}
-
-void RichPresenceMonitorViewModel::StartMonitoring()
-{
-    UpdateWindowTitle();
-
-    switch (m_nState)
-    {
-        default:
-        case MonitorState::None:
-            // not monitoring - start doing so.
-            m_nState = MonitorState::Active;
-            m_tRichPresenceFileTime = GetRichPresenceModified();
-            if (m_tRichPresenceFileTime)
-            {
-                auto& pGameContext = ra::services::ServiceLocator::GetMutable<ra::data::context::GameContext>();
-                auto* pRichPresence = pGameContext.Assets().FindRichPresence();
-                if (pRichPresence != nullptr)
-                {
-                    pRichPresence->ReloadRichPresenceScript();
-
-                    if (pRichPresence->GetChanges() != ra::data::models::AssetChanges::None &&
-                        ra::services::ServiceLocator::Get<ra::services::IConfiguration>().IsFeatureEnabled(ra::services::Feature::Hardcore))
-                    {
-                        pRichPresence->Deactivate();
-                    }
-                    else
-                    {
-                        pRichPresence->Activate();
-                    }
-                }
-            }
-            UpdateDisplayString();
-            ScheduleUpdateDisplayString();
-            break;
-
-        case MonitorState::Deactivated:
-            // asked to stop, but haven't called callback yet, resurrect.
-            m_nState = MonitorState::Active;
-            break;
-
-        case MonitorState::Static:
-            // monitoring, but message is static, update it.
-            UpdateDisplayString();
-            break;
-
-        case MonitorState::Active:
-            // already monitoring, do nothing.
-            break;
-    }
-}
-
-void RichPresenceMonitorViewModel::StopMonitoring() noexcept
-{
-    switch (m_nState)
-    {
-        default:
-        case MonitorState::Active:
-            // monitoring, notify callback to stop rescheduling.
-            m_nState = MonitorState::Deactivated;
-            break;
-
-        case MonitorState::Deactivated:
-            // already asked to stop, but haven't processed it yet.
-            break;
-
-        case MonitorState::Static:
-            // monitoring, but not updating the message, immediately transition to not monitoring
-            m_nState = MonitorState::None;
-            break;
-
-        case MonitorState::None:
-            // not monitoring, do nothing.
-            break;
-    }
-}
-
-void RichPresenceMonitorViewModel::ScheduleUpdateDisplayString()
-{
-    if (m_nState != MonitorState::Active)
-        return;
-
-    ra::services::ServiceLocator::GetMutable<ra::services::IThreadPool>().ScheduleAsync(std::chrono::seconds(1), [this]()
-    {
-        if (m_nState == MonitorState::Deactivated)
-        {
-            // asked to stop, do so now
-            m_nState = MonitorState::None;
-        }
-        else
-        {
-            // check to see if the script was updated
-            const time_t tRichPresenceFileTime = GetRichPresenceModified();
-            if (tRichPresenceFileTime != m_tRichPresenceFileTime)
-            {
-                auto* pRichPresence = ra::services::ServiceLocator::GetMutable<ra::data::context::GameContext>().Assets().FindRichPresence();
-                if (pRichPresence)
-                    pRichPresence->ReloadRichPresenceScript();
-                m_tRichPresenceFileTime = tRichPresenceFileTime;
-
-                UpdateWindowTitle();
-            }
-
-            UpdateDisplayString();
-            ScheduleUpdateDisplayString();
-        }
-    });
-}
-
 void RichPresenceMonitorViewModel::UpdateDisplayString()
 {
-    const auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::context::GameContext>();
-    if (pGameContext.GameId() == 0)
+    auto& pGameContext = ra::services::ServiceLocator::GetMutable<ra::data::context::GameContext>();
+    const auto nGameId = pGameContext.GameId();
+    if (nGameId == 0)
     {
         SetDisplayString(L"No game loaded.");
+        return;
     }
-    else
+
+    auto* pRichPresence = pGameContext.Assets().FindRichPresence();
+
+    // check to see if the script was updated
+    auto& pLocalStorage = ra::services::ServiceLocator::GetMutable<ra::services::ILocalStorage>();
+    const auto tLastModified = pLocalStorage.GetLastModified(ra::services::StorageItemType::RichPresence,
+                                                             std::to_wstring(nGameId));
+    const auto tRichPresenceFileTime = std::chrono::system_clock::to_time_t(tLastModified);
+    if (tRichPresenceFileTime == m_tRichPresenceFileTime)
     {
-        const auto* pRichPresence = pGameContext.Assets().FindRichPresence();
+        // not updated. if no model, set default string and bail
         if (!pRichPresence)
         {
             SetDisplayString(DisplayStringProperty.GetDefaultValue());
-        }
-        else
-        {
-            switch (pRichPresence->GetState())
-            {
-                case ra::data::models::AssetState::Active:
-                case ra::data::models::AssetState::Disabled: // parse error, still display it
-                {
-                    auto& pRuntime = ra::services::ServiceLocator::Get<ra::services::AchievementRuntime>();
-                    const std::wstring sDisplayString = ra::Widen(pRuntime.GetRichPresenceDisplayString());
-                    SetDisplayString(sDisplayString);
-
-                    if (m_nState == MonitorState::Static)
-                    {
-                        m_nState = MonitorState::Active;
-                        ScheduleUpdateDisplayString();
-                    }
-
-                    return;
-                }
-
-                default:
-                    SetDisplayString(L"Rich Presence not active.");
-                    break;
-            }
+            return;
         }
     }
+    else
+    {
+        m_tRichPresenceFileTime = tRichPresenceFileTime;
 
-    if (m_nState == MonitorState::Active)
-        m_nState = MonitorState::Static;
+        if (!pRichPresence)
+        {
+            // new file detected, load it and activate
+            auto pNewRichPresence = std::make_unique<ra::data::models::RichPresenceModel>();
+            pNewRichPresence->CreateServerCheckpoint();
+            pNewRichPresence->CreateLocalCheckpoint();
+            pRichPresence = dynamic_cast<ra::data::models::RichPresenceModel*>(
+                &pGameContext.Assets().Append(std::move(pNewRichPresence)));
+        }
+
+        // modified rich presence cannot be active in hardcore
+        const bool bHardcore = ra::services::ServiceLocator::Get<ra::services::IConfiguration>().IsFeatureEnabled(
+            ra::services::Feature::Hardcore);
+        if (bHardcore)
+            pRichPresence->Deactivate();
+
+        // load the updated file
+        pRichPresence->ReloadRichPresenceScript();
+
+        // automatically activate if not in hardcore
+        if (!bHardcore)
+            pRichPresence->Activate();
+
+        UpdateWindowTitle();
+    }
+
+    switch (pRichPresence->GetState())
+    {
+        case ra::data::models::AssetState::Active:
+        case ra::data::models::AssetState::Disabled: // parse error, still display it
+        {
+            auto& pRuntime = ra::services::ServiceLocator::Get<ra::services::AchievementRuntime>();
+            const std::wstring sDisplayString = ra::Widen(pRuntime.GetRichPresenceDisplayString());
+            SetDisplayString(sDisplayString);
+            return;
+        }
+
+        default:
+            SetDisplayString(L"Rich Presence not active.");
+            break;
+    }
 }
 
 void RichPresenceMonitorViewModel::UpdateWindowTitle()
@@ -200,11 +111,8 @@ void RichPresenceMonitorViewModel::UpdateWindowTitle()
 
 void RichPresenceMonitorViewModel::OnActiveGameChanged()
 {
-    if (IsVisible())
-    {
-        m_nState = MonitorState::None;
-        StartMonitoring();
-    }
+    UpdateDisplayString();
+    UpdateWindowTitle();
 }
 
 void RichPresenceMonitorViewModel::OnValueChanged(const BoolModelProperty::ChangeArgs& args)
@@ -212,14 +120,7 @@ void RichPresenceMonitorViewModel::OnValueChanged(const BoolModelProperty::Chang
     if (args.Property == IsVisibleProperty)
     {
         if (args.tNewValue)
-        {
             UpdateDisplayString();
-            StartMonitoring();
-        }
-        else
-        {
-            StopMonitoring();
-        }
     }
 
     WindowViewModelBase::OnValueChanged(args);

--- a/src/ui/viewmodels/RichPresenceMonitorViewModel.hh
+++ b/src/ui/viewmodels/RichPresenceMonitorViewModel.hh
@@ -28,26 +28,16 @@ public:
     /// </summary>
     const std::wstring& GetDisplayString() const { return GetValue(DisplayStringProperty); }
 
-protected:
     /// <summary>
     /// Refreshes the display string.
     /// </summary>
     void UpdateDisplayString();
 
+protected:
     /// <summary>
     /// Sets the message to display.
     /// </summary>
     void SetDisplayString(const std::wstring& sValue) { SetValue(DisplayStringProperty, sValue); }
-
-    /// <summary>
-    /// Starts periodically updating the display string.
-    /// </summary>
-    void StartMonitoring();
-
-    /// <summary>
-    /// Stops periodically updating the display string.
-    /// </summary>
-    void StopMonitoring() noexcept;
 
     void OnValueChanged(const BoolModelProperty::ChangeArgs& args) override;
 
@@ -55,18 +45,7 @@ protected:
     void OnActiveGameChanged() override;
 
 private:
-    void ScheduleUpdateDisplayString();
     void UpdateWindowTitle();
-
-    enum class MonitorState
-    {
-        None,
-        Active,
-        Deactivated,
-        Static,
-    };
-
-    MonitorState m_nState{ MonitorState::None };
 
     time_t m_tRichPresenceFileTime{ 0 };
 };


### PR DESCRIPTION
Moves timer from rich presence monitor to global. Uses that to update rich presence monitor and call rc_client_idle.