### PR TITLE
support bookmarking indirect addresses

### DIFF
--- a/src/data/models/AchievementModel.cpp
+++ b/src/data/models/AchievementModel.cpp
@@ -437,9 +437,9 @@ void AchievementModel::SyncTrigger()
                 rc_reset_parse_state(&preparse.parse, trigger_buffer, nullptr, 0);
                 trigger = RC_ALLOC(rc_trigger_with_memrefs_t, &preparse.parse);
                 rc_preparse_alloc_memrefs(&trigger->memrefs, &preparse);
+                Expects(preparse.parse.memrefs == &trigger->memrefs);
 
                 preparse.parse.existing_memrefs = pGame->runtime.memrefs;
-                preparse.parse.memrefs = &trigger->memrefs;
 
                 sMemaddr = sTrigger.c_str();
                 m_pAchievement->trigger = &trigger->trigger;

--- a/src/ui/viewmodels/MemoryBookmarksViewModel.cpp
+++ b/src/ui/viewmodels/MemoryBookmarksViewModel.cpp
@@ -8,6 +8,7 @@
 #include "data\context\EmulatorContext.hh"
 #include "data\models\TriggerValidation.hh"
 
+#include "services\AchievementRuntime.hh"
 #include "services\FrameEventQueue.hh"
 #include "services\IConfiguration.hh"
 #include "services\IFileSystem.hh"
@@ -21,6 +22,7 @@
 #include "ui\viewmodels\WindowManager.hh"
 
 #include <rcheevos/src/rcheevos/rc_internal.h>
+#include <rcheevos/src/rc_client_internal.h>
 
 #ifdef RA_UTEST
 // awkward workaround to allow individual bookmarks access to the bookmarks view model being tested
@@ -193,8 +195,28 @@ void MemoryBookmarksViewModel::MemoryBookmarkViewModel::OnValueChanged(const Str
     LookupItemViewModel::OnValueChanged(args);
 }
 
+static const rc_operand_t* FindMeasuredOperand(const rc_value_t* pValue)
+{
+    const rc_condition_t* condition = pValue->conditions->conditions;
+    for (; condition; condition = condition->next)
+    {
+        if (condition->type == RC_CONDITION_MEASURED && rc_operand_is_memref(&condition->operand1))
+            return &condition->operand1;
+    }
+
+    return nullptr;
+}
+
 unsigned MemoryBookmarksViewModel::MemoryBookmarkViewModel::ReadValue() const
 {
+    if (m_pValue)
+    {
+        rc_typed_value_t value;
+        rc_evaluate_value_typed(m_pValue, &value, rc_peek_callback, nullptr, nullptr);
+        rc_typed_value_convert(&value, RC_VALUE_TYPE_UNSIGNED);
+        return value.value.u32;
+    }
+
     const auto& pEmulatorContext = ra::services::ServiceLocator::Get<ra::data::context::EmulatorContext>();
     if (m_nSize == MemSize::Text)
     {
@@ -231,6 +253,10 @@ bool MemoryBookmarksViewModel::MemoryBookmarkViewModel::MemoryChanged()
 {
     const auto& pEmulatorContext = ra::services::ServiceLocator::Get<ra::data::context::EmulatorContext>();
     const auto nValue = ReadValue();
+
+    if (HasIndirectAddress()) // address must be updated after calling ReadValue as ReadValue updates local memrefs
+        UpdateCurrentAddress();
+
     if (nValue == m_nValue)
         return false;
 
@@ -302,6 +328,13 @@ bool MemoryBookmarksViewModel::MemoryBookmarkViewModel::SetCurrentValue(const st
     pEmulatorContext.WriteMemory(nAddress, m_nSize, nValue);
     vmBookmarks.EndWritingMemory();
 
+#ifndef RA_UTEST
+    // memory inspector does not automatically redraw if the emulator is paused. force it to redraw.
+    // will be a no-op if the modified memory is not in the visible addresses.
+    auto& vmMemoryInspector = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::WindowManager>().MemoryInspector;
+    vmMemoryInspector.Viewer().Redraw();
+#endif
+
     return true;
 }
 
@@ -325,6 +358,78 @@ std::wstring MemoryBookmarksViewModel::MemoryBookmarkViewModel::BuildCurrentValu
     }
 
     return ra::data::MemSizeFormat(m_nValue, m_nSize, GetFormat());
+}
+
+void MemoryBookmarksViewModel::MemoryBookmarkViewModel::UpdateCurrentAddress()
+{
+    if (m_pValue)
+    {
+        const auto* pOperand = FindMeasuredOperand(m_pValue);
+        if (pOperand != nullptr && pOperand->value.memref->value.memref_type == RC_MEMREF_TYPE_MODIFIED_MEMREF)
+        {
+            rc_modified_memref_t* pModifiedMemref = (rc_modified_memref_t*)pOperand->value.memref;
+            if (pModifiedMemref->modifier_type == RC_OPERATOR_INDIRECT_READ)
+            {
+                rc_typed_value_t address, offset;
+                rc_evaluate_operand(&address, &pModifiedMemref->parent, NULL);
+                rc_evaluate_operand(&offset, &pModifiedMemref->modifier, NULL);
+                rc_typed_value_add(&address, &offset);
+                rc_typed_value_convert(&address, RC_VALUE_TYPE_UNSIGNED);
+                const auto nNewAddress = static_cast<ra::ByteAddress>(address.value.u32);
+
+                if (m_nAddress != nNewAddress)
+                {
+                    m_nAddress = nNewAddress;
+                    SetAddressWithoutUpdatingValue(nNewAddress);
+                }
+            }
+        }
+    }
+}
+
+void MemoryBookmarksViewModel::MemoryBookmarkViewModel::SetIndirectAddress(const std::string& sSerialized)
+{
+    const auto& pRuntime = ra::services::ServiceLocator::Get<ra::services::AchievementRuntime>();
+    auto* pGame = pRuntime.GetClient()->game;
+
+    rc_preparse_state_t preparse;
+    rc_init_preparse_state(&preparse, nullptr, 0);
+    preparse.parse.existing_memrefs = pGame ? pGame->runtime.memrefs : nullptr;
+
+    rc_value_with_memrefs_t* value = RC_ALLOC(rc_value_with_memrefs_t, &preparse.parse);
+    const char* memaddr = sSerialized.c_str();
+    rc_parse_value_internal(&value->value, &memaddr, &preparse.parse);
+    rc_preparse_alloc_memrefs(nullptr, &preparse);
+
+    const auto nSize = preparse.parse.offset;
+    if (nSize < 0)
+        return;
+
+    m_pBuffer.reset(new uint8_t[nSize]);
+    if (!m_pBuffer)
+        return;
+
+    rc_reset_parse_state(&preparse.parse, m_pBuffer.get(), nullptr, 0);
+    value = RC_ALLOC(rc_value_with_memrefs_t, &preparse.parse);
+    rc_preparse_alloc_memrefs(&value->memrefs, &preparse);
+    Expects(preparse.parse.memrefs == &value->memrefs);
+
+    preparse.parse.existing_memrefs = pGame ? pGame->runtime.memrefs : nullptr;
+
+    memaddr = sSerialized.c_str();
+    rc_parse_value_internal(&value->value, &memaddr, &preparse.parse);
+    Expects(preparse.parse.offset == nSize);
+    value->value.has_memrefs = 1;
+
+    m_pValue = &value->value;
+    m_sIndirectAddress = sSerialized;
+
+    const rc_operand_t* pOperand = FindMeasuredOperand(m_pValue);
+    if (pOperand != nullptr)
+        SetSize(ra::data::models::TriggerValidation::MapRcheevosMemSize(pOperand->size));
+
+    UpdateCurrentValue(); // value must be updated first to populate memrefs
+    UpdateCurrentAddress();
 }
 
 bool MemoryBookmarksViewModel::IsModified() const
@@ -421,14 +526,8 @@ void MemoryBookmarksViewModel::LoadBookmarks(ra::services::TextReader& sBookmark
                 if (bookmark.HasMember("MemAddr"))
                 {
                     // third bookmark format uses the memref serializer
-                    uint8_t size = 0;
-                    unsigned address = 0;
                     const char* memaddr = bookmark["MemAddr"].GetString();
-                    if (rc_parse_memref(&memaddr, &size, &address) == RC_OK)
-                    {
-                        vmBookmark->SetAddress(address);
-                        vmBookmark->SetSize(ra::data::models::TriggerValidation::MapRcheevosMemSize(size));
-                    }
+                    InitializeBookmark(*vmBookmark, memaddr);
                 }
                 else
                 {
@@ -512,8 +611,7 @@ void MemoryBookmarksViewModel::LoadBookmarks(ra::services::TextReader& sBookmark
 
 void MemoryBookmarksViewModel::SaveBookmarks(ra::services::TextWriter& sBookmarksFile)
 {
-    TriggerConditionViewModel vmCondition;
-    vmCondition.SetOperator(ra::ui::viewmodels::TriggerOperatorType::None);
+    std::string sSerialized;
 
     rapidjson::Document document;
     auto& allocator = document.GetAllocator();
@@ -535,9 +633,17 @@ void MemoryBookmarksViewModel::SaveBookmarks(ra::services::TextWriter& sBookmark
                 break;
 
             default:
-                vmCondition.SetSourceSize(nSize);
-                vmCondition.SetSourceValue(vmBookmark.GetAddress());
-                item.AddMember("MemAddr", vmCondition.Serialize(), allocator);
+                if (vmBookmark.HasIndirectAddress())
+                {
+                    item.AddMember("MemAddr", vmBookmark.GetIndirectAddress(), allocator);
+                }
+                else
+                {
+                    sSerialized.clear();
+                    ra::services::AchievementLogicSerializer::AppendOperand(
+                        sSerialized, ra::services::TriggerOperandType::Address, nSize, vmBookmark.GetAddress());
+                    item.AddMember("MemAddr", sSerialized, allocator);
+                }
                 break;
         }
 
@@ -675,27 +781,68 @@ void MemoryBookmarksViewModel::AddBookmark(ra::ByteAddress nAddress, MemSize nSi
 {
     auto vmBookmark = std::make_unique<MemoryBookmarkViewModel>();
     vmBookmark->BeginInitialization();
+
     vmBookmark->SetAddress(nAddress);
     vmBookmark->SetSize(nSize);
-
-    const auto& pConfiguration = ra::services::ServiceLocator::Get<ra::services::IConfiguration>();
-    vmBookmark->SetFormat(pConfiguration.IsFeatureEnabled(ra::services::Feature::PreferDecimal) ? MemFormat::Dec : MemFormat::Hex);
-
-    const auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::context::GameContext>();
-    const auto* pCodeNotes = pGameContext.Assets().FindCodeNotes();
-    const auto* pNote = (pCodeNotes != nullptr) ? pCodeNotes->FindCodeNote(nAddress) : nullptr;
-    if (pNote)
-    {
-        vmBookmark->SetDescription(*pNote);
-
-        // if bookmarking an 8-byte double, automatically adjust the bookmark for the significant bytes
-        if (nSize == MemSize::Double32 && pCodeNotes->GetCodeNoteBytes(nAddress) == 8)
-            vmBookmark->SetAddress(nAddress + 4);
-    }
+    InitializeBookmark(*vmBookmark);
 
     vmBookmark->EndInitialization();
 
     m_vBookmarks.Append(std::move(vmBookmark));
+}
+
+void MemoryBookmarksViewModel::AddBookmark(const std::string& sSerialized)
+{
+    auto vmBookmark = std::make_unique<MemoryBookmarkViewModel>();
+    vmBookmark->BeginInitialization();
+
+    InitializeBookmark(*vmBookmark, sSerialized);
+    InitializeBookmark(*vmBookmark);
+
+    vmBookmark->EndInitialization();
+
+    m_vBookmarks.Append(std::move(vmBookmark));
+}
+
+void MemoryBookmarksViewModel::InitializeBookmark(MemoryBookmarksViewModel::MemoryBookmarkViewModel& vmBookmark)
+{
+    const auto& pConfiguration = ra::services::ServiceLocator::Get<ra::services::IConfiguration>();
+    const auto bPreferDecimal = pConfiguration.IsFeatureEnabled(ra::services::Feature::PreferDecimal);
+    vmBookmark.SetFormat(bPreferDecimal ? MemFormat::Dec : MemFormat::Hex);
+
+    const auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::context::GameContext>();
+    const auto* pCodeNotes = pGameContext.Assets().FindCodeNotes();
+    const auto nAddress = vmBookmark.GetAddress();
+    const auto* pNote = (pCodeNotes != nullptr) ? pCodeNotes->FindCodeNote(nAddress) : nullptr;
+    if (pNote)
+    {
+        vmBookmark.SetDescription(*pNote);
+
+        // if bookmarking an 8-byte double, automatically adjust the bookmark for the significant bytes
+        if (vmBookmark.GetSize() == MemSize::Double32 && pCodeNotes->GetCodeNoteBytes(nAddress) == 8)
+            vmBookmark.SetAddress(nAddress + 4);
+    }
+}
+
+void MemoryBookmarksViewModel::InitializeBookmark(MemoryBookmarksViewModel::MemoryBookmarkViewModel& vmBookmark, const std::string& sSerialized)
+{
+    // if there's no condition separator, it's a simple memref
+    if (sSerialized.find('_') == std::string::npos)
+    {
+        uint8_t size;
+        uint32_t address;
+        const char* memaddr = sSerialized.c_str();
+        if (rc_parse_memref(&memaddr, &size, &address) == RC_OK)
+        {
+            vmBookmark.SetAddress(address);
+            vmBookmark.SetSize(ra::data::models::TriggerValidation::MapRcheevosMemSize(size));
+        }
+
+        return;
+    }
+
+    // complex memref.
+    vmBookmark.SetIndirectAddress(sSerialized);
 }
 
 int MemoryBookmarksViewModel::RemoveSelectedBookmarks()

--- a/src/ui/viewmodels/MemoryBookmarksViewModel.hh
+++ b/src/ui/viewmodels/MemoryBookmarksViewModel.hh
@@ -99,12 +99,12 @@ public:
         /// Gets the indirect bookmark address.
         /// </summary>
         /// <returns></returns>
-        const std::string& GetIndirectAddress() const { return m_sIndirectAddress; }
+        const std::string& GetIndirectAddress() const noexcept { return m_sIndirectAddress; }
 
         /// <summary>
         /// Gets whether or not the bookmark has an indirect bookmark address.
         /// </summary>
-        bool HasIndirectAddress() const { return !m_sIndirectAddress.empty(); }
+        bool HasIndirectAddress() const noexcept { return !m_sIndirectAddress.empty(); }
 
         /// <summary>
         /// Updates the current address from the indirect address chain.

--- a/src/ui/viewmodels/MemoryBookmarksViewModel.hh
+++ b/src/ui/viewmodels/MemoryBookmarksViewModel.hh
@@ -91,6 +91,27 @@ public:
         void SetAddress(ByteAddress value) { SetValue(AddressProperty, value); }
 
         /// <summary>
+        /// Sets an indirect bookmark address.
+        /// </summary>
+        void SetIndirectAddress(const std::string& sSerialized);
+
+        /// <summary>
+        /// Gets the indirect bookmark address.
+        /// </summary>
+        /// <returns></returns>
+        const std::string& GetIndirectAddress() const { return m_sIndirectAddress; }
+
+        /// <summary>
+        /// Gets whether or not the bookmark has an indirect bookmark address.
+        /// </summary>
+        bool HasIndirectAddress() const { return !m_sIndirectAddress.empty(); }
+
+        /// <summary>
+        /// Updates the current address from the indirect address chain.
+        /// </summary>
+        void UpdateCurrentAddress();
+
+        /// <summary>
         /// The <see cref="ModelProperty" /> for the bookmark size.
         /// </summary>
         static const IntModelProperty SizeProperty;
@@ -280,6 +301,10 @@ public:
         MemSize m_nSize = MemSize::EightBit;
         bool m_bModified = false;
         bool m_bInitialized = false;
+
+        std::string m_sIndirectAddress;
+        std::unique_ptr<uint8_t[]> m_pBuffer;
+        rc_value_t* m_pValue = nullptr;
     };
 
     /// <summary>
@@ -336,6 +361,11 @@ public:
     /// Adds a bookmark to the list.
     /// </summary>
     void AddBookmark(ra::ByteAddress nAddress, MemSize nSize);
+
+    /// <summary>
+    /// Adds a bookmark to the list.
+    /// </summary>
+    void AddBookmark(const std::string& sSerialized);
 
     /// <summary>
     /// Removes any bookmarks that are currently selected.
@@ -420,6 +450,9 @@ private:
 
     bool ShouldPause() const;
     void UpdatePauseButtonText();
+
+    static void InitializeBookmark(MemoryBookmarkViewModel& vmBookmark, const std::string& sSerialized);
+    static void InitializeBookmark(MemoryBookmarkViewModel& vmBookmark);
 
     void UpdateHasSelection();
 

--- a/src/ui/viewmodels/MemoryViewerViewModel.cpp
+++ b/src/ui/viewmodels/MemoryViewerViewModel.cpp
@@ -1091,6 +1091,11 @@ void MemoryViewerViewModel::DoFrame()
         m_nNeedsRedraw |= REDRAW_MEMORY;
     }
 
+    Redraw();
+}
+
+void MemoryViewerViewModel::Redraw()
+{
     if (m_nNeedsRedraw)
     {
         if (m_pRepaintNotifyTarget != nullptr)

--- a/src/ui/viewmodels/MemoryViewerViewModel.hh
+++ b/src/ui/viewmodels/MemoryViewerViewModel.hh
@@ -36,6 +36,7 @@ public:
 
     void DoFrame();
 
+    void Redraw();
     bool NeedsRedraw() const noexcept { return (m_nNeedsRedraw != 0); }
 
     class RepaintNotifyTarget

--- a/src/ui/viewmodels/PointerInspectorViewModel.cpp
+++ b/src/ui/viewmodels/PointerInspectorViewModel.cpp
@@ -696,7 +696,9 @@ void PointerInspectorViewModel::BookmarkCurrentField() const
 
     auto& pWindowManager = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::WindowManager>();
     pWindowManager.MemoryBookmarks.AddBookmark(sDefinition);
-    pWindowManager.MemoryBookmarks.Show();
+
+    if (!pWindowManager.MemoryBookmarks.IsVisible())
+        pWindowManager.MemoryBookmarks.Show();
 }
 
 } // namespace viewmodels

--- a/src/ui/viewmodels/PointerInspectorViewModel.cpp
+++ b/src/ui/viewmodels/PointerInspectorViewModel.cpp
@@ -8,6 +8,8 @@
 #include "services\IClipboard.hh"
 #include "services\ServiceLocator.hh"
 
+#include "ui\viewmodels\WindowManager.hh"
+
 namespace ra {
 namespace ui {
 namespace viewmodels {
@@ -679,6 +681,22 @@ std::string PointerInspectorViewModel::GetDefinition() const
                                                             MemSize::ThirtyTwoBit, vmField->GetCurrentValueRaw());
 
     return sBuffer;
+}
+
+void PointerInspectorViewModel::BookmarkCurrentField() const
+{
+    // change "I:0xX1234_0xH0010=0" to "I:0xX1234_M:0xH0010"
+    auto sDefinition = GetDefinition();
+    auto nIndex = sDefinition.find_last_of('=');
+    Expects(nIndex != std::string::npos);
+    sDefinition.erase(nIndex);
+    nIndex = sDefinition.find_last_of('_');
+    Expects(nIndex != std::string::npos);
+    sDefinition.insert(nIndex + 1, "M:");
+
+    auto& pWindowManager = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::WindowManager>();
+    pWindowManager.MemoryBookmarks.AddBookmark(sDefinition);
+    pWindowManager.MemoryBookmarks.Show();
 }
 
 } // namespace viewmodels

--- a/src/ui/viewmodels/PointerInspectorViewModel.hh
+++ b/src/ui/viewmodels/PointerInspectorViewModel.hh
@@ -189,6 +189,7 @@ public:
     void DoFrame() override;
 
     void CopyDefinition() const;
+    void BookmarkCurrentField() const;
 
 protected:
     void OnValueChanged(const IntModelProperty::ChangeArgs& args) override;

--- a/src/ui/win32/PointerInspectorDialog.cpp
+++ b/src/ui/win32/PointerInspectorDialog.cpp
@@ -181,13 +181,13 @@ BOOL PointerInspectorDialog::OnCommand(WORD nCommand)
 {
     switch (nCommand)
     {
-        //case IDC_RA_ADDBOOKMARK: {
-        //    auto* vmPointerInspector = dynamic_cast<PointerInspectorViewModel*>(&m_vmWindow);
-        //    if (vmPointerInspector)
-        //        vmPointerInspector->AddBookmark();
+        case IDC_RA_ADDBOOKMARK: {
+            const auto* vmPointerInspector = dynamic_cast<PointerInspectorViewModel*>(&m_vmWindow);
+            if (vmPointerInspector)
+                vmPointerInspector->BookmarkCurrentField();
 
-        //    return TRUE;
-        //}
+            return TRUE;
+        }
 
         case IDC_RA_COPY_ALL: {
             const auto* vmPointerInspector = dynamic_cast<PointerInspectorViewModel*>(&m_vmWindow);


### PR DESCRIPTION
When selecting an address that contains an [indirect from X] note, the Add Bookmark button will now add a bookmark that follows the indirection.

Indirect addresses are wrapped in parenthesis in the bookmark dialog

![image](https://github.com/user-attachments/assets/207f30d3-9c17-4347-ac80-c10f656c60dd)

![image](https://github.com/user-attachments/assets/24db9b57-e167-4e16-a1ad-874979cfbebf)

These bookmarks behave the same as other bookmarks. They can be written to, frozen, or trigger pause on change events.