### PR TITLE
fix deadlock trying to shutdown from non-UI thread

### DIFF
--- a/src/RA_Core.cpp
+++ b/src/RA_Core.cpp
@@ -101,6 +101,8 @@ static int DoShutdown()
     if (!ra::services::Initialization::IsInitialized())
         return 0;
 
+    ra::services::Initialization::StartShutdown();
+
     // detach any client-registered functions
     _RA_InstallSharedFunctionsExt(nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
 

--- a/src/services/Initialization.cpp
+++ b/src/services/Initialization.cpp
@@ -47,10 +47,16 @@ namespace ra {
 namespace services {
 
 bool Initialization::s_bIsInitialized = false;
+bool Initialization::s_bIsShuttingDown = false;
 
 bool ServiceLocator::IsInitialized() noexcept
 {
     return Initialization::IsInitialized();
+}
+
+bool ServiceLocator::IsShuttingDown() noexcept
+{
+    return Initialization::IsShuttingDown();
 }
 
 static void LogHeader(_In_ const ra::services::ILogger& pLogger,

--- a/src/services/Initialization.hh
+++ b/src/services/Initialization.hh
@@ -18,10 +18,15 @@ public:
 
     static bool IsInitialized() noexcept { return s_bIsInitialized; }
 
+    static bool IsShuttingDown() noexcept { return s_bIsShuttingDown; }
+
+    static void StartShutdown() noexcept { s_bIsShuttingDown = true; }
+
 private:
     static void InitializeNotifyTargets();
 
     static bool s_bIsInitialized;
+    static bool s_bIsShuttingDown;
 };
 
 } // namespace services

--- a/src/services/ServiceLocator.hh
+++ b/src/services/ServiceLocator.hh
@@ -73,6 +73,11 @@ public:
     /// </summary>
     static bool IsInitialized() noexcept;
 
+    /// <summary>
+    /// Gets whether or not shutdown has started
+    /// </summary>
+    static bool IsShuttingDown() noexcept;
+
 #ifdef RA_UTEST
     /// <summary>
     /// Provides a temporary implementation of an interface for the duration of the scope of the ServiceOverride.

--- a/src/ui/win32/Desktop.cpp
+++ b/src/ui/win32/Desktop.cpp
@@ -106,7 +106,7 @@ ra::ui::DialogResult Desktop::ShowModal(WindowViewModelBase& vmViewModel, const 
     return vmViewModel.GetDialogResult();
 }
 
-void Desktop::CloseWindow(WindowViewModelBase& vmViewModel) const
+void Desktop::CloseWindow(WindowViewModelBase& vmViewModel) const noexcept
 {
     auto* pBinding = ra::ui::win32::bindings::WindowBinding::GetBindingFor(vmViewModel);
     if (pBinding != nullptr)
@@ -332,8 +332,11 @@ void Desktop::InvokeOnUIThread(std::function<void()> fAction) const
 
 void Desktop::Shutdown() noexcept
 {
-    // must destroy binding before viewmodel
+    // must destroy binding before viewmodel gets destructed
     m_pWindowBinding.reset();
+
+    // make sure any custom WndProcs are detached
+    ra::ui::win32::bindings::ControlBinding::DetachSubclasses();
 }
 
 } // namespace win32

--- a/src/ui/win32/Desktop.hh
+++ b/src/ui/win32/Desktop.hh
@@ -17,7 +17,7 @@ public:
     void ShowWindow(WindowViewModelBase& vmViewModel) const override;
     ra::ui::DialogResult ShowModal(WindowViewModelBase& vmViewModel) const override;
     ra::ui::DialogResult ShowModal(WindowViewModelBase& vmViewModel, const WindowViewModelBase& vmParentViewModel) const override;
-    void CloseWindow(WindowViewModelBase& vmViewModel) const override;
+    void CloseWindow(WindowViewModelBase& vmViewModel) const noexcept override;
 
     void GetWorkArea(ra::ui::Position& oUpperLeftCorner, ra::ui::Size& oSize) const override;
     ra::ui::Size GetClientSize(const WindowViewModelBase& vmViewModel) const noexcept override;

--- a/src/ui/win32/Desktop.hh
+++ b/src/ui/win32/Desktop.hh
@@ -17,7 +17,7 @@ public:
     void ShowWindow(WindowViewModelBase& vmViewModel) const override;
     ra::ui::DialogResult ShowModal(WindowViewModelBase& vmViewModel) const override;
     ra::ui::DialogResult ShowModal(WindowViewModelBase& vmViewModel, const WindowViewModelBase& vmParentViewModel) const override;
-    void CloseWindow(WindowViewModelBase& vmViewModel) const noexcept override;
+    void CloseWindow(WindowViewModelBase& vmViewModel) const override;
 
     void GetWorkArea(ra::ui::Position& oUpperLeftCorner, ra::ui::Size& oSize) const override;
     ra::ui::Size GetClientSize(const WindowViewModelBase& vmViewModel) const noexcept override;

--- a/src/ui/win32/DialogBase.cpp
+++ b/src/ui/win32/DialogBase.cpp
@@ -64,7 +64,7 @@ void DialogBase::Destroy() noexcept
         // if shutting down, clear out our custom WndProc, as it won't be available to process the message
         // after the DLL is unloaded.
         if (ra::services::ServiceLocator::IsShuttingDown())
-            ::SetWindowLongPtrW(m_hWnd, GWLP_WNDPROC, (LONG_PTR)::DefWindowProc);
+            GSL_SUPPRESS_TYPE1 ::SetWindowLongPtrW(m_hWnd, GWLP_WNDPROC, reinterpret_cast<LONG_PTR>(::DefWindowProc));
 
         // send WM_CLOSE message to the window to ensure it gets destroyed from the UI thread.
         ::PostMessage(m_hWnd, WM_CLOSE, 0L, 0L);

--- a/src/ui/win32/DialogBase.hh
+++ b/src/ui/win32/DialogBase.hh
@@ -67,7 +67,9 @@ public:
     /// <summary>
     /// Returns <c>true</c> if the current thread is the UI thread.
     /// </summary>
-    bool IsOnUIThread() const noexcept { return m_bindWindow.IsOnUIThread(); }
+    bool IsOnUIThread() const noexcept { return ra::ui::win32::bindings::WindowBinding::IsOnUIThread(); }
+
+    void Destroy() noexcept;
 
 protected:
     explicit DialogBase(_Inout_ ra::ui::WindowViewModelBase& vmWindow) noexcept;

--- a/src/ui/win32/bindings/ComboBoxBinding.hh
+++ b/src/ui/win32/bindings/ComboBoxBinding.hh
@@ -142,6 +142,8 @@ protected:
 
     virtual void PopulateComboBox()
     {
+        SendMessage(m_hWnd, WM_SETREDRAW, FALSE, 0);
+
         const auto nCount = ra::to_signed(m_pViewModelCollection->Count());
         for (gsl::index nIndex = 0; nIndex < nCount; ++nIndex)
         {
@@ -149,6 +151,8 @@ protected:
 
             ComboBox_AddString(m_hWnd, NativeStr(pLabel).c_str());
         }
+
+        SendMessage(m_hWnd, WM_SETREDRAW, TRUE, 0);
     }
 
     virtual void UpdateSelectedItem()

--- a/src/ui/win32/bindings/ControlBinding.hh
+++ b/src/ui/win32/bindings/ControlBinding.hh
@@ -168,7 +168,7 @@ protected:
     }
 
     void SubclassWndProc();
-    virtual void UnsubclassWndProc() noexcept;
+    void UnsubclassWndProc() noexcept;
 
     void AddSecondaryControlBinding(HWND hWnd) noexcept
     {

--- a/src/ui/win32/bindings/ControlBinding.hh
+++ b/src/ui/win32/bindings/ControlBinding.hh
@@ -136,6 +136,8 @@ public:
     /// </summary>
     _NODISCARD virtual INT_PTR CALLBACK WndProc(_In_ HWND, _In_ UINT, _In_ WPARAM, _In_ LPARAM) noexcept(false);
 
+    static void DetachSubclasses() noexcept;
+
 protected:
     void DisableBinding() noexcept
     {
@@ -165,7 +167,8 @@ protected:
         return m_pDialog->m_hWnd;
     }
 
-    void SubclassWndProc() noexcept;
+    void SubclassWndProc();
+    virtual void UnsubclassWndProc() noexcept;
 
     void AddSecondaryControlBinding(HWND hWnd) noexcept
     {

--- a/src/ui/win32/bindings/MemoryViewerControlBinding.cpp
+++ b/src/ui/win32/bindings/MemoryViewerControlBinding.cpp
@@ -99,13 +99,6 @@ void MemoryViewerControlBinding::RegisterControlClass() noexcept
     }
 }
 
-void MemoryViewerControlBinding::UnsubclassWndProc() noexcept
-{
-    ControlBinding::UnsubclassWndProc();
-
-    SetWindowLongPtr(m_hWnd, GWLP_WNDPROC, (LONG_PTR)::DefWindowProc);
-}
-
 void MemoryViewerControlBinding::SetHWND(DialogBase& pDialog, HWND hControl)
 {
     ControlBinding::SetHWND(pDialog, hControl);

--- a/src/ui/win32/bindings/MemoryViewerControlBinding.hh
+++ b/src/ui/win32/bindings/MemoryViewerControlBinding.hh
@@ -59,6 +59,9 @@ protected:
 
     void OnSizeChanged(const ra::ui::Size& pNewSize) override;
 
+    void UnsubclassWndProc() noexcept override;
+    INT_PTR CALLBACK WndProc(HWND hControl, UINT uMsg, WPARAM wParam, LPARAM lParam) override;
+
 private:
     bool HandleNavigation(UINT nChar);
     bool m_bSuppressMemoryViewerInvalidate = false;

--- a/src/ui/win32/bindings/MemoryViewerControlBinding.hh
+++ b/src/ui/win32/bindings/MemoryViewerControlBinding.hh
@@ -59,7 +59,6 @@ protected:
 
     void OnSizeChanged(const ra::ui::Size& pNewSize) override;
 
-    void UnsubclassWndProc() noexcept override;
     INT_PTR CALLBACK WndProc(HWND hControl, UINT uMsg, WPARAM wParam, LPARAM lParam) override;
 
 private:

--- a/src/ui/win32/bindings/WindowBinding.cpp
+++ b/src/ui/win32/bindings/WindowBinding.cpp
@@ -129,6 +129,12 @@ void WindowBinding::SetHWND(DialogBase* pDialog, HWND hWnd)
     }
 }
 
+void WindowBinding::DestroyWindow() noexcept
+{
+    if (m_pDialog != nullptr)
+        m_pDialog->Destroy();
+}
+
 void WindowBinding::UpdateAppTitle()
 {
     const auto& pEmulatorViewModel = ra::services::ServiceLocator::Get<ra::ui::viewmodels::WindowManager>().Emulator;

--- a/src/ui/win32/bindings/WindowBinding.hh
+++ b/src/ui/win32/bindings/WindowBinding.hh
@@ -76,6 +76,8 @@ public:
     /// <returns>The window handle.</returns>
     HWND GetHWnd() const noexcept { return m_hWnd; }
 
+    void DestroyWindow() noexcept;
+
     /// <summary>
     /// Specifies a secondary view model to watch for BindLabel and BindEnabled bindings.
     /// </summary>


### PR DESCRIPTION
The shutdown process is expecting the Windows message queue to be available to pump messages. 

In the PPSSPP implementation, the shutdown is called from a background thread, and the UI thread is blocked waiting for the background thread to stop. This causes a deadlock.

The solution is to change the calls that close the windows to use PostMessage, and let the message queue actually close the windows when it frees up. However, at that point the DLL is no longer loaded, so there were several issues trying to dispatch messages to the custom WndProcs. To address that, as part of the shutdown process, replace all of the custom WndProcs with default ones.