### PR TITLE
don't attempt to fetch game data by hash in compatibility mode

### DIFF
--- a/src/ui/viewmodels/IntegrationMenuViewModel.cpp
+++ b/src/ui/viewmodels/IntegrationMenuViewModel.cpp
@@ -7,8 +7,6 @@
 #include "data/context/GameContext.hh"
 #include "data/context/UserContext.hh"
 
-#include "services/AchievementRuntime.hh"
-#include "services/AchievementRuntimeExports.hh"
 #include "services/IConfiguration.hh"
 #include "services/ServiceLocator.hh"
 
@@ -22,8 +20,6 @@
 #include "ui/viewmodels/OverlaySettingsViewModel.hh"
 #include "ui/viewmodels/UnknownGameViewModel.hh"
 #include "ui/viewmodels/WindowManager.hh"
-
-#include "rcheevos/src/rc_client_external.h"
 
 namespace ra {
 namespace ui {
@@ -425,10 +421,6 @@ void IntegrationMenuViewModel::ShowGameHash()
 
                 if (vmUnknownGame.ShowModal() == ra::ui::DialogResult::OK)
                 {
-                    // register the hash so the dialog doesn't immediately reappear
-                    auto* pClient = ra::services::ServiceLocator::GetMutable<ra::services::AchievementRuntime>().GetClient();
-                    rc_client_add_game_hash(pClient, pGameContext.GameHash().c_str(), vmUnknownGame.GetSelectedGameId());
-
                     // attempt to load the newly associated game
                     pGameContext.LoadGame(vmUnknownGame.GetSelectedGameId(), pGameContext.GameHash(),
                                           vmUnknownGame.GetTestMode()

--- a/src/ui/viewmodels/UnknownGameViewModel.cpp
+++ b/src/ui/viewmodels/UnknownGameViewModel.cpp
@@ -9,10 +9,15 @@
 #include "data\context\GameContext.hh"
 #include "data\context\UserContext.hh"
 
+#include "services\AchievementRuntime.hh"
+#include "services\AchievementRuntimeExports.hh"
 #include "services\IClipboard.hh"
 #include "services\ILocalStorage.hh"
 
 #include "ui\viewmodels\MessageBoxViewModel.hh"
+
+#include "rcheevos\src\rc_client_external.h"
+#include "rcheevos\src\rc_client_internal.h"
 
 namespace ra {
 namespace ui {
@@ -157,6 +162,14 @@ std::string UnknownGameViewModel::EncodeID(unsigned nId, const std::wstring& sHa
     return ra::StringPrintf("%08x", nEncodedId);
 }
 
+static void AddClientHash(const std::string& sHash, uint32_t nGameId, bool isUnknown)
+{
+    auto* pClient = ra::services::ServiceLocator::GetMutable<ra::services::AchievementRuntime>().GetClient();
+    rc_client_add_game_hash(pClient, sHash.c_str(), nGameId);
+    auto* game_hash = rc_client_find_game_hash(pClient, sHash.c_str());
+    game_hash->is_unknown = isUnknown ? 1 : 0;
+}
+
 bool UnknownGameViewModel::Associate()
 {
     ra::api::SubmitNewTitle::Request request;
@@ -202,6 +215,8 @@ bool UnknownGameViewModel::Associate()
     if (response.Succeeded())
     {
         SetSelectedGameId(ra::to_signed(response.GameId));
+        SetTestMode(false);
+        AddClientHash(request.Hash, response.GameId, 0);
         return true;
     }
 
@@ -233,6 +248,8 @@ bool UnknownGameViewModel::BeginTest()
     sMapping->WriteLine(sValue);
 
     SetTestMode(true);
+    AddClientHash(ra::Narrow(GetChecksum()), nGameId, 1);
+
     return true;
 }
 

--- a/tests/services/GameIdentifier_Tests.cpp
+++ b/tests/services/GameIdentifier_Tests.cpp
@@ -5,6 +5,7 @@
 #include "tests\data\DataAsserts.hh"
 #include "tests\ui\UIAsserts.hh"
 
+#include "tests\mocks\MockAchievementRuntime.hh"
 #include "tests\mocks\MockAudioSystem.hh"
 #include "tests\mocks\MockClock.hh"
 #include "tests\mocks\MockConfiguration.hh"
@@ -77,6 +78,7 @@ public:
     ra::data::context::mocks::MockGameContext mockGameContext;
     ra::data::context::mocks::MockSessionTracker mockSessionTracker;
     ra::data::context::mocks::MockUserContext mockUserContext;
+    ra::services::mocks::MockAchievementRuntime mockAchievementRuntime;
     ra::services::mocks::MockConfiguration mockConfiguration;
     ra::ui::mocks::MockDesktop mockDesktop;
     ra::ui::viewmodels::mocks::MockOverlayManager mockOverlayManager;


### PR DESCRIPTION
Prevents the unknown game dialog from opening twice when trying to use compatibility mode.

Now that game data is fetched by hash, we have to explicitly mark a hash as unknown so `rc_client` will fetch by ID instead of by hash.