### PR TITLE
hook up multiset events

### DIFF
--- a/src/data/context/GameContext.cpp
+++ b/src/data/context/GameContext.cpp
@@ -425,6 +425,9 @@ void GameContext::InitializeFromAchievementRuntime(const std::map<uint32_t, std:
                 else
                     vmAchievement->Attach(*pAchievementData, nCategory, "");
 
+                if (pSubset != pClient->game->subsets)
+                    vmAchievement->SetSubsetID(pSubset->public_.id);
+
                 m_vAssets.Append(std::move(vmAchievement));
 
 #ifndef RA_UTEST

--- a/src/data/models/AssetModelBase.cpp
+++ b/src/data/models/AssetModelBase.cpp
@@ -9,6 +9,7 @@ const IntModelProperty AssetModelBase::IDProperty("AssetModelBase", "ID", 0);
 const StringModelProperty AssetModelBase::NameProperty("AssetModelBase", "Name", L"");
 const StringModelProperty AssetModelBase::DescriptionProperty("AssetModelBase", "Description", L"");
 const IntModelProperty AssetModelBase::CategoryProperty("AssetModelBase", "Category", ra::etoi(AssetCategory::Core));
+const IntModelProperty AssetModelBase::SubsetIDProperty("AssetModelBase", "SubsetID", 0);
 const StringModelProperty AssetModelBase::AuthorProperty("AssetModelBase", "Author", L"");
 const IntModelProperty AssetModelBase::StateProperty("AssetModelBase", "State", ra::etoi(AssetState::Inactive));
 const IntModelProperty AssetModelBase::ChangesProperty("AssetModelBase", "Changes", ra::etoi(AssetChanges::None));

--- a/src/data/models/AssetModelBase.hh
+++ b/src/data/models/AssetModelBase.hh
@@ -127,6 +127,21 @@ public:
     void SetCategory(AssetCategory nValue) { SetValue(CategoryProperty, ra::etoi(nValue)); }
 
     /// <summary>
+    /// The <see cref="ModelProperty" /> for the owning set id.
+    /// </summary>
+    static const IntModelProperty SubsetIDProperty;
+
+    /// <summary>
+    /// Gets the asset id.
+    /// </summary>
+    uint32_t GetSubsetID() const { return ra::to_unsigned(GetValue(SubsetIDProperty)); }
+
+    /// <summary>
+    /// Sets the asset id.
+    /// </summary>
+    void SetSubsetID(uint32_t nValue) { SetValue(SubsetIDProperty, nValue); }
+
+    /// <summary>
     /// The <see cref="ModelProperty" /> for the badge.
     /// </summary>
     static const StringModelProperty AuthorProperty;

--- a/src/pch.h
+++ b/src/pch.h
@@ -42,6 +42,7 @@
 /* STL Stuff */
 #include <array> // algorithm, iterator, tuple
 #include <atomic>
+#include <chrono>
 #include <fstream>
 #include <iomanip>
 #include <map>

--- a/src/rcheevos.vcxproj
+++ b/src/rcheevos.vcxproj
@@ -208,6 +208,7 @@
   </ItemGroup>
   <ItemGroup>
     <Natvis Include="..\rcheevos\src\rcheevos\rc_runtime_types.natvis" />
+    <Natvis Include="..\rcheevos\src\rc_client_types.natvis" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/src/rcheevos.vcxproj.filters
+++ b/src/rcheevos.vcxproj.filters
@@ -172,5 +172,6 @@
     <Natvis Include="..\rcheevos\src\rcheevos\rc_runtime_types.natvis">
       <Filter>rcheevos</Filter>
     </Natvis>
+    <Natvis Include="..\rcheevos\src\rc_client_types.natvis" />
   </ItemGroup>
 </Project>

--- a/src/services/AchievementRuntime.cpp
+++ b/src/services/AchievementRuntime.cpp
@@ -450,8 +450,8 @@ private:
 
     typedef struct rc_client_subset_wrapper_t
     {
-        rc_client_subset_info_t pCoreSubset{};
-        rc_client_subset_info_t pLocalSubset{};
+        std::vector<rc_client_subset_info_t> pCoreSubset;
+        std::vector<rc_client_subset_info_t> pLocalSubset;
         rc_buffer_t pBuffer{};
         std::vector<void*> vAllocatedMemory;
     } SubsetWrapper;
@@ -542,9 +542,23 @@ private:
                     if (m_pSubsetWrapper != nullptr)
                     {
                         if (vmAchievement->GetCategory() == ra::data::models::AssetCategory::Local)
-                            pSrcAchievement = FindAchievement(&m_pSubsetWrapper->pLocalSubset, nAchievementId);
+                        {
+                            for (auto& pLocalSubset : m_pSubsetWrapper->pLocalSubset)
+                            {
+                                pSrcAchievement = FindAchievement(&pLocalSubset, nAchievementId);
+                                if (pSrcAchievement)
+                                    break;
+                            }
+                        }
                         else
-                            pSrcAchievement = FindAchievement(&m_pSubsetWrapper->pCoreSubset, nAchievementId);
+                        {
+                            for (auto& pCoreSubset : m_pSubsetWrapper->pCoreSubset)
+                            {
+                                pSrcAchievement = FindAchievement(&pCoreSubset, nAchievementId);
+                                if (pSrcAchievement)
+                                    break;
+                            }
+                        }
                     }
 
                     if (pSrcAchievement != nullptr && pSrcAchievement == vmAchievement->GetAttached())
@@ -616,9 +630,23 @@ private:
                     if (m_pSubsetWrapper != nullptr && vmLeaderboard->GetAttached() != nullptr)
                     {
                         if (vmLeaderboard->GetCategory() == ra::data::models::AssetCategory::Local)
-                            pSrcLeaderboard = FindLeaderboard(&m_pSubsetWrapper->pLocalSubset, nLeaderboardId);
+                        {
+                            for (auto& pLocalSubset : m_pSubsetWrapper->pLocalSubset)
+                            {
+                                pSrcLeaderboard = FindLeaderboard(&pLocalSubset, nLeaderboardId);
+                                if (pSrcLeaderboard)
+                                    break;
+                            }
+                        }
                         else
-                            pSrcLeaderboard = FindLeaderboard(&m_pSubsetWrapper->pCoreSubset, nLeaderboardId);
+                        {
+                            for (auto& pCoreSubset : m_pSubsetWrapper->pCoreSubset)
+                            {
+                                pSrcLeaderboard = FindLeaderboard(&pCoreSubset, nLeaderboardId);
+                                if (pSrcLeaderboard)
+                                    break;
+                            }
+                        }
                     }
 
                     if (pSrcLeaderboard != nullptr && pSrcLeaderboard == vmLeaderboard->GetAttached())
@@ -658,21 +686,12 @@ private:
         }
     }
 
-public:
-    void SyncAssets(rc_client_t* pClient)
+    void BuildSubsetWrapper(SubsetWrapper& pSubsetWrapper,
+                            rc_client_subset_info_t& pCoreSubsetWrapper,
+                            rc_client_subset_info_t& pLocalSubsetWrapper,
+                            const rc_client_subset_info_t* pSubset, uint32_t nSubsetId,
+                            ra::data::context::GameAssets& vAssets)
     {
-        if (!pClient->game)
-            return;
-
-        auto& pGameContext = ra::services::ServiceLocator::GetMutable<ra::data::context::GameContext>();
-        auto& vAssets = pGameContext.Assets();
-
-        if (m_pClient == nullptr)
-        {
-            m_pClient = pClient;
-            m_pPublishedSubset = pClient->game->subsets;
-        }
-
         std::vector<ra::data::models::AchievementModel*> vCoreAchievements;
         std::vector<ra::data::models::AchievementModel*> vLocalAchievements;
         std::vector<ra::data::models::LeaderboardModel*> vCoreLeaderboards;
@@ -682,6 +701,9 @@ public:
         {
             auto* pAsset = vAssets.GetItemAt(nIndex);
             Expects(pAsset != nullptr);
+            if (pAsset->GetSubsetID() != nSubsetId)
+                continue;
+
             if (pAsset->GetChanges() == ra::data::models::AssetChanges::Deleted)
                 continue;
 
@@ -708,29 +730,66 @@ public:
             }
         }
 
-        std::unique_ptr<SubsetWrapper> pSubsetWrapper;
-        pSubsetWrapper.reset(new SubsetWrapper);
-        memset(&pSubsetWrapper->pCoreSubset, 0, sizeof(pSubsetWrapper->pCoreSubset));
-        memset(&pSubsetWrapper->pLocalSubset, 0, sizeof(pSubsetWrapper->pLocalSubset));
-        rc_buffer_init(&pSubsetWrapper->pBuffer);
+        memset(&pCoreSubsetWrapper, 0, sizeof(pCoreSubsetWrapper));
+        memset(&pLocalSubsetWrapper, 0, sizeof(pLocalSubsetWrapper));
 
-        pSubsetWrapper->pCoreSubset.public_.id = pClient->game->public_.id;
-        pSubsetWrapper->pCoreSubset.public_.title = pClient->game->public_.title;
-        snprintf(pSubsetWrapper->pCoreSubset.public_.badge_name, sizeof(pSubsetWrapper->pCoreSubset.public_.badge_name),
-                 "%s", pClient->game->public_.badge_name);
+        pCoreSubsetWrapper.public_.id = pSubset->public_.id;
+        pCoreSubsetWrapper.public_.title = pSubset->public_.title;
+        snprintf(pCoreSubsetWrapper.public_.badge_name,
+                 sizeof(pCoreSubsetWrapper.public_.badge_name), "%s", pSubset->public_.badge_name);
 
-        SyncSubset(&pSubsetWrapper->pCoreSubset, pSubsetWrapper.get(), vCoreAchievements, vCoreLeaderboards);
+        SyncSubset(&pCoreSubsetWrapper, &pSubsetWrapper, vCoreAchievements, vCoreLeaderboards);
 
         if (!vLocalAchievements.empty() || !vLocalLeaderboards.empty())
         {
-            pSubsetWrapper->pLocalSubset.public_.id = ra::data::context::GameAssets::LocalSubsetId;
-            pSubsetWrapper->pLocalSubset.public_.title = "Local";
-            snprintf(pSubsetWrapper->pLocalSubset.public_.badge_name,
-                     sizeof(pSubsetWrapper->pLocalSubset.public_.badge_name), "%s", pClient->game->public_.badge_name);
+            pLocalSubsetWrapper.public_.id = ra::data::context::GameAssets::LocalSubsetId;
+            pLocalSubsetWrapper.public_.title = "Local";
+            snprintf(pLocalSubsetWrapper.public_.badge_name,
+                     sizeof(pLocalSubsetWrapper.public_.badge_name), "%s", pSubset->public_.badge_name);
 
-            SyncSubset(&pSubsetWrapper->pLocalSubset, pSubsetWrapper.get(), vLocalAchievements, vLocalLeaderboards);
+            SyncSubset(&pLocalSubsetWrapper, &pSubsetWrapper, vLocalAchievements, vLocalLeaderboards);
+        }
 
-            pSubsetWrapper->pCoreSubset.next = &pSubsetWrapper->pLocalSubset;
+        pCoreSubsetWrapper.next = &pLocalSubsetWrapper;
+    }
+
+public:
+    void SyncAssets(rc_client_t* pClient)
+    {
+        if (!pClient->game)
+            return;
+
+        auto& pGameContext = ra::services::ServiceLocator::GetMutable<ra::data::context::GameContext>();
+        auto& vAssets = pGameContext.Assets();
+
+        if (m_pClient == nullptr)
+        {
+            m_pClient = pClient;
+            m_pPublishedSubset = pClient->game->subsets;
+        }
+
+        std::unique_ptr<SubsetWrapper> pSubsetWrapper;
+        pSubsetWrapper.reset(new SubsetWrapper);
+        rc_buffer_init(&pSubsetWrapper->pBuffer);
+
+        size_t nSubsets = 0;
+        for (auto* pSubset = m_pPublishedSubset; pSubset; pSubset = pSubset->next)
+            nSubsets++;
+
+        pSubsetWrapper->pCoreSubset.resize(nSubsets);
+        pSubsetWrapper->pLocalSubset.resize(nSubsets);
+
+        BuildSubsetWrapper(*pSubsetWrapper, pSubsetWrapper->pCoreSubset[0],
+                           pSubsetWrapper->pLocalSubset[0], m_pPublishedSubset, 0, vAssets);
+
+        nSubsets = 1;
+        for (auto* pSubset = m_pPublishedSubset->next; pSubset; pSubset = pSubset->next, nSubsets++)
+        {
+            BuildSubsetWrapper(*pSubsetWrapper, pSubsetWrapper->pCoreSubset[nSubsets],
+                               pSubsetWrapper->pLocalSubset[nSubsets],
+                               pSubset, pSubset->public_.id, vAssets);
+
+            pSubsetWrapper->pLocalSubset[nSubsets - 1].next = &pSubsetWrapper->pCoreSubset[nSubsets];
         }
 
         std::swap(pSubsetWrapper, m_pSubsetWrapper);
@@ -742,7 +801,7 @@ public:
         }
 
         rc_mutex_lock(&pClient->state.mutex);
-        pClient->game->subsets = &m_pSubsetWrapper->pCoreSubset;
+        pClient->game->subsets = &m_pSubsetWrapper->pCoreSubset[0];
         rc_mutex_unlock(&pClient->state.mutex);
     }
 

--- a/tests/ui/viewmodels/AssetListViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/AssetListViewModel_Tests.cpp
@@ -387,6 +387,25 @@ private:
             AssertButtonState(nCloneButtonState);
         }
 
+    private:
+        void EnsureCoreSubset() const
+        {
+            auto* pGame = mockRuntime.GetClient()->game;
+            if (!pGame->subsets)
+            {
+                // populate a minimal core subset just to prevent a null reference error
+                auto* pSubset =
+                    (rc_client_subset_info_t*)rc_buffer_alloc(&pGame->buffer, sizeof(rc_client_subset_info_t));
+                memset(pSubset, 0, sizeof(*pSubset));
+                pSubset->public_.id = pGame->public_.id;
+                pSubset->public_.title = pGame->public_.title;
+                pSubset->active = true;
+
+                pGame->subsets = pSubset;
+            }
+        }
+
+    public:
         void AddAchievement(AssetCategory nCategory, unsigned nPoints, const std::wstring& sTitle)
         {
             auto vmAchievement = std::make_unique<MockAchievementModel>();
@@ -398,6 +417,8 @@ private:
             vmAchievement->CreateLocalCheckpoint();
             vmAchievement->AttachAndInitialize(*vmAchievement->m_pInfo);
             mockGameContext.Assets().Append(std::move(vmAchievement));
+
+            EnsureCoreSubset();
         }
 
         void AddAchievement(AssetCategory nCategory, unsigned nPoints, const std::wstring& sTitle,
@@ -415,6 +436,8 @@ private:
             vmAchievement->CreateLocalCheckpoint();
             vmAchievement->AttachAndInitialize(*vmAchievement->m_pInfo);
             mockGameContext.Assets().Append(std::move(vmAchievement));
+
+            EnsureCoreSubset();
         }
 
         void AddNewAchievement(unsigned nPoints, const std::wstring& sTitle,
@@ -433,6 +456,8 @@ private:
             vmAchievement->SetNew();
             vmAchievement->AttachAndInitialize(*vmAchievement->m_pInfo);
             mockGameContext.Assets().Append(std::move(vmAchievement));
+
+            EnsureCoreSubset();
         }
 
         void AddThreeAchievements()
@@ -451,6 +476,8 @@ private:
             vmLeaderboard->CreateServerCheckpoint();
             vmLeaderboard->CreateLocalCheckpoint();
             mockGameContext.Assets().Append(std::move(vmLeaderboard));
+
+            EnsureCoreSubset();
         }
 
         void AddLeaderboard()
@@ -465,6 +492,8 @@ private:
             vmRichPresence->CreateServerCheckpoint();
             vmRichPresence->CreateLocalCheckpoint();
             mockGameContext.Assets().Append(std::move(vmRichPresence));
+
+            EnsureCoreSubset();
         }
 
         void ForceUpdateButtons()


### PR DESCRIPTION
Allows subset achievements to be displayed in the overlay. They still cannot be accessed from the asset list.

![image](https://github.com/user-attachments/assets/6d0e0934-2ff1-4157-b741-1d1cc5570b70)
