### PR TITLE
use published achievement trigger when reverting

### DIFF
--- a/src/data/models/AchievementModel.cpp
+++ b/src/data/models/AchievementModel.cpp
@@ -403,6 +403,15 @@ void AchievementModel::SyncTrigger()
             m_pAchievement->trigger = nullptr;
         }
 
+        const auto* pPublishedAchievementInfo = pRuntime.GetPublishedAchievementInfo(m_pAchievement->public_.id);
+        if (pPublishedAchievementInfo && memcmp(pPublishedAchievementInfo->md5, md5, sizeof(md5)) == 0)
+        {
+            Expects(pPublishedAchievementInfo->trigger != nullptr);
+            m_pAchievement->trigger = pPublishedAchievementInfo->trigger;
+            rc_reset_trigger(m_pAchievement->trigger);
+            return;
+        }
+
         const auto nSize = rc_trigger_size(sTrigger.c_str());
         if (nSize > 0)
         {

--- a/src/data/models/LeaderboardModel.cpp
+++ b/src/data/models/LeaderboardModel.cpp
@@ -325,6 +325,15 @@ void LeaderboardModel::SyncDefinition()
             m_pLeaderboard->lboard = nullptr;
         }
 
+        const auto* pPublishedLeaderboardInfo = pRuntime.GetPublishedLeaderboardInfo(m_pLeaderboard->public_.id);
+        if (pPublishedLeaderboardInfo && memcmp(pPublishedLeaderboardInfo->md5, md5, sizeof(md5)) == 0)
+        {
+            Expects(pPublishedLeaderboardInfo->lboard != nullptr);
+            m_pLeaderboard->lboard = pPublishedLeaderboardInfo->lboard;
+            rc_reset_lboard(m_pLeaderboard->lboard);
+            return;
+        }
+
         const auto nSize = rc_lboard_size(sMemAddr.c_str());
         if (nSize > 0)
         {

--- a/src/services/AchievementRuntime.cpp
+++ b/src/services/AchievementRuntime.cpp
@@ -803,6 +803,29 @@ public:
         return DetachMemory(m_pSubsetWrapper->vAllocatedMemory, pMemory);
     }
 
+    const rc_client_achievement_info_t* GetPublishedAchievementInfo(ra::AchievementID nId) const
+    {
+        for (auto* pSubset = m_pPublishedSubset; pSubset; pSubset = pSubset->next)
+        {
+            const auto* pAchievement = FindAchievement(pSubset, nId);
+            if (pAchievement != nullptr)
+                return pAchievement;
+        }
+
+        return nullptr;
+    }
+
+    const rc_client_leaderboard_info_t* GetPublishedLeaderboardInfo(ra::LeaderboardID nId) const
+    {
+        for (auto* pSubset = m_pPublishedSubset; pSubset; pSubset = pSubset->next)
+        {
+            const auto* pLeaderboard = FindLeaderboard(pSubset, nId);
+            if (pLeaderboard != nullptr)
+                return pLeaderboard;
+        }
+
+        return nullptr;
+    }
 };
 
 void AchievementRuntime::SyncAssets()
@@ -848,6 +871,22 @@ rc_trigger_t* AchievementRuntime::GetAchievementTrigger(ra::AchievementID nId) c
 {
     rc_client_achievement_info_t* achievement = GetAchievementInfo(GetClient(), nId);
     return (achievement != nullptr) ? achievement->trigger : nullptr;
+}
+
+const rc_client_achievement_info_t* AchievementRuntime::GetPublishedAchievementInfo(ra::AchievementID nId) const
+{
+    if (m_pClientSynchronizer != nullptr)
+        return m_pClientSynchronizer->GetPublishedAchievementInfo(nId);
+
+    return nullptr;
+}
+
+const rc_client_leaderboard_info_t* AchievementRuntime::GetPublishedLeaderboardInfo(ra::LeaderboardID nId) const
+{
+    if (m_pClientSynchronizer != nullptr)
+        return m_pClientSynchronizer->GetPublishedLeaderboardInfo(nId);
+
+    return nullptr;
 }
 
 std::string AchievementRuntime::GetAchievementBadge(const rc_client_achievement_t& pAchievement)

--- a/src/services/AchievementRuntime.hh
+++ b/src/services/AchievementRuntime.hh
@@ -63,6 +63,7 @@ public:
     /// Gets the raw trigger for the achievement.
     /// </summary>
     rc_trigger_t* GetAchievementTrigger(ra::AchievementID nId) const noexcept;
+    const rc_client_achievement_info_t* GetPublishedAchievementInfo(ra::AchievementID nId) const;
 
     static std::string GetAchievementBadge(const rc_client_achievement_t& pAchievement);
 
@@ -75,6 +76,7 @@ public:
     /// Gets the raw definition for the leaderboard.
     /// </summary>
     rc_lboard_t* GetLeaderboardDefinition(ra::LeaderboardID nId) const noexcept;
+    const rc_client_leaderboard_info_t* GetPublishedLeaderboardInfo(ra::LeaderboardID nId) const;
 
     void ReleaseLeaderboardTracker(ra::LeaderboardID nId) noexcept;
 


### PR DESCRIPTION
Fixes a crash that occurs when reverting an achievement currently loaded in the editor.

The revert was causing the runtime to associate the original achievement trigger with the AchievementModel, and then freeing the local achievement trigger, but the editor was still referencing the local achievement trigger, so when it tried to update the hitcounts for the editor, it crashed.

Solution: If the achievement definition is reverted to the published state, immediately associate the original achievement trigger, preventing the editor from getting a reference to memory that would later be released.