### PR TITLE
extract achievement serialization logic into service

### DIFF
--- a/src/RA_Integration.vcxproj
+++ b/src/RA_Integration.vcxproj
@@ -86,6 +86,7 @@
     <ClCompile Include="RA_Json.cpp" />
     <ClCompile Include="RA_md5factory.cpp" />
     <ClCompile Include="RA_StringUtils.cpp" />
+    <ClCompile Include="services\AchievementLogicSerializer.cpp" />
     <ClCompile Include="services\AchievementRuntime.cpp" />
     <ClCompile Include="services\AchievementRuntimeExports.cpp" />
     <ClCompile Include="services\FrameEventQueue.cpp" />
@@ -232,6 +233,7 @@
     <ClInclude Include="RA_md5factory.h" />
     <ClInclude Include="RA_Resource.h" />
     <ClInclude Include="RA_StringUtils.h" />
+    <ClInclude Include="services\AchievementLogicSerializer.hh" />
     <ClInclude Include="services\AchievementRuntime.hh" />
     <ClInclude Include="services\AchievementRuntimeExports.hh" />
     <ClInclude Include="services\FrameEventQueue.hh" />

--- a/src/RA_Integration.vcxproj.filters
+++ b/src/RA_Integration.vcxproj.filters
@@ -411,6 +411,9 @@
     <ClCompile Include="data\models\CodeNoteModel.cpp">
       <Filter>Data\Models</Filter>
     </ClCompile>
+    <ClCompile Include="services\AchievementLogicSerializer.cpp">
+      <Filter>Services</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="RA_Resource.h">
@@ -976,6 +979,9 @@
     </ClInclude>
     <ClInclude Include="data\models\CodeNoteModel.hh">
       <Filter>Data\Models</Filter>
+    </ClInclude>
+    <ClInclude Include="services\AchievementLogicSerializer.hh">
+      <Filter>Services</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/RA_StringUtils.cpp
+++ b/src/RA_StringUtils.cpp
@@ -162,6 +162,15 @@ bool ParseHex(const std::wstring& sValue, unsigned int nMaximumValue, unsigned i
 }
 
 _Use_decl_annotations_
+bool ParseNumeric(const std::wstring& sValue, _Out_ unsigned int& nValue, _Out_ std::wstring& sError)
+{
+    if (sValue.length() > 2 && sValue.at(1) == 'x')
+        return ra::ParseHex(sValue, 0xFFFFFFFF, nValue, sError);
+
+    return ra::ParseUnsignedInt(sValue, 0xFFFFFFFF, nValue, sError);
+}
+
+_Use_decl_annotations_
 bool ParseFloat(const std::wstring& sValue, float& fValue, std::wstring& sError)
 {
     fValue = 0.0f;

--- a/src/RA_StringUtils.h
+++ b/src/RA_StringUtils.h
@@ -22,6 +22,7 @@ _NODISCARD std::string Narrow(_In_ const std::string& wstr);
 
 bool ParseUnsignedInt(const std::wstring& sValue, unsigned int nMaximumValue, _Out_ unsigned int& nValue, _Out_ std::wstring& sError);
 bool ParseHex(const std::wstring& sValue, unsigned int nMaximumValue, _Out_ unsigned int& nValue, _Out_ std::wstring& sError);
+bool ParseNumeric(const std::wstring& sValue, _Out_ unsigned int& nValue, _Out_ std::wstring& sError);
 bool ParseFloat(const std::wstring& sValue, _Out_ float& fValue, _Out_ std::wstring& sError);
 
 /// <summary>

--- a/src/data/context/ConsoleContext.hh
+++ b/src/data/context/ConsoleContext.hh
@@ -102,6 +102,22 @@ public:
     ra::ByteAddress ByteAddressFromRealAddress(ra::ByteAddress nRealAddress) const noexcept;
 
     /// <summary>
+    /// Converts an "RetroAchievements" address into a real address where the data might be found.
+    /// </summary>
+    /// <returns>Converted address, or <c>0xFFFFFFFF</c> if conversion could not be completed.
+    ra::ByteAddress RealAddressFromByteAddress(ra::ByteAddress nRealAddress) const noexcept;
+
+    /// <summary>
+    /// Gets the read size and mask to use for reading a pointer from memory and converting it to
+    /// a RetroAchievements address.
+    /// </summary>
+    /// <param name="nReadSize">[out] the size to read.</param>
+    /// <param name="nMask">[out] the mask to apply (if 0xFFFFFFFF, no mask is necessary).</param>
+    /// <param name="nOffset">[out] the offset to apply (if 0, no offset is necessary).</param>
+    /// <returns><c>true<c> if a mapping was found, <c>false</c> if not.</returns>
+    bool GetRealAddressConversion(MemSize* nReadSize, uint32_t* nMask, uint32_t* nOffset) const;
+
+    /// <summary>
     /// Gets the maximum valid address for the console.
     /// </summary>
     ra::ByteAddress MaxAddress() const noexcept { return m_nMaxAddress; }

--- a/src/data/models/CodeNoteModel.cpp
+++ b/src/data/models/CodeNoteModel.cpp
@@ -16,6 +16,7 @@ struct CodeNoteModel::PointerData
 {
     uint32_t RawPointerValue = 0xFFFFFFFF;       // last raw value of pointer captured
     ra::ByteAddress PointerAddress = 0xFFFFFFFF; // raw pointer value converted to RA address
+    ra::ByteAddress NoteAddress = 0xFFFFFFFF;    // RA address where RawPointerValue was read from
     unsigned int OffsetRange = 0;                // highest offset captured within pointer block
     unsigned int HeaderLength = 0;               // length of note text not associated to OffsetNotes
     bool HasPointers = false;                    // true if there are nested pointers
@@ -28,12 +29,7 @@ struct CodeNoteModel::PointerData
     };
     OffsetType OffsetType = OffsetType::None;
 
-    struct OffsetCodeNote
-    {
-        CodeNoteModel CodeNote;
-        int Offset = 0;
-    };
-    std::vector<OffsetCodeNote> OffsetNotes;
+    std::vector<CodeNoteModel> OffsetNotes;
 };
 
 // these must be defined here because of forward declaration of PointerData in header file.
@@ -43,6 +39,7 @@ CodeNoteModel::CodeNoteModel(CodeNoteModel&& pOther) noexcept
     : m_sAuthor(std::move(pOther.m_sAuthor)),
       m_sNote(std::move(pOther.m_sNote)),
       m_nBytes(pOther.m_nBytes),
+      m_nAddress(pOther.m_nAddress),
       m_nMemSize(pOther.m_nMemSize),
       m_pPointerData(std::move(pOther.m_pPointerData))
 {
@@ -52,6 +49,7 @@ CodeNoteModel& CodeNoteModel::operator=(CodeNoteModel&& pOther) noexcept
     m_sAuthor = std::move(pOther.m_sAuthor);
     m_sNote = std::move(pOther.m_sNote);
     m_nBytes = pOther.m_nBytes;
+    m_nAddress = pOther.m_nAddress;
     m_nMemSize = pOther.m_nMemSize;
     m_pPointerData = std::move(pOther.m_pPointerData);
     return *this;
@@ -88,6 +86,8 @@ void CodeNoteModel::UpdateRawPointerValue(ra::ByteAddress nAddress, const ra::da
     if (m_pPointerData == nullptr)
         return;
 
+    m_pPointerData->NoteAddress = nAddress;
+
     const uint32_t nValue = pEmulatorContext.ReadMemory(nAddress, GetMemSize());
     if (nValue != m_pPointerData->RawPointerValue)
     {
@@ -104,8 +104,8 @@ void CodeNoteModel::UpdateRawPointerValue(ra::ByteAddress nAddress, const ra::da
             {
                 for (const auto& pNote : m_pPointerData->OffsetNotes)
                 {
-                    if (!pNote.CodeNote.IsPointer())
-                        fNoteMovedCallback(nOldAddress + pNote.Offset, nNewAddress + pNote.Offset, pNote.CodeNote);
+                    if (!pNote.IsPointer())
+                        fNoteMovedCallback(nOldAddress + pNote.GetAddress(), nNewAddress + pNote.GetAddress(), pNote);
                 }
             }
         }
@@ -115,10 +115,10 @@ void CodeNoteModel::UpdateRawPointerValue(ra::ByteAddress nAddress, const ra::da
     {
         for (auto& pNote : m_pPointerData->OffsetNotes)
         {
-            if (pNote.CodeNote.IsPointer())
+            if (pNote.IsPointer())
             {
-                pNote.CodeNote.UpdateRawPointerValue(m_pPointerData->PointerAddress + pNote.Offset,
-                                                     pEmulatorContext, fNoteMovedCallback);
+                pNote.UpdateRawPointerValue(m_pPointerData->PointerAddress + pNote.GetAddress(),
+                                            pEmulatorContext, fNoteMovedCallback);
             }
         }
     }
@@ -132,8 +132,8 @@ const CodeNoteModel* CodeNoteModel::GetPointerNoteAtOffset(int nOffset) const
     // look for explicit offset match
     for (const auto& pOffsetNote : m_pPointerData->OffsetNotes)
     {
-        if (pOffsetNote.Offset == nOffset)
-            return &pOffsetNote.CodeNote;
+        if (ra::to_signed(pOffsetNote.GetAddress()) == nOffset)
+            return &pOffsetNote;
     }
 
     if (m_pPointerData->OffsetType == PointerData::OffsetType::Overflow)
@@ -144,18 +144,18 @@ const CodeNoteModel* CodeNoteModel::GetPointerNoteAtOffset(int nOffset) const
 
         for (const auto& pOffsetNote : m_pPointerData->OffsetNotes)
         {
-            if (pOffsetNote.Offset == nOffset)
-                return &pOffsetNote.CodeNote;
+            if (ra::to_signed(pOffsetNote.GetAddress()) == nOffset)
+                return &pOffsetNote;
         }
     }
 
     return nullptr;
 }
 
-std::pair<ra::ByteAddress, const CodeNoteModel*> CodeNoteModel::GetPointerNoteAtAddress(ra::ByteAddress nAddress) const
+const CodeNoteModel* CodeNoteModel::GetPointerNoteAtAddress(ra::ByteAddress nAddress) const
 {
     if (m_pPointerData == nullptr)
-        return {0, nullptr};
+        return nullptr;
 
     const auto nPointerAddress = m_pPointerData->PointerAddress;
 
@@ -169,23 +169,23 @@ std::pair<ra::ByteAddress, const CodeNoteModel*> CodeNoteModel::GetPointerNoteAt
     // if address is in the struct, look for a matching field
     if (bAddressValid)
     {
-        auto nOffset = ra::to_signed(nAddress - nPointerAddress);
+        const auto nOffset = nAddress - nPointerAddress;
 
         // check for exact matches first
         for (const auto& pOffsetNote : m_pPointerData->OffsetNotes)
         {
-            if (nOffset == pOffsetNote.Offset)
-                return {pOffsetNote.Offset + nPointerAddress, &pOffsetNote.CodeNote};
+            if (nOffset == pOffsetNote.GetAddress())
+                return &pOffsetNote;
         }
 
         // check for trailing bytes in a multi-byte note
         for (const auto& pOffsetNote : m_pPointerData->OffsetNotes)
         {
-            if (nOffset > pOffsetNote.Offset)
+            if (nOffset > pOffsetNote.GetAddress())
             {
-                const auto nBytes = ra::to_signed(pOffsetNote.CodeNote.GetBytes());
-                if (nBytes > 1 && nOffset < pOffsetNote.Offset + nBytes)
-                    return {pOffsetNote.Offset + nPointerAddress, &pOffsetNote.CodeNote};
+                const auto nBytes = ra::to_signed(pOffsetNote.GetBytes());
+                if (nBytes > 1 && nOffset < pOffsetNote.GetAddress() + nBytes)
+                    return &pOffsetNote;
             }
         }
     }
@@ -195,17 +195,55 @@ std::pair<ra::ByteAddress, const CodeNoteModel*> CodeNoteModel::GetPointerNoteAt
     {
         for (const auto& pOffsetNote : m_pPointerData->OffsetNotes)
         {
-            if (pOffsetNote.CodeNote.IsPointer())
+            if (pOffsetNote.IsPointer())
             {
-                auto pNestedObject = pOffsetNote.CodeNote.GetPointerNoteAtAddress(nAddress);
-                if (pNestedObject.second)
+                const auto* pNestedObject = pOffsetNote.GetPointerNoteAtAddress(nAddress);
+                if (pNestedObject != nullptr)
                     return pNestedObject;
             }
         }
     }
 
     // not found
-    return {0, nullptr};
+    return nullptr;
+}
+
+bool CodeNoteModel::GetPointerChain(std::vector<const CodeNoteModel*>& vChain, const CodeNoteModel& pRootNote) const
+{
+    if (!pRootNote.IsPointer())
+        return false;
+
+    vChain.push_back(&pRootNote);
+
+    if (&pRootNote == this)
+        return true;
+
+    return GetPointerChainRecursive(vChain, pRootNote);
+}
+
+bool CodeNoteModel::GetPointerChainRecursive(std::vector<const CodeNoteModel*>& vChain,
+                                             const CodeNoteModel& pParentNote) const
+{
+    for (auto& pNote : pParentNote.m_pPointerData->OffsetNotes)
+    {
+        if (&pNote == this)
+        {
+            vChain.push_back(this);
+            return true;
+        }
+
+        if (pNote.IsPointer())
+        {
+            vChain.push_back(&pNote);
+
+            if (GetPointerChainRecursive(vChain, pNote))
+                return true;
+
+            vChain.pop_back();
+        }
+    }
+
+    return false;
 }
 
 bool CodeNoteModel::GetPreviousAddress(ra::ByteAddress nBeforeAddress, ra::ByteAddress& nPreviousAddress) const
@@ -224,7 +262,7 @@ bool CodeNoteModel::GetPreviousAddress(ra::ByteAddress nBeforeAddress, ra::ByteA
     nPreviousAddress = 0;
     for (const auto& pOffset : m_pPointerData->OffsetNotes)
     {
-        const auto nOffsetAddress = nPointerAddress + pOffset.Offset;
+        const auto nOffsetAddress = nPointerAddress + pOffset.GetAddress();
         if (nOffsetAddress < nBeforeAddress && nOffsetAddress > nPreviousAddress)
         {
             nPreviousAddress = nOffsetAddress;
@@ -251,7 +289,7 @@ bool CodeNoteModel::GetNextAddress(ra::ByteAddress nAfterAddress, ra::ByteAddres
     nNextAddress = 0xFFFFFFFF;
     for (const auto& pOffset : m_pPointerData->OffsetNotes)
     {
-        const auto nOffsetAddress = nPointerAddress + pOffset.Offset;
+        const auto nOffsetAddress = nPointerAddress + pOffset.GetAddress();
         if (nOffsetAddress > nAfterAddress && nOffsetAddress < nNextAddress)
         {
             nNextAddress = nOffsetAddress;
@@ -555,8 +593,8 @@ void CodeNoteModel::ProcessIndirectNotes(const std::wstring& sNote, size_t nInde
 
     do
     {
-        PointerData::OffsetCodeNote offsetNote;
-        offsetNote.CodeNote.SetAuthor(m_sAuthor);
+        CodeNoteModel offsetNote;
+        offsetNote.SetAuthor(m_sAuthor);
 
         // the next note starts when we find a '+' at the start of a line.
         auto nNextIndex = sNote.find(L"\n+", nIndex);
@@ -591,12 +629,13 @@ void CodeNoteModel::ProcessIndirectNotes(const std::wstring& sNote, size_t nInde
         // extract the offset
         wchar_t* pEnd = nullptr;
 
+        int nOffset = 0;
         try
         {
             if (sNextNote.length() > 2 && sNextNote.at(1) == 'x')
-                offsetNote.Offset = gsl::narrow_cast<int>(std::wcstoll(sNextNote.c_str() + 2, &pEnd, 16));
+                nOffset = gsl::narrow_cast<int>(std::wcstoll(sNextNote.c_str() + 2, &pEnd, 16));
             else
-                offsetNote.Offset = gsl::narrow_cast<int>(std::wcstoll(sNextNote.c_str(), &pEnd, 10));
+                nOffset = gsl::narrow_cast<int>(std::wcstoll(sNextNote.c_str(), &pEnd, 10));
         } catch (const std::exception&)
         {
             break;
@@ -617,10 +656,12 @@ void CodeNoteModel::ProcessIndirectNotes(const std::wstring& sNote, size_t nInde
                 pEnd++;
         }
 
-        offsetNote.CodeNote.SetNote(sNextNote.substr(pEnd - sNextNote.c_str()));
-        pointerData->HasPointers |= offsetNote.CodeNote.IsPointer();
+        offsetNote.SetNote(sNextNote.substr(pEnd - sNextNote.c_str()));
+        pointerData->HasPointers |= offsetNote.IsPointer();
 
-        const auto nRangeOffset = offsetNote.Offset + offsetNote.CodeNote.GetBytes();
+        offsetNote.SetAddress(gsl::narrow_cast<ra::ByteAddress>(nOffset));
+
+        const auto nRangeOffset = nOffset + offsetNote.GetBytes();
         pointerData->OffsetRange = std::max(pointerData->OffsetRange, nRangeOffset);
 
         pointerData->OffsetNotes.push_back(std::move(offsetNote));
@@ -644,7 +685,7 @@ void CodeNoteModel::ProcessIndirectNotes(const std::wstring& sNote, size_t nInde
         // overflow math instead of masking, and don't attempt to translate the addresses.
         for (const auto& pNote : pointerData->OffsetNotes)
         {
-            if (ra::to_unsigned(pNote.Offset) >= nMaxAddress)
+            if (pNote.GetAddress() >= nMaxAddress)
             {
                 pointerData->OffsetType = PointerData::OffsetType::Overflow;
                 break;
@@ -675,7 +716,7 @@ void CodeNoteModel::EnumeratePointerNotes(ra::ByteAddress nPointerAddress,
 
     for (const auto& pNote : m_pPointerData->OffsetNotes)
     {
-        if (!fCallback(nPointerAddress + pNote.Offset, pNote.CodeNote))
+        if (!fCallback(nPointerAddress + pNote.GetAddress(), pNote))
             break;
     }
 }

--- a/src/data/models/CodeNoteModel.hh
+++ b/src/data/models/CodeNoteModel.hh
@@ -22,10 +22,12 @@ public:
 
     const std::string& GetAuthor() const noexcept { return m_sAuthor; }
     const std::wstring& GetNote() const noexcept { return m_sNote; }
+    const ra::ByteAddress GetAddress() const noexcept { return m_nAddress; }
     const unsigned int GetBytes() const noexcept { return m_nBytes; }
     const MemSize GetMemSize() const noexcept { return m_nMemSize; }
 
     void SetAuthor(const std::string& sAuthor) { m_sAuthor = sAuthor; }
+    void SetAddress(ra::ByteAddress nAddress) noexcept { m_nAddress = nAddress; }
     void SetNote(const std::wstring& sNote);
 
     bool IsPointer() const noexcept { return m_pPointerData != nullptr; }
@@ -33,7 +35,9 @@ public:
     ra::ByteAddress GetPointerAddress() const noexcept;
     uint32_t GetRawPointerValue() const noexcept;
     const CodeNoteModel* GetPointerNoteAtOffset(int nOffset) const;
-    std::pair<ra::ByteAddress, const CodeNoteModel*> GetPointerNoteAtAddress(ra::ByteAddress nAddress) const;
+    const CodeNoteModel* GetPointerNoteAtAddress(ra::ByteAddress nAddress) const;
+
+    bool GetPointerChain(std::vector<const CodeNoteModel*>& vChain, const CodeNoteModel& pRootNote) const;
 
     typedef std::function<void(ra::ByteAddress nOldAddress, ra::ByteAddress nNewAddress, const CodeNoteModel&)> NoteMovedFunction;
     void UpdateRawPointerValue(ra::ByteAddress nAddress, const ra::data::context::EmulatorContext& pEmulatorContext, NoteMovedFunction fNoteMovedCallback);
@@ -48,6 +52,7 @@ public:
 private:
     std::string m_sAuthor;
     std::wstring m_sNote;
+    ra::ByteAddress m_nAddress = 0; // address of root nodes, offset to indirect nodes
     unsigned int m_nBytes = 1;
     MemSize m_nMemSize = MemSize::Unknown;
 
@@ -55,6 +60,8 @@ private:
     std::unique_ptr<PointerData> m_pPointerData;
 
 private:
+    bool GetPointerChainRecursive(std::vector<const CodeNoteModel*>& vChain, const CodeNoteModel& pParentNote) const;
+
     void ProcessIndirectNotes(const std::wstring& sNote, size_t nIndex);
     void ExtractSize(const std::wstring& sNote);
 };

--- a/src/data/models/CodeNoteModel.hh
+++ b/src/data/models/CodeNoteModel.hh
@@ -35,7 +35,7 @@ public:
     ra::ByteAddress GetPointerAddress() const noexcept;
     uint32_t GetRawPointerValue() const noexcept;
     const CodeNoteModel* GetPointerNoteAtOffset(int nOffset) const;
-    const CodeNoteModel* GetPointerNoteAtAddress(ra::ByteAddress nAddress) const;
+    std::pair<ra::ByteAddress, const CodeNoteModel*> GetPointerNoteAtAddress(ra::ByteAddress nAddress) const;
 
     bool GetPointerChain(std::vector<const CodeNoteModel*>& vChain, const CodeNoteModel& pRootNote) const;
 

--- a/src/data/models/CodeNotesModel.cpp
+++ b/src/data/models/CodeNotesModel.cpp
@@ -174,7 +174,7 @@ ra::ByteAddress CodeNotesModel::FindCodeNoteStart(ra::ByteAddress nAddress) cons
     {
         for (const auto& pNote : m_vCodeNotes)
         {
-            auto pair = pNote.GetPointerNoteAtAddress(nAddress);
+            const auto pair = pNote.GetPointerNoteAtAddress(nAddress);
             if (pair.second != nullptr)
                 return pair.first;
         }

--- a/src/data/models/CodeNotesModel.hh
+++ b/src/data/models/CodeNotesModel.hh
@@ -149,14 +149,14 @@ public:
     /// <summary>
     /// Returns the number of known code notes (not including indirect notes).
     /// </summary>
-    size_t CodeNoteCount() const noexcept { return m_mCodeNotes.size(); }
+    size_t CodeNoteCount() const noexcept { return m_vCodeNotes.size(); }
 
     /// <summary>
     /// Gets the address of the first code note.
     /// </summary>
     ra::ByteAddress FirstCodeNoteAddress() const noexcept
     {
-        return (m_mCodeNotes.size() == 0) ? 0U : m_mCodeNotes.begin()->first;
+        return (m_vCodeNotes.empty()) ? 0U : m_vCodeNotes.front().GetAddress();
     }
 
     /// <summary>
@@ -195,7 +195,7 @@ protected:
     void AddCodeNote(ra::ByteAddress nAddress, const std::string& sAuthor, const std::wstring& sNote);
     void OnCodeNoteChanged(ra::ByteAddress nAddress, const std::wstring& sNewNote);
 
-    std::map<ra::ByteAddress, CodeNoteModel> m_mCodeNotes;
+    std::vector<CodeNoteModel> m_vCodeNotes;
     std::map<ra::ByteAddress, std::pair<std::string, std::wstring>> m_mOriginalCodeNotes;
 
     std::map<ra::ByteAddress, std::wstring> m_mPendingCodeNotes;

--- a/src/services/AchievementLogicSerializer.cpp
+++ b/src/services/AchievementLogicSerializer.cpp
@@ -1,0 +1,354 @@
+#include "AchievementLogicSerializer.hh"
+
+#include "RA_Defs.h"
+#include "RA_StringUtils.h"
+
+#include "data\context\ConsoleContext.hh"
+
+#include "services\ServiceLocator.hh"
+
+namespace ra {
+namespace services {
+
+void AchievementLogicSerializer::AppendConditionType(std::string& sBuffer, TriggerConditionType nType)
+{
+    switch (nType)
+    {
+        case TriggerConditionType::Standard:
+            return;
+        case TriggerConditionType::PauseIf:
+            sBuffer.push_back('P');
+            break;
+        case TriggerConditionType::ResetIf:
+            sBuffer.push_back('R');
+            break;
+        case TriggerConditionType::AddSource:
+            sBuffer.push_back('A');
+            break;
+        case TriggerConditionType::SubSource:
+            sBuffer.push_back('B');
+            break;
+        case TriggerConditionType::AddHits:
+            sBuffer.push_back('C');
+            break;
+        case TriggerConditionType::SubHits:
+            sBuffer.push_back('D');
+            break;
+        case TriggerConditionType::Remember:
+            sBuffer.push_back('K');
+            break;
+        case TriggerConditionType::AndNext:
+            sBuffer.push_back('N');
+            break;
+        case TriggerConditionType::OrNext:
+            sBuffer.push_back('O');
+            break;
+        case TriggerConditionType::Measured:
+            sBuffer.push_back('M');
+            break;
+        case TriggerConditionType::MeasuredAsPercent:
+            sBuffer.push_back('G');
+            break;
+        case TriggerConditionType::MeasuredIf:
+            sBuffer.push_back('Q');
+            break;
+        case TriggerConditionType::AddAddress:
+            sBuffer.push_back('I');
+            break;
+        case TriggerConditionType::Trigger:
+            sBuffer.push_back('T');
+            break;
+        case TriggerConditionType::ResetNextIf:
+            sBuffer.push_back('Z');
+            break;
+        default:
+            assert(!"Unknown condition type");
+            break;
+    }
+
+    sBuffer.push_back(':');
+}
+
+void AchievementLogicSerializer::AppendOperand(std::string& sBuffer, TriggerOperandType nType, MemSize nSize, uint32_t nValue)
+{
+    switch (nType)
+    {
+        case TriggerOperandType::Address:
+            break;
+
+        case TriggerOperandType::Value:
+            sBuffer.append(std::to_string(nValue));
+            return;
+
+        case TriggerOperandType::Float:
+            sBuffer.push_back('f');
+            sBuffer.append(std::to_string(nValue));
+            sBuffer.push_back('.');
+            sBuffer.push_back('0');
+            return;
+
+        case TriggerOperandType::Delta:
+            sBuffer.push_back('d');
+            break;
+
+        case TriggerOperandType::Prior:
+            sBuffer.push_back('p');
+            break;
+
+        case TriggerOperandType::BCD:
+            sBuffer.push_back('b');
+            break;
+
+        case TriggerOperandType::Inverted:
+            sBuffer.push_back('~');
+            break;
+
+        case TriggerOperandType::Recall:
+            sBuffer.append("{recall}");
+            return;
+
+        default:
+            assert(!"Unknown operand type");
+            break;
+    }
+
+    sBuffer.push_back('0');
+    sBuffer.push_back('x');
+
+    switch (nSize)
+    {
+        case MemSize::BitCount:              sBuffer.push_back('K'); break;
+        case MemSize::Bit_0:                 sBuffer.push_back('M'); break;
+        case MemSize::Bit_1:                 sBuffer.push_back('N'); break;
+        case MemSize::Bit_2:                 sBuffer.push_back('O'); break;
+        case MemSize::Bit_3:                 sBuffer.push_back('P'); break;
+        case MemSize::Bit_4:                 sBuffer.push_back('Q'); break;
+        case MemSize::Bit_5:                 sBuffer.push_back('R'); break;
+        case MemSize::Bit_6:                 sBuffer.push_back('S'); break;
+        case MemSize::Bit_7:                 sBuffer.push_back('T'); break;
+        case MemSize::Nibble_Lower:          sBuffer.push_back('L'); break;
+        case MemSize::Nibble_Upper:          sBuffer.push_back('U'); break;
+        case MemSize::EightBit:              sBuffer.push_back('H'); break;
+        case MemSize::TwentyFourBit:         sBuffer.push_back('W'); break;
+        case MemSize::ThirtyTwoBit:          sBuffer.push_back('X'); break;
+        case MemSize::SixteenBit:            sBuffer.push_back(' '); break;
+        case MemSize::ThirtyTwoBitBigEndian: sBuffer.push_back('G'); break;
+        case MemSize::SixteenBitBigEndian:   sBuffer.push_back('I'); break;
+        case MemSize::TwentyFourBitBigEndian:sBuffer.push_back('J'); break;
+
+        case MemSize::Float:
+            sBuffer.pop_back();
+            sBuffer.pop_back();
+            sBuffer.push_back('f');
+            sBuffer.push_back('F');
+            break;
+
+        case MemSize::FloatBigEndian:
+            sBuffer.pop_back();
+            sBuffer.pop_back();
+            sBuffer.push_back('f');
+            sBuffer.push_back('B');
+            break;
+
+        case MemSize::Double32:
+            sBuffer.pop_back();
+            sBuffer.pop_back();
+            sBuffer.push_back('f');
+            sBuffer.push_back('H');
+            break;
+
+        case MemSize::Double32BigEndian:
+            sBuffer.pop_back();
+            sBuffer.pop_back();
+            sBuffer.push_back('f');
+            sBuffer.push_back('I');
+            break;
+
+        case MemSize::MBF32:
+            sBuffer.pop_back();
+            sBuffer.pop_back();
+            sBuffer.push_back('f');
+            sBuffer.push_back('M');
+            break;
+
+        case MemSize::MBF32LE:
+            sBuffer.pop_back();
+            sBuffer.pop_back();
+            sBuffer.push_back('f');
+            sBuffer.push_back('L');
+            break;
+
+        default:
+            assert(!"Unknown memory size");
+            break;
+    }
+
+    sBuffer.append(ra::ByteAddressToString(nValue), 2);
+}
+
+void AchievementLogicSerializer::AppendOperand(std::string& sBuffer, TriggerOperandType nType, MemSize, float fValue)
+{
+    switch (nType)
+    {
+        case TriggerOperandType::Value:
+            sBuffer.append(std::to_string(ra::to_unsigned(gsl::narrow_cast<int>(fValue))));
+            break;
+
+        case TriggerOperandType::Float: {
+            std::string sFloat = std::to_string(fValue);
+            if (sFloat.find('.') != std::string::npos)
+            {
+                while (sFloat.back() == '0') // remove insignificant zeros
+                    sFloat.pop_back();
+                if (sFloat.back() == '.') // if everything after the decimal was removed, add back a zero
+                    sFloat.push_back('0');
+            }
+
+            sBuffer.push_back('f');
+            sBuffer.append(sFloat);
+            break;
+        }
+
+        default:
+            assert(!"Operand does not support float value");
+            break;
+    }
+}
+
+void AchievementLogicSerializer::AppendOperator(std::string& sBuffer, TriggerOperatorType nType)
+{
+    switch (nType)
+    {
+        case TriggerOperatorType::Equals:
+            sBuffer.push_back('=');
+            break;
+
+        case TriggerOperatorType::NotEquals:
+            sBuffer.push_back('!');
+            sBuffer.push_back('=');
+            break;
+
+        case TriggerOperatorType::LessThan:
+            sBuffer.push_back('<');
+            break;
+
+        case TriggerOperatorType::LessThanOrEqual:
+            sBuffer.push_back('<');
+            sBuffer.push_back('=');
+            break;
+
+        case TriggerOperatorType::GreaterThan:
+            sBuffer.push_back('>');
+            break;
+
+        case TriggerOperatorType::GreaterThanOrEqual:
+            sBuffer.push_back('>');
+            sBuffer.push_back('=');
+            break;
+
+        case TriggerOperatorType::Multiply:
+            sBuffer.push_back('*');
+            break;
+
+        case TriggerOperatorType::Divide:
+            sBuffer.push_back('/');
+            break;
+
+        case TriggerOperatorType::BitwiseAnd:
+            sBuffer.push_back('&');
+            break;
+
+        case TriggerOperatorType::BitwiseXor:
+            sBuffer.push_back('^');
+            break;
+
+        case TriggerOperatorType::Modulus:
+            sBuffer.push_back('%');
+            break;
+
+        case TriggerOperatorType::Add:
+            sBuffer.push_back('+');
+            break;
+
+        case TriggerOperatorType::Subtract:
+            sBuffer.push_back('-');
+            break;
+
+        default:
+            assert(!"Unknown comparison");
+            break;
+    }
+}
+
+void AchievementLogicSerializer::AppendHitTarget(std::string& sBuffer, uint32_t nTarget)
+{
+    if (nTarget > 0)
+    {
+        sBuffer.push_back('.');
+        sBuffer.append(std::to_string(nTarget));
+        sBuffer.push_back('.');
+    }
+}
+
+std::string AchievementLogicSerializer::BuildMemRefChain(const ra::data::models::CodeNoteModel& pRootNote,
+    const ra::data::models::CodeNoteModel& pLeafNote)
+{
+    std::vector<const ra::data::models::CodeNoteModel*> vChain;
+    if (!pLeafNote.GetPointerChain(vChain, pRootNote))
+        return std::string();
+
+    MemSize nSize = MemSize::ThirtyTwoBit;
+    uint32_t nMask = 0xFFFFFFFF;
+    uint32_t nOffset = 0;
+
+    const auto& pConsoleContext = ra::services::ServiceLocator::Get<ra::data::context::ConsoleContext>();
+    if (!pConsoleContext.GetRealAddressConversion(&nSize, &nMask, &nOffset))
+    {
+        nSize = pRootNote.GetMemSize();
+        nMask = 0xFFFFFFFF;
+        nOffset = pConsoleContext.RealAddressFromByteAddress(0);
+        if (nOffset == 0xFFFFFFFF)
+            nOffset = 0;
+    }
+
+    std::string sBuffer;
+    ra::ByteAddress nPointerBase = 0;
+    for (size_t i = 0; i < vChain.size() - 1; ++i)
+    {
+        const auto* pNote = vChain.at(i);
+        Expects(pNote != nullptr);
+
+        AppendConditionType(sBuffer, ra::services::TriggerConditionType::AddAddress);
+        AppendOperand(sBuffer, ra::services::TriggerOperandType::Address, nSize, pNote->GetAddress());
+        nPointerBase = pNote->GetPointerAddress();
+
+        if (nOffset != 0)
+        {
+            AppendOperator(sBuffer, ra::services::TriggerOperatorType::Subtract);
+            AppendOperand(sBuffer, ra::services::TriggerOperandType::Value, MemSize::ThirtyTwoBit, nOffset);
+        }
+        else if (nMask != 0xFFFFFFFF)
+        {
+            const auto nBitsMask = ra::to_unsigned((1 << ra::data::MemSizeBits(nSize)) - 1);
+            if (nMask != nBitsMask)
+            {
+                AppendOperator(sBuffer, ra::services::TriggerOperatorType::BitwiseAnd);
+                AppendOperand(sBuffer, ra::services::TriggerOperandType::Value, MemSize::ThirtyTwoBit, nMask);
+            }
+        }
+
+        AppendConditionSeparator(sBuffer);
+    }
+
+    AppendConditionType(sBuffer, ra::services::TriggerConditionType::Measured);
+
+    nSize = pLeafNote.GetMemSize();
+    if (nSize == MemSize::Unknown)
+        nSize = MemSize::EightBit;
+    AppendOperand(sBuffer, ra::services::TriggerOperandType::Address, nSize, pLeafNote.GetAddress());
+
+    return sBuffer;
+}
+
+} // namespace services
+} // namespace ra

--- a/src/services/AchievementLogicSerializer.hh
+++ b/src/services/AchievementLogicSerializer.hh
@@ -1,0 +1,93 @@
+#ifndef RA_ACHIEVEMENT_LOGIC_SERIALIZER_HH
+#define RA_ACHIEVEMENT_LOGIC_SERIALIZER_HH
+#pragma once
+
+#include "ra_fwd.h"
+
+#include "data\Types.hh"
+
+#include "data\models\CodeNoteModel.hh"
+
+namespace ra {
+namespace services {
+
+enum class TriggerConditionType : uint8_t
+{
+    Standard = RC_CONDITION_STANDARD,
+    PauseIf = RC_CONDITION_PAUSE_IF,
+    ResetIf = RC_CONDITION_RESET_IF,
+    AddSource = RC_CONDITION_ADD_SOURCE,
+    SubSource = RC_CONDITION_SUB_SOURCE,
+    AddHits = RC_CONDITION_ADD_HITS,
+    SubHits = RC_CONDITION_SUB_HITS,
+    Remember = RC_CONDITION_REMEMBER,
+    AndNext = RC_CONDITION_AND_NEXT,
+    Measured = RC_CONDITION_MEASURED,
+    AddAddress = RC_CONDITION_ADD_ADDRESS,
+    OrNext = RC_CONDITION_OR_NEXT,
+    Trigger = RC_CONDITION_TRIGGER,
+    MeasuredIf = RC_CONDITION_MEASURED_IF,
+    ResetNextIf = RC_CONDITION_RESET_NEXT_IF,
+    MeasuredAsPercent = 99
+};
+
+enum class TriggerOperandType : uint8_t
+{
+    Address = RC_OPERAND_ADDRESS,   // compare to the value of a live address in RAM
+    Delta = RC_OPERAND_DELTA,       // the value last known at this address.
+    Value = RC_OPERAND_CONST,       // a 32 bit unsigned integer
+    Prior = RC_OPERAND_PRIOR,       // the last differing value at this address.
+    BCD = RC_OPERAND_BCD,           // Address, but decoded from binary-coded-decimal
+    Float = RC_OPERAND_FP,          // a 32-bit floating point value
+    Inverted = RC_OPERAND_INVERTED, // the bitwise compliment of the current value at the address
+    Recall = RC_OPERAND_RECALL      // the last value stored by RC_CONDITION_REMEMBER
+};
+
+enum class TriggerOperatorType : uint8_t
+{
+    Equals = RC_OPERATOR_EQ,
+    LessThan = RC_OPERATOR_LT,
+    LessThanOrEqual = RC_OPERATOR_LE,
+    GreaterThan = RC_OPERATOR_GT,
+    GreaterThanOrEqual = RC_OPERATOR_GE,
+    NotEquals = RC_OPERATOR_NE,
+    None = RC_OPERATOR_NONE,
+    Multiply = RC_OPERATOR_MULT,
+    Divide = RC_OPERATOR_DIV,
+    BitwiseAnd = RC_OPERATOR_AND,
+    BitwiseXor = RC_OPERATOR_XOR,
+    Modulus = RC_OPERATOR_MOD,
+    Add = RC_OPERATOR_ADD,
+    Subtract = RC_OPERATOR_SUB
+};
+
+class AchievementLogicSerializer
+{
+public:
+    GSL_SUPPRESS_F6 AchievementLogicSerializer() = default;
+    virtual ~AchievementLogicSerializer() = default;
+
+    AchievementLogicSerializer(const AchievementLogicSerializer&) noexcept = delete;
+    AchievementLogicSerializer& operator=(const AchievementLogicSerializer&) noexcept = delete;
+    AchievementLogicSerializer(AchievementLogicSerializer&&) noexcept = delete;
+    AchievementLogicSerializer& operator=(AchievementLogicSerializer&&) noexcept = delete;
+
+    static void AppendConditionSeparator(std::string& sBuffer) { sBuffer.push_back('_'); }
+
+    static void AppendConditionType(std::string& sBuffer, TriggerConditionType nType);
+
+    static void AppendOperand(std::string& sBuffer, TriggerOperandType nType, MemSize nSize, uint32_t nValue);
+    static void AppendOperand(std::string& sBuffer, TriggerOperandType nType, MemSize nSize, float fValue);
+
+    static void AppendOperator(std::string& sBuffer, TriggerOperatorType nType);
+
+    static void AppendHitTarget(std::string& sBuffer, uint32_t nTarget);
+
+    static std::string BuildMemRefChain(const ra::data::models::CodeNoteModel& pRootNote,
+                                        const ra::data::models::CodeNoteModel& pLeafNote);
+};
+
+} // namespace services
+} // namespace ra
+
+#endif // !RA_ACHIEVEMENT_LOGIC_SERIALIZER_HH

--- a/src/ui/viewmodels/TriggerConditionViewModel.hh
+++ b/src/ui/viewmodels/TriggerConditionViewModel.hh
@@ -7,6 +7,8 @@
 
 #include "data\Types.hh"
 
+#include "services\AchievementLogicSerializer.hh"
+
 #include "ra_utility.h"
 
 struct rc_condition_t;
@@ -15,54 +17,9 @@ namespace ra {
 namespace ui {
 namespace viewmodels {
 
-enum class TriggerConditionType : uint8_t
-{
-    Standard = RC_CONDITION_STANDARD,
-    PauseIf = RC_CONDITION_PAUSE_IF,
-    ResetIf = RC_CONDITION_RESET_IF,
-    AddSource = RC_CONDITION_ADD_SOURCE,
-    SubSource = RC_CONDITION_SUB_SOURCE,
-    AddHits = RC_CONDITION_ADD_HITS,
-    SubHits = RC_CONDITION_SUB_HITS,
-    Remember = RC_CONDITION_REMEMBER,
-    AndNext = RC_CONDITION_AND_NEXT,
-    Measured = RC_CONDITION_MEASURED,
-    AddAddress = RC_CONDITION_ADD_ADDRESS,
-    OrNext = RC_CONDITION_OR_NEXT,
-    Trigger = RC_CONDITION_TRIGGER,
-    MeasuredIf = RC_CONDITION_MEASURED_IF,
-    ResetNextIf = RC_CONDITION_RESET_NEXT_IF
-};
-
-enum class TriggerOperandType : uint8_t
-{
-    Address = RC_OPERAND_ADDRESS,       // compare to the value of a live address in RAM
-    Delta = RC_OPERAND_DELTA,           // the value last known at this address.
-    Value = RC_OPERAND_CONST,           // a 32 bit unsigned integer
-    Prior = RC_OPERAND_PRIOR,           // the last differing value at this address.
-    BCD = RC_OPERAND_BCD,               // Address, but decoded from binary-coded-decimal
-    Float = RC_OPERAND_FP,              // a 32-bit floating point value
-    Inverted = RC_OPERAND_INVERTED,     // the bitwise compliment of the current value at the address
-    Recall = RC_OPERAND_RECALL          // the last value stored by RC_CONDITION_REMEMBER 
-};
-
-enum class TriggerOperatorType : uint8_t
-{
-    Equals = RC_OPERATOR_EQ,
-    LessThan = RC_OPERATOR_LT,
-    LessThanOrEqual = RC_OPERATOR_LE,
-    GreaterThan = RC_OPERATOR_GT,
-    GreaterThanOrEqual = RC_OPERATOR_GE,
-    NotEquals = RC_OPERATOR_NE,
-    None = RC_OPERATOR_NONE,
-    Multiply = RC_OPERATOR_MULT,
-    Divide = RC_OPERATOR_DIV,
-    BitwiseAnd = RC_OPERATOR_AND,
-    BitwiseXor = RC_OPERATOR_XOR,
-    Modulus = RC_OPERATOR_MOD,
-    Add = RC_OPERATOR_ADD,
-    Subtract = RC_OPERATOR_SUB
-};
+using ra::services::TriggerConditionType;
+using ra::services::TriggerOperandType;
+using ra::services::TriggerOperatorType;
 
 class TriggerConditionViewModel : public ViewModelBase
 {

--- a/src/ui/viewmodels/TriggerViewModel.cpp
+++ b/src/ui/viewmodels/TriggerViewModel.cpp
@@ -894,11 +894,7 @@ static unsigned int ParseNumeric(const std::wstring& sValue)
 {
     unsigned int nValue = 0;
     std::wstring sError;
-
-    if (sValue.length() > 2 && sValue.at(1) == 'x' && ra::ParseHex(sValue, 0xFFFFFFFF, nValue, sError))
-        return nValue;
-
-    if (ra::ParseUnsignedInt(sValue, 0xFFFFFFFF, nValue, sError))
+    if (ra::ParseNumeric(sValue, nValue, sError))
         return nValue;
 
     return 0;

--- a/tests/RA_Integration.Tests.vcxproj
+++ b/tests/RA_Integration.Tests.vcxproj
@@ -313,6 +313,7 @@
     <ClCompile Include="..\src\RA_Json.cpp" />
     <ClCompile Include="..\src\RA_md5factory.cpp" />
     <ClCompile Include="..\src\RA_StringUtils.cpp" />
+    <ClCompile Include="..\src\services\AchievementLogicSerializer.cpp" />
     <ClCompile Include="..\src\services\AchievementRuntime.cpp" />
     <ClCompile Include="..\src\services\AchievementRuntimeExports.cpp" />
     <ClCompile Include="..\src\services\FrameEventQueue.cpp" />
@@ -386,6 +387,7 @@
     <ClCompile Include="data\models\TriggerValidation_Tests.cpp" />
     <ClCompile Include="Exports_Tests.cpp" />
     <ClCompile Include="mocks\MockAchievementRuntime.cpp" />
+    <ClCompile Include="services\AchievementLogicSerializer_Tests.cpp" />
     <ClCompile Include="services\AchievementRuntimeExports_Tests.cpp" />
     <ClCompile Include="services\AchievementRuntime_Tests.cpp" />
     <ClCompile Include="services\FileLocalStorage_Tests.cpp" />

--- a/tests/RA_Integration.Tests.vcxproj.filters
+++ b/tests/RA_Integration.Tests.vcxproj.filters
@@ -474,6 +474,12 @@
     <ClCompile Include="data\models\CodeNoteModel_Tests.cpp">
       <Filter>Tests\Data\Models</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\services\AchievementLogicSerializer.cpp">
+      <Filter>Code</Filter>
+    </ClCompile>
+    <ClCompile Include="services\AchievementLogicSerializer_Tests.cpp">
+      <Filter>Tests\Services</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="base.props" />

--- a/tests/services/AchievementLogicSerializer_Tests.cpp
+++ b/tests/services/AchievementLogicSerializer_Tests.cpp
@@ -1,0 +1,124 @@
+#include "CppUnitTest.h"
+
+#include "services\AchievementLogicSerializer.hh"
+
+#include "tests\RA_UnitTestHelpers.h"
+#include "tests\data\DataAsserts.hh"
+
+#include "tests\mocks\MockConsoleContext.hh"
+#include "tests\mocks\MockEmulatorContext.hh"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace ra {
+namespace services {
+namespace tests {
+
+TEST_CLASS(AchievementLogicSerializer_Tests)
+{
+public:
+    TEST_METHOD(TestBuildMemRefChain)
+    {
+        ra::data::context::mocks::MockConsoleContext mockConsoleContext;
+        ra::data::context::mocks::MockEmulatorContext mockEmulatorContext;
+
+        ra::data::models::CodeNoteModel note;
+        const std::wstring sNote =
+            L"Pointer [32bit]\n"
+            L"+0x428 | Obj1 pointer\n"
+            L"++0x24C | [16-bit] State\n"
+            L"-- Increments\n"
+            L"+0x438 | Obj2 pointer\n"
+            L"++0x08 | Flag\n"
+            L"-- b0=quest1 complete\n"
+            L"-- b1=quest2 complete\n"
+            L"+0x448 | [32-bit BE] Not-nested number";
+        note.SetNote(sNote);
+        note.SetAddress(0x1234);
+        note.UpdateRawPointerValue(0x1234, mockEmulatorContext, nullptr);
+
+        const auto* note2 = note.GetPointerNoteAtOffset(0x438);
+        Assert::IsNotNull(note2);
+        const auto* note3 = note2->GetPointerNoteAtOffset(0x08);
+        Assert::IsNotNull(note3);
+
+        std::string sSerialized = AchievementLogicSerializer::BuildMemRefChain(note, *note3);
+        Assert::AreEqual(std::string("I:0xX1234_I:0xX0438_M:0xH0008"), sSerialized);
+    }
+
+    TEST_METHOD(TestBuildMemRefChain24Bit)
+    {
+        ra::data::context::mocks::MockConsoleContext mockConsoleContext;
+        ra::data::context::mocks::MockEmulatorContext mockEmulatorContext;
+        mockConsoleContext.SetId(ConsoleID::PlayStation); // 24-bit read
+
+        ra::data::models::CodeNoteModel note;
+        const std::wstring sNote =
+            L"Pointer [32bit]\n"
+            L"+0x428 | Obj1 pointer\n"
+            L"++0x24C | [16-bit] State";
+        note.SetNote(sNote);
+        note.SetAddress(0x1234);
+        note.UpdateRawPointerValue(0x1234, mockEmulatorContext, nullptr);
+
+        const auto* note2 = note.GetPointerNoteAtOffset(0x428);
+        Assert::IsNotNull(note2);
+        const auto* note3 = note2->GetPointerNoteAtOffset(0x24C);
+        Assert::IsNotNull(note3);
+
+        std::string sSerialized = AchievementLogicSerializer::BuildMemRefChain(note, *note3);
+        Assert::AreEqual(std::string("I:0xW1234_I:0xW0428_M:0x 024c"), sSerialized);
+    }
+
+    TEST_METHOD(TestBuildMemRefChain25Bit)
+    {
+        ra::data::context::mocks::MockConsoleContext mockConsoleContext;
+        ra::data::context::mocks::MockEmulatorContext mockEmulatorContext;
+        mockConsoleContext.SetId(ConsoleID::PSP); // 25-bit read
+
+        ra::data::models::CodeNoteModel note;
+        const std::wstring sNote =
+            L"Pointer [32bit]\n"
+            L"+0x428 | Obj1 pointer\n"
+            L"++0x24C | [16-bit] State";
+        note.SetNote(sNote);
+        note.SetAddress(0x1234);
+        note.UpdateRawPointerValue(0x1234, mockEmulatorContext, nullptr);
+
+        const auto* note2 = note.GetPointerNoteAtOffset(0x428);
+        Assert::IsNotNull(note2);
+        const auto* note3 = note2->GetPointerNoteAtOffset(0x24C);
+        Assert::IsNotNull(note3);
+
+        std::string sSerialized = AchievementLogicSerializer::BuildMemRefChain(note, *note3);
+        Assert::AreEqual(std::string("I:0xX1234&33554431_I:0xX0428&33554431_M:0x 024c"), sSerialized);
+    }
+
+    TEST_METHOD(TestBuildMemRefChain25BitBE)
+    {
+        ra::data::context::mocks::MockConsoleContext mockConsoleContext;
+        ra::data::context::mocks::MockEmulatorContext mockEmulatorContext;
+        mockConsoleContext.SetId(ConsoleID::GameCube); // 25-bit BE read
+
+        ra::data::models::CodeNoteModel note;
+        const std::wstring sNote =
+            L"Pointer [32bit]\n"
+            L"+0x428 | Obj1 pointer\n"
+            L"++0x24C | [16-bit] State";
+        note.SetNote(sNote);
+        note.SetAddress(0x1234);
+        note.UpdateRawPointerValue(0x1234, mockEmulatorContext, nullptr);
+
+        const auto* note2 = note.GetPointerNoteAtOffset(0x428);
+        Assert::IsNotNull(note2);
+        const auto* note3 = note2->GetPointerNoteAtOffset(0x24C);
+        Assert::IsNotNull(note3);
+
+        std::string sSerialized = AchievementLogicSerializer::BuildMemRefChain(note, *note3);
+        Assert::AreEqual(std::string("I:0xG1234&33554431_I:0xG0428&33554431_M:0x 024c"), sSerialized);
+    }
+};
+
+} // namespace tests
+} // namespace services
+} // namespace ra


### PR DESCRIPTION
Moves code from TriggerConditionViewModel into a separate service so it can be used by other features.

Introduces functionality for serializing a pointer chain, which required some additional changes to CodeNotesModel.