### PR TITLE
change report issue dialog to redirect to website

### DIFF
--- a/src/RA_Integration.vcxproj
+++ b/src/RA_Integration.vcxproj
@@ -189,7 +189,6 @@
     <ClInclude Include="api\IServer.hh" />
     <ClInclude Include="api\LatestClient.hh" />
     <ClInclude Include="api\SubmitNewTitle.hh" />
-    <ClInclude Include="api\SubmitTicket.hh" />
     <ClInclude Include="api\UpdateAchievement.hh" />
     <ClInclude Include="api\UpdateCodeNote.hh" />
     <ClInclude Include="api\UpdateLeaderboard.hh" />

--- a/src/RA_Integration.vcxproj.filters
+++ b/src/RA_Integration.vcxproj.filters
@@ -704,9 +704,6 @@
     <ClInclude Include="services\GameIdentifier.hh">
       <Filter>Services</Filter>
     </ClInclude>
-    <ClInclude Include="api\SubmitTicket.hh">
-      <Filter>API</Filter>
-    </ClInclude>
     <ClInclude Include="ui\viewmodels\OverlayViewModel.hh">
       <Filter>UI\ViewModels</Filter>
     </ClInclude>

--- a/src/RA_Shared.rc
+++ b/src/RA_Shared.rc
@@ -193,14 +193,9 @@ STYLE DS_SETFONT | DS_FIXEDSYS | WS_POPUP | WS_CAPTION | WS_SYSMENU | WS_THICKFR
 CAPTION "Report Achievement Problem"
 FONT 8, "MS Shell Dlg", 400, 0, 0x1
 BEGIN
-    LTEXT           "Which achievement(s) would you like to report?",IDC_RA_SELECT_ACHIEVEMENTS,4,4,331,8
-    CONTROL         "",IDC_RA_REPORTBROKENACHIEVEMENTSLIST,"SysListView32",LVS_REPORT | LVS_SINGLESEL | LVS_ALIGNLEFT | LVS_NOSORTHEADER | WS_BORDER | WS_TABSTOP,4,14,331,87
-    LTEXT           "What problem are you having with the selected achievement(s)?",IDC_RA_PROBLEMHEADER,4,104,207,8
-    CONTROL         "Triggered at wrong time",IDC_RA_PROBLEMTYPE1,"Button",BS_AUTORADIOBUTTON | WS_GROUP | WS_TABSTOP,4,114,93,10
-    CONTROL         "Didn't trigger at all",IDC_RA_PROBLEMTYPE2,"Button",BS_AUTORADIOBUTTON,98,114,75,10
-    LTEXT           "Please include any additional information that might help the developer diagnose the issue: selected difficulty or character, use of level select or other cheat codes, where it did trigger, links to a video or image showing the problem, etc.",IDC_RA_COMMENT_HEADER,4,127,331,27
-    EDITTEXT        IDC_RA_BROKENACHIEVEMENTREPORTCOMMENT,4,154,331,44,ES_MULTILINE | ES_AUTOHSCROLL | ES_WANTRETURN
-    DEFPUSHBUTTON   "Submit Ticket",IDOK,178,201,75,17
+    LTEXT           "Which achievement would you like to report?",IDC_RA_SELECT_ACHIEVEMENTS,4,4,331,8
+    CONTROL         "",IDC_RA_REPORTBROKENACHIEVEMENTSLIST,"SysListView32",LVS_REPORT | LVS_SINGLESEL | LVS_ALIGNLEFT | LVS_NOSORTHEADER | WS_BORDER | WS_TABSTOP,4,14,331,185
+    DEFPUSHBUTTON   "Report Problem",IDOK,178,201,75,17
     PUSHBUTTON      "Cancel",IDCANCEL,259,201,76,17
 END
 

--- a/src/RA_StringUtils.cpp
+++ b/src/RA_StringUtils.cpp
@@ -492,6 +492,42 @@ GSL_SUPPRESS_F6 _NODISCARD bool StringContainsCaseInsensitive(_In_ const std::ws
     return false;
 }
 
+std::string Base64(const std::string& sString)
+{
+    const char base64EncTable[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+    std::string sEncoded;
+    sEncoded.reserve(((sString.length() + 2) / 3) * 4 + 1);
+
+    const size_t nLength = sString.length();
+    size_t i = 0;
+    while (i < nLength)
+    {
+        const uint8_t a = sString[i++];
+        const uint8_t b = (i < nLength) ? sString[i] : 0; i++;
+        const uint8_t c = (i < nLength) ? sString[i] : 0; i++;
+        const uint32_t merged = (a << 16 | b << 8 | c);
+
+        sEncoded.push_back(base64EncTable[(merged >> 18) & 0x3F]);
+        sEncoded.push_back(base64EncTable[(merged >> 12) & 0x3F]);
+        sEncoded.push_back(base64EncTable[(merged >>  6) & 0x3F]);
+        sEncoded.push_back(base64EncTable[(merged      ) & 0x3F]);
+    }
+
+    if (i > nLength)
+    {
+        sEncoded.pop_back();
+        if (i - 1 > nLength)
+        {
+            sEncoded.pop_back();
+            sEncoded.push_back('=');
+        }
+        sEncoded.push_back('=');
+    }
+
+    return sEncoded;
+}
+
 #pragma warning(pop)
 
 } /* namespace ra */

--- a/src/RA_StringUtils.cpp
+++ b/src/RA_StringUtils.cpp
@@ -503,15 +503,15 @@ std::string Base64(const std::string& sString)
     size_t i = 0;
     while (i < nLength)
     {
-        const uint8_t a = sString[i++];
-        const uint8_t b = (i < nLength) ? sString[i] : 0; i++;
-        const uint8_t c = (i < nLength) ? sString[i] : 0; i++;
+        GSL_SUPPRESS_BOUNDS4 const uint8_t a = sString[i++];
+        GSL_SUPPRESS_BOUNDS4 const uint8_t b = (i < nLength) ? sString[i] : 0; i++;
+        GSL_SUPPRESS_BOUNDS4 const uint8_t c = (i < nLength) ? sString[i] : 0; i++;
         const uint32_t merged = (a << 16 | b << 8 | c);
 
-        sEncoded.push_back(base64EncTable[(merged >> 18) & 0x3F]);
-        sEncoded.push_back(base64EncTable[(merged >> 12) & 0x3F]);
-        sEncoded.push_back(base64EncTable[(merged >>  6) & 0x3F]);
-        sEncoded.push_back(base64EncTable[(merged      ) & 0x3F]);
+        GSL_SUPPRESS_BOUNDS4 sEncoded.push_back(base64EncTable[(merged >> 18) & 0x3F]);
+        GSL_SUPPRESS_BOUNDS4 sEncoded.push_back(base64EncTable[(merged >> 12) & 0x3F]);
+        GSL_SUPPRESS_BOUNDS4 sEncoded.push_back(base64EncTable[(merged >> 6) & 0x3F]);
+        GSL_SUPPRESS_BOUNDS4 sEncoded.push_back(base64EncTable[(merged) & 0x3F]);
     }
 
     if (i > nLength)

--- a/src/RA_StringUtils.h
+++ b/src/RA_StringUtils.h
@@ -862,6 +862,8 @@ constexpr int StringHash(const std::basic_string<CharT>& sString) noexcept
     return nHash;
 }
 
+std::string Base64(const std::string& sString);
+
 } // namespace ra
 
 #ifdef UNICODE

--- a/src/api/ApiCall.cpp
+++ b/src/api/ApiCall.cpp
@@ -26,7 +26,6 @@ FetchLeaderboardInfo::Response FetchLeaderboardInfo::Request::Call() const { ret
 LatestClient::Response LatestClient::Request::Call() const { return Server().LatestClient(*this); }
 FetchGamesList::Response FetchGamesList::Request::Call() const { return Server().FetchGamesList(*this); }
 SubmitNewTitle::Response SubmitNewTitle::Request::Call() const { return Server().SubmitNewTitle(*this); }
-SubmitTicket::Response SubmitTicket::Request::Call() const { return Server().SubmitTicket(*this); }
 FetchBadgeIds::Response FetchBadgeIds::Request::Call() const { return Server().FetchBadgeIds(*this); }
 UploadBadge::Response UploadBadge::Request::Call() const { return Server().UploadBadge(*this); }
 

--- a/src/api/IServer.hh
+++ b/src/api/IServer.hh
@@ -43,7 +43,6 @@ public:
     virtual LatestClient::Response LatestClient(const LatestClient::Request& request) = 0;
     virtual FetchGamesList::Response FetchGamesList(const FetchGamesList::Request& request) = 0;
     virtual SubmitNewTitle::Response SubmitNewTitle(const SubmitNewTitle::Request& request) = 0;
-    virtual SubmitTicket::Response SubmitTicket(const SubmitTicket::Request& request) = 0;
     virtual FetchBadgeIds::Response FetchBadgeIds(const FetchBadgeIds::Request& request) = 0;
     virtual UploadBadge::Response UploadBadge(const UploadBadge::Request& request) = 0;
 

--- a/src/api/impl/ConnectedServer.cpp
+++ b/src/api/impl/ConnectedServer.cpp
@@ -976,43 +976,6 @@ SubmitNewTitle::Response ConnectedServer::SubmitNewTitle(const SubmitNewTitle::R
     return response;
 }
 
-SubmitTicket::Response ConnectedServer::SubmitTicket(const SubmitTicket::Request& request)
-{
-    SubmitTicket::Response response;
-    rapidjson::Document document;
-    std::string sPostData;
-
-    std::string sAchievementIds;
-    for (auto nAchievementId : request.AchievementIds)
-    {
-        sAchievementIds.append(std::to_string(nAchievementId));
-        sAchievementIds.push_back(',');
-    }
-    sAchievementIds.pop_back();
-
-    AppendUrlParam(sPostData, "i", sAchievementIds);
-    AppendUrlParam(sPostData, "m", request.GameHash);
-    AppendUrlParam(sPostData, "p", std::to_string(ra::etoi(request.Problem)));
-    AppendUrlParam(sPostData, "n", request.Comment);
-
-    if (DoRequest(m_sHost, SubmitTicket::Name(), "submitticket", sPostData, response, document))
-    {
-        if (!document.HasMember("Response"))
-        {
-            response.Result = ApiResult::Error;
-            if (response.ErrorMessage.empty())
-                response.ErrorMessage = ra::StringPrintf("%s not found in response", "Response");
-        }
-        else
-        {
-            response.Result = ApiResult::Success;
-            GetRequiredJsonField(response.TicketsCreated, document["Response"], "Added", response);
-        }
-    }
-
-    return response;
-}
-
 FetchBadgeIds::Response ConnectedServer::FetchBadgeIds(const FetchBadgeIds::Request&)
 {
     FetchBadgeIds::Response response;

--- a/src/api/impl/ConnectedServer.cpp
+++ b/src/api/impl/ConnectedServer.cpp
@@ -214,27 +214,6 @@ static void GetRequiredJsonField(_Out_ std::wstring& sValue, _In_ const rapidjso
     }
 }
 
-static void GetRequiredJsonField(_Out_ unsigned int& nValue, _In_ const rapidjson::Value& pDocument,
-    _In_ const char* const sField, _Inout_ ApiResponseBase& response)
-{
-    if (!pDocument.HasMember(sField))
-    {
-        nValue = 0;
-
-        response.Result = ApiResult::Error;
-        if (response.ErrorMessage.empty())
-            response.ErrorMessage = ra::StringPrintf("%s not found in response", sField);
-    }
-    else
-    {
-        auto& pField = pDocument[sField];
-        if (pField.IsUint())
-            nValue = pField.GetUint();
-        else
-            nValue = 0;
-    }
-}
-
 static void AppendUrlParam(_Inout_ std::string& sParams, _In_ const char* const sParam, _In_ const std::string& sValue)
 {
     if (!sParams.empty() && sParams.back() != '?')

--- a/src/api/impl/ConnectedServer.hh
+++ b/src/api/impl/ConnectedServer.hh
@@ -27,7 +27,6 @@ public:
     LatestClient::Response LatestClient(const LatestClient::Request& request) override;
     FetchGamesList::Response FetchGamesList(const FetchGamesList::Request& request) override;
     SubmitNewTitle::Response SubmitNewTitle(const SubmitNewTitle::Request& request) override;
-    SubmitTicket::Response SubmitTicket(const SubmitTicket::Request& request) override;
     FetchBadgeIds::Response FetchBadgeIds(const FetchBadgeIds::Request& request) override;
     UploadBadge::Response UploadBadge(const UploadBadge::Request& request) override;
 

--- a/src/api/impl/ServerBase.hh
+++ b/src/api/impl/ServerBase.hh
@@ -82,11 +82,6 @@ public:
         return UnsupportedApi<SubmitNewTitle::Response>(SubmitNewTitle::Name());
     }
 
-    SubmitTicket::Response SubmitTicket(const SubmitTicket::Request&) override
-    {
-        return UnsupportedApi<SubmitTicket::Response>(SubmitTicket::Name());
-    }
-
     FetchBadgeIds::Response FetchBadgeIds(const FetchBadgeIds::Request&) override
     {
         return UnsupportedApi<FetchBadgeIds::Response>(FetchBadgeIds::Name());

--- a/src/data/models/AchievementModel.cpp
+++ b/src/data/models/AchievementModel.cpp
@@ -249,12 +249,15 @@ void AchievementModel::SyncState()
             if (m_pAchievement->trigger)
                 m_pAchievement->trigger->state = RC_TRIGGER_STATE_TRIGGERED;
 
-            const auto& pClock = ra::services::ServiceLocator::Get<ra::services::IClock>();
-            m_tUnlock = pClock.Now();
+            if (m_bCaptureTrigger)
+            {
+                const auto& pClock = ra::services::ServiceLocator::Get<ra::services::IClock>();
+                m_tUnlock = pClock.Now();
 
-            auto& pRuntime = ra::services::ServiceLocator::GetMutable<ra::services::AchievementRuntime>();
-            if (pRuntime.HasRichPresence())
-                SetUnlockRichPresence(pRuntime.GetRichPresenceDisplayString());
+                auto& pRuntime = ra::services::ServiceLocator::GetMutable<ra::services::AchievementRuntime>();
+                if (pRuntime.HasRichPresence())
+                    SetUnlockRichPresence(pRuntime.GetRichPresenceDisplayString());
+            }
             break;
         }
 
@@ -484,7 +487,9 @@ void AchievementModel::Attach(struct rc_client_achievement_info_t& pAchievement,
 
     m_pAchievement = &pAchievement;
 
+    m_bCaptureTrigger = false;
     DoFrame(); // sync state
+    m_bCaptureTrigger = true;
 }
 
 void AchievementModel::ReplaceAttached(struct rc_client_achievement_info_t& pAchievement) noexcept
@@ -503,7 +508,11 @@ void AchievementModel::AttachAndInitialize(struct rc_client_achievement_info_t& 
     SyncPoints();
     SyncCategory();
     SyncTrigger();
+
+    m_bCaptureTrigger = false;
     SyncState();
+    m_bCaptureTrigger = true;
+
     SyncAchievementType();
 }
 

--- a/src/data/models/AchievementModel.hh
+++ b/src/data/models/AchievementModel.hh
@@ -184,6 +184,7 @@ private:
     static const std::array<int, 10> s_vValidPoints;
 
     void HandleStateChanged(AssetState nOldState, AssetState nNewState);
+    void SetStateFromTrigger(const rc_trigger_t* pTrigger);
     void SyncID();
     void SyncTitle();
     void SyncDescription();
@@ -202,6 +203,7 @@ private:
     std::string m_sDescriptionBuffer;
 
     CapturedTriggerHits m_pCapturedTriggerHits;
+    bool m_bCaptureTrigger = false;
 };
 
 } // namespace models

--- a/src/ui/viewmodels/BrokenAchievementsViewModel.cpp
+++ b/src/ui/viewmodels/BrokenAchievementsViewModel.cpp
@@ -7,8 +7,10 @@
 #include "data\context\GameContext.hh"
 #include "data\context\GameAssets.hh"
 
+#include "services\IConfiguration.hh"
 #include "services\ServiceLocator.hh"
 
+#include "ui\IDesktop.hh"
 #include "ui\viewmodels\MessageBoxViewModel.hh"
 #include "ui\viewmodels\WindowManager.hh"
 
@@ -16,8 +18,7 @@ namespace ra {
 namespace ui {
 namespace viewmodels {
 
-const IntModelProperty BrokenAchievementsViewModel::SelectedProblemIdProperty("BrokenAchievementsViewModel", "SelectedProblemId", 0);
-const StringModelProperty BrokenAchievementsViewModel::CommentProperty("BrokenAchievementsViewModel", "Comment", L"");
+const IntModelProperty BrokenAchievementsViewModel::SelectedIndexProperty("BrokenAchievementsViewModel", "SelectedIndex", -1);
 
 const StringModelProperty BrokenAchievementsViewModel::BrokenAchievementViewModel::DescriptionProperty("BrokenAchievementViewModel", "Description", L"");
 const BoolModelProperty BrokenAchievementsViewModel::BrokenAchievementViewModel::IsAchievedProperty("BrokenAchievementViewModel", "IsAchieved", false);
@@ -80,197 +81,50 @@ bool BrokenAchievementsViewModel::InitializeAchievements()
     return true;
 }
 
-static std::wstring GetRichPresence(const ra::data::context::GameContext& pGameContext, const std::set<unsigned int> vAchievementIds)
-{
-    bool bMultipleRichPresence = false;
-    std::wstring sRichPresence;
-    for (const auto nId : vAchievementIds)
-    {
-        const auto* pAchievement = pGameContext.Assets().FindAchievement(nId);
-        if (pAchievement == nullptr)
-            continue;
-
-        if (!pAchievement->GetUnlockRichPresence().empty())
-        {
-            if (sRichPresence.empty())
-                sRichPresence = pAchievement->GetUnlockRichPresence();
-            else if (sRichPresence != pAchievement->GetUnlockRichPresence())
-                bMultipleRichPresence = true;
-        }
-    }
-
-    if (bMultipleRichPresence)
-    {
-        sRichPresence.clear();
-
-        for (const auto nId : vAchievementIds)
-        {
-            const auto* pAchievement = pGameContext.Assets().FindAchievement(nId);
-            if (pAchievement != nullptr && !pAchievement->GetUnlockRichPresence().empty())
-                sRichPresence.append(ra::StringPrintf(L"%u: %s\n", nId, pAchievement->GetUnlockRichPresence()));
-        }
-
-        sRichPresence.pop_back(); // remove last newline
-    }
-
-    return sRichPresence;
-}
-
 bool BrokenAchievementsViewModel::Submit()
 {
-    if (GetSelectedProblemId() == 0)
+    const auto nSelectedIndex = GetSelectedIndex();
+    if (nSelectedIndex == -1)
     {
-        ra::ui::viewmodels::MessageBoxViewModel::ShowErrorMessage(L"Please select a problem type.");
+        ra::ui::viewmodels::MessageBoxViewModel::ShowErrorMessage(L"Please select an achievement.");
         return false;
     }
 
-    ra::api::SubmitTicket::Request request;
-    std::string sBuggedIDs;
-    size_t nAchievedSelected = 0U;
-    size_t nUnachievedSelected = 0U;
+    std::string sExtra = "{";
 
-    for (gsl::index nIndex = 0; nIndex < ra::to_signed(m_vAchievements.Count()); ++nIndex)
+    const auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::context::GameContext>();
+    const auto nAchievementId = m_vAchievements.GetItemAt(nSelectedIndex)->GetId();
+    const auto* pAchievement = pGameContext.Assets().FindAchievement(nAchievementId);
+    if (pAchievement)
     {
-        const auto* pAchievement = m_vAchievements.GetItemAt(nIndex);
-        if (pAchievement && pAchievement->IsSelected())
+        const auto& sRichPresence = ra::Narrow(pAchievement->GetUnlockRichPresence());
+        if (!sRichPresence.empty())
         {
-            request.AchievementIds.insert(pAchievement->GetId());
-            sBuggedIDs.append(std::to_string(pAchievement->GetId()));
-            sBuggedIDs.push_back(',');
+            sExtra.append("\"triggerRichPresence\":\"");
 
-            if (pAchievement->IsAchieved())
-                ++nAchievedSelected;
-            else
-                ++nUnachievedSelected;
+            for (auto c : sRichPresence)
+            {
+                if (c == '"')
+                    sExtra.push_back('\\');
+                sExtra.push_back(c);
+            }
+
+            sExtra.push_back('"');
         }
     }
 
-    if (request.AchievementIds.empty())
+    const auto& pConfiguration = ra::services::ServiceLocator::Get<ra::services::IConfiguration>();
+    std::string sUrl = ra::StringPrintf("%s/achievement/%u/report-issue", pConfiguration.GetHostUrl(), nAchievementId);
+
+    if (sExtra.length() > 2)
     {
-        ra::ui::viewmodels::MessageBoxViewModel::ShowErrorMessage(L"You must select at least one achievement to submit a ticket.");
-        return false;
+        sExtra.push_back('}');
+
+        sUrl.append("?extra=");
+        sUrl.append(ra::Base64(sExtra));
     }
 
-    sBuggedIDs.pop_back(); // remove last comma
-
-    const auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::context::GameContext>();
-    const auto sComment = GetComment();
-
-    const char* sProblemType = "";
-    request.Problem = ra::itoe<ra::api::SubmitTicket::ProblemType>(GetSelectedProblemId());
-    switch (request.Problem)
-    {
-        case ra::api::SubmitTicket::ProblemType::DidNotTrigger:
-            if (request.AchievementIds.size() > 5)
-            {
-                ra::ui::viewmodels::MessageBoxViewModel::ShowErrorMessage(L"Too many achievements selected.",
-                    L"You cannot report more than 5 achievements at a time for not triggering. Please provide separate details for each achievement that did not trigger for you.");
-                return false;
-            }
-
-            if (nUnachievedSelected == 0)
-            {
-                if (ra::ui::viewmodels::MessageBoxViewModel::ShowWarningMessage(L"Submit anyway?",
-                    ra::StringPrintf(L"The achievement%s you have selected %s triggered, but you have selected 'Did not trigger'.",
-                        request.AchievementIds.size() == 1 ? "" : "s", request.AchievementIds.size() == 1 ? "has" : "have"),
-                    ra::ui::viewmodels::MessageBoxViewModel::Buttons::YesNo) == ra::ui::DialogResult::No)
-                {
-                    return false;
-                }
-            }
-
-            if (sComment.length() < 20)
-            {
-                ra::ui::viewmodels::MessageBoxViewModel::ShowErrorMessage(L"Please be more specific.",
-                    L"Any information that you can provide to help the developer reproduce the issue will make it easier to fix.");
-                return false;
-            }
-
-            sProblemType = " did not trigger";
-            break;
-
-        case ra::api::SubmitTicket::ProblemType::WrongTime:
-            if (nAchievedSelected == 0)
-            {
-                if (ra::ui::viewmodels::MessageBoxViewModel::ShowWarningMessage(L"Submit anyway?",
-                    ra::StringPrintf(L"The achievement%s you have selected %s not triggered, but you have selected 'Triggered at the wrong time'.",
-                        request.AchievementIds.size() == 1 ? "" : "s", request.AchievementIds.size() == 1 ? "has" : "have"),
-                    ra::ui::viewmodels::MessageBoxViewModel::Buttons::YesNo) == ra::ui::DialogResult::No)
-                {
-                    return false;
-                }
-            }
-
-            if (sComment.length() < 20)
-            {
-                ra::ui::viewmodels::MessageBoxViewModel::ShowErrorMessage(ra::StringPrintf(
-                    L"Please describe when the achievement%s did trigger.", request.AchievementIds.size() == 1 ? "" : "s"));
-                return false;
-            }
-
-            sProblemType = " triggered at the wrong time";
-            break;
-    }
-
-    ra::ui::viewmodels::MessageBoxViewModel vmConfirm;
-    if (request.AchievementIds.size() == 1)
-    {
-        const auto nIndex = m_vAchievements.FindItemIndex(LookupItemViewModel::IdProperty, *request.AchievementIds.begin());
-        const auto* pAchievement = m_vAchievements.GetItemAt(nIndex);
-
-        vmConfirm.SetHeader(ra::StringPrintf(L"Are you sure that you want to create a%s ticket for %s?",
-            sProblemType, pAchievement ? pAchievement->GetLabel() : pGameContext.GameTitle()));
-    }
-    else
-    {
-        vmConfirm.SetHeader(ra::StringPrintf(L"Are you sure that you want to create %u%s tickets for %s?",
-            request.AchievementIds.size(), sProblemType, pGameContext.GameTitle()));
-    }
-
-    vmConfirm.SetMessage(ra::StringPrintf(L""
-        "Achievement ID%s: %s\n"
-        "RetroAchievements Hash: %s\n"
-        "Comment: %s",
-        request.AchievementIds.size() == 1 ? "" : "s",
-        sBuggedIDs, pGameContext.GameHash(), GetComment()
-    ));
-    vmConfirm.SetButtons(ra::ui::viewmodels::MessageBoxViewModel::Buttons::YesNo);
-
-    if (vmConfirm.ShowModal() != ra::ui::DialogResult::Yes)
-        return false;
-
-    request.GameHash = pGameContext.GameHash();
-    request.Comment = ra::Narrow(sComment);
-
-    const std::wstring sRichPresence = GetRichPresence(pGameContext, request.AchievementIds);
-    if (!sRichPresence.empty())
-    {
-        request.Comment.append("\n\nRich Presence at time of trigger:\n");
-        request.Comment.append(ra::Narrow(sRichPresence));
-    }
-
-    const auto response = request.Call();
-    if (!response.Succeeded())
-    {
-        ra::ui::viewmodels::MessageBoxViewModel::ShowErrorMessage(L"Failed to submit tickets",
-            !response.ErrorMessage.empty() ? ra::Widen(response.ErrorMessage) : L"Unknown error");
-        return false;
-    }
-
-    if (response.TicketsCreated == 1)
-    {
-        ra::ui::viewmodels::MessageBoxViewModel vmMessageBox;
-        vmMessageBox.SetHeader(L"1 ticket created");
-        vmMessageBox.SetMessage(L"Thank you for reporting the issue. The development team will investigate and you will be notified when the ticket is updated or resolved.");
-        vmMessageBox.ShowModal();
-    }
-    else
-    {
-        ra::ui::viewmodels::MessageBoxViewModel vmMessageBox;
-        vmMessageBox.SetHeader(ra::StringPrintf(L"%u tickets created", response.TicketsCreated));
-        vmMessageBox.SetMessage(L"Thank you for reporting the issues. The development team will investigate and you will be notified when the tickets are updated or resolved.");
-        vmMessageBox.ShowModal();
-    }
+    ra::services::ServiceLocator::Get<ra::ui::IDesktop>().OpenUrl(sUrl);
 
     return true;
 }
@@ -285,37 +139,15 @@ void BrokenAchievementsViewModel::OnItemSelectedChanged(gsl::index nIndex, const
 {
     if (args.tNewValue)
     {
-        // if something is checked and no problem type has been selected, automatically select it
-        if (GetSelectedProblemId() == 0)
-        {
-            const auto* pItem = m_vAchievements.GetItemAt(nIndex);
-            if (pItem != nullptr)
-            {
-                SetSelectedProblemId(pItem->IsAchieved() ?
-                    ra::etoi(ra::api::SubmitTicket::ProblemType::WrongTime) :
-                    ra::etoi(ra::api::SubmitTicket::ProblemType::DidNotTrigger));
-            }
-        }
+        const auto nPreviousSelectedIndex = GetSelectedIndex();
+        if (nPreviousSelectedIndex != -1)
+            m_vAchievements.GetItemAt(nPreviousSelectedIndex)->SetSelected(false);
+
+        SetSelectedIndex(nIndex);
     }
     else
     {
-        // if all items are unchecked, reset the problem type to unknown
-        if (GetSelectedProblemId() != 0)
-        {
-            bool bHasCheck = false;
-            for (gsl::index i = 0; i < ra::to_signed(m_vAchievements.Count()); ++i)
-            {
-                const auto* pItem = m_vAchievements.GetItemAt(i);
-                if (pItem != nullptr && pItem->IsSelected())
-                {
-                    bHasCheck = true;
-                    break;
-                }
-            }
-
-            if (!bHasCheck)
-                SetSelectedProblemId(0);
-        }
+        SetSelectedIndex(-1);
     }
 }
 

--- a/src/ui/viewmodels/BrokenAchievementsViewModel.cpp
+++ b/src/ui/viewmodels/BrokenAchievementsViewModel.cpp
@@ -143,7 +143,7 @@ void BrokenAchievementsViewModel::OnItemSelectedChanged(gsl::index nIndex, const
         if (nPreviousSelectedIndex != -1)
             m_vAchievements.GetItemAt(nPreviousSelectedIndex)->SetSelected(false);
 
-        SetSelectedIndex(nIndex);
+        SetSelectedIndex(gsl::narrow_cast<int>(nIndex));
     }
     else
     {

--- a/src/ui/viewmodels/BrokenAchievementsViewModel.hh
+++ b/src/ui/viewmodels/BrokenAchievementsViewModel.hh
@@ -22,39 +22,24 @@ public:
     BrokenAchievementsViewModel& operator=(BrokenAchievementsViewModel&&) noexcept = delete;
     
     /// <summary>
-    /// Initializes the <see cref="Achievements"/> collection (asynchronously).
+    /// Initializes the <see cref="Achievements"/> collection.
     /// </summary>
     bool InitializeAchievements(); // shows error and returns false for Local achievements
     
     /// <summary>
-    /// The <see cref="ModelProperty" /> for the selected problem.
+    /// The <see cref="ModelProperty" /> for the selected achievement index.
     /// </summary>
-    static const IntModelProperty SelectedProblemIdProperty;
+    static const IntModelProperty SelectedIndexProperty;
 
     /// <summary>
-    /// Gets the selected problem ID.
+    /// Gets the index of the selected achievement.
     /// </summary>
-    int GetSelectedProblemId() const { return GetValue(SelectedProblemIdProperty); }
+    int GetSelectedIndex() const { return GetValue(SelectedIndexProperty); }
 
     /// <summary>
-    /// Sets the selected problem ID.
+    /// Sets the index of the selected achievement.
     /// </summary>
-    void SetSelectedProblemId(int nValue) { SetValue(SelectedProblemIdProperty, nValue); }
-
-    /// <summary>
-    /// The <see cref="ModelProperty" /> for the comment.
-    /// </summary>
-    static const StringModelProperty CommentProperty;
-
-    /// <summary>
-    /// Gets the comment.
-    /// </summary>
-    const std::wstring& GetComment() const { return GetValue(CommentProperty); }
-
-    /// <summary>
-    /// Sets the comment.
-    /// </summary>
-    void SetComment(const std::wstring& sValue) { SetValue(CommentProperty, sValue); }
+    void SetSelectedIndex(int nValue) { SetValue(SelectedIndexProperty, nValue); }
 
     /// <summary>
     /// Command handler for Submit button.

--- a/src/ui/win32/BrokenAchievementsDialog.cpp
+++ b/src/ui/win32/BrokenAchievementsDialog.cpp
@@ -38,19 +38,9 @@ void BrokenAchievementsDialog::Presenter::ShowWindow(ra::ui::WindowViewModelBase
 
 BrokenAchievementsDialog::BrokenAchievementsDialog(BrokenAchievementsViewModel& vmBrokenAchievements)
     : DialogBase(vmBrokenAchievements),
-      m_bindWrongTime(vmBrokenAchievements),
-      m_bindDidNotTrigger(vmBrokenAchievements),
-      m_bindComment(vmBrokenAchievements),
       m_bindAchievements(vmBrokenAchievements)
 {
     m_bindWindow.SetInitialPosition(RelativePosition::Center, RelativePosition::Center, "Report Broken Achievements");
-
-    m_bindWrongTime.BindCheck(BrokenAchievementsViewModel::SelectedProblemIdProperty,
-        ra::etoi(ra::api::SubmitTicket::ProblemType::WrongTime));
-    m_bindDidNotTrigger.BindCheck(BrokenAchievementsViewModel::SelectedProblemIdProperty,
-        ra::etoi(ra::api::SubmitTicket::ProblemType::DidNotTrigger));
-
-    m_bindComment.BindText(BrokenAchievementsViewModel::CommentProperty);
 
     auto pSelectedColumn = std::make_unique<ra::ui::win32::bindings::GridCheckBoxColumnBinding>(
         BrokenAchievementsViewModel::BrokenAchievementViewModel::IsSelectedProperty);
@@ -80,11 +70,6 @@ BrokenAchievementsDialog::BrokenAchievementsDialog(BrokenAchievementsViewModel& 
     using namespace ra::bitwise_ops;
     SetAnchor(IDC_RA_SELECT_ACHIEVEMENTS, Anchor::Top | Anchor::Left | Anchor::Right);
     SetAnchor(IDC_RA_REPORTBROKENACHIEVEMENTSLIST, Anchor::Top | Anchor::Left | Anchor::Bottom | Anchor::Right);
-    SetAnchor(IDC_RA_PROBLEMHEADER, Anchor::Bottom | Anchor::Left);
-    SetAnchor(IDC_RA_PROBLEMTYPE1, Anchor::Bottom | Anchor::Left);
-    SetAnchor(IDC_RA_PROBLEMTYPE2, Anchor::Bottom | Anchor::Left);
-    SetAnchor(IDC_RA_COMMENT_HEADER, Anchor::Left | Anchor::Bottom | Anchor::Right);
-    SetAnchor(IDC_RA_BROKENACHIEVEMENTREPORTCOMMENT, Anchor::Left | Anchor::Bottom | Anchor::Right);
     SetAnchor(IDCANCEL, Anchor::Bottom | Anchor::Right);
     SetAnchor(IDOK, Anchor::Bottom | Anchor::Right);
 
@@ -93,11 +78,6 @@ BrokenAchievementsDialog::BrokenAchievementsDialog(BrokenAchievementsViewModel& 
 
 BOOL BrokenAchievementsDialog::OnInitDialog()
 {
-    m_bindWrongTime.SetControl(*this, IDC_RA_PROBLEMTYPE1);
-    m_bindDidNotTrigger.SetControl(*this, IDC_RA_PROBLEMTYPE2);
-
-    m_bindComment.SetControl(*this, IDC_RA_BROKENACHIEVEMENTREPORTCOMMENT);
-
     m_bindAchievements.SetControl(*this, IDC_RA_REPORTBROKENACHIEVEMENTSLIST);
 
     return DialogBase::OnInitDialog();

--- a/src/ui/win32/BrokenAchievementsDialog.hh
+++ b/src/ui/win32/BrokenAchievementsDialog.hh
@@ -4,8 +4,6 @@
 
 #include "ui/viewmodels/BrokenAchievementsViewModel.hh"
 #include "ui/win32/bindings/GridBinding.hh"
-#include "ui/win32/bindings/RadioButtonBinding.hh"
-#include "ui/win32/bindings/TextBoxBinding.hh"
 #include "ui/win32/DialogBase.hh"
 #include "ui/win32/IDialogPresenter.hh"
 
@@ -36,9 +34,6 @@ protected:
     BOOL OnCommand(WORD nCommand) override;
     
 private:
-    ra::ui::win32::bindings::RadioButtonBinding m_bindWrongTime;
-    ra::ui::win32::bindings::RadioButtonBinding m_bindDidNotTrigger;
-    ra::ui::win32::bindings::TextBoxBinding m_bindComment;
     ra::ui::win32::bindings::GridBinding m_bindAchievements;
 };
 

--- a/src/ui/win32/bindings/GridBinding.cpp
+++ b/src/ui/win32/bindings/GridBinding.cpp
@@ -361,7 +361,19 @@ void GridBinding::OnViewModelBoolValueChanged(gsl::index nIndex, const BoolModel
     {
         const auto& pColumn = *m_vColumns.at(nColumnIndex);
         if (pColumn.DependsOn(args.Property))
-            UpdateCell(nIndex, nColumnIndex);
+        {
+            const auto* pCheckBoxColumn = dynamic_cast<const GridCheckBoxColumnBinding*>(&pColumn);
+            if (pCheckBoxColumn != nullptr)
+            {
+                InvokeOnUIThread([this, nIndex, nValue = args.tNewValue]() noexcept {
+                    ListView_SetCheckState(m_hWnd, nIndex, nValue);
+                });
+            }
+            else
+            {
+                UpdateCell(nIndex, nColumnIndex);
+            }
+        }
     }
 }
 
@@ -888,11 +900,7 @@ void GridBinding::OnLvnItemChanged(const LPNMLISTVIEW pnmListView)
         {
             const auto* pCheckBoxBinding = dynamic_cast<GridCheckBoxColumnBinding*>(m_vColumns.at(0).get());
             if (pCheckBoxBinding != nullptr)
-            {
-                m_vmItems->RemoveNotifyTarget(*this);
                 m_vmItems->SetItemValue(nIndex, pCheckBoxBinding->GetBoundProperty(), true);
-                m_vmItems->AddNotifyTarget(*this);
-            }
         }
         break;
 
@@ -900,11 +908,7 @@ void GridBinding::OnLvnItemChanged(const LPNMLISTVIEW pnmListView)
         {
             const auto* pCheckBoxBinding = dynamic_cast<GridCheckBoxColumnBinding*>(m_vColumns.at(0).get());
             if (pCheckBoxBinding != nullptr)
-            {
-                m_vmItems->RemoveNotifyTarget(*this);
                 m_vmItems->SetItemValue(nIndex, pCheckBoxBinding->GetBoundProperty(), false);
-                m_vmItems->AddNotifyTarget(*this);
-            }
         }
         break;
     }

--- a/tests/mocks/MockServer.hh
+++ b/tests/mocks/MockServer.hh
@@ -122,11 +122,6 @@ public:
         return HandleRequest<ra::api::SubmitNewTitle>(request);
     }
 
-    SubmitTicket::Response SubmitTicket(const SubmitTicket::Request& request) override
-    {
-        return HandleRequest<ra::api::SubmitTicket>(request);
-    }
-
     FetchBadgeIds::Response FetchBadgeIds(const FetchBadgeIds::Request& request) override
     {
         return HandleRequest<ra::api::FetchBadgeIds>(request);

--- a/tests/ui/viewmodels/BrokenAchievementsViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/BrokenAchievementsViewModel_Tests.cpp
@@ -5,7 +5,6 @@
 #include "tests\ui\UIAsserts.hh"
 #include "tests\mocks\MockDesktop.hh"
 #include "tests\mocks\MockGameContext.hh"
-#include "tests\mocks\MockServer.hh"
 #include "tests\mocks\MockThreadPool.hh"
 #include "tests\mocks\MockWindowManager.hh"
 
@@ -24,21 +23,14 @@ private:
     class BrokenAchievementsViewModelHarness : public BrokenAchievementsViewModel
     {
     public:
-        ra::api::mocks::MockServer mockServer;
         ra::data::context::mocks::MockGameContext mockGameContext;
-        ra::services::mocks::MockThreadPool mockThreadPool;
+        ra::services::mocks::MockThreadPool mockThreadPool; // needed by asset list
         ra::ui::mocks::MockDesktop mockDesktop;
         ra::ui::viewmodels::mocks::MockWindowManager mockWindowManager;
 
         BrokenAchievementsViewModelHarness() noexcept
         {
             GSL_SUPPRESS_F6 mockWindowManager.AssetList.InitializeNotifyTargets();
-        }
-
-
-        void SetDefaultComment()
-        {
-            SetComment(L"The achievement failed to trigger when I jumped.");
         }
 
         void MockAchievements()
@@ -86,8 +78,7 @@ public:
     TEST_METHOD(TestInitialValues)
     {
         BrokenAchievementsViewModelHarness vmBrokenAchievements;
-        Assert::AreEqual(0, vmBrokenAchievements.GetSelectedProblemId());
-        Assert::AreEqual(std::wstring(L""), vmBrokenAchievements.GetComment());
+        Assert::AreEqual(-1, vmBrokenAchievements.GetSelectedIndex());
         Assert::AreEqual({ 0U }, vmBrokenAchievements.Achievements().Count());
     }
 
@@ -165,562 +156,68 @@ public:
         Assert::IsTrue(bDialogSeen);
     }
 
-    TEST_METHOD(TestSubmitNoProblemType)
-    {
-        BrokenAchievementsViewModelHarness vmBrokenAchievements;
-        vmBrokenAchievements.MockAchievements();
-
-        bool bDialogSeen = false;
-        vmBrokenAchievements.mockDesktop.ExpectWindow<MessageBoxViewModel>([&bDialogSeen](const MessageBoxViewModel& vmMessageBox)
-        {
-            bDialogSeen = true;
-
-            Assert::AreEqual(std::wstring(L"Please select a problem type."), vmMessageBox.GetMessage());
-            return ra::ui::DialogResult::OK;
-        });
-
-        vmBrokenAchievements.mockServer.ExpectUncalled<ra::api::SubmitTicket>();
-
-        Assert::IsFalse(vmBrokenAchievements.Submit());
-        Assert::IsTrue(bDialogSeen);
-    }
-
     TEST_METHOD(TestSubmitNoAchievementsSelected)
     {
         BrokenAchievementsViewModelHarness vmBrokenAchievements;
         vmBrokenAchievements.MockAchievements();
-        vmBrokenAchievements.SetSelectedProblemId(1);
-        vmBrokenAchievements.SetDefaultComment();
 
         bool bDialogSeen = false;
         vmBrokenAchievements.mockDesktop.ExpectWindow<MessageBoxViewModel>([&bDialogSeen](const MessageBoxViewModel& vmMessageBox)
         {
             bDialogSeen = true;
 
-            Assert::AreEqual(std::wstring(L"You must select at least one achievement to submit a ticket."), vmMessageBox.GetMessage());
+            Assert::AreEqual(std::wstring(L"Please select an achievement."), vmMessageBox.GetMessage());
             return ra::ui::DialogResult::OK;
         });
 
-        vmBrokenAchievements.mockServer.ExpectUncalled<ra::api::SubmitTicket>();
+        Assert::AreEqual(std::string(), vmBrokenAchievements.mockDesktop.LastOpenedUrl());
 
         Assert::IsFalse(vmBrokenAchievements.Submit());
         Assert::IsTrue(bDialogSeen);
     }
 
-    TEST_METHOD(TestSubmitDidNotTriggerAsTriggeredWrongTimeCancel)
+    TEST_METHOD(TestSubmitAchievement)
     {
         BrokenAchievementsViewModelHarness vmBrokenAchievements;
         vmBrokenAchievements.MockAchievements();
-        vmBrokenAchievements.SetSelectedProblemId(1);
-        vmBrokenAchievements.SetDefaultComment();
-        vmBrokenAchievements.Achievements().GetItemAt(1)->SetSelected(true);
-
-        bool bDialogSeen = false;
-        vmBrokenAchievements.mockDesktop.ExpectWindow<MessageBoxViewModel>([&bDialogSeen](const MessageBoxViewModel& vmMessageBox)
-        {
-            bDialogSeen = true;
-            Assert::AreEqual(std::wstring(L"The achievement you have selected has not triggered, but you have selected 'Triggered at the wrong time'."), vmMessageBox.GetMessage());
-            return ra::ui::DialogResult::No;
-        });
-
-        vmBrokenAchievements.mockServer.ExpectUncalled<ra::api::SubmitTicket>();
-
-        Assert::IsFalse(vmBrokenAchievements.Submit());
-        Assert::IsTrue(bDialogSeen);
-    }
-
-    TEST_METHOD(TestSubmitDidNotTriggerAsTriggeredWrongTimeProceed)
-    {
-        BrokenAchievementsViewModelHarness vmBrokenAchievements;
-        vmBrokenAchievements.MockAchievements();
-        vmBrokenAchievements.SetSelectedProblemId(1);
-        vmBrokenAchievements.SetDefaultComment();
-        vmBrokenAchievements.Achievements().GetItemAt(1)->SetSelected(true);
-
-        bool bDialogSeen = false;
-        vmBrokenAchievements.mockDesktop.ExpectWindow<MessageBoxViewModel>([&bDialogSeen](const MessageBoxViewModel& vmMessageBox)
-        {
-            if (!bDialogSeen)
-            {
-                // first dialog is warning we want to capture, second dialog is confirmation
-                bDialogSeen = true;
-                Assert::AreEqual(std::wstring(L"The achievement you have selected has not triggered, but you have selected 'Triggered at the wrong time'."), vmMessageBox.GetMessage());
-            }
-            return ra::ui::DialogResult::Yes;
-        });
-
-        vmBrokenAchievements.mockServer.HandleRequest<ra::api::SubmitTicket>([](const ra::api::SubmitTicket::Request&, ra::api::SubmitTicket::Response& response)
-        {
-            response.Result = ra::api::ApiResult::Success;
-            response.TicketsCreated = 1;
-            return true;
-        });
+        vmBrokenAchievements.Achievements().GetItemAt(2)->SetSelected(true);
 
         Assert::IsTrue(vmBrokenAchievements.Submit());
-        Assert::IsTrue(bDialogSeen);
+        Assert::IsFalse(vmBrokenAchievements.mockDesktop.WasDialogShown());
+
+        Assert::AreEqual(std::string("http://host/achievement/2/report-issue"),
+                         vmBrokenAchievements.mockDesktop.LastOpenedUrl());
     }
 
-    TEST_METHOD(TestSubmitTriggeredWrongTimeAsDidNotTriggerCancel)
+    TEST_METHOD(TestSubmitAchievementWithRichPresence)
     {
         BrokenAchievementsViewModelHarness vmBrokenAchievements;
         vmBrokenAchievements.MockAchievements();
-        vmBrokenAchievements.SetSelectedProblemId(2);
-        vmBrokenAchievements.SetDefaultComment();
-        vmBrokenAchievements.Achievements().GetItemAt(2)->SetSelected(true);
-
-        bool bDialogSeen = false;
-        vmBrokenAchievements.mockDesktop.ExpectWindow<MessageBoxViewModel>([&bDialogSeen](const MessageBoxViewModel& vmMessageBox)
-        {
-            bDialogSeen = true;
-            Assert::AreEqual(std::wstring(L"The achievement you have selected has triggered, but you have selected 'Did not trigger'."), vmMessageBox.GetMessage());
-            return ra::ui::DialogResult::No;
-        });
-
-        vmBrokenAchievements.mockServer.ExpectUncalled<ra::api::SubmitTicket>();
-
-        Assert::IsFalse(vmBrokenAchievements.Submit());
-        Assert::IsTrue(bDialogSeen);
-    }
-
-    TEST_METHOD(TestSubmitTriggeredWrongTimeAsDidNotTriggerProceed)
-    {
-        BrokenAchievementsViewModelHarness vmBrokenAchievements;
-        vmBrokenAchievements.MockAchievements();
-        vmBrokenAchievements.SetSelectedProblemId(2);
-        vmBrokenAchievements.SetDefaultComment();
-        vmBrokenAchievements.Achievements().GetItemAt(2)->SetSelected(true);
-
-        bool bDialogSeen = false;
-        vmBrokenAchievements.mockDesktop.ExpectWindow<MessageBoxViewModel>([&bDialogSeen](const MessageBoxViewModel& vmMessageBox)
-        {
-            if (!bDialogSeen)
-            {
-                // first dialog is warning we want to capture, second dialog is confirmation
-                bDialogSeen = true;
-                Assert::AreEqual(std::wstring(L"The achievement you have selected has triggered, but you have selected 'Did not trigger'."), vmMessageBox.GetMessage());
-            }
-            return ra::ui::DialogResult::Yes;
-        });
-
-        vmBrokenAchievements.mockServer.HandleRequest<ra::api::SubmitTicket>([](const ra::api::SubmitTicket::Request&, ra::api::SubmitTicket::Response& response)
-        {
-            response.Result = ra::api::ApiResult::Success;
-            response.TicketsCreated = 1;
-            return true;
-        });
-
-        Assert::IsTrue(vmBrokenAchievements.Submit());
-        Assert::IsTrue(bDialogSeen);
-    }
-
-    TEST_METHOD(TestSubmitTriggeredWrongTimeNoComment)
-    {
-        BrokenAchievementsViewModelHarness vmBrokenAchievements;
-        vmBrokenAchievements.MockAchievements();
-        vmBrokenAchievements.SetSelectedProblemId(1);
-        vmBrokenAchievements.Achievements().GetItemAt(2)->SetSelected(true);
-
-        bool bDialogSeen = false;
-        vmBrokenAchievements.mockDesktop.ExpectWindow<MessageBoxViewModel>([&bDialogSeen](const MessageBoxViewModel& vmMessageBox)
-        {
-            bDialogSeen = true;
-            Assert::AreEqual(std::wstring(L"Please describe when the achievement did trigger."), vmMessageBox.GetMessage());
-            return ra::ui::DialogResult::OK;
-        });
-
-        vmBrokenAchievements.mockServer.ExpectUncalled<ra::api::SubmitTicket>();
-
-        Assert::IsFalse(vmBrokenAchievements.Submit());
-        Assert::IsTrue(bDialogSeen);
-    }
-
-    TEST_METHOD(TestSubmitOneAchievementsCancel)
-    {
-        BrokenAchievementsViewModelHarness vmBrokenAchievements;
-        vmBrokenAchievements.MockAchievements();
-        vmBrokenAchievements.SetSelectedProblemId(1);
-        vmBrokenAchievements.SetDefaultComment();
-        vmBrokenAchievements.Achievements().GetItemAt(2)->SetSelected(true);
-
-        bool bDialogSeen = false;
-        vmBrokenAchievements.mockDesktop.ExpectWindow<MessageBoxViewModel>([&bDialogSeen](const MessageBoxViewModel& vmMessageBox)
-        {
-            bDialogSeen = true;
-
-            Assert::AreEqual(std::wstring(L"Are you sure that you want to create a triggered at the wrong time ticket for Title3?"), vmMessageBox.GetHeader());
-            Assert::AreEqual(std::wstring(L"Achievement ID: 3\nRetroAchievements Hash: HASH\nComment: The achievement failed to trigger when I jumped."), vmMessageBox.GetMessage());
-
-            return ra::ui::DialogResult::No;
-        });
-
-        vmBrokenAchievements.mockServer.ExpectUncalled<ra::api::SubmitTicket>();
-
-        Assert::IsFalse(vmBrokenAchievements.Submit());
-        Assert::IsTrue(bDialogSeen);
-    }
-
-    TEST_METHOD(TestSubmitMultipleAchievementsCancel)
-    {
-        BrokenAchievementsViewModelHarness vmBrokenAchievements;
-        vmBrokenAchievements.MockAchievements();
-        vmBrokenAchievements.SetSelectedProblemId(2);
-        vmBrokenAchievements.SetDefaultComment();
-        vmBrokenAchievements.Achievements().GetItemAt(2)->SetSelected(true);
-        vmBrokenAchievements.Achievements().GetItemAt(4)->SetSelected(true);
-
-        bool bDialogSeen = false;
-        vmBrokenAchievements.mockDesktop.ExpectWindow<MessageBoxViewModel>([&bDialogSeen](const MessageBoxViewModel& vmMessageBox)
-        {
-            bDialogSeen = true;
-
-            Assert::AreEqual(std::wstring(L"Are you sure that you want to create 2 did not trigger tickets for GAME?"), vmMessageBox.GetHeader());
-            Assert::AreEqual(std::wstring(L"Achievement IDs: 3,5\nRetroAchievements Hash: HASH\nComment: The achievement failed to trigger when I jumped."), vmMessageBox.GetMessage());
-
-            return ra::ui::DialogResult::No;
-        });
-
-        vmBrokenAchievements.mockServer.ExpectUncalled<ra::api::SubmitTicket>();
-
-        Assert::IsFalse(vmBrokenAchievements.Submit());
-        Assert::IsTrue(bDialogSeen);
-    }
-
-    TEST_METHOD(TestSubmitOneAchievement)
-    {
-        BrokenAchievementsViewModelHarness vmBrokenAchievements;
-        vmBrokenAchievements.MockAchievements();
-        vmBrokenAchievements.SetSelectedProblemId(1);
-        vmBrokenAchievements.Achievements().GetItemAt(2)->SetSelected(true);
-        vmBrokenAchievements.SetDefaultComment();
-
-        bool bDialogSeen = false;
-        vmBrokenAchievements.mockDesktop.ExpectWindow<MessageBoxViewModel>([&bDialogSeen](const MessageBoxViewModel& vmMessageBox)
-        {
-            if (vmMessageBox.GetButtons() == MessageBoxViewModel::Buttons::OK)
-            {
-                bDialogSeen = true;
-                Assert::AreEqual(std::wstring(L"1 ticket created"), vmMessageBox.GetHeader());
-                Assert::AreEqual(std::wstring(L"Thank you for reporting the issue. The development team will investigate and you will be notified when the ticket is updated or resolved."), vmMessageBox.GetMessage());
-                return ra::ui::DialogResult::OK;
-            }
-
-            return ra::ui::DialogResult::Yes;
-        });
-
-        vmBrokenAchievements.mockServer.HandleRequest<ra::api::SubmitTicket>([](const ra::api::SubmitTicket::Request& request, ra::api::SubmitTicket::Response& response)
-        {
-            Assert::AreEqual(1, ra::etoi(request.Problem));
-            Assert::AreEqual(std::string("HASH"), request.GameHash);
-            Assert::AreEqual(std::string("The achievement failed to trigger when I jumped."), request.Comment);
-            Assert::AreEqual({ 1U }, request.AchievementIds.size());
-            Assert::IsTrue(request.AchievementIds.find(3U) != request.AchievementIds.end());
-
-            response.Result = ra::api::ApiResult::Success;
-            response.TicketsCreated = 1;
-            return true;
-        });
-
-        Assert::IsTrue(vmBrokenAchievements.Submit());
-        Assert::IsTrue(bDialogSeen);
-    }
-
-    TEST_METHOD(TestSubmitMultipleAchievements)
-    {
-        BrokenAchievementsViewModelHarness vmBrokenAchievements;
-        vmBrokenAchievements.MockAchievements();
-        vmBrokenAchievements.SetSelectedProblemId(2);
-        vmBrokenAchievements.Achievements().GetItemAt(2)->SetSelected(true);
-        vmBrokenAchievements.Achievements().GetItemAt(4)->SetSelected(true);
-        vmBrokenAchievements.SetDefaultComment();
-
-        bool bDialogSeen = false;
-        vmBrokenAchievements.mockDesktop.ExpectWindow<MessageBoxViewModel>([&bDialogSeen](const MessageBoxViewModel& vmMessageBox)
-        {
-            if (vmMessageBox.GetButtons() == MessageBoxViewModel::Buttons::OK)
-            {
-                bDialogSeen = true;
-                Assert::AreEqual(std::wstring(L"2 tickets created"), vmMessageBox.GetHeader());
-                Assert::AreEqual(std::wstring(L"Thank you for reporting the issues. The development team will investigate and you will be notified when the tickets are updated or resolved."), vmMessageBox.GetMessage());
-                return ra::ui::DialogResult::OK;
-            }
-
-            return ra::ui::DialogResult::Yes;
-        });
-
-        vmBrokenAchievements.mockServer.HandleRequest<ra::api::SubmitTicket>([](const ra::api::SubmitTicket::Request& request, ra::api::SubmitTicket::Response& response)
-        {
-            Assert::AreEqual(2, ra::etoi(request.Problem));
-            Assert::AreEqual(std::string("HASH"), request.GameHash);
-            Assert::AreEqual(std::string("The achievement failed to trigger when I jumped."), request.Comment);
-            Assert::AreEqual({ 2U }, request.AchievementIds.size());
-            Assert::IsTrue(request.AchievementIds.find(3U) != request.AchievementIds.end());
-            Assert::IsTrue(request.AchievementIds.find(5U) != request.AchievementIds.end());
-
-            response.Result = ra::api::ApiResult::Success;
-            response.TicketsCreated = 2;
-            return true;
-        });
-
-        Assert::IsTrue(vmBrokenAchievements.Submit());
-        Assert::IsTrue(bDialogSeen);
-    }
-
-    TEST_METHOD(TestSubmitMultipleAchievementsDidNotTriggerLimit)
-    {
-        BrokenAchievementsViewModelHarness vmBrokenAchievements;
-        vmBrokenAchievements.MockAchievements();
-        vmBrokenAchievements.SetSelectedProblemId(2);
         vmBrokenAchievements.Achievements().GetItemAt(0)->SetSelected(true);
-        vmBrokenAchievements.Achievements().GetItemAt(1)->SetSelected(true);
-        vmBrokenAchievements.Achievements().GetItemAt(2)->SetSelected(true);
-        vmBrokenAchievements.Achievements().GetItemAt(3)->SetSelected(true);
-        vmBrokenAchievements.Achievements().GetItemAt(4)->SetSelected(true);
-        vmBrokenAchievements.Achievements().GetItemAt(5)->SetSelected(true);
-        vmBrokenAchievements.SetDefaultComment();
-
-        bool bDialogSeen = false;
-        vmBrokenAchievements.mockDesktop.ExpectWindow<MessageBoxViewModel>(
-            [&bDialogSeen](const MessageBoxViewModel& vmMessageBox) {
-                bDialogSeen = true;
-                Assert::AreEqual(std::wstring(L"Too many achievements selected."), vmMessageBox.GetHeader());
-                Assert::AreEqual(std::wstring(L"You cannot report more than 5 achievements at a time for not triggering. Please provide separate details for each achievement that did not trigger for you."), vmMessageBox.GetMessage());
-                return ra::ui::DialogResult::OK;
-            });
-
-        vmBrokenAchievements.mockServer.ExpectUncalled<ra::api::SubmitTicket>();
-
-        Assert::IsFalse(vmBrokenAchievements.Submit());
-        Assert::IsTrue(bDialogSeen);
-    }
-
-    TEST_METHOD(TestSubmitMultipleAchievementsWrongTimeNoLimit)
-    {
-        BrokenAchievementsViewModelHarness vmBrokenAchievements;
-        vmBrokenAchievements.MockAchievements();
-        vmBrokenAchievements.SetSelectedProblemId(1);
-        vmBrokenAchievements.Achievements().GetItemAt(0)->SetSelected(true);
-        vmBrokenAchievements.Achievements().GetItemAt(1)->SetSelected(true);
-        vmBrokenAchievements.Achievements().GetItemAt(2)->SetSelected(true);
-        vmBrokenAchievements.Achievements().GetItemAt(3)->SetSelected(true);
-        vmBrokenAchievements.Achievements().GetItemAt(4)->SetSelected(true);
-        vmBrokenAchievements.Achievements().GetItemAt(5)->SetSelected(true);
-        vmBrokenAchievements.SetDefaultComment();
-
-        bool bDialogSeen = false;
-        vmBrokenAchievements.mockDesktop.ExpectWindow<MessageBoxViewModel>([&bDialogSeen](const MessageBoxViewModel& vmMessageBox)
-        {
-            if (vmMessageBox.GetButtons() == MessageBoxViewModel::Buttons::OK)
-            {
-                bDialogSeen = true;
-                Assert::AreEqual(std::wstring(L"6 tickets created"), vmMessageBox.GetHeader());
-                return ra::ui::DialogResult::OK;
-            }
-
-            return ra::ui::DialogResult::Yes;
-        });
-
-        vmBrokenAchievements.mockServer.HandleRequest<ra::api::SubmitTicket>([](const ra::api::SubmitTicket::Request& request, ra::api::SubmitTicket::Response& response)
-        {
-            Assert::AreEqual(1, ra::etoi(request.Problem));
-            Assert::AreEqual({ 6U }, request.AchievementIds.size());
-
-            response.Result = ra::api::ApiResult::Success;
-            response.TicketsCreated = 6;
-            return true;
-        });
-
-        Assert::IsTrue(vmBrokenAchievements.Submit());
-        Assert::IsTrue(bDialogSeen);
-    }
-
-    TEST_METHOD(TestSubmitOneAchievementFailed)
-    {
-        BrokenAchievementsViewModelHarness vmBrokenAchievements;
-        vmBrokenAchievements.MockAchievements();
-        vmBrokenAchievements.SetSelectedProblemId(2);
-        vmBrokenAchievements.Achievements().GetItemAt(2)->SetSelected(true);
-        vmBrokenAchievements.Achievements().GetItemAt(4)->SetSelected(true);
-        vmBrokenAchievements.SetDefaultComment();
-
-
-        bool bDialogSeen = false;
-        vmBrokenAchievements.mockDesktop.ExpectWindow<MessageBoxViewModel>([&bDialogSeen](const MessageBoxViewModel& vmMessageBox)
-        {
-            if (vmMessageBox.GetButtons() == MessageBoxViewModel::Buttons::OK)
-            {
-                bDialogSeen = true;
-                Assert::AreEqual(std::wstring(L"Failed to submit tickets"), vmMessageBox.GetHeader());
-                Assert::AreEqual(std::wstring(L"API ERROR 3"), vmMessageBox.GetMessage());
-                return ra::ui::DialogResult::OK;
-            }
-
-            return ra::ui::DialogResult::Yes;
-        });
-
-        vmBrokenAchievements.mockServer.HandleRequest<ra::api::SubmitTicket>([](const ra::api::SubmitTicket::Request&, ra::api::SubmitTicket::Response& response)
-        {
-            response.Result = ra::api::ApiResult::Error;
-            response.ErrorMessage = "API ERROR 3";
-            return true;
-        });
-
-        Assert::IsFalse(vmBrokenAchievements.Submit());
-        Assert::IsTrue(bDialogSeen);
-    }
-
-    TEST_METHOD(TestSubmitOneAchievementWithRichPresence)
-    {
-        BrokenAchievementsViewModelHarness vmBrokenAchievements;
-        vmBrokenAchievements.MockAchievements();
-        vmBrokenAchievements.SetSelectedProblemId(1);
-        vmBrokenAchievements.Achievements().GetItemAt(0)->SetSelected(true);
-        vmBrokenAchievements.SetDefaultComment();
 
         vmBrokenAchievements.mockGameContext.Assets().FindAchievement(1U)->SetUnlockRichPresence(L"Nowhere, 2 Lives");
 
-        vmBrokenAchievements.mockDesktop.ExpectWindow<MessageBoxViewModel>([](const MessageBoxViewModel& vmMessageBox)
-        {
-            if (vmMessageBox.GetButtons() == MessageBoxViewModel::Buttons::OK)
-                return ra::ui::DialogResult::OK;
-            return ra::ui::DialogResult::Yes;
-        });
-
-        vmBrokenAchievements.mockServer.HandleRequest<ra::api::SubmitTicket>([](const ra::api::SubmitTicket::Request& request, ra::api::SubmitTicket::Response& response)
-        {
-            Assert::AreEqual(1, ra::etoi(request.Problem));
-            Assert::AreEqual(std::string("HASH"), request.GameHash);
-            Assert::AreEqual(std::string("The achievement failed to trigger when I jumped.\n\nRich Presence at time of trigger:\nNowhere, 2 Lives"), request.Comment);
-            Assert::AreEqual({ 1U }, request.AchievementIds.size());
-
-            response.Result = ra::api::ApiResult::Success;
-            response.TicketsCreated = 1;
-            return true;
-        });
-
         Assert::IsTrue(vmBrokenAchievements.Submit());
+        Assert::IsFalse(vmBrokenAchievements.mockDesktop.WasDialogShown());
+
+        Assert::AreEqual(std::string("http://host/achievement/2/report-issue?extra=eyJ0cmlnZ2VyUmljaFByZXNlbmNlIjoiTm93aGVyZSwgMiBMaXZlcyJ9"),
+                         vmBrokenAchievements.mockDesktop.LastOpenedUrl());
     }
 
-    TEST_METHOD(TestSubmitMultipleAchievementsWithSameRichPresence)
+    TEST_METHOD(TestMultiSelect)
     {
         BrokenAchievementsViewModelHarness vmBrokenAchievements;
         vmBrokenAchievements.MockAchievements();
-        vmBrokenAchievements.SetSelectedProblemId(1);
-        vmBrokenAchievements.Achievements().GetItemAt(0)->SetSelected(true);
+
+        Assert::AreEqual(-1, vmBrokenAchievements.GetSelectedIndex());
+
         vmBrokenAchievements.Achievements().GetItemAt(2)->SetSelected(true);
-        vmBrokenAchievements.SetDefaultComment();
+        Assert::AreEqual(2, vmBrokenAchievements.GetSelectedIndex());
 
-        vmBrokenAchievements.mockGameContext.Assets().FindAchievement(1U)->SetUnlockRichPresence(L"Nowhere, 2 Lives");
-        vmBrokenAchievements.mockGameContext.Assets().FindAchievement(3U)->SetUnlockRichPresence(L"Nowhere, 2 Lives");
+        vmBrokenAchievements.Achievements().GetItemAt(4)->SetSelected(true);
+        Assert::AreEqual(4, vmBrokenAchievements.GetSelectedIndex());
 
-        vmBrokenAchievements.mockDesktop.ExpectWindow<MessageBoxViewModel>([](const MessageBoxViewModel& vmMessageBox)
-        {
-            if (vmMessageBox.GetButtons() == MessageBoxViewModel::Buttons::OK)
-                return ra::ui::DialogResult::OK;
-            return ra::ui::DialogResult::Yes;
-        });
-
-        vmBrokenAchievements.mockServer.HandleRequest<ra::api::SubmitTicket>([](const ra::api::SubmitTicket::Request& request, ra::api::SubmitTicket::Response& response)
-        {
-            Assert::AreEqual(1, ra::etoi(request.Problem));
-            Assert::AreEqual(std::string("HASH"), request.GameHash);
-            Assert::AreEqual(std::string("The achievement failed to trigger when I jumped.\n\nRich Presence at time of trigger:\nNowhere, 2 Lives"), request.Comment);
-            Assert::AreEqual({ 2U }, request.AchievementIds.size());
-
-            response.Result = ra::api::ApiResult::Success;
-            response.TicketsCreated = 2;
-            return true;
-        });
-
-        Assert::IsTrue(vmBrokenAchievements.Submit());
-    }
-
-    TEST_METHOD(TestSubmitMultipleAchievementsWithDifferingRichPresence)
-    {
-        BrokenAchievementsViewModelHarness vmBrokenAchievements;
-        vmBrokenAchievements.MockAchievements();
-        vmBrokenAchievements.SetSelectedProblemId(1);
-        vmBrokenAchievements.Achievements().GetItemAt(0)->SetSelected(true);
-        vmBrokenAchievements.Achievements().GetItemAt(2)->SetSelected(true);
-        vmBrokenAchievements.SetDefaultComment();
-
-        vmBrokenAchievements.mockGameContext.Assets().FindAchievement(1U)->SetUnlockRichPresence(L"Nowhere, 2 Lives");
-        vmBrokenAchievements.mockGameContext.Assets().FindAchievement(3U)->SetUnlockRichPresence(L"Somewhere, 2 Lives");
-
-        vmBrokenAchievements.mockDesktop.ExpectWindow<MessageBoxViewModel>([](const MessageBoxViewModel& vmMessageBox)
-        {
-            if (vmMessageBox.GetButtons() == MessageBoxViewModel::Buttons::OK)
-                return ra::ui::DialogResult::OK;
-            return ra::ui::DialogResult::Yes;
-        });
-
-        vmBrokenAchievements.mockServer.HandleRequest<ra::api::SubmitTicket>([](const ra::api::SubmitTicket::Request& request, ra::api::SubmitTicket::Response& response)
-        {
-            Assert::AreEqual(1, ra::etoi(request.Problem));
-            Assert::AreEqual(std::string("HASH"), request.GameHash);
-            Assert::AreEqual(std::string("The achievement failed to trigger when I jumped.\n\nRich Presence at time of trigger:\n1: Nowhere, 2 Lives\n3: Somewhere, 2 Lives"), request.Comment);
-            Assert::AreEqual({ 2U }, request.AchievementIds.size());
-
-            response.Result = ra::api::ApiResult::Success;
-            response.TicketsCreated = 2;
-            return true;
-        });
-
-        Assert::IsTrue(vmBrokenAchievements.Submit());
-    }
-
-    TEST_METHOD(TestAutoSelectProblemType)
-    {
-        BrokenAchievementsViewModelHarness vmBrokenAchievements;
-        vmBrokenAchievements.MockAchievements();
-
-        Assert::AreEqual(0, vmBrokenAchievements.GetSelectedProblemId());
-
-        // a non-active achievement has been triggered, set problem type to WrongTime
-        vmBrokenAchievements.Achievements().GetItemAt(0)->SetSelected(true);
-        Assert::AreEqual(ra::etoi(ra::api::SubmitTicket::ProblemType::WrongTime), vmBrokenAchievements.GetSelectedProblemId());
-
-        // when nothing is selected, problem type should be reset
-        vmBrokenAchievements.Achievements().GetItemAt(0)->SetSelected(false);
-        Assert::AreEqual(0, vmBrokenAchievements.GetSelectedProblemId());
-
-        // an active achievement has not been triggered, set problem type to DidNotTrigger
-        vmBrokenAchievements.Achievements().GetItemAt(1)->SetSelected(true);
-        Assert::AreEqual(ra::etoi(ra::api::SubmitTicket::ProblemType::DidNotTrigger), vmBrokenAchievements.GetSelectedProblemId());
-
-        // don't change problem type if it's already set
-        vmBrokenAchievements.Achievements().GetItemAt(0)->SetSelected(true);
-        Assert::AreEqual(ra::etoi(ra::api::SubmitTicket::ProblemType::DidNotTrigger), vmBrokenAchievements.GetSelectedProblemId());
-
-        // don't reset problem type if anything is still selected
-        vmBrokenAchievements.Achievements().GetItemAt(1)->SetSelected(false);
-        Assert::AreEqual(ra::etoi(ra::api::SubmitTicket::ProblemType::DidNotTrigger), vmBrokenAchievements.GetSelectedProblemId());
-
-        // do reset problem type after everything is deselected
-        vmBrokenAchievements.Achievements().GetItemAt(0)->SetSelected(false);
-        Assert::AreEqual(0, vmBrokenAchievements.GetSelectedProblemId());
-    }
-
-    TEST_METHOD(TestSubmitNoComment)
-    {
-        BrokenAchievementsViewModelHarness vmBrokenAchievements;
-        vmBrokenAchievements.MockAchievements();
-        vmBrokenAchievements.SetSelectedProblemId(2);
-        vmBrokenAchievements.Achievements().GetItemAt(1)->SetSelected(true);
-
-        bool bDialogSeen = false;
-        vmBrokenAchievements.mockDesktop.ExpectWindow<MessageBoxViewModel>([&bDialogSeen](const MessageBoxViewModel& vmMessageBox)
-        {
-            bDialogSeen = true;
-
-            Assert::AreEqual(std::wstring(L"Please be more specific."), vmMessageBox.GetHeader());
-            Assert::AreEqual(std::wstring(L"Any information that you can provide to help the developer reproduce the issue will make it easier to fix."), vmMessageBox.GetMessage());
-            return ra::ui::DialogResult::OK;
-        });
-
-        vmBrokenAchievements.mockServer.ExpectUncalled<ra::api::SubmitTicket>();
-
-        Assert::IsFalse(vmBrokenAchievements.Submit());
-        Assert::IsTrue(bDialogSeen);
+        Assert::IsFalse(vmBrokenAchievements.Achievements().GetItemAt(2)->IsSelected());
     }
 };
 

--- a/tests/ui/viewmodels/BrokenAchievementsViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/BrokenAchievementsViewModel_Tests.cpp
@@ -3,6 +3,7 @@
 #include "ui\viewmodels\BrokenAchievementsViewModel.hh"
 
 #include "tests\ui\UIAsserts.hh"
+#include "tests\mocks\MockConfiguration.hh"
 #include "tests\mocks\MockDesktop.hh"
 #include "tests\mocks\MockGameContext.hh"
 #include "tests\mocks\MockThreadPool.hh"
@@ -24,6 +25,7 @@ private:
     {
     public:
         ra::data::context::mocks::MockGameContext mockGameContext;
+        ra::services::mocks::MockConfiguration mockConfiguration;
         ra::services::mocks::MockThreadPool mockThreadPool; // needed by asset list
         ra::ui::mocks::MockDesktop mockDesktop;
         ra::ui::viewmodels::mocks::MockWindowManager mockWindowManager;
@@ -31,6 +33,7 @@ private:
         BrokenAchievementsViewModelHarness() noexcept
         {
             GSL_SUPPRESS_F6 mockWindowManager.AssetList.InitializeNotifyTargets();
+            mockConfiguration.SetHostUrl("http://host");
         }
 
         void MockAchievements()
@@ -185,7 +188,7 @@ public:
         Assert::IsTrue(vmBrokenAchievements.Submit());
         Assert::IsFalse(vmBrokenAchievements.mockDesktop.WasDialogShown());
 
-        Assert::AreEqual(std::string("http://host/achievement/2/report-issue"),
+        Assert::AreEqual(std::string("http://host/achievement/3/report-issue"),
                          vmBrokenAchievements.mockDesktop.LastOpenedUrl());
     }
 
@@ -200,7 +203,7 @@ public:
         Assert::IsTrue(vmBrokenAchievements.Submit());
         Assert::IsFalse(vmBrokenAchievements.mockDesktop.WasDialogShown());
 
-        Assert::AreEqual(std::string("http://host/achievement/2/report-issue?extra=eyJ0cmlnZ2VyUmljaFByZXNlbmNlIjoiTm93aGVyZSwgMiBMaXZlcyJ9"),
+        Assert::AreEqual(std::string("http://host/achievement/1/report-issue?extra=eyJ0cmlnZ2VyUmljaFByZXNlbmNlIjoiTm93aGVyZSwgMiBMaXZlcyJ9"),
                          vmBrokenAchievements.mockDesktop.LastOpenedUrl());
     }
 


### PR DESCRIPTION
Replaces the report issue dialog with a simple list. The user can select a single achievement from the list, and clicking on the Report Issue button will take them to the report issue page on the server, where they can create a ticket, or submit a request for a manual unlock or a grammatical fix or anything else that's been integrated into the server ticket creation flow.

![image](https://github.com/user-attachments/assets/f99732fb-3b1f-4f6a-ab97-e7fb9f652e90)
