### PR TITLE
Add +/- shortcuts on the memory viewer

### DIFF
--- a/src/ui/viewmodels/MemoryViewerViewModel.cpp
+++ b/src/ui/viewmodels/MemoryViewerViewModel.cpp
@@ -658,7 +658,7 @@ void MemoryViewerViewModel::RetreatCursorPage()
     }
 }
 
-bool MemoryViewerViewModel::IncreaseCurrentValue(int nModifier)
+bool MemoryViewerViewModel::IncreaseCurrentValue(uint32_t nModifier)
 {
     if (m_bReadOnly)
         return false;
@@ -670,7 +670,7 @@ bool MemoryViewerViewModel::IncreaseCurrentValue(int nModifier)
 
     if (nMem >= nMaxValue)
         return false;
-    if (nMaxValue - nMem < nModifier)
+    if ((nMaxValue - nMem) < nModifier)
         nModifier = (nMaxValue - nMem);
     nMem += nModifier;
 
@@ -678,7 +678,7 @@ bool MemoryViewerViewModel::IncreaseCurrentValue(int nModifier)
     return true;
 }
 
-bool MemoryViewerViewModel::DecreaseCurrentValue(int nModifier)
+bool MemoryViewerViewModel::DecreaseCurrentValue(uint32_t nModifier)
 {
     if (m_bReadOnly)
         return false;

--- a/src/ui/viewmodels/MemoryViewerViewModel.cpp
+++ b/src/ui/viewmodels/MemoryViewerViewModel.cpp
@@ -658,6 +658,45 @@ void MemoryViewerViewModel::RetreatCursorPage()
     }
 }
 
+bool MemoryViewerViewModel::IncreaseCurrentValue(int nModifier)
+{
+    if (m_bReadOnly)
+        return false;
+
+    auto nAddress = GetAddress();
+    const auto& pEmulatorContext = ra::services::ServiceLocator::Get<ra::data::context::EmulatorContext>();
+    auto nMem = pEmulatorContext.ReadMemory(GetAddress(), GetSize());
+    auto nMaxValue = ra::data::MemSizeMax(GetSize());
+
+    if (nMem >= nMaxValue)
+        return false;
+    if (nMaxValue - nMem < nModifier)
+        nModifier = (nMaxValue - nMem);
+    nMem += nModifier;
+
+    pEmulatorContext.WriteMemory(nAddress, GetSize(), nMem);
+    return true;
+}
+
+bool MemoryViewerViewModel::DecreaseCurrentValue(int nModifier)
+{
+    if (m_bReadOnly)
+        return false;
+
+    auto nAddress = GetAddress();
+    const auto& pEmulatorContext = ra::services::ServiceLocator::Get<ra::data::context::EmulatorContext>();
+    auto nMem = pEmulatorContext.ReadMemory(GetAddress(), GetSize());
+
+    if (nMem == 0)
+        return false;
+    if (nMem < nModifier)
+        nModifier = nMem;
+    nMem -= nModifier;
+
+    pEmulatorContext.WriteMemory(nAddress, GetSize(), nMem);
+    return true;
+}
+
 void MemoryViewerViewModel::OnActiveGameChanged()
 {
     m_nNeedsRedraw |= REDRAW_ADDRESSES;

--- a/src/ui/viewmodels/MemoryViewerViewModel.cpp
+++ b/src/ui/viewmodels/MemoryViewerViewModel.cpp
@@ -663,10 +663,10 @@ bool MemoryViewerViewModel::IncreaseCurrentValue(uint32_t nModifier)
     if (m_bReadOnly)
         return false;
 
-    auto nAddress = GetAddress();
+    const auto nAddress = GetAddress();
     const auto& pEmulatorContext = ra::services::ServiceLocator::Get<ra::data::context::EmulatorContext>();
     auto nMem = pEmulatorContext.ReadMemory(GetAddress(), GetSize());
-    auto nMaxValue = ra::data::MemSizeMax(GetSize());
+    auto const nMaxValue = ra::data::MemSizeMax(GetSize());
 
     if (nMem >= nMaxValue)
         return false;
@@ -683,7 +683,7 @@ bool MemoryViewerViewModel::DecreaseCurrentValue(uint32_t nModifier)
     if (m_bReadOnly)
         return false;
 
-    auto nAddress = GetAddress();
+    auto const nAddress = GetAddress();
     const auto& pEmulatorContext = ra::services::ServiceLocator::Get<ra::data::context::EmulatorContext>();
     auto nMem = pEmulatorContext.ReadMemory(GetAddress(), GetSize());
 

--- a/src/ui/viewmodels/MemoryViewerViewModel.hh
+++ b/src/ui/viewmodels/MemoryViewerViewModel.hh
@@ -175,8 +175,8 @@ public:
     void AdvanceCursorPage();
     void RetreatCursorPage();
 
-    bool IncreaseCurrentValue(int nModifier);
-    bool DecreaseCurrentValue(int nModifier);
+    bool IncreaseCurrentValue(uint32_t nModifier);
+    bool DecreaseCurrentValue(uint32_t nModifier);
 
 protected:
     void OnValueChanged(const IntModelProperty::ChangeArgs& args) override;

--- a/src/ui/viewmodels/MemoryViewerViewModel.hh
+++ b/src/ui/viewmodels/MemoryViewerViewModel.hh
@@ -175,6 +175,9 @@ public:
     void AdvanceCursorPage();
     void RetreatCursorPage();
 
+    bool IncreaseCurrentValue(int nModifier);
+    bool DecreaseCurrentValue(int nModifier);
+
 protected:
     void OnValueChanged(const IntModelProperty::ChangeArgs& args) override;
 

--- a/src/ui/win32/bindings/MemoryViewerControlBinding.cpp
+++ b/src/ui/win32/bindings/MemoryViewerControlBinding.cpp
@@ -242,20 +242,26 @@ bool MemoryViewerControlBinding::HandleShortcut(UINT nChar)
 {
     const bool bShiftHeld = (GetKeyState(VK_SHIFT) < 0);
     const bool bControlHeld = (GetKeyState(VK_CONTROL) < 0);
-    auto nModifier = 1;
-
-    // Increase by 1 or 2 on the high and lower nibble depending key pressed
-    if (bControlHeld)
-        nModifier *= 2;
-    if (bShiftHeld)
-        nModifier *= 16;
 
     switch (nChar)
     {
+        // Increment/Decrement value Shortcuts
         case VK_ADD:
-            return m_pViewModel.IncreaseCurrentValue(nModifier);
         case VK_SUBTRACT:
-            return m_pViewModel.DecreaseCurrentValue(nModifier);
+        {
+            auto nModifier = 1;
+
+            // Increase/decrease by 1 or 2 on the high and lower nibble depending key pressed
+            if (bControlHeld)
+                nModifier *= 2;
+            if (bShiftHeld)
+                nModifier *= 16;
+
+            if (nChar == VK_ADD)
+                return m_pViewModel.IncreaseCurrentValue(nModifier);
+            else
+                return m_pViewModel.DecreaseCurrentValue(nModifier);
+        }
 
         default:
             return false;

--- a/src/ui/win32/bindings/MemoryViewerControlBinding.hh
+++ b/src/ui/win32/bindings/MemoryViewerControlBinding.hh
@@ -63,6 +63,7 @@ protected:
 
 private:
     bool HandleNavigation(UINT nChar);
+    bool HandleShortcut(UINT nChar);
     bool m_bSuppressMemoryViewerInvalidate = false;
 
     ra::ui::viewmodels::MemoryViewerViewModel& m_pViewModel;

--- a/tests/ui/viewmodels/MemoryViewerViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/MemoryViewerViewModel_Tests.cpp
@@ -1932,21 +1932,31 @@ public:
         Assert::IsFalse(viewer.IsReadOnly());
 
         viewer.SetAddress(0x0U);
-        Assert::AreEqual({0U}, viewer.GetAddress());
-        Assert::AreEqual({0x0U}, viewer.mockEmulatorContext.ReadMemoryByte(0U));
+        Assert::AreEqual({ 0U }, viewer.GetAddress());
+        Assert::AreEqual({ 0x0U }, viewer.mockEmulatorContext.ReadMemoryByte(0U));
 
         // Increase by 1 from 0x0 should result to 0X1
         Assert::IsTrue(viewer.IncreaseCurrentValue(1));
-        Assert::AreEqual({0x1U}, viewer.mockEmulatorContext.ReadMemoryByte(0U));
+        Assert::AreEqual({ 0x1U }, viewer.mockEmulatorContext.ReadMemoryByte(0U));
 
         // Increase by 1 from 0xFE should result to 0XFF
-        viewer.mockEmulatorContext.WriteMemoryByte(0x0, 0XFEU);
+        viewer.mockEmulatorContext.WriteMemoryByte(0x0U, 0XFEU);
         Assert::IsTrue(viewer.IncreaseCurrentValue(1));
-        Assert::AreEqual({0xFFU}, viewer.mockEmulatorContext.ReadMemoryByte(0U));
+        Assert::AreEqual({ 0xFFU }, viewer.mockEmulatorContext.ReadMemoryByte(0U));
 
         // Increase by 1 from 0xFF should not change the value
         Assert::IsFalse(viewer.IncreaseCurrentValue(1));
-        Assert::AreEqual({0xFFU}, viewer.mockEmulatorContext.ReadMemoryByte(0U));
+        Assert::AreEqual({ 0xFFU }, viewer.mockEmulatorContext.ReadMemoryByte(0U));
+
+        // Increase by 1 from 0x0 should result to 0X0001
+        viewer.mockEmulatorContext.WriteMemory(0x0U, MemSize::SixteenBit, 0X0U);
+        Assert::IsTrue(viewer.IncreaseCurrentValue(1));
+        Assert::AreEqual({ 0x1U }, viewer.mockEmulatorContext.ReadMemory(0U, MemSize::SixteenBit));
+
+        // Increase by 1 from 0xFFFF should not change the value
+        viewer.mockEmulatorContext.WriteMemory(0x0U, MemSize::SixteenBit, 0XFFFFU);
+        Assert::IsFalse(viewer.IncreaseCurrentValue(1));
+        Assert::AreEqual({ 0xFFFFU }, viewer.mockEmulatorContext.ReadMemory(0U, MemSize::SixteenBit));
     }
 
     TEST_METHOD(TestIncreaseCurrentValueBySixTeen)
@@ -1956,27 +1966,37 @@ public:
 
         // ignore if readonly
         Assert::IsTrue(viewer.IsReadOnly());
-        Assert::IsFalse(viewer.IncreaseCurrentValue(1));
+        Assert::IsFalse(viewer.IncreaseCurrentValue(16));
 
         viewer.SetReadOnly(false);
         Assert::IsFalse(viewer.IsReadOnly());
 
         viewer.SetAddress(0x0U);
-        Assert::AreEqual({0U}, viewer.GetAddress());
-        Assert::AreEqual({0x0U}, viewer.mockEmulatorContext.ReadMemoryByte(0U));
+        Assert::AreEqual({ 0U }, viewer.GetAddress());
+        Assert::AreEqual({ 0x0U }, viewer.mockEmulatorContext.ReadMemoryByte(0U));
 
         // Increase by 16 from 0x0 should result to 0X10
         Assert::IsTrue(viewer.IncreaseCurrentValue(16));
-        Assert::AreEqual({0x10U}, viewer.mockEmulatorContext.ReadMemoryByte(0U));
+        Assert::AreEqual({ 0x10U }, viewer.mockEmulatorContext.ReadMemoryByte(0U));
 
         // Increase by 16 from 0xFE should result to 0XFF
-        viewer.mockEmulatorContext.WriteMemoryByte(0x0, 0XFEU);
+        viewer.mockEmulatorContext.WriteMemoryByte(0x0U, 0XFEU);
         Assert::IsTrue(viewer.IncreaseCurrentValue(16));
-        Assert::AreEqual({0xFFU}, viewer.mockEmulatorContext.ReadMemoryByte(0U));
+        Assert::AreEqual({ 0xFFU }, viewer.mockEmulatorContext.ReadMemoryByte(0U));
 
         // Increase by 16 from 0xFF should not change the value
         Assert::IsFalse(viewer.IncreaseCurrentValue(16));
-        Assert::AreEqual({0xFFU}, viewer.mockEmulatorContext.ReadMemoryByte(0U));
+        Assert::AreEqual({ 0xFFU }, viewer.mockEmulatorContext.ReadMemoryByte(0U));
+
+        // Increase by 16 from 0x0 should result to 0X0010
+        viewer.mockEmulatorContext.WriteMemory(0x0U, MemSize::SixteenBit, 0X0U);
+        Assert::IsTrue(viewer.IncreaseCurrentValue(16));
+        Assert::AreEqual({ 0x10U }, viewer.mockEmulatorContext.ReadMemory(0U, MemSize::SixteenBit));
+
+        // Increase by 16 from 0xFFFF should not change the value
+        viewer.mockEmulatorContext.WriteMemory(0x0U, MemSize::SixteenBit, 0XFFFFU);
+        Assert::IsFalse(viewer.IncreaseCurrentValue(16));
+        Assert::AreEqual({ 0xFFFFU }, viewer.mockEmulatorContext.ReadMemory(0U, MemSize::SixteenBit));
     }
 
     TEST_METHOD(TestDecreaseCurrentValueByOne)
@@ -1992,53 +2012,73 @@ public:
         Assert::IsFalse(viewer.IsReadOnly());
 
         viewer.SetAddress(0x0U);
-        Assert::AreEqual({0U}, viewer.GetAddress());
-        Assert::AreEqual({0x0U}, viewer.mockEmulatorContext.ReadMemoryByte(0U));
+        Assert::AreEqual({ 0U }, viewer.GetAddress());
+        Assert::AreEqual({ 0x0U }, viewer.mockEmulatorContext.ReadMemoryByte(0U));
 
         // Decrease by 1 from 0x0 should not change the value
         Assert::IsFalse(viewer.DecreaseCurrentValue(1));
-        Assert::AreEqual({0x0U}, viewer.mockEmulatorContext.ReadMemoryByte(0U));
+        Assert::AreEqual({ 0x0U }, viewer.mockEmulatorContext.ReadMemoryByte(0U));
 
         // Decrease by 1 from 0xFF should result to 0XFE
-        viewer.mockEmulatorContext.WriteMemoryByte(0x0, 0XFFU);
+        viewer.mockEmulatorContext.WriteMemoryByte(0x0U, 0XFFU);
         Assert::IsTrue(viewer.DecreaseCurrentValue(1));
-        Assert::AreEqual({0xFEU}, viewer.mockEmulatorContext.ReadMemoryByte(0U));
+        Assert::AreEqual({ 0xFEU }, viewer.mockEmulatorContext.ReadMemoryByte(0U));
 
         // Decrease by 1 from 0x1 should result to 0X0
-        viewer.mockEmulatorContext.WriteMemoryByte(0x0, 0X1U);
+        viewer.mockEmulatorContext.WriteMemoryByte(0x0U, 0X1U);
         Assert::IsTrue(viewer.DecreaseCurrentValue(1));
-        Assert::AreEqual({0x0U}, viewer.mockEmulatorContext.ReadMemoryByte(0U));
+        Assert::AreEqual({ 0x0U }, viewer.mockEmulatorContext.ReadMemoryByte(0U));
+
+        // Decrease by 1 from 0x0 should not change the value
+        viewer.mockEmulatorContext.WriteMemory(0x0U, MemSize::SixteenBit, 0X0U);
+        Assert::IsFalse(viewer.DecreaseCurrentValue(1));
+        Assert::AreEqual({ 0x0U }, viewer.mockEmulatorContext.ReadMemory(0U, MemSize::SixteenBit));
+
+        // Decrease by 1 from 0xFFFF should result to 0XFFFE
+        viewer.mockEmulatorContext.WriteMemory(0x0U, MemSize::SixteenBit, 0XFFFFU);
+        Assert::IsTrue(viewer.DecreaseCurrentValue(1));
+        Assert::AreEqual({ 0xFFFEU }, viewer.mockEmulatorContext.ReadMemory(0U, MemSize::SixteenBit));
     }
 
-    TEST_METHOD(TestDecreaseCurrentValueBySixTeen)
+    TEST_METHOD(TestDecreaseCurrentValueBySixteen)
     {
         MemoryViewerViewModelHarness viewer;
         viewer.InitializeMemory(256);
 
         // ignore if readonly
         Assert::IsTrue(viewer.IsReadOnly());
-        Assert::IsFalse(viewer.DecreaseCurrentValue(1));
+        Assert::IsFalse(viewer.DecreaseCurrentValue(16));
 
         viewer.SetReadOnly(false);
         Assert::IsFalse(viewer.IsReadOnly());
 
         viewer.SetAddress(0x0U);
-        Assert::AreEqual({0U}, viewer.GetAddress());
-        Assert::AreEqual({0x0U}, viewer.mockEmulatorContext.ReadMemoryByte(0U));
+        Assert::AreEqual({ 0U }, viewer.GetAddress());
+        Assert::AreEqual({ 0x0U }, viewer.mockEmulatorContext.ReadMemoryByte(0U));
 
         // Decrease by 16 from 0x0 should not change the value
         Assert::IsFalse(viewer.DecreaseCurrentValue(16));
-        Assert::AreEqual({0x0U}, viewer.mockEmulatorContext.ReadMemoryByte(0U));
+        Assert::AreEqual({ 0x0U }, viewer.mockEmulatorContext.ReadMemoryByte(0U));
 
         // Decrease by 16 from 0xFF should result to 0XEF
-        viewer.mockEmulatorContext.WriteMemoryByte(0x0, 0XFFU);
+        viewer.mockEmulatorContext.WriteMemoryByte(0x0U, 0XFFU);
         Assert::IsTrue(viewer.DecreaseCurrentValue(16));
-        Assert::AreEqual({0xEFU}, viewer.mockEmulatorContext.ReadMemoryByte(0U));
+        Assert::AreEqual({ 0xEFU }, viewer.mockEmulatorContext.ReadMemoryByte(0U));
 
         // Decrease by 16 from 0x1 should result to 0X0
-        viewer.mockEmulatorContext.WriteMemoryByte(0x0, 0X1U);
+        viewer.mockEmulatorContext.WriteMemoryByte(0x0U, 0X1U);
         Assert::IsTrue(viewer.DecreaseCurrentValue(16));
-        Assert::AreEqual({0x0U}, viewer.mockEmulatorContext.ReadMemoryByte(0U));
+        Assert::AreEqual({ 0x0U }, viewer.mockEmulatorContext.ReadMemoryByte(0U));
+
+        // Decrease by 16 from 0x0 should not change the value
+        viewer.mockEmulatorContext.WriteMemory(0x0U, MemSize::SixteenBit, 0X0U);
+        Assert::IsFalse(viewer.DecreaseCurrentValue(16));
+        Assert::AreEqual({ 0x0U }, viewer.mockEmulatorContext.ReadMemory(0U, MemSize::SixteenBit));
+
+        // Decrease by 16 from 0xFFFF should result to 0XFFEF
+        viewer.mockEmulatorContext.WriteMemory(0x0U, MemSize::SixteenBit, 0XFFFFU);
+        Assert::IsTrue(viewer.DecreaseCurrentValue(16));
+        Assert::AreEqual({ 0xFFEFU }, viewer.mockEmulatorContext.ReadMemory(0U, MemSize::SixteenBit));
     }
 };
 

--- a/tests/ui/viewmodels/MemoryViewerViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/MemoryViewerViewModel_Tests.cpp
@@ -1918,6 +1918,128 @@ public:
         Assert::IsTrue(viewer.NeedsRedraw());
         viewer.MockRender();
     }
+
+    TEST_METHOD(TestIncreaseCurrentValueByOne)
+    {
+        MemoryViewerViewModelHarness viewer;
+        viewer.InitializeMemory(256);
+
+        // ignore if readonly
+        Assert::IsTrue(viewer.IsReadOnly());
+        Assert::IsFalse(viewer.IncreaseCurrentValue(1));
+
+        viewer.SetReadOnly(false);
+        Assert::IsFalse(viewer.IsReadOnly());
+
+        viewer.SetAddress(0x0U);
+        Assert::AreEqual({0U}, viewer.GetAddress());
+        Assert::AreEqual({0x0U}, viewer.mockEmulatorContext.ReadMemoryByte(0U));
+
+        // Increase by 1 from 0x0 should result to 0X1
+        Assert::IsTrue(viewer.IncreaseCurrentValue(1));
+        Assert::AreEqual({0x1U}, viewer.mockEmulatorContext.ReadMemoryByte(0U));
+
+        // Increase by 1 from 0xFE should result to 0XFF
+        viewer.mockEmulatorContext.WriteMemoryByte(0x0, 0XFEU);
+        Assert::IsTrue(viewer.IncreaseCurrentValue(1));
+        Assert::AreEqual({0xFFU}, viewer.mockEmulatorContext.ReadMemoryByte(0U));
+
+        // Increase by 1 from 0xFF should not change the value
+        Assert::IsFalse(viewer.IncreaseCurrentValue(1));
+        Assert::AreEqual({0xFFU}, viewer.mockEmulatorContext.ReadMemoryByte(0U));
+    }
+
+    TEST_METHOD(TestIncreaseCurrentValueBySixTeen)
+    {
+        MemoryViewerViewModelHarness viewer;
+        viewer.InitializeMemory(256);
+
+        // ignore if readonly
+        Assert::IsTrue(viewer.IsReadOnly());
+        Assert::IsFalse(viewer.IncreaseCurrentValue(1));
+
+        viewer.SetReadOnly(false);
+        Assert::IsFalse(viewer.IsReadOnly());
+
+        viewer.SetAddress(0x0U);
+        Assert::AreEqual({0U}, viewer.GetAddress());
+        Assert::AreEqual({0x0U}, viewer.mockEmulatorContext.ReadMemoryByte(0U));
+
+        // Increase by 16 from 0x0 should result to 0X10
+        Assert::IsTrue(viewer.IncreaseCurrentValue(16));
+        Assert::AreEqual({0x10U}, viewer.mockEmulatorContext.ReadMemoryByte(0U));
+
+        // Increase by 16 from 0xFE should result to 0XFF
+        viewer.mockEmulatorContext.WriteMemoryByte(0x0, 0XFEU);
+        Assert::IsTrue(viewer.IncreaseCurrentValue(16));
+        Assert::AreEqual({0xFFU}, viewer.mockEmulatorContext.ReadMemoryByte(0U));
+
+        // Increase by 16 from 0xFF should not change the value
+        Assert::IsFalse(viewer.IncreaseCurrentValue(16));
+        Assert::AreEqual({0xFFU}, viewer.mockEmulatorContext.ReadMemoryByte(0U));
+    }
+
+    TEST_METHOD(TestDecreaseCurrentValueByOne)
+    {
+        MemoryViewerViewModelHarness viewer;
+        viewer.InitializeMemory(256);
+
+        // ignore if readonly
+        Assert::IsTrue(viewer.IsReadOnly());
+        Assert::IsFalse(viewer.DecreaseCurrentValue(1));
+
+        viewer.SetReadOnly(false);
+        Assert::IsFalse(viewer.IsReadOnly());
+
+        viewer.SetAddress(0x0U);
+        Assert::AreEqual({0U}, viewer.GetAddress());
+        Assert::AreEqual({0x0U}, viewer.mockEmulatorContext.ReadMemoryByte(0U));
+
+        // Decrease by 1 from 0x0 should not change the value
+        Assert::IsFalse(viewer.DecreaseCurrentValue(1));
+        Assert::AreEqual({0x0U}, viewer.mockEmulatorContext.ReadMemoryByte(0U));
+
+        // Decrease by 1 from 0xFF should result to 0XFE
+        viewer.mockEmulatorContext.WriteMemoryByte(0x0, 0XFFU);
+        Assert::IsTrue(viewer.DecreaseCurrentValue(1));
+        Assert::AreEqual({0xFEU}, viewer.mockEmulatorContext.ReadMemoryByte(0U));
+
+        // Decrease by 1 from 0x1 should result to 0X0
+        viewer.mockEmulatorContext.WriteMemoryByte(0x0, 0X1U);
+        Assert::IsTrue(viewer.DecreaseCurrentValue(1));
+        Assert::AreEqual({0x0U}, viewer.mockEmulatorContext.ReadMemoryByte(0U));
+    }
+
+    TEST_METHOD(TestDecreaseCurrentValueBySixTeen)
+    {
+        MemoryViewerViewModelHarness viewer;
+        viewer.InitializeMemory(256);
+
+        // ignore if readonly
+        Assert::IsTrue(viewer.IsReadOnly());
+        Assert::IsFalse(viewer.DecreaseCurrentValue(1));
+
+        viewer.SetReadOnly(false);
+        Assert::IsFalse(viewer.IsReadOnly());
+
+        viewer.SetAddress(0x0U);
+        Assert::AreEqual({0U}, viewer.GetAddress());
+        Assert::AreEqual({0x0U}, viewer.mockEmulatorContext.ReadMemoryByte(0U));
+
+        // Decrease by 16 from 0x0 should not change the value
+        Assert::IsFalse(viewer.DecreaseCurrentValue(16));
+        Assert::AreEqual({0x0U}, viewer.mockEmulatorContext.ReadMemoryByte(0U));
+
+        // Decrease by 16 from 0xFF should result to 0XEF
+        viewer.mockEmulatorContext.WriteMemoryByte(0x0, 0XFFU);
+        Assert::IsTrue(viewer.DecreaseCurrentValue(16));
+        Assert::AreEqual({0xEFU}, viewer.mockEmulatorContext.ReadMemoryByte(0U));
+
+        // Decrease by 16 from 0x1 should result to 0X0
+        viewer.mockEmulatorContext.WriteMemoryByte(0x0, 0X1U);
+        Assert::IsTrue(viewer.DecreaseCurrentValue(16));
+        Assert::AreEqual({0x0U}, viewer.mockEmulatorContext.ReadMemoryByte(0U));
+    }
 };
 
 } // namespace tests


### PR DESCRIPTION
Enhanced user experience by providing a way to increment or decrement a value with +/- directly in the memory view.