### PR TITLE
Handle Indirect Address Navigation for Right-Click and Tooltip with Remember and Recall

### DIFF
--- a/src/ui/viewmodels/TriggerConditionViewModel.cpp
+++ b/src/ui/viewmodels/TriggerConditionViewModel.cpp
@@ -741,13 +741,12 @@ ra::ByteAddress TriggerConditionViewModel::GetIndirectAddress(ra::ByteAddress nA
     oEvalState.recall_value.type = RC_VALUE_TYPE_UNSIGNED;
     oEvalState.recall_value.value.u32 = 0;
 
-    gsl::index nPassesLeft = (bProcessPause ? 2 : 1);
+    int nPassesLeft = (bProcessPause ? 2 : 1); //If there are pauses, they may have remembered values that need to be processed first, so we do [up to] two passes.
     while (nPassesLeft > 0) {
         rc_condition_t* pCondition = pFirstCondition;
         gsl::index nConditionIndex = 0;
         for (; pCondition != nullptr; pCondition = pCondition->next)
         {
-
             auto* vmCondition = pTriggerViewModel->Conditions().GetItemAt(nConditionIndex++);
             if (!vmCondition)
                 break;
@@ -850,7 +849,7 @@ ra::ByteAddress TriggerConditionViewModel::GetIndirectAddress(ra::ByteAddress nA
             }
         }
         nPassesLeft--;
-        bProcessPause = false;
+        bProcessPause = false; //pause pass is always first, so we are no longer to process pause logic
     }
 
     return nAddress;

--- a/src/ui/viewmodels/TriggerConditionViewModel.cpp
+++ b/src/ui/viewmodels/TriggerConditionViewModel.cpp
@@ -752,7 +752,7 @@ ra::ByteAddress TriggerConditionViewModel::GetIndirectAddress(ra::ByteAddress nA
             if (!vmCondition)
                 break;
 
-            if (!pCondition->pause ^ bProcessPause) continue;
+            if ((pCondition->pause > 0) != bProcessPause) continue;
 
             if (vmCondition == this)
             {

--- a/src/ui/viewmodels/TriggerConditionViewModel.cpp
+++ b/src/ui/viewmodels/TriggerConditionViewModel.cpp
@@ -752,7 +752,7 @@ ra::ByteAddress TriggerConditionViewModel::GetIndirectAddress(ra::ByteAddress nA
             if (!vmCondition)
                 break;
 
-            if ((pCondition->pause) ^ !bProcessPause) continue;
+            if (!pCondition->pause ^ bProcessPause) continue;
 
             if (vmCondition == this)
             {


### PR DESCRIPTION
Updates logic to handle remember and recall potentially being involved in resolving the indirect address for purposes of right-click navigation and displaying the resolved address in the tooltip. Processes the pause logic in a first pass if there is pause logic, so that remembered values that may be in later pause logic are attributed properly should they be later used in non-pause logic.

Design decision is to navigate as if no remember conditions were affect by a pause.

Some possible improvement could be made were the rcheevos logic to flag that remember/recall are used in the conditionset as then additional processing of the pause logic as well as add source, sub source, and remember could be skipped.