### PR TITLE
support for indirect code notes via overflow math

### DIFF
--- a/src/data/models/CodeNotesModel.hh
+++ b/src/data/models/CodeNotesModel.hh
@@ -72,7 +72,7 @@ public:
     /// Returns the note associated with the specified address.
     /// </summary>
     /// <returns>The note associated to the address, <c>nullptr</c> if no note is associated to the address.</returns>
-    const std::wstring* FindIndirectCodeNote(ra::ByteAddress nAddress, unsigned nOffset) const noexcept;
+    const std::wstring* FindIndirectCodeNote(ra::ByteAddress nAddress, unsigned nOffset) const;
 
     /// <summary>
     /// Returns the number of bytes associated to the code note at the specified address.
@@ -104,7 +104,7 @@ public:
     /// <returns>
     ///  Returns 0xFFFFFFFF if not found, or not an indirect note.
     /// </returns>
-    ra::ByteAddress GetIndirectSource(ra::ByteAddress nAddress) const noexcept;
+    ra::ByteAddress GetIndirectSource(ra::ByteAddress nAddress) const;
 
     /// <summary>
     /// Returns the address of the next code note after the provided address.
@@ -209,11 +209,19 @@ protected:
         int Offset = 0;
     };
 
+    enum OffsetType
+    {
+        None = 0,
+        Converted,
+        Overflow,
+    };
+
     struct PointerData
     {
         ra::ByteAddress RawPointerValue = 0;
         ra::ByteAddress PointerValue = 0;
         unsigned int OffsetRange = 0;
+        OffsetType OffsetType = OffsetType::None;
         std::vector<OffsetCodeNote> OffsetNotes;
     };
 
@@ -223,7 +231,9 @@ protected:
     std::map<ra::ByteAddress, std::wstring> m_mPendingCodeNotes;
 
     const CodeNote* FindCodeNoteInternal(ra::ByteAddress nAddress) const;
-    void EnumerateCodeNotes(std::function<bool(ra::ByteAddress nAddress, const CodeNote& pCodeNote)> callback, bool bIncludeDerived) const;
+    std::pair<ra::ByteAddress, const CodeNotesModel::CodeNote*> FindIndirectCodeNoteInternal(ra::ByteAddress nAddress) const;
+    void EnumerateCodeNotes(std::function<bool(ra::ByteAddress nAddress, const CodeNote& pCodeNote)> callback,
+                            bool bIncludeDerived) const;
 
     unsigned int m_nGameId = 0;
     bool m_bHasPointers = false;

--- a/tests/data/models/CodeNotesModel_Tests.cpp
+++ b/tests/data/models/CodeNotesModel_Tests.cpp
@@ -677,6 +677,46 @@ public:
         Assert::AreEqual(std::wstring(), notes.FindCodeNote(18, MemSize::SixteenBit));
     }
 
+    
+    TEST_METHOD(TestFindCodeNoteSizedPointerOverflow)
+    {
+        CodeNotesModelHarness notes;
+        notes.mockConsoleContext.AddMemoryRegion(0, 31, ra::data::context::ConsoleContext::AddressType::SystemRAM, 0x80);
+        std::array<unsigned char, 32> memory{};
+        notes.mockEmulatorContext.MockMemory(memory);
+        memory.at(4) = 0x88; // start with initial value for pointer (real address = 0x88, RA address = 0x08)
+
+        const std::wstring sPointerNote =
+            L"Pointer (32-bit)\n"              // only 32-bit pointers are eligible for real address conversion
+            L"+0xFFFFFF88 = Small (8-bit)\n"   // 8+8=16
+            L"+0xFFFFFF90 = Medium (16-bit)\n" // 16+8=24
+            L"+0xFFFFFF98 = Large (32-bit)";   // 24+8=32
+        notes.AddCodeNote(4, "Author", sPointerNote);
+        notes.AddCodeNote(40, "Author", L"After [32-bit]");
+        notes.AddCodeNote(1, "Author", L"Before");
+        notes.AddCodeNote(20, "Author", L"In the middle");
+
+        Assert::AreEqual(std::wstring(), notes.FindCodeNote(0, MemSize::EightBit));
+        Assert::AreEqual(std::wstring(L"Before"), notes.FindCodeNote(1, MemSize::EightBit));
+        Assert::AreEqual(std::wstring(L"Pointer (32-bit) [1/4]"), notes.FindCodeNote(4, MemSize::EightBit));
+        Assert::AreEqual(std::wstring(L"Small (8-bit) [indirect]"), notes.FindCodeNote(16, MemSize::EightBit));
+        Assert::AreEqual(std::wstring(L"Medium (16-bit) [1/2] [indirect]"), notes.FindCodeNote(24, MemSize::EightBit));
+        Assert::AreEqual(std::wstring(L"Medium (16-bit) [2/2] [indirect]"), notes.FindCodeNote(25, MemSize::EightBit));
+        Assert::AreEqual(std::wstring(L"Large (32-bit) [1/4] [indirect]"), notes.FindCodeNote(32, MemSize::EightBit));
+        Assert::AreEqual(std::wstring(L"Large (32-bit) [4/4] [indirect]"), notes.FindCodeNote(35, MemSize::EightBit));
+        Assert::AreEqual(std::wstring(), notes.FindCodeNote(36, MemSize::EightBit));
+
+        Assert::AreEqual(std::wstring(L"Before [partial]"), notes.FindCodeNote(0, MemSize::SixteenBit));
+        Assert::AreEqual(std::wstring(L"Before [partial]"), notes.FindCodeNote(1, MemSize::SixteenBit));
+        Assert::AreEqual(std::wstring(L"Pointer (32-bit) [partial]"), notes.FindCodeNote(4, MemSize::SixteenBit));
+        Assert::AreEqual(std::wstring(L"Small (8-bit) [partial] [indirect]"), notes.FindCodeNote(16, MemSize::SixteenBit));
+        Assert::AreEqual(std::wstring(L"Medium (16-bit) [indirect]"), notes.FindCodeNote(24, MemSize::SixteenBit));
+        Assert::AreEqual(std::wstring(L"Medium (16-bit) [partial] [indirect]"), notes.FindCodeNote(25, MemSize::SixteenBit));
+        Assert::AreEqual(std::wstring(L"Large (32-bit) [partial] [indirect]"), notes.FindCodeNote(32, MemSize::SixteenBit));
+        Assert::AreEqual(std::wstring(L"Large (32-bit) [partial] [indirect]"), notes.FindCodeNote(35, MemSize::SixteenBit));
+        Assert::AreEqual(std::wstring(), notes.FindCodeNote(36, MemSize::SixteenBit));
+    }
+
     TEST_METHOD(TestFindIndirectCodeNote)
     {
         CodeNotesModelHarness notes;
@@ -695,6 +735,28 @@ public:
         Assert::IsNull(notes.FindIndirectCodeNote(1234U, 0)); // no offset
         Assert::IsNull(notes.FindIndirectCodeNote(1234U, 21)); // unknown offset
         Assert::IsNull(notes.FindIndirectCodeNote(1235U, 5)); // wrong base address
+    }
+
+    TEST_METHOD(TestFindIndirectCodeNoteOverflow)
+    {
+        CodeNotesModelHarness notes;
+        notes.mockConsoleContext.AddMemoryRegion(0, 31, ra::data::context::ConsoleContext::AddressType::SystemRAM, 0x80);
+        std::array<unsigned char, 32> memory{};
+        notes.mockEmulatorContext.MockMemory(memory);
+        memory.at(4) = 0x90; // start with initial value for pointer (real address = 0x90, RA address = 0x10)
+
+        const std::wstring sNote =
+            L"Pointer (32-bit)\n" // only 32-bit pointers are eligible for real address conversion
+            L"+0xFFFFFF81 = Small (8-bit)\n"
+            L"+0xFFFFFF82 = Medium (16-bit)\n"
+            L"+0xFFFFFF84 = Large (32-bit)";
+        notes.AddCodeNote(4, "Author", sNote);
+
+        notes.AssertIndirectNote(4U, 0x01, L"Small (8-bit)");
+        notes.AssertIndirectNote(4U, 0x04, L"Large (32-bit)");
+        Assert::IsNull(notes.FindIndirectCodeNote(4U, 0x00)); // no offset
+        Assert::IsNull(notes.FindIndirectCodeNote(4U, 0x30)); // unknown offset
+        Assert::IsNull(notes.FindIndirectCodeNote(8U, 0x01)); // wrong base address
     }
 
     TEST_METHOD(TestEnumerateCodeNotes)
@@ -788,6 +850,71 @@ public:
                     Assert::AreEqual(sPointerNote, sNote);
                     break;
                 case 6:
+                    Assert::Fail(L"Too many notes");
+                    break;
+            }
+            return true;
+        }, true);
+    }
+    
+    TEST_METHOD(TestEnumerateCodeNotesWithIndirectOverflow)
+    {
+        CodeNotesModelHarness notes;
+        notes.mockConsoleContext.AddMemoryRegion(0, 31, ra::data::context::ConsoleContext::AddressType::SystemRAM, 0x80);
+        std::array<unsigned char, 32> memory{};
+        notes.mockEmulatorContext.MockMemory(memory);
+        memory.at(4) = 0x88; // start with initial value for pointer (real address = 0x88, RA address = 0x08)
+
+        const std::wstring sPointerNote =
+            L"Pointer (32-bit)\n"              // only 32-bit pointers are eligible for real address conversion
+            L"+0xFFFFFF88 = Small (8-bit)\n"   // 8+8=16
+            L"+0xFFFFFF90 = Medium (16-bit)\n" // 16+8=24
+            L"+0xFFFFFF98 = Large (32-bit)";   // 24+8=32
+        notes.AddCodeNote(4, "Author", sPointerNote);
+        notes.AddCodeNote(40, "Author", L"After [32-bit]");
+        notes.AddCodeNote(1, "Author", L"Before");
+        notes.AddCodeNote(20, "Author", L"In the middle");
+
+        int i = 0;
+        notes.EnumerateCodeNotes([&i, &sPointerNote](ra::ByteAddress nAddress, unsigned nBytes, const std::wstring& sNote) {
+            switch (i++)
+            {
+                case 0:
+                    Assert::AreEqual({1U}, nAddress);
+                    Assert::AreEqual(1U, nBytes);
+                    Assert::AreEqual(std::wstring(L"Before"), sNote);
+                    break;
+                case 1:
+                    Assert::AreEqual({4U}, nAddress);
+                    Assert::AreEqual(4U, nBytes);
+                    Assert::AreEqual(sPointerNote, sNote);
+                    break;
+                case 2:
+                    Assert::AreEqual({16U}, nAddress);
+                    Assert::AreEqual(1U, nBytes);
+                    Assert::AreEqual(std::wstring(L"Small (8-bit)"), sNote);
+                    break;
+                case 3:
+                    Assert::AreEqual({20U}, nAddress);
+                    Assert::AreEqual(1U, nBytes);
+                    Assert::AreEqual(std::wstring(L"In the middle"), sNote);
+                    break;
+                case 4:
+                    Assert::AreEqual({24U}, nAddress);
+                    Assert::AreEqual(2U, nBytes);
+                    Assert::AreEqual(std::wstring(L"Medium (16-bit)"), sNote);
+                    break;
+                case 5:
+                    Assert::AreEqual({32}, nAddress);
+                    Assert::AreEqual(4U, nBytes);
+                    Assert::AreEqual(std::wstring(L"Large (32-bit)"), sNote);
+                    break;
+                case 6:
+                    Assert::AreEqual({40}, nAddress);
+                    Assert::AreEqual(4U, nBytes);
+                    Assert::AreEqual(std::wstring(L"After [32-bit]"), sNote);
+                    break;
+                case 7:
                     Assert::Fail(L"Too many notes");
                     break;
             }
@@ -913,6 +1040,100 @@ public:
         notes.AssertNote(0x0AU, L"Medium (16-bit)", MemSize::SixteenBit, 2);
     }
 
+    TEST_METHOD(TestDoFrameRealAddressConversionBigEndian)
+    {
+        CodeNotesModelHarness notes;
+        notes.MonitorCodeNoteChanges();
+        notes.mockConsoleContext.AddMemoryRegion(0, 31, ra::data::context::ConsoleContext::AddressType::SystemRAM, 0x80);
+
+        std::array<unsigned char, 32> memory{};
+        for (uint8_t i = 4; i < memory.size(); i++)
+            memory.at(i) = i;
+        notes.mockEmulatorContext.MockMemory(memory);
+        memory.at(3) = 0x90; // start with initial value for pointer (real address = 0x90, RA address = 0x10)
+
+        const std::wstring sNote =
+            L"Pointer (32-bit BE)\n" // only 32-bit pointers are eligible for real address conversion
+            L"+1 = Small (8-bit)\n"
+            L"+2 = Medium (16-bit)\n"
+            L"+4 = Large (32-bit)";
+        notes.AddCodeNote(0x0000, "Author", sNote);
+
+        // should receive notifications for the pointer note, and for each subnote
+        Assert::AreEqual({4U}, notes.mNewNotes.size());
+        Assert::AreEqual(sNote, notes.mNewNotes[0x00]);
+        Assert::AreEqual(std::wstring(L"Small (8-bit)"), notes.mNewNotes[0x11]);
+        Assert::AreEqual(std::wstring(L"Medium (16-bit)"), notes.mNewNotes[0x12]);
+        Assert::AreEqual(std::wstring(L"Large (32-bit)"), notes.mNewNotes[0x14]);
+
+        notes.AssertNoNote(0x02U);
+        notes.AssertNote(0x12U, L"Medium (16-bit)", MemSize::SixteenBit, 2);
+
+        // calling DoFrame after updating the pointer should notify about all the affected subnotes
+        notes.mNewNotes.clear();
+        memory.at(3) = 0x88;
+        notes.DoFrame();
+
+        Assert::AreEqual({6U}, notes.mNewNotes.size());
+        Assert::AreEqual(std::wstring(L""), notes.mNewNotes[0x11]);
+        Assert::AreEqual(std::wstring(L""), notes.mNewNotes[0x12]);
+        Assert::AreEqual(std::wstring(L""), notes.mNewNotes[0x14]);
+        Assert::AreEqual(std::wstring(L"Small (8-bit)"), notes.mNewNotes[0x09]);
+        Assert::AreEqual(std::wstring(L"Medium (16-bit)"), notes.mNewNotes[0x0A]);
+        Assert::AreEqual(std::wstring(L"Large (32-bit)"), notes.mNewNotes[0x0C]);
+
+        notes.AssertNoNote(0x02U);
+        notes.AssertNoNote(0x12U);
+        notes.AssertNote(0x0AU, L"Medium (16-bit)", MemSize::SixteenBit, 2);
+    }
+    
+    TEST_METHOD(TestDoFrameRealAddressConversionAvoidedByOverflow)
+    {
+        CodeNotesModelHarness notes;
+        notes.MonitorCodeNoteChanges();
+        notes.mockConsoleContext.AddMemoryRegion(0, 31, ra::data::context::ConsoleContext::AddressType::SystemRAM, 0x80);
+
+        std::array<unsigned char, 32> memory{};
+        for (uint8_t i = 4; i < memory.size(); i++)
+            memory.at(i) = i;
+        notes.mockEmulatorContext.MockMemory(memory);
+        memory.at(0) = 0x90; // start with initial value for pointer (real address = 0x90, RA address = 0x10)
+
+        const std::wstring sNote =
+            L"Pointer (32-bit)\n" // only 32-bit pointers are eligible for real address conversion
+            L"+0xFFFFFF81 = Small (8-bit)\n"
+            L"+0xFFFFFF82 = Medium (16-bit)\n"
+            L"+0xFFFFFF84 = Large (32-bit)";
+        notes.AddCodeNote(0x0000, "Author", sNote);
+
+        // should receive notifications for the pointer note, and for each subnote
+        Assert::AreEqual({4U}, notes.mNewNotes.size());
+        Assert::AreEqual(sNote, notes.mNewNotes[0x00]);
+        Assert::AreEqual(std::wstring(L"Small (8-bit)"), notes.mNewNotes[0x11]);
+        Assert::AreEqual(std::wstring(L"Medium (16-bit)"), notes.mNewNotes[0x12]);
+        Assert::AreEqual(std::wstring(L"Large (32-bit)"), notes.mNewNotes[0x14]);
+
+        notes.AssertNoNote(0x02U);
+        notes.AssertNote(0x12U, L"Medium (16-bit)", MemSize::SixteenBit, 2);
+
+        // calling DoFrame after updating the pointer should notify about all the affected subnotes
+        notes.mNewNotes.clear();
+        memory.at(0) = 0x88;
+        notes.DoFrame();
+
+        Assert::AreEqual({6U}, notes.mNewNotes.size());
+        Assert::AreEqual(std::wstring(L""), notes.mNewNotes[0x11]);
+        Assert::AreEqual(std::wstring(L""), notes.mNewNotes[0x12]);
+        Assert::AreEqual(std::wstring(L""), notes.mNewNotes[0x14]);
+        Assert::AreEqual(std::wstring(L"Small (8-bit)"), notes.mNewNotes[0x09]);
+        Assert::AreEqual(std::wstring(L"Medium (16-bit)"), notes.mNewNotes[0x0A]);
+        Assert::AreEqual(std::wstring(L"Large (32-bit)"), notes.mNewNotes[0x0C]);
+
+        notes.AssertNoNote(0x02U);
+        notes.AssertNoNote(0x12U);
+        notes.AssertNote(0x0AU, L"Medium (16-bit)", MemSize::SixteenBit, 2);
+    }
+
     TEST_METHOD(TestFindCodeNoteStartPointer)
     {
         CodeNotesModelHarness notes;
@@ -943,6 +1164,36 @@ public:
         Assert::AreEqual(0xFFFFFFFF, notes.FindCodeNoteStart(0x18));
     }
 
+    TEST_METHOD(TestFindCodeNoteStartPointerOverflow)
+    {
+        CodeNotesModelHarness notes;
+        notes.mockConsoleContext.AddMemoryRegion(0, 31, ra::data::context::ConsoleContext::AddressType::SystemRAM, 0x80);
+        std::array<unsigned char, 32> memory{};
+        notes.mockEmulatorContext.MockMemory(memory);
+        memory.at(4) = 0x88; // start with initial value for pointer (real address = 0x88, RA address = 0x08)
+
+        const std::wstring sPointerNote =
+            L"Pointer (32-bit)\n"              // only 32-bit pointers are eligible for real address conversion
+            L"+0xFFFFFF88 = Small (8-bit)\n"   // 8+8=16
+            L"+0xFFFFFF90 = Medium (16-bit)\n" // 16+8=24
+            L"+0xFFFFFF98 = Large (32-bit)";   // 24+8=32
+        notes.AddCodeNote(4, "Author", sPointerNote);
+
+        // indirect notes are at 16 (byte), 24 (word), and 32 (dword)
+        Assert::AreEqual(0xFFFFFFFF, notes.FindCodeNoteStart(15));
+        Assert::AreEqual(16U, notes.FindCodeNoteStart(16));
+        Assert::AreEqual(0xFFFFFFFF, notes.FindCodeNoteStart(17));
+        Assert::AreEqual(0xFFFFFFFF, notes.FindCodeNoteStart(23));
+        Assert::AreEqual(24U, notes.FindCodeNoteStart(24));
+        Assert::AreEqual(24U, notes.FindCodeNoteStart(25));
+        Assert::AreEqual(0xFFFFFFFF, notes.FindCodeNoteStart(31));
+        Assert::AreEqual(32U, notes.FindCodeNoteStart(32));
+        Assert::AreEqual(32U, notes.FindCodeNoteStart(33));
+        Assert::AreEqual(32U, notes.FindCodeNoteStart(34));
+        Assert::AreEqual(32U, notes.FindCodeNoteStart(35));
+        Assert::AreEqual(0xFFFFFFFF, notes.FindCodeNoteStart(36));
+    }
+
     TEST_METHOD(TestGetIndirectSource)
     {
         CodeNotesModelHarness notes;
@@ -968,6 +1219,37 @@ public:
         Assert::AreEqual(0x0U, notes.GetIndirectSource(0x12));
         Assert::AreEqual(0xFFFFFFFF, notes.GetIndirectSource(0x13));
         Assert::AreEqual(0x0U, notes.GetIndirectSource(0x14));
+        Assert::AreEqual(0xFFFFFFFF, notes.GetIndirectSource(0x15));
+        Assert::AreEqual(0xFFFFFFFF, notes.GetIndirectSource(0x16));
+        Assert::AreEqual(0xFFFFFFFF, notes.GetIndirectSource(0x17));
+        Assert::AreEqual(0xFFFFFFFF, notes.FindCodeNoteStart(0x18));
+
+        // non-indirect
+        Assert::AreEqual(0xFFFFFFFF, notes.GetIndirectSource(0x08));
+    }
+
+    TEST_METHOD(TestGetIndirectSourceOverflow)
+    {
+        CodeNotesModelHarness notes;
+        notes.mockConsoleContext.AddMemoryRegion(0, 31, ra::data::context::ConsoleContext::AddressType::SystemRAM, 0x80);
+        std::array<unsigned char, 32> memory{};
+        notes.mockEmulatorContext.MockMemory(memory);
+        memory.at(4) = 0x90; // start with initial value for pointer (real address = 0x90, RA address = 0x10)
+
+        const std::wstring sNote =
+            L"Pointer (32-bit)\n" // only 32-bit pointers are eligible for real address conversion
+            L"+0xFFFFFF81 = Small (8-bit)\n"
+            L"+0xFFFFFF82 = Medium (16-bit)\n"
+            L"+0xFFFFFF84 = Large (32-bit)";
+        notes.AddCodeNote(0x0004, "Author", sNote);
+        notes.AddCodeNote(0x0008, "Author", L"Not indirect");
+
+        // indirect notes are at 0x11 (byte), 0x12 (word), and 0x14 (dword)
+        Assert::AreEqual(0xFFFFFFFF, notes.GetIndirectSource(0x10));
+        Assert::AreEqual(0x4U, notes.GetIndirectSource(0x11));
+        Assert::AreEqual(0x4U, notes.GetIndirectSource(0x12));
+        Assert::AreEqual(0xFFFFFFFF, notes.GetIndirectSource(0x13));
+        Assert::AreEqual(0x4U, notes.GetIndirectSource(0x14));
         Assert::AreEqual(0xFFFFFFFF, notes.GetIndirectSource(0x15));
         Assert::AreEqual(0xFFFFFFFF, notes.GetIndirectSource(0x16));
         Assert::AreEqual(0xFFFFFFFF, notes.GetIndirectSource(0x17));
@@ -1130,6 +1412,40 @@ public:
         Assert::AreEqual({0xFFFFFFFFU}, notes.GetNextNoteAddress({1234U}, true));
     }
 
+    TEST_METHOD(TestGetNextNoteAddressOverflow)
+    {
+        CodeNotesModelHarness notes;
+        notes.mockConsoleContext.AddMemoryRegion(0, 31, ra::data::context::ConsoleContext::AddressType::SystemRAM, 0x80);
+        std::array<unsigned char, 32> memory{};
+        notes.mockEmulatorContext.MockMemory(memory);
+        memory.at(4) = 0x88; // start with initial value for pointer (real address = 0x88, RA address = 0x08)
+
+        const std::wstring sPointerNote =
+            L"Pointer (32-bit)\n"              // only 32-bit pointers are eligible for real address conversion
+            L"+0xFFFFFF88 = Small (8-bit)\n"   // 8+8=16
+            L"+0xFFFFFF90 = Medium (16-bit)\n" // 16+8=24
+            L"+0xFFFFFF98 = Large (32-bit)";   // 24+8=32
+        notes.AddCodeNote(4, "Author", sPointerNote);
+        notes.AddCodeNote(40, "Author", L"After [32-bit]");
+        notes.AddCodeNote(1, "Author", L"Before");
+        notes.AddCodeNote(20, "Author", L"In the middle");
+
+        Assert::AreEqual({1U}, notes.GetNextNoteAddress({0U}));
+        Assert::AreEqual({4U}, notes.GetNextNoteAddress({1U}));
+        Assert::AreEqual({20U}, notes.GetNextNoteAddress({4U}));
+        Assert::AreEqual({40U}, notes.GetNextNoteAddress({20U}));
+        Assert::AreEqual({0xFFFFFFFFU}, notes.GetNextNoteAddress({40U}));
+
+        Assert::AreEqual({1U}, notes.GetNextNoteAddress({0U}, true));
+        Assert::AreEqual({4U}, notes.GetNextNoteAddress({1U}, true));
+        Assert::AreEqual({16U}, notes.GetNextNoteAddress({4U}, true));
+        Assert::AreEqual({20U}, notes.GetNextNoteAddress({16U}, true));
+        Assert::AreEqual({24U}, notes.GetNextNoteAddress({20U}, true));
+        Assert::AreEqual({32U}, notes.GetNextNoteAddress({24U}, true));
+        Assert::AreEqual({40U}, notes.GetNextNoteAddress({32U}, true));
+        Assert::AreEqual({0xFFFFFFFFU}, notes.GetNextNoteAddress({40U}, true));
+    }
+
     TEST_METHOD(TestGetPreviousNoteAddress)
     {
         CodeNotesModelHarness notes;
@@ -1155,6 +1471,40 @@ public:
         Assert::AreEqual({8U}, notes.GetPreviousNoteAddress({12U}, true));
         Assert::AreEqual({4U}, notes.GetPreviousNoteAddress({8U}, true));
         Assert::AreEqual({0xFFFFFFFFU}, notes.GetPreviousNoteAddress({4U}, true));
+    }
+    
+    TEST_METHOD(TestGetPreviousNoteAddressOverflow)
+    {
+        CodeNotesModelHarness notes;
+        notes.mockConsoleContext.AddMemoryRegion(0, 31, ra::data::context::ConsoleContext::AddressType::SystemRAM, 0x80);
+        std::array<unsigned char, 32> memory{};
+        notes.mockEmulatorContext.MockMemory(memory);
+        memory.at(4) = 0x88; // start with initial value for pointer (real address = 0x88, RA address = 0x08)
+
+        const std::wstring sPointerNote =
+            L"Pointer (32-bit)\n"              // only 32-bit pointers are eligible for real address conversion
+            L"+0xFFFFFF88 = Small (8-bit)\n"   // 8+8=16
+            L"+0xFFFFFF90 = Medium (16-bit)\n" // 16+8=24
+            L"+0xFFFFFF98 = Large (32-bit)";   // 24+8=32
+        notes.AddCodeNote(4, "Author", sPointerNote);
+        notes.AddCodeNote(40, "Author", L"After [32-bit]");
+        notes.AddCodeNote(1, "Author", L"Before");
+        notes.AddCodeNote(20, "Author", L"In the middle");
+
+        Assert::AreEqual({40U}, notes.GetPreviousNoteAddress({0xFFFFFFFFU}));
+        Assert::AreEqual({20U}, notes.GetPreviousNoteAddress({40U}));
+        Assert::AreEqual({4U}, notes.GetPreviousNoteAddress({20U}));
+        Assert::AreEqual({1U}, notes.GetPreviousNoteAddress({4U}));
+        Assert::AreEqual({0xFFFFFFFFU}, notes.GetPreviousNoteAddress({1U}));
+
+        Assert::AreEqual({40U}, notes.GetPreviousNoteAddress({0xFFFFFFFFU}, true));
+        Assert::AreEqual({32U}, notes.GetPreviousNoteAddress({40U}, true));
+        Assert::AreEqual({24U}, notes.GetPreviousNoteAddress({32U}, true));
+        Assert::AreEqual({20U}, notes.GetPreviousNoteAddress({24U}, true));
+        Assert::AreEqual({16U}, notes.GetPreviousNoteAddress({20U}, true));
+        Assert::AreEqual({4U}, notes.GetPreviousNoteAddress({16U}, true));
+        Assert::AreEqual({1U}, notes.GetPreviousNoteAddress({4U}, true));
+        Assert::AreEqual({0xFFFFFFFFU}, notes.GetPreviousNoteAddress({1U}, true));
     }
 };
 

--- a/tests/data/models/CodeNotesModel_Tests.cpp
+++ b/tests/data/models/CodeNotesModel_Tests.cpp
@@ -240,6 +240,7 @@ public:
         TestCodeNoteSize(L"[float bigendian] Test", 4U, MemSize::FloatBigEndian);
         TestCodeNoteSize(L"[be float] Test", 4U, MemSize::FloatBigEndian);
         TestCodeNoteSize(L"[bigendian float] Test", 4U, MemSize::FloatBigEndian);
+        TestCodeNoteSize(L"[32-bit] pointer to float", 4U, MemSize::ThirtyTwoBit);
 
         TestCodeNoteSize(L"[MBF32] Test", 4U, MemSize::MBF32);
         TestCodeNoteSize(L"[MBF40] Test", 5U, MemSize::MBF32);

--- a/tests/ui/viewmodels/TriggerConditionViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/TriggerConditionViewModel_Tests.cpp
@@ -831,6 +831,7 @@ public:
         vmTrigger.mockGameContext.InitializeCodeNotes();
         vmTrigger.Parse("I:0xH0001_I:0xH0002_0xH0003=4");
         vmTrigger.mockConfiguration.SetFeatureEnabled(ra::services::Feature::PreferDecimal, true);
+        vmTrigger.mockGameContext.SetCodeNote({1U}, L"[8-bit pointer]\n+2=First Level A\n  +3=Second Level.");
 
         const auto* pCondition1 = vmTrigger.Conditions().GetItemAt(0);
         Expects(pCondition1 != nullptr);
@@ -844,15 +845,15 @@ public:
         Assert::IsTrue(pCondition3->IsIndirect());
 
         // $0001 = 1, 1+2 = $0003, $0003 = 3, 3+3 = $0006
-        Assert::AreEqual(std::wstring(L"0x0001\r\n[No code note]"), pCondition1->GetTooltip(TriggerConditionViewModel::SourceValueProperty));
-        Assert::AreEqual(std::wstring(L"0x0003 (indirect)\r\n[No code note]"), pCondition2->GetTooltip(TriggerConditionViewModel::SourceValueProperty));
-        Assert::AreEqual(std::wstring(L"0x0006 (indirect)\r\n[No code note]"), pCondition3->GetTooltip(TriggerConditionViewModel::SourceValueProperty));
+        Assert::AreEqual(std::wstring(L"0x0001\r\n[8-bit pointer]\n+2=First Level A\n  +3=Second Level."), pCondition1->GetTooltip(TriggerConditionViewModel::SourceValueProperty));
+        Assert::AreEqual(std::wstring(L"0x0003 (indirect)\r\nFirst Level A\n  +3=Second Level."), pCondition2->GetTooltip(TriggerConditionViewModel::SourceValueProperty));
+        Assert::AreEqual(std::wstring(L"0x0006 (indirect)\r\n[Nested pointer code note not supported]"), pCondition3->GetTooltip(TriggerConditionViewModel::SourceValueProperty));
 
         // $0001 = 3, 3+2 = $0005, $0005 = 5, 5+3 = $0008
         vmTrigger.SetMemory({ 1 }, 3);
-        Assert::AreEqual(std::wstring(L"0x0001\r\n[No code note]"), pCondition1->GetTooltip(TriggerConditionViewModel::SourceValueProperty));
-        Assert::AreEqual(std::wstring(L"0x0005 (indirect)\r\n[No code note]"), pCondition2->GetTooltip(TriggerConditionViewModel::SourceValueProperty));
-        Assert::AreEqual(std::wstring(L"0x0008 (indirect)\r\n[No code note]"), pCondition3->GetTooltip(TriggerConditionViewModel::SourceValueProperty));
+        Assert::AreEqual(std::wstring(L"0x0001\r\n[8-bit pointer]\n+2=First Level A\n  +3=Second Level."), pCondition1->GetTooltip(TriggerConditionViewModel::SourceValueProperty));
+        Assert::AreEqual(std::wstring(L"0x0005 (indirect)\r\nFirst Level A\n  +3=Second Level."), pCondition2->GetTooltip(TriggerConditionViewModel::SourceValueProperty));
+        Assert::AreEqual(std::wstring(L"0x0008 (indirect)\r\n[Nested pointer code note not supported]"), pCondition3->GetTooltip(TriggerConditionViewModel::SourceValueProperty));
     }
 
     TEST_METHOD(TestTooltipDoubleIndirectAddressExternal)


### PR DESCRIPTION
Instead of masking off the upper bit of GameCube addresses, some clever dev has decided to include the uppermost bit as part of the offset, causing an overflow that results in the uppermost bit being removed.

Normal way to write logic using a masked address:
![image](https://github.com/RetroAchievements/RAIntegration/assets/32680403/25155419-a3c6-448d-aefa-c169099db7a9)

Alternate way to write logic using overflow:
![image](https://github.com/RetroAchievements/RAIntegration/assets/32680403/f4184e53-feee-4481-9ba7-e86b9901f114)

This PR updates the achievement editor's tooltip code and memory inspector's code note field to support indirect addresses derived in this manner.

