### PR TITLE
separate Pointer Finder from windows associated to Open All

### DIFF
--- a/src/ui/viewmodels/IntegrationMenuViewModel.cpp
+++ b/src/ui/viewmodels/IntegrationMenuViewModel.cpp
@@ -80,9 +80,10 @@ void IntegrationMenuViewModel::AddCommonMenuItems(LookupItemViewModelCollection&
     vmMenu.Add(IDM_RA_FILES_ACHIEVEMENTEDITOR, L"Assets &Editor");
     vmMenu.Add(IDM_RA_FILES_MEMORYFINDER, L"&Memory Inspector");
     vmMenu.Add(IDM_RA_FILES_MEMORYBOOKMARKS, L"Memory &Bookmarks");
-    vmMenu.Add(IDM_RA_FILES_POINTERFINDER, L"Pointer &Finder");
     vmMenu.Add(IDM_RA_FILES_CODENOTES, L"Code &Notes");
     vmMenu.Add(IDM_RA_PARSERICHPRESENCE, L"Rich &Presence Monitor");
+    vmMenu.Add(0, L"-----");
+    vmMenu.Add(IDM_RA_FILES_POINTERFINDER, L"Pointer &Finder");
 }
 
 void IntegrationMenuViewModel::ActivateMenuItem(int nMenuItemId)

--- a/tests/Exports_Tests.cpp
+++ b/tests/Exports_Tests.cpp
@@ -469,7 +469,7 @@ private:
         ra::data::context::mocks::MockUserContext mockUserContext;
 
         RA_MenuItem menu[32];
-        Assert::AreEqual(16, _RA_GetPopupMenuItems(menu));
+        Assert::AreEqual(17, _RA_GetPopupMenuItems(menu));
         AssertMenuItem(&menu[0], IDM_RA_FILES_LOGIN, L"&Login");
         AssertMenuItem(&menu[1], 0, nullptr);
         AssertMenuItem(&menu[2], IDM_RA_HARDCORE_MODE, L"&Hardcore Mode");
@@ -483,9 +483,10 @@ private:
         AssertMenuItem(&menu[10], IDM_RA_FILES_ACHIEVEMENTEDITOR, L"Assets &Editor");
         AssertMenuItem(&menu[11], IDM_RA_FILES_MEMORYFINDER, L"&Memory Inspector");
         AssertMenuItem(&menu[12], IDM_RA_FILES_MEMORYBOOKMARKS, L"Memory &Bookmarks");
-        AssertMenuItem(&menu[13], IDM_RA_FILES_POINTERFINDER, L"Pointer &Finder");
-        AssertMenuItem(&menu[14], IDM_RA_FILES_CODENOTES, L"Code &Notes");
-        AssertMenuItem(&menu[15], IDM_RA_PARSERICHPRESENCE, L"Rich &Presence Monitor");
+        AssertMenuItem(&menu[13], IDM_RA_FILES_CODENOTES, L"Code &Notes");
+        AssertMenuItem(&menu[14], IDM_RA_PARSERICHPRESENCE, L"Rich &Presence Monitor");
+        AssertMenuItem(&menu[15], 0, nullptr);
+        AssertMenuItem(&menu[16], IDM_RA_FILES_POINTERFINDER, L"Pointer &Finder");
     }
 
     TEST_METHOD(TestGetPopupMenuItemsLoggedIn)
@@ -495,7 +496,7 @@ private:
         mockUserContext.Initialize("User", "TOKEN");
 
         RA_MenuItem menu[32];
-        Assert::AreEqual(22, _RA_GetPopupMenuItems(menu));
+        Assert::AreEqual(23, _RA_GetPopupMenuItems(menu));
         AssertMenuItem(&menu[0], IDM_RA_FILES_LOGOUT, L"Log&out");
         AssertMenuItem(&menu[1], 0, nullptr);
         AssertMenuItem(&menu[2], IDM_RA_OPENUSERPAGE, L"Open my &User Page");
@@ -512,12 +513,13 @@ private:
         AssertMenuItem(&menu[13], IDM_RA_FILES_ACHIEVEMENTEDITOR, L"Assets &Editor");
         AssertMenuItem(&menu[14], IDM_RA_FILES_MEMORYFINDER, L"&Memory Inspector");
         AssertMenuItem(&menu[15], IDM_RA_FILES_MEMORYBOOKMARKS, L"Memory &Bookmarks");
-        AssertMenuItem(&menu[16], IDM_RA_FILES_POINTERFINDER, L"Pointer &Finder");
-        AssertMenuItem(&menu[17], IDM_RA_FILES_CODENOTES, L"Code &Notes");
-        AssertMenuItem(&menu[18], IDM_RA_PARSERICHPRESENCE, L"Rich &Presence Monitor");
-        AssertMenuItem(&menu[19], 0, nullptr);
-        AssertMenuItem(&menu[20], IDM_RA_REPORTBROKENACHIEVEMENTS, L"&Report Achievement Problem");
-        AssertMenuItem(&menu[21], IDM_RA_GETROMCHECKSUM, L"View Game H&ash");
+        AssertMenuItem(&menu[16], IDM_RA_FILES_CODENOTES, L"Code &Notes");
+        AssertMenuItem(&menu[17], IDM_RA_PARSERICHPRESENCE, L"Rich &Presence Monitor");
+        AssertMenuItem(&menu[18], 0, nullptr);
+        AssertMenuItem(&menu[19], IDM_RA_FILES_POINTERFINDER, L"Pointer &Finder");
+        AssertMenuItem(&menu[20], 0, nullptr);
+        AssertMenuItem(&menu[21], IDM_RA_REPORTBROKENACHIEVEMENTS, L"&Report Achievement Problem");
+        AssertMenuItem(&menu[22], IDM_RA_GETROMCHECKSUM, L"View Game H&ash");
     }
 
     TEST_METHOD(TestGetPopupMenuItemsChecked)
@@ -530,7 +532,7 @@ private:
         mockConfiguration.SetFeatureEnabled(ra::services::Feature::Leaderboards, true);
 
         RA_MenuItem menu[32];
-        Assert::AreEqual(22, _RA_GetPopupMenuItems(menu));
+        Assert::AreEqual(23, _RA_GetPopupMenuItems(menu));
         AssertMenuItem(&menu[0], IDM_RA_FILES_LOGOUT, L"Log&out");
         AssertMenuItem(&menu[1], 0, nullptr);
         AssertMenuItem(&menu[2], IDM_RA_OPENUSERPAGE, L"Open my &User Page");
@@ -547,12 +549,13 @@ private:
         AssertMenuItem(&menu[13], IDM_RA_FILES_ACHIEVEMENTEDITOR, L"Assets &Editor");
         AssertMenuItem(&menu[14], IDM_RA_FILES_MEMORYFINDER, L"&Memory Inspector");
         AssertMenuItem(&menu[15], IDM_RA_FILES_MEMORYBOOKMARKS, L"Memory &Bookmarks");
-        AssertMenuItem(&menu[16], IDM_RA_FILES_POINTERFINDER, L"Pointer &Finder");
-        AssertMenuItem(&menu[17], IDM_RA_FILES_CODENOTES, L"Code &Notes");
-        AssertMenuItem(&menu[18], IDM_RA_PARSERICHPRESENCE, L"Rich &Presence Monitor");
-        AssertMenuItem(&menu[19], 0, nullptr);
-        AssertMenuItem(&menu[20], IDM_RA_REPORTBROKENACHIEVEMENTS, L"&Report Achievement Problem");
-        AssertMenuItem(&menu[21], IDM_RA_GETROMCHECKSUM, L"View Game H&ash");
+        AssertMenuItem(&menu[16], IDM_RA_FILES_CODENOTES, L"Code &Notes");
+        AssertMenuItem(&menu[17], IDM_RA_PARSERICHPRESENCE, L"Rich &Presence Monitor");
+        AssertMenuItem(&menu[18], 0, nullptr);
+        AssertMenuItem(&menu[19], IDM_RA_FILES_POINTERFINDER, L"Pointer &Finder");
+        AssertMenuItem(&menu[20], 0, nullptr);
+        AssertMenuItem(&menu[21], IDM_RA_REPORTBROKENACHIEVEMENTS, L"&Report Achievement Problem");
+        AssertMenuItem(&menu[22], IDM_RA_GETROMCHECKSUM, L"View Game H&ash");
     }
 
     TEST_METHOD(TestUpdateAppTitle)

--- a/tests/services/AchievementRuntimeExports_Tests.cpp
+++ b/tests/services/AchievementRuntimeExports_Tests.cpp
@@ -312,7 +312,7 @@ public:
         const rc_client_raintegration_menu_t* pMenu;
 
         pMenu = _Rcheevos_RAIntegrationGetMenu();
-        Assert::AreEqual(11U, pMenu->num_items);
+        Assert::AreEqual(12U, pMenu->num_items);
         AssertMenuItem(pMenu, 0, IDM_RA_HARDCORE_MODE, "&Hardcore Mode");
         AssertMenuItem(pMenu, 1, IDM_RA_NON_HARDCORE_WARNING, "Non-Hardcore &Warning");
         AssertMenuSeparator(pMenu, 2);
@@ -321,16 +321,17 @@ public:
         AssertMenuItem(pMenu, 5, IDM_RA_FILES_ACHIEVEMENTEDITOR, "Assets &Editor");
         AssertMenuItem(pMenu, 6, IDM_RA_FILES_MEMORYFINDER, "&Memory Inspector");
         AssertMenuItem(pMenu, 7, IDM_RA_FILES_MEMORYBOOKMARKS, "Memory &Bookmarks");
-        AssertMenuItem(pMenu, 8, IDM_RA_FILES_POINTERFINDER, "Pointer &Finder");
-        AssertMenuItem(pMenu, 9, IDM_RA_FILES_CODENOTES, "Code &Notes");
-        AssertMenuItem(pMenu, 10, IDM_RA_PARSERICHPRESENCE, "Rich &Presence Monitor");
+        AssertMenuItem(pMenu, 8, IDM_RA_FILES_CODENOTES, "Code &Notes");
+        AssertMenuItem(pMenu, 9, IDM_RA_PARSERICHPRESENCE, "Rich &Presence Monitor");
+        AssertMenuSeparator(pMenu, 10);
+        AssertMenuItem(pMenu, 11, IDM_RA_FILES_POINTERFINDER, "Pointer &Finder");
 
         runtime.mockUserContext.Initialize("User", "ApiToken");
         runtime.AssertMenuChangedEventSeen();
         runtime.ResetSeenEvents();
 
         pMenu = _Rcheevos_RAIntegrationGetMenu();
-        Assert::AreEqual(17U, pMenu->num_items);
+        Assert::AreEqual(18U, pMenu->num_items);
         AssertMenuItem(pMenu, 0, IDM_RA_OPENUSERPAGE, "Open my &User Page");
         AssertMenuItem(pMenu, 1, IDM_RA_OPENGAMEPAGE, "Open this &Game's Page");
         AssertMenuSeparator(pMenu, 2);
@@ -342,18 +343,19 @@ public:
         AssertMenuItem(pMenu, 8, IDM_RA_FILES_ACHIEVEMENTEDITOR, "Assets &Editor");
         AssertMenuItem(pMenu, 9, IDM_RA_FILES_MEMORYFINDER, "&Memory Inspector");
         AssertMenuItem(pMenu, 10, IDM_RA_FILES_MEMORYBOOKMARKS, "Memory &Bookmarks");
-        AssertMenuItem(pMenu, 11, IDM_RA_FILES_POINTERFINDER, "Pointer &Finder");
-        AssertMenuItem(pMenu, 12, IDM_RA_FILES_CODENOTES, "Code &Notes");
-        AssertMenuItem(pMenu, 13, IDM_RA_PARSERICHPRESENCE, "Rich &Presence Monitor");
-        AssertMenuSeparator(pMenu, 14);
-        AssertMenuItem(pMenu, 15, IDM_RA_REPORTBROKENACHIEVEMENTS, "&Report Achievement Problem");
-        AssertMenuItem(pMenu, 16, IDM_RA_GETROMCHECKSUM, "View Game H&ash");
+        AssertMenuItem(pMenu, 11, IDM_RA_FILES_CODENOTES, "Code &Notes");
+        AssertMenuItem(pMenu, 12, IDM_RA_PARSERICHPRESENCE, "Rich &Presence Monitor");
+        AssertMenuSeparator(pMenu, 13);
+        AssertMenuItem(pMenu, 14, IDM_RA_FILES_POINTERFINDER, "Pointer &Finder");
+        AssertMenuSeparator(pMenu, 15);
+        AssertMenuItem(pMenu, 16, IDM_RA_REPORTBROKENACHIEVEMENTS, "&Report Achievement Problem");
+        AssertMenuItem(pMenu, 17, IDM_RA_GETROMCHECKSUM, "View Game H&ash");
 
         runtime.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, true);
         runtime.mockConfiguration.SetFeatureEnabled(ra::services::Feature::NonHardcoreWarning, true);
 
         pMenu = _Rcheevos_RAIntegrationGetMenu();
-        Assert::AreEqual(17U, pMenu->num_items);
+        Assert::AreEqual(18U, pMenu->num_items);
         AssertMenuItem(pMenu, 0, IDM_RA_OPENUSERPAGE, "Open my &User Page");
         AssertMenuItem(pMenu, 1, IDM_RA_OPENGAMEPAGE, "Open this &Game's Page");
         AssertMenuSeparator(pMenu, 2);
@@ -365,12 +367,13 @@ public:
         AssertMenuItem(pMenu, 8, IDM_RA_FILES_ACHIEVEMENTEDITOR, "Assets &Editor");
         AssertMenuItem(pMenu, 9, IDM_RA_FILES_MEMORYFINDER, "&Memory Inspector");
         AssertMenuItem(pMenu, 10, IDM_RA_FILES_MEMORYBOOKMARKS, "Memory &Bookmarks");
-        AssertMenuItem(pMenu, 11, IDM_RA_FILES_POINTERFINDER, "Pointer &Finder");
-        AssertMenuItem(pMenu, 12, IDM_RA_FILES_CODENOTES, "Code &Notes");
-        AssertMenuItem(pMenu, 13, IDM_RA_PARSERICHPRESENCE, "Rich &Presence Monitor");
-        AssertMenuSeparator(pMenu, 14);
-        AssertMenuItem(pMenu, 15, IDM_RA_REPORTBROKENACHIEVEMENTS, "&Report Achievement Problem");
-        AssertMenuItem(pMenu, 16, IDM_RA_GETROMCHECKSUM, "View Game H&ash");
+        AssertMenuItem(pMenu, 11, IDM_RA_FILES_CODENOTES, "Code &Notes");
+        AssertMenuItem(pMenu, 12, IDM_RA_PARSERICHPRESENCE, "Rich &Presence Monitor");
+        AssertMenuSeparator(pMenu, 13);
+        AssertMenuItem(pMenu, 14, IDM_RA_FILES_POINTERFINDER, "Pointer &Finder");
+        AssertMenuSeparator(pMenu, 15);
+        AssertMenuItem(pMenu, 16, IDM_RA_REPORTBROKENACHIEVEMENTS, "&Report Achievement Problem");
+        AssertMenuItem(pMenu, 17, IDM_RA_GETROMCHECKSUM, "View Game H&ash");
     }
 
     

--- a/tests/ui/viewmodels/IntegrationMenuViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/IntegrationMenuViewModel_Tests.cpp
@@ -134,7 +134,7 @@ public:
 
         menu.BuildMenu();
 
-        menu.AssertMenuSize(16);
+        menu.AssertMenuSize(17);
         menu.AssertMenuItem(0, IDM_RA_FILES_LOGIN, L"&Login");
         menu.AssertMenuSeparator(1);
         menu.AssertMenuItem(2, IDM_RA_HARDCORE_MODE, L"&Hardcore Mode");
@@ -148,9 +148,10 @@ public:
         menu.AssertMenuItem(10, IDM_RA_FILES_ACHIEVEMENTEDITOR, L"Assets &Editor");
         menu.AssertMenuItem(11, IDM_RA_FILES_MEMORYFINDER, L"&Memory Inspector");
         menu.AssertMenuItem(12, IDM_RA_FILES_MEMORYBOOKMARKS, L"Memory &Bookmarks");
-        menu.AssertMenuItem(13, IDM_RA_FILES_POINTERFINDER, L"Pointer &Finder");
-        menu.AssertMenuItem(14, IDM_RA_FILES_CODENOTES, L"Code &Notes");
-        menu.AssertMenuItem(15, IDM_RA_PARSERICHPRESENCE, L"Rich &Presence Monitor");
+        menu.AssertMenuItem(13, IDM_RA_FILES_CODENOTES, L"Code &Notes");
+        menu.AssertMenuItem(14, IDM_RA_PARSERICHPRESENCE, L"Rich &Presence Monitor");
+        menu.AssertMenuSeparator(15);
+        menu.AssertMenuItem(16, IDM_RA_FILES_POINTERFINDER, L"Pointer &Finder");
     }
 
     TEST_METHOD(TestBuildMenuLoggedIn)
@@ -160,7 +161,7 @@ public:
 
         menu.BuildMenu();
 
-        menu.AssertMenuSize(22);
+        menu.AssertMenuSize(23);
         menu.AssertMenuItem(0, IDM_RA_FILES_LOGOUT, L"Log&out");
         menu.AssertMenuSeparator(1);
         menu.AssertMenuItem(2, IDM_RA_OPENUSERPAGE, L"Open my &User Page");
@@ -177,12 +178,13 @@ public:
         menu.AssertMenuItem(13, IDM_RA_FILES_ACHIEVEMENTEDITOR, L"Assets &Editor");
         menu.AssertMenuItem(14, IDM_RA_FILES_MEMORYFINDER, L"&Memory Inspector");
         menu.AssertMenuItem(15, IDM_RA_FILES_MEMORYBOOKMARKS, L"Memory &Bookmarks");
-        menu.AssertMenuItem(16, IDM_RA_FILES_POINTERFINDER, L"Pointer &Finder");
-        menu.AssertMenuItem(17, IDM_RA_FILES_CODENOTES, L"Code &Notes");
-        menu.AssertMenuItem(18, IDM_RA_PARSERICHPRESENCE, L"Rich &Presence Monitor");
-        menu.AssertMenuSeparator(19);
-        menu.AssertMenuItem(20, IDM_RA_REPORTBROKENACHIEVEMENTS, L"&Report Achievement Problem");
-        menu.AssertMenuItem(21, IDM_RA_GETROMCHECKSUM, L"View Game H&ash");
+        menu.AssertMenuItem(16, IDM_RA_FILES_CODENOTES, L"Code &Notes");
+        menu.AssertMenuItem(17, IDM_RA_PARSERICHPRESENCE, L"Rich &Presence Monitor");
+        menu.AssertMenuSeparator(18);
+        menu.AssertMenuItem(19, IDM_RA_FILES_POINTERFINDER, L"Pointer &Finder");
+        menu.AssertMenuSeparator(20);
+        menu.AssertMenuItem(21, IDM_RA_REPORTBROKENACHIEVEMENTS, L"&Report Achievement Problem");
+        menu.AssertMenuItem(22, IDM_RA_GETROMCHECKSUM, L"View Game H&ash");
     }
 
     TEST_METHOD(TestBuildMenuOffline)
@@ -192,7 +194,7 @@ public:
 
         menu.BuildMenu();
 
-        menu.AssertMenuSize(16);
+        menu.AssertMenuSize(17);
         menu.AssertMenuItem(0, IDM_RA_HARDCORE_MODE, L"&Hardcore Mode");
         menu.AssertMenuItem(1, IDM_RA_NON_HARDCORE_WARNING, L"Non-Hardcore &Warning");
         menu.AssertMenuSeparator(2);
@@ -204,11 +206,12 @@ public:
         menu.AssertMenuItem(8, IDM_RA_FILES_ACHIEVEMENTEDITOR, L"Assets &Editor");
         menu.AssertMenuItem(9, IDM_RA_FILES_MEMORYFINDER, L"&Memory Inspector");
         menu.AssertMenuItem(10, IDM_RA_FILES_MEMORYBOOKMARKS, L"Memory &Bookmarks");
-        menu.AssertMenuItem(11, IDM_RA_FILES_POINTERFINDER, L"Pointer &Finder");
-        menu.AssertMenuItem(12, IDM_RA_FILES_CODENOTES, L"Code &Notes");
-        menu.AssertMenuItem(13, IDM_RA_PARSERICHPRESENCE, L"Rich &Presence Monitor");
-        menu.AssertMenuSeparator(14);
-        menu.AssertMenuItem(15, IDM_RA_GETROMCHECKSUM, L"View Game H&ash");
+        menu.AssertMenuItem(11, IDM_RA_FILES_CODENOTES, L"Code &Notes");
+        menu.AssertMenuItem(12, IDM_RA_PARSERICHPRESENCE, L"Rich &Presence Monitor");
+        menu.AssertMenuSeparator(13);
+        menu.AssertMenuItem(14, IDM_RA_FILES_POINTERFINDER, L"Pointer &Finder");
+        menu.AssertMenuSeparator(15);
+        menu.AssertMenuItem(16, IDM_RA_GETROMCHECKSUM, L"View Game H&ash");
     }
 
     TEST_METHOD(TestLoginHardcoreValidClient)


### PR DESCRIPTION
As suggested in https://github.com/RetroAchievements/RAIntegration/pull/1000#issuecomment-1556021343, but it's been over a year and the author doesn't seem to want to make the changes himself.