### PR TITLE
Destroy overlay on new window instead of updating parent

### DIFF
--- a/src/ui/win32/OverlayWindow.cpp
+++ b/src/ui/win32/OverlayWindow.cpp
@@ -57,14 +57,15 @@ void OverlayWindow::CreateOverlayWindow(HWND hWnd)
 
     if (m_hOverlayWnd && IsWindow(m_hOverlayWnd))
     {
-        // overlay window exists, just update the parent (if necessary)
+        // overlay window already exists, destroy before creating a new one
         if (m_hWnd != hWnd)
         {
-            m_hWnd = hWnd;
-            SetParent(m_hOverlayWnd, hWnd);
-            UpdateOverlayPosition();
+            DestroyOverlayWindow();
         }
-        return;
+        else
+        {
+            return;
+        }
     }
 
     // overlay window does not exist, create it
@@ -197,8 +198,13 @@ void OverlayWindow::CreateOverlayWindow()
     });
 }
 
-void OverlayWindow::DestroyOverlayWindow() noexcept
+void OverlayWindow::DestroyOverlayWindow() 
 {
+
+    //clear current popups so they don't interfere with creation of a new overlay
+    auto& pOverlayManager = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>();
+    pOverlayManager.ClearPopups();
+
     if (m_hEventHook)
     {
         UnhookWinEvent(m_hEventHook);

--- a/src/ui/win32/OverlayWindow.hh
+++ b/src/ui/win32/OverlayWindow.hh
@@ -13,7 +13,7 @@ class OverlayWindow
 {
 public:
     void CreateOverlayWindow(HWND hWnd);
-    void DestroyOverlayWindow() noexcept;
+    void DestroyOverlayWindow();
 
     void OnOverlayMoved() noexcept;
 


### PR DESCRIPTION
Using RAIntegration with Dolphin, the issue came up that when changing the overlay from the menu window to the game window, using SetParent wasn't working properly, causing the overlay to be relative to the screen and not the new window. Destroying the overlay and then creating a new one seems to work fine, at least for my tests I did with Dolphin and RALibretro.

I also noticed that if the overlay gets destroyed while a popup is still shown, the new overlay would not work, so I added 2 lines to clear all popups before destroying the window.