### PR TITLE
Add History to Memory Viewer

### DIFF
--- a/src/ui/viewmodels/MemoryInspectorViewModel.cpp
+++ b/src/ui/viewmodels/MemoryInspectorViewModel.cpp
@@ -287,6 +287,7 @@ void MemoryInspectorViewModel::OnCurrentAddressChanged(ra::ByteAddress nNewAddre
     SetValue(CurrentAddressValueProperty, nValue);
 
     m_pViewer.SetAddress(nNewAddress);
+    m_pViewer.SaveToMemViewHistory();
 }
 
 void MemoryInspectorViewModel::BookmarkCurrentAddress() const

--- a/src/ui/viewmodels/MemoryInspectorViewModel.cpp
+++ b/src/ui/viewmodels/MemoryInspectorViewModel.cpp
@@ -287,7 +287,6 @@ void MemoryInspectorViewModel::OnCurrentAddressChanged(ra::ByteAddress nNewAddre
     SetValue(CurrentAddressValueProperty, nValue);
 
     m_pViewer.SetAddress(nNewAddress);
-    m_pViewer.SaveToMemViewHistory();
 }
 
 void MemoryInspectorViewModel::BookmarkCurrentAddress() const

--- a/src/ui/viewmodels/MemoryViewerViewModel.hh
+++ b/src/ui/viewmodels/MemoryViewerViewModel.hh
@@ -175,9 +175,10 @@ public:
     void AdvanceCursorPage();
     void RetreatCursorPage();
 
-    void SaveToMemViewHistory();
-    void MoveMemViewHistoryBackward();
-    void MoveMemViewHistoryForward();
+    void AddToHistory(ra::ByteAddress nAddress);
+    void ClearHistory();
+    void MoveHistoryBackward();
+    void MoveHistoryForward();
 
 protected:
     void OnValueChanged(const IntModelProperty::ChangeArgs& args) override;
@@ -210,6 +211,8 @@ protected:
     static constexpr int REDRAW_ALL = REDRAW_MEMORY | REDRAW_ADDRESSES | REDRAW_HEADERS;
     int m_nNeedsRedraw = REDRAW_ALL;
 
+
+
     static constexpr int MaxLines = 128;
 
 private:
@@ -239,12 +242,13 @@ private:
     static std::unique_ptr<ra::ui::drawing::ISurface> s_pFontSurface;
     static std::unique_ptr<ra::ui::drawing::ISurface> s_pFontASCIISurface;
     static int s_nFont;
-    static std::list<ra::ByteAddress> s_listMemViewHistory;
-    static std::list<ra::ByteAddress>::iterator s_iterMemViewHistoryIndex;
 
     class MemoryBookmarkMonitor;
     friend class MemoryBookmarkMonitor;
     std::unique_ptr<MemoryBookmarkMonitor> m_pBookmarkMonitor;
+
+    std::vector<ra::ByteAddress> vHistory;
+    std::vector<ra::ByteAddress>::iterator iterHistoryIndex;
 };
 
 } // namespace viewmodels

--- a/src/ui/viewmodels/MemoryViewerViewModel.hh
+++ b/src/ui/viewmodels/MemoryViewerViewModel.hh
@@ -175,6 +175,10 @@ public:
     void AdvanceCursorPage();
     void RetreatCursorPage();
 
+    void SaveToMemViewHistory();
+    void MoveMemViewHistoryBackward();
+    void MoveMemViewHistoryForward();
+
 protected:
     void OnValueChanged(const IntModelProperty::ChangeArgs& args) override;
 
@@ -235,6 +239,8 @@ private:
     static std::unique_ptr<ra::ui::drawing::ISurface> s_pFontSurface;
     static std::unique_ptr<ra::ui::drawing::ISurface> s_pFontASCIISurface;
     static int s_nFont;
+    static std::list<ra::ByteAddress> s_listMemViewHistory;
+    static std::list<ra::ByteAddress>::iterator s_iterMemViewHistoryIndex;
 
     class MemoryBookmarkMonitor;
     friend class MemoryBookmarkMonitor;

--- a/src/ui/win32/bindings/MemoryViewerControlBinding.cpp
+++ b/src/ui/win32/bindings/MemoryViewerControlBinding.cpp
@@ -57,6 +57,13 @@ INT_PTR CALLBACK MemoryViewerControlBinding::WndProc(HWND hControl, UINT uMsg, W
         case WM_USER_INVALIDATE:
             Invalidate();
             return FALSE;
+
+        case WM_XBUTTONUP:
+            if (GET_XBUTTON_WPARAM(wParam) == XBUTTON1)
+                m_pViewModel.MoveMemViewHistoryBackward();
+            else
+                m_pViewModel.MoveMemViewHistoryForward();
+            return FALSE;
     }
 
     return ControlBinding::WndProc(hControl, uMsg, wParam, lParam);

--- a/src/ui/win32/bindings/MemoryViewerControlBinding.cpp
+++ b/src/ui/win32/bindings/MemoryViewerControlBinding.cpp
@@ -60,9 +60,9 @@ INT_PTR CALLBACK MemoryViewerControlBinding::WndProc(HWND hControl, UINT uMsg, W
 
         case WM_XBUTTONUP:
             if (GET_XBUTTON_WPARAM(wParam) == XBUTTON1)
-                m_pViewModel.MoveMemViewHistoryBackward();
-            else
-                m_pViewModel.MoveMemViewHistoryForward();
+                m_pViewModel.MoveHistoryBackward();
+            else if (GET_XBUTTON_WPARAM(wParam) == XBUTTON2)
+                m_pViewModel.MoveHistoryForward();
             return FALSE;
     }
 


### PR DESCRIPTION
Enhanced user experience by providing an history on the memory viewer with the last 50 explored addresses (can move backward or forward)