### PR TITLE
Add Modulus Operator

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,8 @@
 	url = https://github.com/Tencent/rapidjson.git
 [submodule "rcheevos"]
 	path = rcheevos
-	url = https://github.com/RetroAchievements/rcheevos.git
+	url = https://github.com/redwizard42/rcheevos-tmo.git
+	branch = modulus
 [submodule "lua"]
 	path = lua
 	url = https://github.com/lua/lua.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,8 +3,7 @@
 	url = https://github.com/Tencent/rapidjson.git
 [submodule "rcheevos"]
 	path = rcheevos
-	url = https://github.com/redwizard42/rcheevos-tmo.git
-	branch = modulus
+	url = https://github.com/RetroAchievements/rcheevos.git
 [submodule "lua"]
 	path = lua
 	url = https://github.com/lua/lua.git

--- a/src/ui/viewmodels/TriggerConditionViewModel.cpp
+++ b/src/ui/viewmodels/TriggerConditionViewModel.cpp
@@ -136,6 +136,10 @@ void TriggerConditionViewModel::SerializeAppend(std::string& sBuffer) const
                 sBuffer.push_back('^');
                 break;
 
+            case TriggerOperatorType::Modulus:
+                sBuffer.push_back('%');
+                break;
+
             default:
                 assert(!"Unknown comparison");
                 break;
@@ -515,6 +519,7 @@ static constexpr bool IsModifyingOperator(TriggerOperatorType nType)
         case TriggerOperatorType::Divide:
         case TriggerOperatorType::BitwiseAnd:
         case TriggerOperatorType::BitwiseXor:
+        case TriggerOperatorType::Modulus:
             return true;
 
         default:

--- a/src/ui/viewmodels/TriggerConditionViewModel.hh
+++ b/src/ui/viewmodels/TriggerConditionViewModel.hh
@@ -56,7 +56,8 @@ enum class TriggerOperatorType : uint8_t
     Multiply = RC_OPERATOR_MULT,
     Divide = RC_OPERATOR_DIV,
     BitwiseAnd = RC_OPERATOR_AND,
-    BitwiseXor = RC_OPERATOR_XOR
+    BitwiseXor = RC_OPERATOR_XOR,
+    Modulus = RC_OPERATOR_MOD
 };
 
 class TriggerConditionViewModel : public ViewModelBase

--- a/src/ui/viewmodels/TriggerViewModel.cpp
+++ b/src/ui/viewmodels/TriggerViewModel.cpp
@@ -84,6 +84,7 @@ TriggerViewModel::TriggerViewModel() noexcept
     m_vOperatorTypes.Add(ra::etoi(TriggerOperatorType::None), L"");
     m_vOperatorTypes.Add(ra::etoi(TriggerOperatorType::Multiply), L"*");
     m_vOperatorTypes.Add(ra::etoi(TriggerOperatorType::Divide), L"/");
+    m_vOperatorTypes.Add(ra::etoi(TriggerOperatorType::Modulus), L"%");
     m_vOperatorTypes.Add(ra::etoi(TriggerOperatorType::BitwiseAnd), L"&");
     m_vOperatorTypes.Add(ra::etoi(TriggerOperatorType::BitwiseXor), L"^");
 }

--- a/tests/ui/viewmodels/TriggerConditionAsserts.hh
+++ b/tests/ui/viewmodels/TriggerConditionAsserts.hh
@@ -103,6 +103,8 @@ std::wstring ToString<ra::ui::viewmodels::TriggerOperatorType>(
             return L"Divide";
         case ra::ui::viewmodels::TriggerOperatorType::BitwiseAnd:
             return L"BitwiseAnd";
+        case ra::ui::viewmodels::TriggerOperatorType::Modulus:
+            return L"Modulus";
         default:
             return std::to_wstring(static_cast<int>(nConditionType));
     }

--- a/tests/ui/viewmodels/TriggerConditionViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/TriggerConditionViewModel_Tests.cpp
@@ -189,6 +189,10 @@ public:
         vmCondition.SetOperator(TriggerOperatorType::BitwiseAnd);
         Assert::AreEqual(TriggerOperatorType::BitwiseAnd, vmCondition.GetOperator());
         Assert::IsTrue(vmCondition.HasTarget());
+
+        vmCondition.SetOperator(TriggerOperatorType::Modulus);
+        Assert::AreEqual(TriggerOperatorType::Modulus, vmCondition.GetOperator());
+        Assert::IsTrue(vmCondition.HasTarget());
     }
 
     TEST_METHOD(TestHasTargetSize)
@@ -1124,6 +1128,7 @@ public:
         Assert::IsFalse(TriggerConditionViewModel::IsComparisonVisible(condition, ra::etoi(TriggerOperatorType::Divide)));
         Assert::IsFalse(TriggerConditionViewModel::IsComparisonVisible(condition, ra::etoi(TriggerOperatorType::BitwiseAnd)));
         Assert::IsFalse(TriggerConditionViewModel::IsComparisonVisible(condition, ra::etoi(TriggerOperatorType::BitwiseXor)));
+        Assert::IsFalse(TriggerConditionViewModel::IsComparisonVisible(condition, ra::etoi(TriggerOperatorType::Modulus)));
 
         condition.SetType(TriggerConditionType::AddAddress);
         Assert::IsFalse(TriggerConditionViewModel::IsComparisonVisible(condition, ra::etoi(TriggerOperatorType::Equals)));
@@ -1137,6 +1142,7 @@ public:
         Assert::IsTrue(TriggerConditionViewModel::IsComparisonVisible(condition, ra::etoi(TriggerOperatorType::Divide)));
         Assert::IsTrue(TriggerConditionViewModel::IsComparisonVisible(condition, ra::etoi(TriggerOperatorType::BitwiseAnd)));
         Assert::IsTrue(TriggerConditionViewModel::IsComparisonVisible(condition, ra::etoi(TriggerOperatorType::BitwiseXor)));
+        Assert::IsTrue(TriggerConditionViewModel::IsComparisonVisible(condition, ra::etoi(TriggerOperatorType::Modulus)));
     }
 
     TEST_METHOD(TestIsComparisonVisibleMeasured)
@@ -1155,6 +1161,7 @@ public:
         Assert::IsFalse(TriggerConditionViewModel::IsComparisonVisible(condition, ra::etoi(TriggerOperatorType::Divide)));
         Assert::IsFalse(TriggerConditionViewModel::IsComparisonVisible(condition, ra::etoi(TriggerOperatorType::BitwiseAnd)));
         Assert::IsFalse(TriggerConditionViewModel::IsComparisonVisible(condition, ra::etoi(TriggerOperatorType::BitwiseXor)));
+        Assert::IsFalse(TriggerConditionViewModel::IsComparisonVisible(condition, ra::etoi(TriggerOperatorType::Modulus)));
 
         TriggerViewModel vmTrigger;
         vmTrigger.SetIsValue(true);
@@ -1172,6 +1179,7 @@ public:
         Assert::IsTrue(TriggerConditionViewModel::IsComparisonVisible(condition, ra::etoi(TriggerOperatorType::Divide)));
         Assert::IsTrue(TriggerConditionViewModel::IsComparisonVisible(condition, ra::etoi(TriggerOperatorType::BitwiseAnd)));
         Assert::IsTrue(TriggerConditionViewModel::IsComparisonVisible(condition, ra::etoi(TriggerOperatorType::BitwiseXor)));
+        Assert::IsTrue(TriggerConditionViewModel::IsComparisonVisible(condition, ra::etoi(TriggerOperatorType::Modulus)));
     }
 
     TEST_METHOD(TestFormatValueNumber)

--- a/tests/ui/viewmodels/TriggerViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/TriggerViewModel_Tests.cpp
@@ -214,7 +214,7 @@ public:
         Assert::AreEqual((int)MemSize::MBF32LE, vmTrigger.OperandSizes().GetItemAt(23)->GetId());
         Assert::AreEqual(std::wstring(L"MBF32 LE"), vmTrigger.OperandSizes().GetItemAt(23)->GetLabel());
 
-        Assert::AreEqual({ 11U }, vmTrigger.OperatorTypes().Count());
+        Assert::AreEqual({ 12U }, vmTrigger.OperatorTypes().Count());
         Assert::AreEqual((int)TriggerOperatorType::Equals, vmTrigger.OperatorTypes().GetItemAt(0)->GetId());
         Assert::AreEqual(std::wstring(L"="), vmTrigger.OperatorTypes().GetItemAt(0)->GetLabel());
         Assert::AreEqual((int)TriggerOperatorType::LessThan, vmTrigger.OperatorTypes().GetItemAt(1)->GetId());
@@ -233,12 +233,12 @@ public:
         Assert::AreEqual(std::wstring(L"*"), vmTrigger.OperatorTypes().GetItemAt(7)->GetLabel());
         Assert::AreEqual((int)TriggerOperatorType::Divide, vmTrigger.OperatorTypes().GetItemAt(8)->GetId());
         Assert::AreEqual(std::wstring(L"/"), vmTrigger.OperatorTypes().GetItemAt(8)->GetLabel());
-        Assert::AreEqual((int)TriggerOperatorType::BitwiseAnd, vmTrigger.OperatorTypes().GetItemAt(9)->GetId());
-        Assert::AreEqual(std::wstring(L"&"), vmTrigger.OperatorTypes().GetItemAt(9)->GetLabel());
-        Assert::AreEqual((int)TriggerOperatorType::BitwiseXor, vmTrigger.OperatorTypes().GetItemAt(10)->GetId());
-        Assert::AreEqual(std::wstring(L"^"), vmTrigger.OperatorTypes().GetItemAt(10)->GetLabel());
-        Assert::AreEqual((int)TriggerOperatorType::Modulus, vmTrigger.OperatorTypes().GetItemAt(11)->GetId());
-        Assert::AreEqual(std::wstring(L"%"), vmTrigger.OperatorTypes().GetItemAt(8)->GetLabel());
+        Assert::AreEqual((int)TriggerOperatorType::Modulus, vmTrigger.OperatorTypes().GetItemAt(9)->GetId());
+        Assert::AreEqual(std::wstring(L"%"), vmTrigger.OperatorTypes().GetItemAt(9)->GetLabel());
+        Assert::AreEqual((int)TriggerOperatorType::BitwiseAnd, vmTrigger.OperatorTypes().GetItemAt(10)->GetId());
+        Assert::AreEqual(std::wstring(L"&"), vmTrigger.OperatorTypes().GetItemAt(10)->GetLabel());
+        Assert::AreEqual((int)TriggerOperatorType::BitwiseXor, vmTrigger.OperatorTypes().GetItemAt(11)->GetId());
+        Assert::AreEqual(std::wstring(L"^"), vmTrigger.OperatorTypes().GetItemAt(11)->GetLabel());
     }
 
     TEST_METHOD(TestParseAndRegenerateCoreOnly)

--- a/tests/ui/viewmodels/TriggerViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/TriggerViewModel_Tests.cpp
@@ -237,6 +237,8 @@ public:
         Assert::AreEqual(std::wstring(L"&"), vmTrigger.OperatorTypes().GetItemAt(9)->GetLabel());
         Assert::AreEqual((int)TriggerOperatorType::BitwiseXor, vmTrigger.OperatorTypes().GetItemAt(10)->GetId());
         Assert::AreEqual(std::wstring(L"^"), vmTrigger.OperatorTypes().GetItemAt(10)->GetLabel());
+        Assert::AreEqual((int)TriggerOperatorType::Modulus, vmTrigger.OperatorTypes().GetItemAt(11)->GetId());
+        Assert::AreEqual(std::wstring(L"%"), vmTrigger.OperatorTypes().GetItemAt(8)->GetLabel());
     }
 
     TEST_METHOD(TestParseAndRegenerateCoreOnly)


### PR DESCRIPTION
Adds the modulus operator to allow scaling to the remainder of a division. Most useful for anytime you have an increasing index that in practice has looping behavior without its value actually looping.

Example: A Game with 5 stages that loop, but the 0-based stage identified only ever increases, with no loop counter is present in RAM. With modulus operator, the developer could check that you are on 'any third stage' in the sequence using "Add Source Stage % 5 = Value 2"

Currently only modulo using a power of two can be accomplished (with Bitwise And)