### PR TITLE
improve reporting reset causer in chains

### DIFF
--- a/src/ui/viewmodels/TriggerConditionViewModel.cpp
+++ b/src/ui/viewmodels/TriggerConditionViewModel.cpp
@@ -743,8 +743,18 @@ void TriggerConditionViewModel::UpdateRowColor(const rc_condition_t* pCondition)
     }
     else if (pCondition->required_hits != 0 && pCondition->current_hits != pCondition->required_hits)
     {
-        // true this frame, but target hitcount not met
-        SetRowColor(pTheme.ColorTriggerBecomingTrue());
+        if (pCondition->current_hits == 0 && pCondition->type == RC_CONDITION_RESET_IF && (pCondition->is_true & 0x02))
+        {
+            // a ResetIf condition with a hit target may have met the hit target before
+            // being reset. if the second is_true bit is non-zero, the condition was
+            // responsible for resetting the trigger.
+            SetRowColor(pTheme.ColorTriggerResetTrue());
+        }
+        else
+        {
+            // true this frame, but target hitcount not met
+            SetRowColor(pTheme.ColorTriggerBecomingTrue());
+        }
     }
     else
     {

--- a/tests/ui/viewmodels/TriggerConditionViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/TriggerConditionViewModel_Tests.cpp
@@ -1615,7 +1615,7 @@ public:
         ra::services::ServiceLocator::ServiceOverride<ra::ui::EditorTheme> pThemeOverride(&pTheme);
         const auto nDefaultColor = ra::to_unsigned(TriggerConditionViewModel::RowColorProperty.GetDefaultValue());
 
-        const std::string sInput = "R:0xH0000=1_P:0xH0001=1_0xH0002=1(2)_0xH0003=1";
+        const std::string sInput = "R:0xH0000=1_P:0xH0001=1_0xH0002=1(2)_0xH0003=1_R:0xH0004=1.2.";
         const auto nSize = rc_trigger_size(sInput.c_str());
         std::string sBuffer;
         sBuffer.resize(nSize);
@@ -1702,6 +1702,36 @@ public:
         Assert::AreEqual(pTheme.ColorTriggerIsTrue().ARGB, condition.GetRowColor().ARGB);
 
         pCondition->is_true = 0;
+        condition.UpdateRowColor(pCondition);
+        Assert::AreEqual(nDefaultColor, condition.GetRowColor().ARGB);
+
+        // ResetIf with a hit target
+        pCondition = pCondition->next;
+        Expects(pCondition != nullptr);
+        condition.InitializeFrom(*pCondition);
+
+        pCondition->is_true = 0;
+        pCondition->current_hits = 0;
+        condition.UpdateRowColor(pCondition);
+        Assert::AreEqual(nDefaultColor, condition.GetRowColor().ARGB);
+
+        pCondition->is_true = 1;
+        pCondition->current_hits = 1;
+        condition.UpdateRowColor(pCondition);
+        Assert::AreEqual(pTheme.ColorTriggerBecomingTrue().ARGB, condition.GetRowColor().ARGB);
+
+        pCondition->is_true = 0;
+        pCondition->current_hits = 1;
+        condition.UpdateRowColor(pCondition);
+        Assert::AreEqual(nDefaultColor, condition.GetRowColor().ARGB);
+
+        pCondition->is_true = 3;
+        pCondition->current_hits = 0;
+        condition.UpdateRowColor(pCondition);
+        Assert::AreEqual(pTheme.ColorTriggerResetTrue().ARGB, condition.GetRowColor().ARGB);
+
+        pCondition->is_true = 0;
+        pCondition->current_hits = 0;
         condition.UpdateRowColor(pCondition);
         Assert::AreEqual(nDefaultColor, condition.GetRowColor().ARGB);
     }


### PR DESCRIPTION
Fixes highlight for ResetIf with hit target triggered by AddHits chain (where ResetIf condition itself is not true).
![image](https://github.com/user-attachments/assets/c6fc3111-a7d2-457c-be2c-2988488bc69d)

https://discord.com/channels/310192285306454017/310195377993416714/1336569375720869950
