### PR TITLE
fix first operand of complex measured

### DIFF
--- a/src/RA_Version.rc
+++ b/src/RA_Version.rc
@@ -77,7 +77,7 @@ BEGIN
             VALUE "FileDescription", "RetroAchievements Integration Toolkit"
             VALUE "FileVersion", RA_INTEGRATION_VERSION_MAJOR, RA_INTEGRATION_VERSION_MINOR, RA_INTEGRATION_VERSION_PATCH, RA_INTEGRATION_VERSION_REVISION
             VALUE "InternalName", "RA_Integration"
-            VALUE "LegalCopyright", "Copyright (C) 2024 retroachievements.org"
+            VALUE "LegalCopyright", "Copyright (C) 2025 retroachievements.org"
             VALUE "OriginalFilename", "RA_Integration.dll"
             VALUE "ProductName", "RetroAchievements Integration Toolkit"
             VALUE "ProductVersion", RA_INTEGRATION_VERSION_PRODUCT_ARCH

--- a/src/ui/viewmodels/TriggerViewModel.cpp
+++ b/src/ui/viewmodels/TriggerViewModel.cpp
@@ -1278,12 +1278,12 @@ void TriggerViewModel::UpdateConditionColors(const rc_trigger_t* pTrigger)
                     auto* vmCondition = m_vConditions.GetItemAt(nConditionIndex);
                     if (vmCondition != nullptr)
                     {
-                        if (pCondition < pEndPauseConditions && pCondition > pPauseConditions && bFirstPause)
+                        if (pCondition < pEndPauseConditions && pCondition >= pPauseConditions && bFirstPause)
                         {
                             vmCondition->UpdateRowColor(pCondition);
 
                             // processing stops when a PauseIf has met its hit target
-                            if (pCondition->type == RC_CONDITION_PAUSE_IF)
+                            if (pCondition->type == RC_CONDITION_PAUSE_IF && pCondition->is_true)
                             {
                                 if (pCondition->required_hits == 0 || pCondition->current_hits == pCondition->required_hits)
                                     bFirstPause = false;

--- a/tests/ui/viewmodels/TriggerConditionViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/TriggerConditionViewModel_Tests.cpp
@@ -84,7 +84,10 @@ private:
         Assert::IsNotNull(pValue);
         Ensures(pValue != nullptr);
 
+        TriggerViewModel vmTrigger;
+        vmTrigger.SetIsValue(true);
         TriggerConditionViewModelHarness vmCondition;
+        vmCondition.SetTriggerViewModel(&vmTrigger);
         vmCondition.InitializeFrom(*pValue->conditions->conditions);
 
         const std::string sOutput = vmCondition.Serialize();
@@ -650,12 +653,13 @@ public:
         ParseAndRegenerate("T:0xH1234=5"); // trigger
     }
 
-    TEST_METHOD(TestRequiredHits)
+    TEST_METHOD(TestParseAndRegenerate)
     {
-        ParseAndRegenerate("0xH1234=5"); // none
-        ParseAndRegenerate("R:0xH1234=5.100."); // 100
+        ParseAndRegenerate("0xH1234=5"); // simple
+        ParseAndRegenerate("R:0xH1234=5.100."); // flag and 100 hits
         ParseAndRegenerateValue("M:0xH1234=5"); // measured without hit target
         ParseAndRegenerateValue("M:0xH1234"); // measured without comparison
+        ParseAndRegenerateValue("M:0xH1234/5"); // measured with modifier
     }
 
     TEST_METHOD(TestTooltipAddress)

--- a/tests/ui/viewmodels/TriggerViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/TriggerViewModel_Tests.cpp
@@ -271,6 +271,7 @@ public:
     {
         ParseAndRegenerateValue(""); // empty
         ParseAndRegenerateValue("A:0xH1234*10_M:0xH1235"); // multiplication
+        ParseAndRegenerateValue("A:0xH1234*10_M:0xH1235*5"); // multiplication
         ParseAndRegenerateValue("M:0xH1234$M:0xX5555"); // one alt
         ParseAndRegenerateValue("M:0xH1234$M:0xX5555$M:b0xL3333"); // several alts
         ParseAndRegenerateValue("M:0xH1234$I:0x 1234_A:0xH2345_M:0xH7777"); // addsource/addaddress chain


### PR DESCRIPTION
fixes an issue displaying some conditions caused by the modified memref logic.

the left side of this should be a memory read:
![image](https://github.com/user-attachments/assets/4de9178d-0dbc-4ba6-aefb-48fbe2f75884)

