### PR TITLE
allow unknown game dialog to be reopened

### DIFF
--- a/src/services/AchievementRuntimeExports.cpp
+++ b/src/services/AchievementRuntimeExports.cpp
@@ -283,6 +283,12 @@ public:
     {
         auto& pClient = ra::services::ServiceLocator::GetMutable<ra::services::AchievementRuntime>();
         rc_client_load_unknown_game(pClient.GetClient(), hash);
+
+        auto& pGameContext = ra::services::ServiceLocator::GetMutable<ra::data::context::GameContext>();
+        pGameContext.SetGameHash(hash);
+
+        const auto& pConsoleContext = ra::services::ServiceLocator::Get<ra::data::context::ConsoleContext>();
+        pClient.GetClient()->game->public_.console_id = ra::etoi(pConsoleContext.Id());
     }
 
     static void unload_game()

--- a/src/ui/viewmodels/IntegrationMenuViewModel.cpp
+++ b/src/ui/viewmodels/IntegrationMenuViewModel.cpp
@@ -7,6 +7,8 @@
 #include "data/context/GameContext.hh"
 #include "data/context/UserContext.hh"
 
+#include "services/AchievementRuntime.hh"
+#include "services/AchievementRuntimeExports.hh"
 #include "services/IConfiguration.hh"
 #include "services/ServiceLocator.hh"
 
@@ -20,6 +22,8 @@
 #include "ui/viewmodels/OverlaySettingsViewModel.hh"
 #include "ui/viewmodels/UnknownGameViewModel.hh"
 #include "ui/viewmodels/WindowManager.hh"
+
+#include "rcheevos/src/rc_client_external.h"
 
 namespace ra {
 namespace ui {
@@ -388,6 +392,39 @@ void IntegrationMenuViewModel::ShowGameHash()
     }
     else
     {
+        if (pGameContext.GameId() == 0 && !pGameContext.GameHash().empty())
+        {
+            const auto& pConsoleContext = ra::services::ServiceLocator::Get<ra::data::context::ConsoleContext>();
+            const auto nConsoleId = pConsoleContext.Id();
+            if (nConsoleId != ConsoleID::UnknownConsoleID)
+            {
+                const auto& pEmulatorContext = ra::services::ServiceLocator::Get<ra::data::context::EmulatorContext>();
+                auto sEstimatedGameTitle = ra::Widen(pEmulatorContext.GetGameTitle());
+
+                ra::ui::viewmodels::UnknownGameViewModel vmUnknownGame;
+                vmUnknownGame.InitializeGameTitles(nConsoleId);
+                vmUnknownGame.SetSystemName(pConsoleContext.Name());
+                vmUnknownGame.SetChecksum(ra::Widen(pGameContext.GameHash()));
+                vmUnknownGame.SetEstimatedGameName(sEstimatedGameTitle);
+                vmUnknownGame.SetNewGameName(sEstimatedGameTitle);
+
+                if (vmUnknownGame.ShowModal() == ra::ui::DialogResult::OK)
+                {
+                    // register the hash so the dialog doesn't immediately reappear
+                    auto* pClient = ra::services::ServiceLocator::GetMutable<ra::services::AchievementRuntime>().GetClient();
+                    rc_client_add_game_hash(pClient, pGameContext.GameHash().c_str(), vmUnknownGame.GetSelectedGameId());
+
+                    // attempt to load the newly associated game
+                    pGameContext.LoadGame(vmUnknownGame.GetSelectedGameId(), pGameContext.GameHash(),
+                                          vmUnknownGame.GetTestMode()
+                                              ? ra::data::context::GameContext::Mode::CompatibilityTest
+                                              : ra::data::context::GameContext::Mode::Normal);
+                }
+
+                return;
+            }
+        }
+
         ra::ui::viewmodels::GameChecksumViewModel vmGameChecksum;
         vmGameChecksum.ShowModal();
     }

--- a/tests/ui/viewmodels/IntegrationMenuViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/IntegrationMenuViewModel_Tests.cpp
@@ -834,6 +834,83 @@ public:
         Assert::IsTrue(bDialogShown);
         Assert::AreEqual(ra::data::context::GameContext::Mode::Normal, menu.mockGameContext.GetMode());
     }
+
+    TEST_METHOD(TestShowGameHashUnknownHashCancel)
+    {
+        IntegrationMenuViewModelHarness menu;
+
+        menu.mockConsoleContext.SetId(ConsoleID::Arcade);
+        menu.mockGameContext.SetGameHash("ABCDEF0123456789");
+
+        bool bDialogShown = false;
+        menu.mockDesktop.ExpectWindow<ra::ui::viewmodels::UnknownGameViewModel>(
+            [&bDialogShown](ra::ui::viewmodels::UnknownGameViewModel& vmUnknown) {
+                bDialogShown = true;
+
+                Assert::IsTrue(vmUnknown.IsSelectedGameEnabled());
+
+                return DialogResult::Cancel;
+            });
+
+        menu.ActivateMenuItem(IDM_RA_GETROMCHECKSUM);
+
+        Assert::IsTrue(bDialogShown);
+        Assert::AreEqual(ra::data::context::GameContext::Mode::Normal, menu.mockGameContext.GetMode());
+        Assert::AreEqual({ 0U }, menu.mockGameContext.GameId());
+    }
+
+    TEST_METHOD(TestShowGameHashUnknownHashAssociate)
+    {
+        IntegrationMenuViewModelHarness menu;
+
+        menu.mockConsoleContext.SetId(ConsoleID::Arcade);
+        menu.mockGameContext.SetGameHash("ABCDEF0123456789");
+
+        bool bDialogShown = false;
+        menu.mockDesktop.ExpectWindow<ra::ui::viewmodels::UnknownGameViewModel>(
+            [&bDialogShown](ra::ui::viewmodels::UnknownGameViewModel& vmUnknown) {
+                bDialogShown = true;
+
+                Assert::IsTrue(vmUnknown.IsSelectedGameEnabled());
+                vmUnknown.SetSelectedGameId(523);
+
+                return DialogResult::OK;
+            });
+
+        menu.ActivateMenuItem(IDM_RA_GETROMCHECKSUM);
+
+        Assert::IsTrue(bDialogShown);
+        Assert::AreEqual(ra::data::context::GameContext::Mode::Normal, menu.mockGameContext.GetMode());
+        Assert::AreEqual({ 523U }, menu.mockGameContext.GameId());
+        Assert::IsTrue(menu.mockGameContext.WasLoaded());
+    }
+
+    TEST_METHOD(TestShowGameHashUnknownHashTestCompatibility)
+    {
+        IntegrationMenuViewModelHarness menu;
+
+        menu.mockConsoleContext.SetId(ConsoleID::Arcade);
+        menu.mockGameContext.SetGameHash("ABCDEF0123456789");
+
+        bool bDialogShown = false;
+        menu.mockDesktop.ExpectWindow<ra::ui::viewmodels::UnknownGameViewModel>(
+            [&bDialogShown](ra::ui::viewmodels::UnknownGameViewModel& vmUnknown) {
+                bDialogShown = true;
+
+                Assert::IsTrue(vmUnknown.IsSelectedGameEnabled());
+                vmUnknown.SetSelectedGameId(523);
+                vmUnknown.SetTestMode(true);
+
+                return DialogResult::OK;
+            });
+
+        menu.ActivateMenuItem(IDM_RA_GETROMCHECKSUM);
+
+        Assert::IsTrue(bDialogShown);
+        Assert::AreEqual(ra::data::context::GameContext::Mode::CompatibilityTest, menu.mockGameContext.GetMode());
+        Assert::AreEqual({ 523U }, menu.mockGameContext.GameId());
+        Assert::IsTrue(menu.mockGameContext.WasLoaded());
+    }
 };
 
 } // namespace tests


### PR DESCRIPTION
allows rc_client_raintegration implementations to do compatibility testing and link hashes.