### PR TITLE
prevent exception cloning search results with partial filter

### DIFF
--- a/src/services/SearchResults.h
+++ b/src/services/SearchResults.h
@@ -68,9 +68,15 @@ public:
         if (!AreAllAddressesMatching())
         {
             if ((m_nMatchingAddresses + 7) / 8 > sizeof(m_vAddresses))
-                std::memcpy(m_pAddresses, other.m_pAddresses, (m_nMatchingAddresses + 7) / 8);
+            {
+                auto* pAddresses = AllocateMatchingAddresses();
+                if (pAddresses != nullptr)
+                    std::memcpy(pAddresses, other.m_pAddresses, (m_nMatchingAddresses + 7) / 8);
+            }
             else
+            {
                 std::memcpy(m_vAddresses, other.m_vAddresses, sizeof(m_vAddresses));
+            }
         }
     }
 


### PR DESCRIPTION
https://discord.com/channels/310192285306454017/310195377993416714/1233514881823539301

The `SearchResults` copy constructor was not allocating a block of memory before trying to fill it.