### PR TITLE
pass correct alias for FRAMES/SECS leaderboards

### DIFF
--- a/src/RA_Defs.cpp
+++ b/src/RA_Defs.cpp
@@ -103,10 +103,10 @@ const char* ValueFormatToString(ValueFormat nFormat) noexcept
     switch (nFormat)
     {
         case ValueFormat::Centiseconds: return "MILLISECS";
-        case ValueFormat::Frames: return "FRAMES";
+        case ValueFormat::Frames: return "TIME";
         case ValueFormat::Minutes: return "MINUTES";
         case ValueFormat::Score: return "SCORE";
-        case ValueFormat::Seconds: return "SECS";
+        case ValueFormat::Seconds: return "TIMESECS";
         case ValueFormat::SecondsAsMinutes: return "SECS_AS_MINS";
         case ValueFormat::Value: return "VALUE";
         case ValueFormat::Float1: return "FLOAT1";

--- a/tests/data/models/LeaderboardModel_Tests.cpp
+++ b/tests/data/models/LeaderboardModel_Tests.cpp
@@ -158,9 +158,9 @@ public:
     {
         TestSerializeValueFormat(ValueFormat::Score, "SCORE");
         TestSerializeValueFormat(ValueFormat::Value, "VALUE");
-        TestSerializeValueFormat(ValueFormat::Frames, "FRAMES");
+        TestSerializeValueFormat(ValueFormat::Frames, "TIME");
         TestSerializeValueFormat(ValueFormat::Centiseconds, "MILLISECS");
-        TestSerializeValueFormat(ValueFormat::Seconds, "SECS");
+        TestSerializeValueFormat(ValueFormat::Seconds, "TIMESECS");
         TestSerializeValueFormat(ValueFormat::Minutes, "MINUTES");
         TestSerializeValueFormat(ValueFormat::SecondsAsMinutes, "SECS_AS_MINS");
         TestSerializeValueFormat(ValueFormat::Fixed1, "FIXED1");


### PR DESCRIPTION
fixes regression introduced by #1056. 

https://discord.com/channels/310192285306454017/1149693430306447380/1204910485825261648