### PR TITLE
ensure game is fully unloaded before calling rc_client_logout

### DIFF
--- a/src/data/context/UserContext.cpp
+++ b/src/data/context/UserContext.cpp
@@ -34,16 +34,14 @@ void UserContext::Logout()
     if (!IsLoggedIn())
         return;
 
+    _RA_ActivateGame(0U);
+
     auto* pClient = ra::services::ServiceLocator::Get<ra::services::AchievementRuntime>().GetClient();
     rc_client_logout(pClient);
 
     m_sUsername.clear();
     m_sDisplayName.clear();
     m_sApiToken.clear();
-
-    auto& pOverlayManager = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::OverlayManager>();
-    pOverlayManager.ClearPopups();
-    pOverlayManager.HideOverlay();
 
     ra::services::ServiceLocator::Get<ra::services::IConfiguration>().Save();
 

--- a/src/services/AchievementRuntime.cpp
+++ b/src/services/AchievementRuntime.cpp
@@ -944,6 +944,9 @@ void AchievementRuntime::UpdateActiveLeaderboards() noexcept
 
 static rc_client_leaderboard_info_t* GetLeaderboardInfo(rc_client_t* pClient, ra::LeaderboardID nId) noexcept
 {
+    if (!pClient || !pClient->game)
+        return nullptr;
+
     rc_client_subset_info_t* subset = pClient->game->subsets;
     for (; subset; subset = subset->next)
     {

--- a/src/ui/viewmodels/OverlayManager.cpp
+++ b/src/ui/viewmodels/OverlayManager.cpp
@@ -357,6 +357,16 @@ void OverlayManager::UpdateProgressTracker(ra::ui::ImageType imageType, const st
     RequestRender();
 }
 
+void OverlayManager::HideOverlayImmediately()
+{
+    // expect the emulator to be paused while the overlay is open and tell it to unpause
+    // as we're about to discard the overlay.
+    if (m_vmOverlay.CurrentState() != OverlayViewModel::State::Hidden)
+        ra::services::ServiceLocator::Get<ra::data::context::EmulatorContext>().Unpause();
+
+    m_vmOverlay.DeactivateImmediately();
+}
+
 int OverlayManager::QueueMessage(std::unique_ptr<PopupMessageViewModel>& pMessage)
 {
     if (pMessage->GetImage().Type() != ra::ui::ImageType::None)

--- a/src/ui/viewmodels/OverlayManager.hh
+++ b/src/ui/viewmodels/OverlayManager.hh
@@ -70,10 +70,7 @@ public:
     /// <summary>
     /// Hides the overlay without animating it.
     /// </summary>
-    void HideOverlayImmediately()
-    {
-        m_vmOverlay.DeactivateImmediately();
-    }
+    void HideOverlayImmediately();
 
     /// <summary>
     /// Determines if the overlay is completely covering the emulator screen.


### PR DESCRIPTION
Fixes a crash that occurs if the Logout menu option is used while a game is loaded with active assets.

When logging out, the underlying game data is destroyed, but the Models were not being destroyed. When the emulator calls DoFrame, we attempt to update the Models to keep them in sync with the underlying data. Solution: unload game from Asset List when logging out to destroy models.