### PR TITLE
resync asset list state after game assets list updated

### DIFF
--- a/src/ui/viewmodels/AssetListViewModel.cpp
+++ b/src/ui/viewmodels/AssetListViewModel.cpp
@@ -491,6 +491,22 @@ void AssetListViewModel::AddOrRemoveFilteredItem(gsl::index nAssetIndex)
     }
 }
 
+void AssetListViewModel::SyncAsset(AssetSummaryViewModel& vmSummary, const ra::data::models::AssetModelBase& pAsset)
+{
+    vmSummary.SetLabel(pAsset.GetName());
+    vmSummary.SetType(pAsset.GetType());
+    vmSummary.SetCategory(pAsset.GetCategory());
+    vmSummary.SetChanges(pAsset.GetChanges());
+    vmSummary.SetState(pAsset.GetState());
+    vmSummary.SetWarning(pAsset.GetValidationError());
+
+    const auto* pAchievement = dynamic_cast<const ra::data::models::AchievementModel*>(&pAsset);
+    if (pAchievement != nullptr)
+        vmSummary.SetPoints(pAchievement->GetPoints());
+    else
+        vmSummary.SetPoints(0);
+}
+
 bool AssetListViewModel::AddOrRemoveFilteredItem(const ra::data::models::AssetModelBase& pAsset)
 {
     const auto nIndex = GetFilteredAssetIndex(pAsset);
@@ -501,21 +517,14 @@ bool AssetListViewModel::AddOrRemoveFilteredItem(const ra::data::models::AssetMo
         {
             auto pSummary = std::make_unique<AssetSummaryViewModel>();
             pSummary->SetId(ra::to_signed(pAsset.GetID()));
-            pSummary->SetLabel(pAsset.GetName());
-            pSummary->SetType(pAsset.GetType());
-            pSummary->SetCategory(pAsset.GetCategory());
-            pSummary->SetChanges(pAsset.GetChanges());
-            pSummary->SetState(pAsset.GetState());
-            pSummary->SetWarning(pAsset.GetValidationError());
-
-            const auto* pAchievement = dynamic_cast<const ra::data::models::AchievementModel*>(&pAsset);
-            if (pAchievement != nullptr)
-                pSummary->SetPoints(pAchievement->GetPoints());
-            else
-                pSummary->SetPoints(0);
+            SyncAsset(*pSummary, pAsset);
 
             m_vFilteredAssets.Append(std::move(pSummary));
             return true;
+        }
+        else
+        {
+            SyncAsset(*m_vFilteredAssets.GetItemAt(nIndex), pAsset);
         }
     }
     else

--- a/src/ui/viewmodels/AssetListViewModel.hh
+++ b/src/ui/viewmodels/AssetListViewModel.hh
@@ -312,6 +312,7 @@ private:
     bool MatchesFilter(const ra::data::models::AssetModelBase& pAsset) const;
     void AddOrRemoveFilteredItem(gsl::index nAssetIndex);
     bool AddOrRemoveFilteredItem(const ra::data::models::AssetModelBase& pAsset);
+    static void SyncAsset(AssetSummaryViewModel& vmSummary, const ra::data::models::AssetModelBase& pAsset);
     gsl::index GetFilteredAssetIndex(const ra::data::models::AssetModelBase& pAsset) const;
     void ApplyFilter();
 

--- a/src/ui/win32/FileDialog.cpp
+++ b/src/ui/win32/FileDialog.cpp
@@ -144,7 +144,7 @@ static void ShowFolder(FileDialogViewModel& vmFileDialog, HWND hParentWnd)
 
 void FileDialog::Presenter::DoShowModal(ra::ui::WindowViewModelBase& oViewModel, HWND hParentWnd)
 {
-    auto& vmFileDialog = reinterpret_cast<FileDialogViewModel&>(oViewModel);
+    auto& vmFileDialog = dynamic_cast<FileDialogViewModel&>(oViewModel);
 
     if (vmFileDialog.GetMode() == FileDialogViewModel::Mode::Folder)
     {

--- a/src/ui/win32/MessageBoxDialog.cpp
+++ b/src/ui/win32/MessageBoxDialog.cpp
@@ -43,7 +43,7 @@ void MessageBoxDialog::Presenter::ShowModal(ra::ui::WindowViewModelBase& oViewMo
 
 void MessageBoxDialog::Presenter::DoShowModal(ra::ui::WindowViewModelBase& oViewModel, HWND hParentWnd)
 {
-    auto& oMessageBoxViewModel = reinterpret_cast<MessageBoxViewModel&>(oViewModel);
+    auto& oMessageBoxViewModel = dynamic_cast<MessageBoxViewModel&>(oViewModel);
     int nButton = 0;
 
     if (pTaskDialog == nullptr || oMessageBoxViewModel.GetHeader().empty())

--- a/src/ui/win32/OverlaySettingsDialog.cpp
+++ b/src/ui/win32/OverlaySettingsDialog.cpp
@@ -14,7 +14,7 @@ bool OverlaySettingsDialog::Presenter::IsSupported(const ra::ui::WindowViewModel
 
 void OverlaySettingsDialog::Presenter::ShowModal(ra::ui::WindowViewModelBase& vmViewModel, HWND hParentWnd)
 {
-    auto& vmSettings = reinterpret_cast<ra::ui::viewmodels::OverlaySettingsViewModel&>(vmViewModel);
+    auto& vmSettings = dynamic_cast<ra::ui::viewmodels::OverlaySettingsViewModel&>(vmViewModel);
 
     OverlaySettingsDialog oDialog(vmSettings);
     oDialog.CreateModalWindow(MAKEINTRESOURCE(IDD_RA_OVERLAYSETTINGS), this, hParentWnd);
@@ -96,7 +96,7 @@ BOOL OverlaySettingsDialog::OnCommand(WORD nCommand)
 {
     if (nCommand == IDC_RA_BROWSE)
     {
-        auto& vmSettings = reinterpret_cast<ra::ui::viewmodels::OverlaySettingsViewModel&>(m_vmWindow);
+        auto& vmSettings = dynamic_cast<ra::ui::viewmodels::OverlaySettingsViewModel&>(m_vmWindow);
         vmSettings.BrowseLocation();
         return TRUE;
     }

--- a/src/ui/win32/bindings/ComboBoxBinding.hh
+++ b/src/ui/win32/bindings/ComboBoxBinding.hh
@@ -64,7 +64,10 @@ public:
 
     void BindItems(ViewModelCollectionBase& pViewModels, const IntModelProperty& pIdProperty, const StringModelProperty& pTextProperty)
     {
+#pragma warning(push)
+#pragma warning(disable : 26465) // const_cast forces a call to the const implementation
         BindItems(const_cast<const ViewModelCollectionBase&>(pViewModels), pIdProperty, pTextProperty);
+#pragma warning(pop)
 
         m_pMutableViewModelCollection = &pViewModels;
         pViewModels.AddNotifyTarget(*this);


### PR DESCRIPTION
Fixes an issue where assets deactivated by reloading the loaded game still appeared as active in the asset list.

Reloading the game would discarding any previously loaded assets and load local assets from the XXX-User.txt file in an inactive state. Then the asset list would update itself from the new asset list, but only adding or removing rows. Since the local asset already had a visible row, it was ignored, leaving the appearance of the asset still being active. Actually opening the asset in the asset editor would correctly reflect that the asset was inactive.

Solution: When updating the assets list after reloading the game, re-sync the assets that are neither removed or added to the list.