### PR TITLE
simplify PauseOnTrigger logic; fix interaction with KeepActive

### DIFF
--- a/src/data/models/AchievementModel.hh
+++ b/src/data/models/AchievementModel.hh
@@ -184,7 +184,6 @@ private:
     static const std::array<int, 10> s_vValidPoints;
 
     void HandleStateChanged(AssetState nOldState, AssetState nNewState);
-    void SetStateFromTrigger(const rc_trigger_t* pTrigger);
     void SyncID();
     void SyncTitle();
     void SyncDescription();

--- a/src/ui/viewmodels/AssetListViewModel.cpp
+++ b/src/ui/viewmodels/AssetListViewModel.cpp
@@ -192,19 +192,6 @@ void AssetListViewModel::OnDataModelIntValueChanged(gsl::index nIndex, const Int
                 }
             }
         }
-
-        const auto nNewState = ra::itoe<ra::data::models::AssetState>(args.tNewValue);
-        if (nNewState == ra::data::models::AssetState::Triggered && KeepActive())
-        {
-            // if KeepActive is selected, set a Triggered achievement back to Waiting
-            auto& pGameContext = ra::services::ServiceLocator::GetMutable<ra::data::context::GameContext>();
-            auto* pAsset = pGameContext.Assets().GetItemAt(nIndex);
-            if (pAsset != nullptr)
-                pAsset->SetState(ra::data::models::AssetState::Waiting);
-
-            // SetState is re-entrant - we don't want to do any further processing with the previous new value
-            return;
-        }
     }
 
     // these properties potentially affect visibility

--- a/tests/services/AchievementRuntime_Tests.cpp
+++ b/tests/services/AchievementRuntime_Tests.cpp
@@ -136,6 +136,14 @@ public:
         m_fRealEventHandler(&event, GetClient());
     }
 
+    void ProcessCapturedEvents()
+    {
+        for (const auto& pEvent : m_vEvents)
+            RaiseEvent(pEvent);
+
+        ResetEvents();
+    }
+
     rc_client_achievement_info_t* MockAchievement(uint32_t nId, const std::string& sTrigger)
     {
         auto* game = GetClient()->game;
@@ -1244,9 +1252,9 @@ public:
         memory.at(0) = 1;
         runtime.DoFrame();
         Assert::AreEqual({1U}, runtime.GetEventCount());
+        runtime.ProcessCapturedEvents();
         Assert::AreEqual({1U}, runtime.mockFrameEventQueue.NumTriggeredTriggers());
         runtime.mockFrameEventQueue.Reset();
-        runtime.ResetEvents();
 
         // already triggered, shouldn't get repeated notification
         runtime.DoFrame();
@@ -2142,6 +2150,42 @@ public:
         Assert::AreEqual(ra::ui::ImageType::Badge, pPopup->GetImage().Type());
         Assert::AreEqual(std::string("012345"), pPopup->GetImage().Name());
         Assert::IsTrue(runtime.mockAudioSystem.WasAudioFilePlayed(L"Overlay\\acherror.wav"));
+    }
+
+    TEST_METHOD(TestHandleAchievementTriggeredKeepActive)
+    {
+        AchievementRuntimeHarness runtime;
+        runtime.mockWindowManager.AssetList.SetKeepActive(true);
+        auto* pAch6 = runtime.MockAchievement(6U, "0xH0000=1");
+        pAch6->public_.rarity = 23.45f;
+        pAch6->public_.rarity_hardcore = 12.34f;
+        memcpy(pAch6->public_.badge_name, "012345", 7);
+        auto* vmAch6 = runtime.WrapAchievement(pAch6);
+        runtime.mockGameContext.SetRichPresenceDisplayString(L"Titles");
+        runtime.mockGameContext.Assets().FindRichPresence()->Activate();
+        runtime.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, false);
+        runtime.mockConfiguration.SetPopupLocation(ra::ui::viewmodels::Popup::AchievementTriggered,
+                                                   ra::ui::viewmodels::PopupLocation::BottomLeft);
+
+        rc_client_event_t event;
+        memset(&event, 0, sizeof(event));
+        event.type = RC_CLIENT_EVENT_ACHIEVEMENT_TRIGGERED;
+        event.achievement = &pAch6->public_;
+        runtime.RaiseEvent(event);
+
+        Assert::AreEqual(ra::data::models::AssetState::Waiting, vmAch6->GetState());
+        Assert::AreEqual(std::wstring(L"Titles"), vmAch6->GetUnlockRichPresence());
+
+        auto* pPopup = runtime.mockOverlayManager.GetMessage(1);
+        Expects(pPopup != nullptr);
+        Assert::AreEqual(ra::ui::viewmodels::Popup::AchievementTriggered, pPopup->GetPopupType());
+        Assert::AreEqual(std::wstring(L"Achievement Unlocked - 23.45%"), pPopup->GetTitle());
+        Assert::AreEqual(std::wstring(L"Ach6 (5)"), pPopup->GetDescription());
+        Assert::AreEqual(std::wstring(L"Description 6"), pPopup->GetDetail());
+        Assert::AreEqual(ra::ui::ImageType::Badge, pPopup->GetImage().Type());
+        Assert::AreEqual(std::string("012345"), pPopup->GetImage().Name());
+        Assert::AreEqual({0U}, runtime.mockFrameEventQueue.NumTriggeredTriggers());
+        Assert::IsTrue(runtime.mockAudioSystem.WasAudioFilePlayed(L"Overlay\\unlock.wav"));
     }
 
     TEST_METHOD(TestHandleChallengeIndicatorShowEvent)

--- a/tests/ui/viewmodels/AssetListViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/AssetListViewModel_Tests.cpp
@@ -1258,37 +1258,6 @@ public:
         Assert::AreEqual(AssetState::Active, pItem->GetState());
     }
 
-    TEST_METHOD(TestKeepActive)
-    {
-        AssetListViewModelHarness vmAssetList;
-        vmAssetList.SetFilterCategory(AssetListViewModel::FilterCategory::Core);
-        vmAssetList.SetSpecialFilter(AssetListViewModel::SpecialFilter::Active);
-
-        vmAssetList.AddAchievement(AssetCategory::Core, 5, L"Ach1");
-
-        Assert::AreEqual({ 1U }, vmAssetList.mockGameContext.Assets().Count());
-        auto* pAsset = dynamic_cast<ra::data::models::AchievementModel*>(vmAssetList.mockGameContext.Assets().GetItemAt(0));
-        Expects(pAsset != nullptr);
-        pAsset->SetState(AssetState::Active);
-        Assert::AreEqual(AssetState::Active, pAsset->GetState());
-        Assert::AreEqual({ 1U }, vmAssetList.FilteredAssets().Count());
-
-        vmAssetList.SetKeepActive(true);
-        pAsset->SetState(AssetState::Triggered);
-        Assert::AreEqual(AssetState::Waiting, pAsset->GetState());
-        Assert::AreEqual({ 1U }, vmAssetList.FilteredAssets().Count()); // should remain visible
-        Assert::IsTrue(vmAssetList.mockClock.Now() == pAsset->GetUnlockTime()); // should be marked as unlocked
-
-        pAsset->SetState(AssetState::Active);
-        Assert::AreEqual(AssetState::Active, pAsset->GetState());
-        Assert::AreEqual({ 1U }, vmAssetList.FilteredAssets().Count());
-
-        vmAssetList.SetKeepActive(false);
-        pAsset->SetState(AssetState::Triggered);
-        Assert::AreEqual(AssetState::Triggered, pAsset->GetState());
-        Assert::AreEqual({ 0U }, vmAssetList.FilteredAssets().Count());
-    }
-
     TEST_METHOD(TestUpdateButtonsNoGame)
     {
         AssetListViewModelHarness vmAssetList;


### PR DESCRIPTION
fixes https://github.com/RetroAchievements/RALibretro/issues/430

Instead of capturing active pause-on-trigger achievements before processing a frame and checking to see if they're still active after processing the frame, just intercept the TRIGGER event and queue up the pause-on-trigger behavior from there.

This fixes the problem reported where Keep Active was preventing the pause-on-trigger from actively pausing things. The Keep Active behavior would set the achievement back to waiting before the code that checked for no longer active achievements after the frame was processed.