### PR TITLE
prevent crash if recent games list contains a large number of not-so-recent games

### DIFF
--- a/src/ui/viewmodels/OverlayRecentGamesPageViewModel.cpp
+++ b/src/ui/viewmodels/OverlayRecentGamesPageViewModel.cpp
@@ -109,8 +109,18 @@ void OverlayRecentGamesPageViewModel::Refresh()
                     httpRequest.CallAsync([this, nGameId](const ra::services::Http::Response& pResponse)
                     {
                         rc_api_fetch_game_data_response_t response;
-                        if (rc_api_process_fetch_game_data_response(&response, pResponse.Content().c_str()) == RC_OK)
+                        rc_api_server_response_t server_response;
+
+                        memset(&server_response, 0, sizeof(server_response));
+                        server_response.body = pResponse.Content().c_str();
+                        server_response.body_length = pResponse.Content().length();
+                        server_response.http_status_code = ra::etoi(pResponse.StatusCode());
+
+                        if (rc_api_process_fetch_game_data_server_response(&response, &server_response) == RC_OK &&
+                            response.response.succeeded)
+                        {
                             UpdateGameEntry(nGameId, ra::Widen(response.title), response.image_name);
+                        }
                     });
                 }
             }

--- a/src/ui/viewmodels/OverlayRecentGamesPageViewModel.cpp
+++ b/src/ui/viewmodels/OverlayRecentGamesPageViewModel.cpp
@@ -108,7 +108,7 @@ void OverlayRecentGamesPageViewModel::Refresh()
 
                     httpRequest.CallAsync([this, nGameId](const ra::services::Http::Response& pResponse)
                     {
-                        rc_api_fetch_game_data_response_t response;
+                        rc_api_fetch_game_data_response_t response{};
                         rc_api_server_response_t server_response;
 
                         memset(&server_response, 0, sizeof(server_response));


### PR DESCRIPTION
When displaying the Recent Games overlay page, if the data isn't available in the local cache, it has to be fetched from the server. If many items get fetched from the server at the same time, some may come back with a "429 Too Many Requests" error, which was not being handled properly.