### PR TITLE
show softcore score when hardcore disabled

### DIFF
--- a/src/Exports.cpp
+++ b/src/Exports.cpp
@@ -325,10 +325,18 @@ static void HandleLoginResponse(int nResult, const char* sErrorMessage, rc_clien
             new ra::ui::viewmodels::PopupMessageViewModel);
         vmMessage->SetTitle(ra::StringPrintf(L"Welcome %s%s", pSessionTracker.HasSessionData() ? L"back " : L"",
                                              pUser->display_name));
-        vmMessage->SetDescription((pUser->num_unread_messages == 1)
+
+        const auto& pConfiguration = ra::services::ServiceLocator::Get<ra::services::IConfiguration>();
+        const auto bHardcore = pConfiguration.IsFeatureEnabled(ra::services::Feature::Hardcore);
+        if (bHardcore)
+            vmMessage->SetDescription(ra::StringPrintf(L"%u points", pUser->score));
+        else
+            vmMessage->SetDescription(ra::StringPrintf(L"%u points (softcore)", pUser->score_softcore));
+
+        vmMessage->SetDetail((pUser->num_unread_messages == 1)
             ? L"You have 1 new message"
             : ra::StringPrintf(L"You have %u new messages", pUser->num_unread_messages));
-        vmMessage->SetDetail(ra::StringPrintf(L"%u points", pUser->score));
+
         vmMessage->SetImage(ra::ui::ImageType::UserPic, pUser->username);
         ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>().QueueMessage(vmMessage);
     }

--- a/src/ui/viewmodels/OverlayViewModel.cpp
+++ b/src/ui/viewmodels/OverlayViewModel.cpp
@@ -164,7 +164,7 @@ void OverlayViewModel::CreateRenderImage()
 
     const auto& pConfiguration = ra::services::ServiceLocator::Get<ra::services::IConfiguration>();
     const auto bHardcore = pConfiguration.IsFeatureEnabled(ra::services::Feature::Hardcore);
-    const auto pClient = ra::services::ServiceLocator::Get<ra::services::AchievementRuntime>().GetClient();
+    const auto* pClient = ra::services::ServiceLocator::Get<ra::services::AchievementRuntime>().GetClient();
     const auto* pUser = rc_client_get_user_info(pClient);
     const auto sPoints = ra::StringPrintf(L"%u Points", !pUser ? 0 : bHardcore ? pUser->score : pUser->score_softcore);
     const auto szPoints = m_pSurface->MeasureText(nSubFont, sPoints);

--- a/src/ui/viewmodels/OverlayViewModel.cpp
+++ b/src/ui/viewmodels/OverlayViewModel.cpp
@@ -6,6 +6,7 @@
 #include "data\context\EmulatorContext.hh"
 #include "data\context\UserContext.hh"
 
+#include "services\AchievementRuntime.hh"
 #include "services\IClock.hh"
 #include "services\IConfiguration.hh"
 
@@ -161,12 +162,14 @@ void OverlayViewModel::CreateRenderImage()
     const auto sUserName = ra::Widen(pUserContext.GetDisplayName());
     const auto szUsername = m_pSurface->MeasureText(nFont, sUserName);
 
-    const auto sPoints = ra::StringPrintf(L"%u Points", pUserContext.GetScore());
-    const auto szPoints = m_pSurface->MeasureText(nSubFont, sPoints);
-
     const auto& pConfiguration = ra::services::ServiceLocator::Get<ra::services::IConfiguration>();
     const auto bHardcore = pConfiguration.IsFeatureEnabled(ra::services::Feature::Hardcore);
-    const auto sHardcore = std::wstring(L"HARDCORE");
+    const auto pClient = ra::services::ServiceLocator::Get<ra::services::AchievementRuntime>().GetClient();
+    const auto* pUser = rc_client_get_user_info(pClient);
+    const auto sPoints = ra::StringPrintf(L"%u Points", !pUser ? 0 : bHardcore ? pUser->score : pUser->score_softcore);
+    const auto szPoints = m_pSurface->MeasureText(nSubFont, sPoints);
+
+    const auto sHardcore = bHardcore ? std::wstring(L"HARDCORE") : std::wstring(L"SOFTCORE");
     const auto szHardcore = m_pSurface->MeasureText(nDetailFont, sHardcore);
 
     constexpr auto nImageSize = 64;
@@ -189,14 +192,13 @@ void OverlayViewModel::CreateRenderImage()
         m_pSurface->WriteText(nX + nPadding, nY + nPadding + szUsername.Height, nSubFont,
                               pTheme.ColorOverlaySubText(), sPoints);
 
-        if (bHardcore)
-            m_pSurface->WriteText(nX + nPadding, nY + nUserFrameHeight - nPadding - szHardcore.Height, nDetailFont,
-                                  pTheme.ColorError(), sHardcore);
+        m_pSurface->WriteText(nX + nPadding, nY + nUserFrameHeight - nPadding - szHardcore.Height, nDetailFont,
+                              pTheme.ColorOverlayDisabledText(), sHardcore);
     }
-    else if (bHardcore)
+    else if (!bHardcore)
     {
         m_pSurface->WriteText(nWidth - nMargin - szHardcore.Width, nMargin, nDetailFont,
-                              pTheme.ColorError(), sHardcore);
+                              pTheme.ColorOverlayDisabledText(), sHardcore);
     }
 
     // page header


### PR DESCRIPTION
Shows the user's softcore points and a "(softcore)" indicator on the login popup when hardcore is disabled. Also shows the softcore points and a "SOFTCORE" indicator on the overlay. The "HARDCORE" indicator on the overlay is no longer bright red, and a hardcore indicator was not added to the login popup.

![image](https://github.com/RetroAchievements/RAIntegration/assets/32680403/4a682c4c-3e35-489e-b02a-310f13fcad54)

Also switches the order of the Messages and Points lines in the login popup.