### PR TITLE
prevent infinite recursion trying to invoke to inaccessible UI thread

### DIFF
--- a/src/ui/win32/DialogBase.hh
+++ b/src/ui/win32/DialogBase.hh
@@ -65,7 +65,7 @@ public:
     void SetDialogResult(DialogResult nResult);
 
     /// <summary>
-    /// Returns <c>true</c> if the current thread is the UI thread.
+    /// Returns <c>true</c> if the current thread is the UI thread (or invoking to the UI thread is disabled).
     /// </summary>
     bool IsOnUIThread() const noexcept { return ra::ui::win32::bindings::WindowBinding::IsOnUIThread(); }
 

--- a/src/ui/win32/bindings/WindowBinding.hh
+++ b/src/ui/win32/bindings/WindowBinding.hh
@@ -138,9 +138,9 @@ public:
     static void EnableInvokeOnUIThread();
 
     /// <summary>
-    /// Returns <c>true</c> if the current thread is the UI thread.
+    /// Returns <c>true</c> if the current thread is the UI thread (or invoking to the UI thread is disabled).
     /// </summary>
-    static bool IsOnUIThread() noexcept { return GetCurrentThreadId() == s_hUIThreadId; }
+    static bool IsOnUIThread() noexcept { return s_bInvokeOnUIThreadDisabled || GetCurrentThreadId() == s_hUIThreadId; }
 
     /// <summary>
     /// Dispatches a function to the UI thread.
@@ -212,6 +212,7 @@ private:
     HWND m_hWnd{};
 
     static DWORD s_hUIThreadId;
+    static bool s_bInvokeOnUIThreadDisabled;
 
     static std::vector<WindowBinding*> s_vKnownBindings;
 };


### PR DESCRIPTION
https://discord.com/channels/310192285306454017/1231413250915307580/1231413250915307580

RAMeka has two message pump threads - one for the Allegro window (main window), and one for the console window. The DLL has to be attached to the Allegro window for the overlay functionality, but the editor windows have to be parented to the console window or shortcuts don't work because the Allegro message pump doesn't call TranslateMessage.

Because the DLL is only told about the Allegro window, it assumes the message pump for the Allegro window is the UI thread. When it tries to invoke to the UI thread, the messages are sent to the console window because that's where the child windows are being managed. Some of the methods that try to redirect to the UI thread say "if I'm not on the UI thread, call me from the UI thread". However, because the DLL is looking for the UI thread belonging to the Allegro window, and the method keeps getting called from the console window thread, it just keeps trying to switch threads, and eventually the stack overflows and the application crashes.

Solution: If the thread identified as the UI thread is not the thread that a child window is being created from, disable the ability to invoke to the identified thread. This should only affect RAMeka. 