### PR TITLE
Fix bug where modifying conditions improperly hide the target value cell.

### DIFF
--- a/src/ui/viewmodels/TriggerConditionViewModel.cpp
+++ b/src/ui/viewmodels/TriggerConditionViewModel.cpp
@@ -513,9 +513,7 @@ void TriggerConditionViewModel::OnValueChanged(const IntModelProperty::ChangeArg
     }
     else if (args.Property == OperatorProperty)
     {
-        const auto nCurrentType = ra::itoe<TriggerOperandType>(GetValue(TargetTypeProperty));
         SetValue(HasTargetProperty, ra::itoe<TriggerOperatorType>(args.tNewValue) != TriggerOperatorType::None);
-        SetValue(HasTargetValueProperty, !IsParameterlessType(nCurrentType) && GetValue(HasTargetProperty));
         UpdateHasHits();
     }
     else if (args.Property == TypeProperty)
@@ -583,7 +581,11 @@ void TriggerConditionViewModel::UpdateHasHits()
 void TriggerConditionViewModel::OnValueChanged(const BoolModelProperty::ChangeArgs& args)
 {
     if (args.Property == HasTargetProperty)
+    {
+        const auto nTargetType = GetTargetType();
         SetValue(HasTargetSizeProperty, args.tNewValue && IsAddressType(GetTargetType()));
+        SetValue(HasTargetValueProperty, args.tNewValue && !IsParameterlessType(nTargetType));
+    }
 
     ViewModelBase::OnValueChanged(args);
 }

--- a/src/ui/viewmodels/TriggerConditionViewModel.cpp
+++ b/src/ui/viewmodels/TriggerConditionViewModel.cpp
@@ -583,7 +583,7 @@ void TriggerConditionViewModel::OnValueChanged(const BoolModelProperty::ChangeAr
     if (args.Property == HasTargetProperty)
     {
         const auto nTargetType = GetTargetType();
-        SetValue(HasTargetSizeProperty, args.tNewValue && IsAddressType(GetTargetType()));
+        SetValue(HasTargetSizeProperty, args.tNewValue && IsAddressType(nTargetType));
         SetValue(HasTargetValueProperty, args.tNewValue && !IsParameterlessType(nTargetType));
     }
 

--- a/src/ui/viewmodels/TriggerConditionViewModel.cpp
+++ b/src/ui/viewmodels/TriggerConditionViewModel.cpp
@@ -513,7 +513,9 @@ void TriggerConditionViewModel::OnValueChanged(const IntModelProperty::ChangeArg
     }
     else if (args.Property == OperatorProperty)
     {
+        const auto nCurrentType = ra::itoe<TriggerOperandType>(GetValue(TargetTypeProperty));
         SetValue(HasTargetProperty, ra::itoe<TriggerOperatorType>(args.tNewValue) != TriggerOperatorType::None);
+        SetValue(HasTargetValueProperty, !IsParameterlessType(nCurrentType) && GetValue(HasTargetProperty));
         UpdateHasHits();
     }
     else if (args.Property == TypeProperty)

--- a/tests/ui/viewmodels/TriggerConditionViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/TriggerConditionViewModel_Tests.cpp
@@ -365,6 +365,15 @@ public:
         Assert::AreEqual(MemSize::ThirtyTwoBit, vmCondition.GetTargetSize());
     }
 
+    TEST_METHOD(TestModifyingConditionUpdatesHasTargetValue)
+    {
+        TriggerConditionViewModelHarness vmCondition;
+        vmCondition.SetType(TriggerConditionType::AddSource);
+        Assert::IsFalse(vmCondition.HasTargetValue());
+        vmCondition.SetOperator(TriggerOperatorType::Divide);
+        Assert::IsTrue(vmCondition.HasTargetValue());
+    }
+
     TEST_METHOD(TestHasTargetSizeHasTarget)
     {
         TriggerConditionViewModelHarness vmCondition;


### PR DESCRIPTION
Selecting a modifying condition like Add Source, the Target Value will be hidden when you first change the operator away form 'None', until you change the Target Type.  This was especially noticeable when pasting in something like Add Source Mem 0x1234 / Mem 0x1234, but also evident if you just created a new condition and immediately changed the flag to Add Source, followed by setting the operator.

OnValueChanged handler is updated to re-evaluate the HasTargetValuePropertly when the operator is changed.