### PR TITLE
add rarity to achievement popups

### DIFF
--- a/tests/services/AchievementRuntime_Tests.cpp
+++ b/tests/services/AchievementRuntime_Tests.cpp
@@ -1579,10 +1579,13 @@ public:
     {
         AchievementRuntimeHarness runtime;
         auto* pAch6 = runtime.MockAchievement(6U, "0xH0000=1");
+        pAch6->public_.rarity = 23.45f;
+        pAch6->public_.rarity_hardcore = 12.34f;
         memcpy(pAch6->public_.badge_name, "012345", 7);
         auto* vmAch6 = runtime.WrapAchievement(pAch6);
         runtime.mockGameContext.SetRichPresenceDisplayString(L"Titles");
         runtime.mockGameContext.Assets().FindRichPresence()->Activate();
+        runtime.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, false);
         runtime.mockConfiguration.SetPopupLocation(ra::ui::viewmodels::Popup::AchievementTriggered,
                                                    ra::ui::viewmodels::PopupLocation::BottomLeft);
 
@@ -1598,7 +1601,7 @@ public:
         auto* pPopup = runtime.mockOverlayManager.GetMessage(1);
         Expects(pPopup != nullptr);
         Assert::AreEqual(ra::ui::viewmodels::Popup::AchievementTriggered, pPopup->GetPopupType());
-        Assert::AreEqual(std::wstring(L"Achievement Unlocked"), pPopup->GetTitle());
+        Assert::AreEqual(std::wstring(L"Achievement Unlocked - 23.45%"), pPopup->GetTitle());
         Assert::AreEqual(std::wstring(L"Ach6 (5)"), pPopup->GetDescription());
         Assert::AreEqual(std::wstring(L"Description 6"), pPopup->GetDetail());
         Assert::AreEqual(ra::ui::ImageType::Badge, pPopup->GetImage().Type());
@@ -1607,11 +1610,84 @@ public:
         Assert::IsTrue(runtime.mockAudioSystem.WasAudioFilePlayed(L"Overlay\\unlock.wav"));
     }
 
+    TEST_METHOD(TestHandleAchievementTriggeredEventHardcore)
+    {
+        AchievementRuntimeHarness runtime;
+        auto* pAch6 = runtime.MockAchievement(6U, "0xH0000=1");
+        pAch6->public_.rarity = 23.45f;
+        pAch6->public_.rarity_hardcore = 12.34f;
+        memcpy(pAch6->public_.badge_name, "012345", 7);
+        auto* vmAch6 = runtime.WrapAchievement(pAch6);
+        runtime.mockGameContext.SetRichPresenceDisplayString(L"Titles");
+        runtime.mockGameContext.Assets().FindRichPresence()->Activate();
+        runtime.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, true);
+        runtime.mockConfiguration.SetPopupLocation(ra::ui::viewmodels::Popup::AchievementTriggered,
+                                                   ra::ui::viewmodels::PopupLocation::BottomLeft);
+
+        rc_client_event_t event;
+        memset(&event, 0, sizeof(event));
+        event.type = RC_CLIENT_EVENT_ACHIEVEMENT_TRIGGERED;
+        event.achievement = &pAch6->public_;
+        runtime.RaiseEvent(event);
+
+        Assert::AreEqual(ra::data::models::AssetState::Triggered, vmAch6->GetState());
+        Assert::AreEqual(std::wstring(L"Titles"), vmAch6->GetUnlockRichPresence());
+
+        auto* pPopup = runtime.mockOverlayManager.GetMessage(1);
+        Expects(pPopup != nullptr);
+        Assert::AreEqual(ra::ui::viewmodels::Popup::AchievementTriggered, pPopup->GetPopupType());
+        Assert::AreEqual(std::wstring(L"Achievement Unlocked - 12.34%"), pPopup->GetTitle());
+        Assert::AreEqual(std::wstring(L"Ach6 (5)"), pPopup->GetDescription());
+        Assert::AreEqual(std::wstring(L"Description 6"), pPopup->GetDetail());
+        Assert::AreEqual(ra::ui::ImageType::Badge, pPopup->GetImage().Type());
+        Assert::AreEqual(std::string("012345"), pPopup->GetImage().Name());
+        Assert::AreEqual({0U}, runtime.mockFrameEventQueue.NumTriggeredTriggers());
+        Assert::IsTrue(runtime.mockAudioSystem.WasAudioFilePlayed(L"Overlay\\unlock.wav"));
+    }
+
+    TEST_METHOD(TestHandleAchievementTriggeredEventHardcoreRare)
+    {
+        AchievementRuntimeHarness runtime;
+        auto* pAch6 = runtime.MockAchievement(6U, "0xH0000=1");
+        pAch6->public_.rarity = 23.45f;
+        pAch6->public_.rarity_hardcore = 9.87f;
+        memcpy(pAch6->public_.badge_name, "012345", 7);
+        auto* vmAch6 = runtime.WrapAchievement(pAch6);
+        runtime.mockGameContext.SetRichPresenceDisplayString(L"Titles");
+        runtime.mockGameContext.Assets().FindRichPresence()->Activate();
+        runtime.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, true);
+        runtime.mockConfiguration.SetPopupLocation(ra::ui::viewmodels::Popup::AchievementTriggered,
+                                                   ra::ui::viewmodels::PopupLocation::BottomLeft);
+        runtime.mockFileSystem.MockFileSize(runtime.mockFileSystem.BaseDirectory() + L"Overlay\\rareunlock.wav", 12345);
+
+        rc_client_event_t event;
+        memset(&event, 0, sizeof(event));
+        event.type = RC_CLIENT_EVENT_ACHIEVEMENT_TRIGGERED;
+        event.achievement = &pAch6->public_;
+        runtime.RaiseEvent(event);
+
+        Assert::AreEqual(ra::data::models::AssetState::Triggered, vmAch6->GetState());
+        Assert::AreEqual(std::wstring(L"Titles"), vmAch6->GetUnlockRichPresence());
+
+        auto* pPopup = runtime.mockOverlayManager.GetMessage(1);
+        Expects(pPopup != nullptr);
+        Assert::AreEqual(ra::ui::viewmodels::Popup::AchievementTriggered, pPopup->GetPopupType());
+        Assert::AreEqual(std::wstring(L"Rare Achievement Unlocked - 9.87%"), pPopup->GetTitle());
+        Assert::AreEqual(std::wstring(L"Ach6 (5)"), pPopup->GetDescription());
+        Assert::AreEqual(std::wstring(L"Description 6"), pPopup->GetDetail());
+        Assert::AreEqual(ra::ui::ImageType::Badge, pPopup->GetImage().Type());
+        Assert::AreEqual(std::string("012345"), pPopup->GetImage().Name());
+        Assert::AreEqual({0U}, runtime.mockFrameEventQueue.NumTriggeredTriggers());
+        Assert::IsTrue(runtime.mockAudioSystem.WasAudioFilePlayed(L"Overlay\\rareunlock.wav"));
+    }
+
     TEST_METHOD(TestHandleAchievementTriggeredEventNoRichPresence)
     {
         AchievementRuntimeHarness runtime;
         auto* pAch6 = runtime.MockAchievement(6U, "0xH0000=1");
         memcpy(pAch6->public_.badge_name, "012345", 7);
+        pAch6->public_.rarity = 23.45f;
+        pAch6->public_.rarity_hardcore = 12.34f;
         auto* vmAch6 = runtime.WrapAchievement(pAch6);
         runtime.mockConfiguration.SetPopupLocation(ra::ui::viewmodels::Popup::AchievementTriggered,
                                                    ra::ui::viewmodels::PopupLocation::BottomLeft);
@@ -1628,7 +1704,7 @@ public:
         auto* pPopup = runtime.mockOverlayManager.GetMessage(1);
         Expects(pPopup != nullptr);
         Assert::AreEqual(ra::ui::viewmodels::Popup::AchievementTriggered, pPopup->GetPopupType());
-        Assert::AreEqual(std::wstring(L"Achievement Unlocked"), pPopup->GetTitle());
+        Assert::AreEqual(std::wstring(L"Achievement Unlocked - 23.45%"), pPopup->GetTitle());
         Assert::AreEqual(std::wstring(L"Ach6 (5)"), pPopup->GetDescription());
         Assert::AreEqual(std::wstring(L"Description 6"), pPopup->GetDetail());
         Assert::AreEqual(ra::ui::ImageType::Badge, pPopup->GetImage().Type());
@@ -1874,6 +1950,8 @@ public:
         AchievementRuntimeHarness runtime;
         auto* pAch6 = runtime.MockAchievement(6U, "0xH0000=1");
         memcpy(pAch6->public_.badge_name, "012345", 7);
+        pAch6->public_.rarity = 23.45f;
+        pAch6->public_.rarity_hardcore = 12.34f;
         auto* vmAch6 = runtime.WrapAchievement(pAch6);
         runtime.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, false);
         runtime.GetClient()->state.hardcore = 0;
@@ -1895,7 +1973,7 @@ public:
         auto* pPopup = runtime.mockOverlayManager.GetMessage(1);
         Expects(pPopup != nullptr);
         Assert::AreEqual(ra::ui::viewmodels::Popup::AchievementTriggered, pPopup->GetPopupType());
-        Assert::AreEqual(std::wstring(L"Achievement Unlocked"), pPopup->GetTitle());
+        Assert::AreEqual(std::wstring(L"Achievement Unlocked - 23.45%"), pPopup->GetTitle());
         Assert::AreEqual(std::wstring(L"Ach6 (5)"), pPopup->GetDescription());
         Assert::AreEqual(std::wstring(L"Description 6"), pPopup->GetDetail());
         Assert::AreEqual(ra::ui::ImageType::Badge, pPopup->GetImage().Type());


### PR DESCRIPTION
If rarity is less than 10%, the popup is modified to say "Rare Achievement Unlocked", and an alternate sound can be played. If the alternate sound (`rareunlock.wav`) doesn't exist, the standard `unlock.wav` will be played instead.

In this video, a rare achievement is unlocked first (whistling sound), then a normal achievement (boop).

https://github.com/RetroAchievements/RAIntegration/assets/32680403/2629db64-589c-45ac-8ed2-0ca426721928

Hardcore rarity only include hardcore unlocks. Non-hardcore rarity includes all unlocks. If an achievement has 7% hardcore unlocks and 15% total unlocks, it would be reported as a rare achievement for a hardcore player, and a normal achievement for a non-hardcore player.