### PR TITLE
fix achievement type dropdown not updating when resetting achievement

### DIFF
--- a/src/ui/viewmodels/AssetEditorViewModel.cpp
+++ b/src/ui/viewmodels/AssetEditorViewModel.cpp
@@ -428,7 +428,7 @@ void AssetEditorViewModel::OnDataModelIntValueChanged(const IntModelProperty::Ch
         SetCategory(ra::itoe<ra::data::models::AssetCategory>(args.tNewValue));
     else if (args.Property == ra::data::models::AchievementModel::PointsProperty)
         SetPoints(args.tNewValue);
-    else if (args.Property == ra::data::models::AchievementModel::TypeProperty)
+    else if (args.Property == ra::data::models::AchievementModel::AchievementTypeProperty)
         SetAchievementType(ra::itoe<ra::data::models::AchievementType>(args.tNewValue));
     else if (args.Property == ra::data::models::LeaderboardModel::ValueFormatProperty)
         SetValueFormat(ra::itoe<ra::data::ValueFormat>(args.tNewValue));

--- a/tests/ui/viewmodels/AssetEditorViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/AssetEditorViewModel_Tests.cpp
@@ -1018,6 +1018,10 @@ public:
         editor.SetAchievementType(ra::data::models::AchievementType::Missable);
         Assert::AreEqual(ra::data::models::AchievementType::Missable, editor.GetAchievementType());
         Assert::AreEqual(ra::data::models::AchievementType::Missable, achievement.GetAchievementType());
+
+        achievement.SetAchievementType(ra::data::models::AchievementType::None);
+        Assert::AreEqual(ra::data::models::AchievementType::None, editor.GetAchievementType());
+        Assert::AreEqual(ra::data::models::AchievementType::None, achievement.GetAchievementType());
     }
 
     TEST_METHOD(TestSyncBadge)


### PR DESCRIPTION
Fixes an issue where resetting an achievement that causes its type (win/progression/missable) to change, the dropdown in the active editor was not updating.