### PR TITLE
don't clear conditions if toggling decimal while in an error state

### DIFF
--- a/src/ui/viewmodels/AssetEditorViewModel.cpp
+++ b/src/ui/viewmodels/AssetEditorViewModel.cpp
@@ -499,7 +499,7 @@ void AssetEditorViewModel::OnValueChanged(const BoolModelProperty::ChangeArgs& a
         auto& pConfiguration = ra::services::ServiceLocator::GetMutable<ra::services::IConfiguration>();
         pConfiguration.SetFeatureEnabled(ra::services::Feature::PreferDecimal, args.tNewValue);
 
-        m_vmTrigger.UpdateConditions();
+        m_vmTrigger.ToggleDecimal();
     }
     else if (args.Property == IsVisibleProperty)
     {

--- a/src/ui/viewmodels/TriggerViewModel.cpp
+++ b/src/ui/viewmodels/TriggerViewModel.cpp
@@ -879,6 +879,41 @@ void TriggerViewModel::UpdateConditions(const GroupViewModel* pGroup)
     m_vConditions.AddNotifyTarget(m_pConditionsMonitor);
 }
 
+static unsigned int ParseNumeric(const std::wstring& sValue)
+{
+    unsigned int nValue = 0;
+    std::wstring sError;
+
+    if (sValue.length() > 2 && sValue.at(1) == 'x' && ra::ParseHex(sValue, 0xFFFFFFFF, nValue, sError))
+        return nValue;
+
+    if (ra::ParseUnsignedInt(sValue, 0xFFFFFFFF, nValue, sError))
+        return nValue;
+
+    return 0;
+}
+
+void TriggerViewModel::ToggleDecimal()
+{
+    m_vConditions.RemoveNotifyTarget(m_pConditionsMonitor);
+    m_vConditions.BeginUpdate();
+
+    for (gsl::index nIndex = m_vConditions.Count() - 1; nIndex >= 0; --nIndex)
+    {
+        auto* pItem = m_vConditions.GetItemAt(nIndex);
+        if (!pItem)
+            continue;
+
+        if (pItem->GetSourceType() == TriggerOperandType::Value)
+            pItem->SetSourceValue(ParseNumeric(pItem->GetSourceValue()));
+        if (pItem->GetTargetType() == TriggerOperandType::Value)
+            pItem->SetTargetValue(ParseNumeric(pItem->GetTargetValue()));
+    }
+
+    m_vConditions.EndUpdate();
+    m_vConditions.AddNotifyTarget(m_pConditionsMonitor);
+}
+
 void TriggerViewModel::UpdateTotalHits()
 {
     unsigned int nHits = 0;

--- a/src/ui/viewmodels/TriggerViewModel.hh
+++ b/src/ui/viewmodels/TriggerViewModel.hh
@@ -144,6 +144,7 @@ public:
     void DoFrame();
     void UpdateColors(const rc_trigger_t* pTrigger);
     void UpdateConditions();
+    void ToggleDecimal();
 
     static bool BuildHitChainTooltip(std::wstring& sTooltip, const ViewModelCollection<TriggerConditionViewModel>& vmConditions, gsl::index nIndex);
 

--- a/tests/mocks/MockAchievementRuntime.cpp
+++ b/tests/mocks/MockAchievementRuntime.cpp
@@ -161,9 +161,12 @@ rc_client_achievement_info_t* MockAchievementRuntime::ActivateAchievement(uint32
     m_mAchievementDefinitions[nId] = sTrigger;
 
     auto nSize = rc_trigger_size(sTrigger.c_str());
-    void* trigger_buffer = rc_buffer_alloc(&game->buffer, nSize);
-    achievement->trigger = rc_parse_trigger(trigger_buffer, sTrigger.c_str(), nullptr, 0);
-    achievement->public_.state = RC_CLIENT_ACHIEVEMENT_STATE_ACTIVE;
+    if (nSize > 0)
+    {
+        void* trigger_buffer = rc_buffer_alloc(&game->buffer, nSize);
+        achievement->trigger = rc_parse_trigger(trigger_buffer, sTrigger.c_str(), nullptr, 0);
+        achievement->public_.state = RC_CLIENT_ACHIEVEMENT_STATE_ACTIVE;
+    }
 
     return achievement;
 }


### PR DESCRIPTION
https://discord.com/channels/310192285306454017/962817919698501702/1150788489303048292

When toggling the "Show Decimal" checkbox, the conditions were being rebuilt from the parsed trigger. If there's a parse error (such as multiple measured conditions), there is no parsed trigger to rebuild the editor from. 

Solution: Instead of rebuilding the trigger, just update the affected cells of the grid.


