### PR TITLE
don't show unknown game dialog when switching between disks previously selected for compatibility testing

### DIFF
--- a/src/ui/viewmodels/UnknownGameViewModel.cpp
+++ b/src/ui/viewmodels/UnknownGameViewModel.cpp
@@ -91,20 +91,30 @@ void UnknownGameViewModel::CheckForPreviousAssociation()
     if (sHash.empty())
         return;
 
+    const auto nId = GetPreviousAssociation(sHash);
+    if (nId != 0)
+    {
+        const auto& sGameName = m_vGameTitles.GetLabelForId(nId);
+        if (!sGameName.empty())
+            SetSelectedGameId(nId);
+    }
+}
+
+unsigned int UnknownGameViewModel::GetPreviousAssociation(const std::wstring& sHash)
+{
     auto& pLocalStorage = ra::services::ServiceLocator::GetMutable<ra::services::ILocalStorage>();
     auto sMapping = pLocalStorage.ReadText(ra::services::StorageItemType::HashMapping, sHash);
+
     std::string sLine;
     if (sMapping && sMapping->GetLine(sLine))
     {
         const auto& pConsoleContext = ra::services::ServiceLocator::Get<ra::data::context::ConsoleContext>();
         const unsigned nId = DecodeID(sLine, sHash, pConsoleContext.Id());
         if (nId > 0)
-        {
-            const auto& sGameName = m_vGameTitles.GetLabelForId(nId);
-            if (!sGameName.empty())
-                SetSelectedGameId(nId);
-        }
+            return nId;
     }
+
+    return 0;
 }
 
 static constexpr unsigned GenerateMask(const std::wstring& sHash, ConsoleID nConsoleId)

--- a/src/ui/viewmodels/UnknownGameViewModel.hh
+++ b/src/ui/viewmodels/UnknownGameViewModel.hh
@@ -176,6 +176,8 @@ public:
     /// <returns><c>true</c> if the dialog should be closed, <c>false</c> if not.</returns>
     bool BeginTest();
 
+    static unsigned int GetPreviousAssociation(const std::wstring& sHash);
+
 protected:
     void OnValueChanged(const StringModelProperty::ChangeArgs& args) override;
     void OnValueChanged(const IntModelProperty::ChangeArgs& args) override;


### PR DESCRIPTION
When testing compatibility of a multi-disc game, the user should only be prompted for each unknown disc once during the session, not each time the discs are switched.