### PR TITLE
allow creating new condition from indirect chain

### DIFF
--- a/src/ui/viewmodels/MemoryBookmarksViewModel.cpp
+++ b/src/ui/viewmodels/MemoryBookmarksViewModel.cpp
@@ -860,6 +860,9 @@ void MemoryBookmarksViewModel::InitializeBookmark(MemoryBookmarksViewModel::Memo
         uint8_t size = 0;
         uint32_t address = 0;
         const char* memaddr = sSerialized.c_str();
+        if (ra::StringStartsWith(sSerialized, "M:"))
+            memaddr += 2;
+
         if (rc_parse_memref(&memaddr, &size, &address) == RC_OK)
         {
             vmBookmark.SetAddress(address);

--- a/src/ui/viewmodels/MemoryInspectorViewModel.hh
+++ b/src/ui/viewmodels/MemoryInspectorViewModel.hh
@@ -64,6 +64,7 @@ public:
     const std::wstring& GetCurrentAddressText() const { return GetValue(CurrentAddressTextProperty); }
 
     void BookmarkCurrentAddress() const;
+    std::string GetCurrentAddressMemRefChain() const;
 
     /// <summary>
     /// The <see cref="ModelProperty" /> for the current address's note.

--- a/src/ui/viewmodels/TriggerViewModel.cpp
+++ b/src/ui/viewmodels/TriggerViewModel.cpp
@@ -6,6 +6,8 @@
 
 #include "RA_StringUtils.h"
 
+#include "data\models\TriggerValidation.hh"
+
 #include "services\AchievementRuntime.hh"
 #include "services\IClipboard.hh"
 #include "services\ServiceLocator.hh"
@@ -231,6 +233,8 @@ void TriggerViewModel::DeselectAllConditions()
         m_vConditions.SetItemValue(nIndex, TriggerConditionViewModel::IsSelectedProperty, false);
 }
 
+static constexpr int RC_MULTIPLE_GROUPS = -99;
+
 void TriggerViewModel::PasteFromClipboard()
 {
     const std::wstring sClipboardText = ra::services::ServiceLocator::Get<ra::services::IClipboard>().GetText();
@@ -240,35 +244,54 @@ void TriggerViewModel::PasteFromClipboard()
         return;
     }
 
+    const auto nResult = AppendMemRefChain(ra::Narrow(sClipboardText));
+    if (nResult != RC_OK)
+    {
+        if (nResult == RC_MULTIPLE_GROUPS)
+        {
+            ra::ui::viewmodels::MessageBoxViewModel::ShowErrorMessage(
+                L"Paste failed.", L"Clipboard contained multiple groups.");
+        }
+        else
+        {
+            ra::ui::viewmodels::MessageBoxViewModel::ShowErrorMessage(
+                L"Paste failed.", ra::StringPrintf(L"Clipboard did not contain valid %s conditions.", IsValue() ? "value" : "trigger"));
+        }
+    }
+}
+
+int TriggerViewModel::AppendMemRefChain(const std::string& sTrigger)
+{
     // have to use internal parsing functions to decode conditions without full trigger/value
     // restriction validation (full validation will occur after new conditions are added)
     rc_preparse_state_t preparse;
     rc_init_preparse_state(&preparse);
     preparse.parse.is_value = IsValue();
-    std::string sTrigger = ra::Narrow(sClipboardText);
+    preparse.parse.ignore_non_parse_errors = 1;
     const char* memaddr = sTrigger.c_str();
     Expects(memaddr != nullptr);
     rc_parse_condset(&memaddr, &preparse.parse);
 
     const auto nSize = preparse.parse.offset;
-    if (nSize > 0 && *memaddr == 'S')
-    {
-        ra::ui::viewmodels::MessageBoxViewModel::ShowErrorMessage(
-            L"Paste failed.", L"Clipboard contained multiple groups.");
-        return;
-    }
+    if (nSize == 0) // nothing to do
+        return RC_OK;
 
-    if (nSize <= 0 || *memaddr != '\0')
+    if (nSize < 0) // error occurred
+        return nSize;
+
+    if (*memaddr != '\0')
     {
-        ra::ui::viewmodels::MessageBoxViewModel::ShowErrorMessage(L"Paste failed.",
-            ra::StringPrintf(L"Clipboard did not contain valid %s conditions.", IsValue() ? "value" : "trigger"));
-        return;
+        if (nSize > 0 && *memaddr == 'S') // alts detected
+            return RC_MULTIPLE_GROUPS;
+
+        return RC_INVALID_STATE; // additional test that was not parsed
     }
 
     std::string sTriggerBuffer;
     sTriggerBuffer.resize(nSize);
     rc_reset_parse_state(&preparse.parse, sTriggerBuffer.data());
     preparse.parse.is_value = IsValue();
+    preparse.parse.ignore_non_parse_errors = 1;
 
     if (ra::services::ServiceLocator::Exists<ra::services::AchievementRuntime>())
     {
@@ -301,6 +324,7 @@ void TriggerViewModel::PasteFromClipboard()
     m_vConditions.EndUpdate();
 
     SetValue(EnsureVisibleConditionIndexProperty, gsl::narrow_cast<int>(m_vConditions.Count()) - 1);
+    return RC_OK;
 }
 
 void TriggerViewModel::RemoveSelectedConditions()
@@ -377,71 +401,55 @@ void TriggerViewModel::UpdateIndicesAndEnsureSelectionVisible()
 
 void TriggerViewModel::NewCondition()
 {
-    m_vConditions.BeginUpdate();
-
-    DeselectAllConditions();
-
-    auto& vmCondition = m_vConditions.Add();
-    vmCondition.SetTriggerViewModel(this);
-    vmCondition.SetIndex(gsl::narrow_cast<int>(m_vConditions.Count()));
-
     // assume the user wants to create a condition for the currently watched memory address.
     const auto& pMemoryInspector = ra::services::ServiceLocator::Get<ra::ui::viewmodels::WindowManager>().MemoryInspector;
-    const auto nAddress = pMemoryInspector.Viewer().GetAddress();
+    auto sMemRef = pMemoryInspector.GetCurrentAddressMemRefChain();
 
-    // if the code note specifies an explicit size, use it. otherwise, use the selected viewer mode size.
-    const auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::context::GameContext>();
-    auto* pCodeNotes = pGameContext.Assets().FindCodeNotes();
-    auto nSize = (pCodeNotes != nullptr) ? pCodeNotes->GetCodeNoteMemSize(nAddress) : MemSize::Unknown;
-    if (nSize >= MemSize::Unknown)
-        nSize = pMemoryInspector.Viewer().GetSize();
-
-    vmCondition.SetSourceType(TriggerOperandType::Address);
-    vmCondition.SetSourceSize(nSize);
-    vmCondition.SetSourceValue(nAddress);
-
-    if (m_bIsValue && m_vConditions.Count() == 1)
+    if (m_bIsValue && m_vConditions.Count() == 0)
     {
         // first condition added to a value should be Measured and not have a operator/target.
-        vmCondition.SetType(TriggerConditionType::Measured);
-
-        // if the operator is None when changing to a non-modifying type, the operator is
-        // automatically changed to Equals. change it back.
-        vmCondition.SetOperator(TriggerOperatorType::None);
+#ifndef NDEBUG
+        const auto nIndex = sMemRef.find_last_of('_');
+        assert(sMemRef.find_first_of("M:", (nIndex == std::string::npos) ? 0 : nIndex + 1) != std::string::npos);
+#endif
     }
     else
     {
+        MemSize nSize = MemSize::EightBit;
+        const auto nIndex = sMemRef.find_last_of('_');
+        const auto nIndex2 = (nIndex == std::string::npos) ? 0 : nIndex + 1;
+        uint8_t nMemRefSize = RC_MEMSIZE_8_BITS;
+        uint32_t nAddress = 0;
+
+        // last condition of memref chain should be Measured. remove the Measured
+        if (sMemRef.at(nIndex2) == 'M' && sMemRef.at(nIndex2 + 1) == ':')
+            sMemRef.erase(nIndex2, 2);
+
+        // extract the size
+        const char* sMemRefPtr = &sMemRef.at(nIndex2);
+        if (rc_parse_memref(&sMemRefPtr, &nMemRefSize, &nAddress) == RC_OK)
+            nSize = ra::data::models::TriggerValidation::MapRcheevosMemSize(nMemRefSize);
+
         // assume the user wants to compare to the current value of the watched memory address
-        vmCondition.SetOperator(TriggerOperatorType::Equals);
+        ra::services::AchievementLogicSerializer::AppendOperator(sMemRef, ra::services::TriggerOperatorType::Equals);
 
         const auto& pEmulatorContext = ra::services::ServiceLocator::Get<ra::data::context::EmulatorContext>();
-        const auto nValue = pEmulatorContext.ReadMemory(nAddress, nSize);
+        const auto nValue = pEmulatorContext.ReadMemory(pMemoryInspector.GetCurrentAddress(), nSize);
 
-        vmCondition.SetTargetSize(nSize);
-        switch (nSize)
+        if (ra::data::MemSizeIsFloat(nSize))
         {
-            case MemSize::Float:
-            case MemSize::FloatBigEndian:
-            case MemSize::Double32:
-            case MemSize::Double32BigEndian:
-            case MemSize::MBF32:
-            case MemSize::MBF32LE:
-                vmCondition.SetTargetType(TriggerOperandType::Float);
-                vmCondition.SetTargetValue(ra::data::U32ToFloat(nValue, nSize));
-                break;
-
-            default:
-                vmCondition.SetTargetType(TriggerOperandType::Value);
-                vmCondition.SetTargetValue(nValue);
-                break;
+            ra::services::AchievementLogicSerializer::AppendOperand(sMemRef,
+                ra::services::TriggerOperandType::Float,
+                nSize, ra::data::U32ToFloat(nValue, nSize));
+        }
+        else
+        {
+            ra::services::AchievementLogicSerializer::AppendOperand(sMemRef,
+                ra::services::TriggerOperandType::Value, nSize, nValue);
         }
     }
 
-    vmCondition.SetSelected(true);
-
-    m_vConditions.EndUpdate();
-
-    SetValue(EnsureVisibleConditionIndexProperty, gsl::narrow_cast<int>(m_vConditions.Count()) - 1);
+    AppendMemRefChain(sMemRef);
 }
 
 static void AddAltGroup(ViewModelCollection<TriggerViewModel::GroupViewModel>& vGroups,

--- a/src/ui/viewmodels/TriggerViewModel.hh
+++ b/src/ui/viewmodels/TriggerViewModel.hh
@@ -166,6 +166,8 @@ private:
     void UpdateConditions(const GroupViewModel* pGroup);
     void UpdateTotalHits();
 
+    int AppendMemRefChain(const std::string& sTrigger);
+
     void DeselectAllConditions();
     void UpdateIndicesAndEnsureSelectionVisible();
     rc_trigger_t* ParseTrigger(const std::string& sTrigger);

--- a/tests/ui/viewmodels/TriggerViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/TriggerViewModel_Tests.cpp
@@ -5,6 +5,7 @@
 #include "tests\ui\UIAsserts.hh"
 #include "tests\mocks\MockClipboard.hh"
 #include "tests\mocks\MockConfiguration.hh"
+#include "tests\mocks\MockConsoleContext.hh"
 #include "tests\mocks\MockDesktop.hh"
 #include "tests\mocks\MockGameContext.hh"
 #include "tests\mocks\MockEmulatorContext.hh"
@@ -466,7 +467,7 @@ public:
                 bDialogShown = true;
 
                 Assert::AreEqual(std::wstring(L"Paste failed."), vmMessageBox.GetHeader());
-                Assert::AreEqual(std::wstring(L"Clipboard did not contain valid value conditions."),
+                Assert::AreEqual(std::wstring(L"Clipboard did not contain valid trigger conditions."),
                                  vmMessageBox.GetMessage());
 
                 return DialogResult::OK;
@@ -478,11 +479,14 @@ public:
 
         Assert::IsFalse(bDialogShown);
 
-        // Values do not allow conditions without flags
-        vmTrigger.SetIsValue(true);
-        bDialogShown = false;
+        // Measured requires a comparison for triggers - but allow the paste so the user can add one
+        vmTrigger.mockClipboard.SetText(L"M:0xH1234");
+        vmTrigger.PasteFromClipboard();
 
-        vmTrigger.mockClipboard.SetText(L"0xH1234=7");
+        Assert::IsFalse(bDialogShown);
+
+        // cannot paste unparseable value
+        vmTrigger.mockClipboard.SetText(L"banana");
         vmTrigger.PasteFromClipboard();
 
         Assert::IsTrue(bDialogShown);
@@ -493,6 +497,7 @@ public:
         TriggerViewModelHarness vmTrigger;
         Parse(vmTrigger, "A:0xH1235*100");
         Assert::AreEqual({1U}, vmTrigger.Conditions().Count());
+        vmTrigger.SetIsValue(true);
 
         // Measured requires a comparison for triggers
         bool bDialogShown = false;
@@ -501,25 +506,29 @@ public:
                 bDialogShown = true;
 
                 Assert::AreEqual(std::wstring(L"Paste failed."), vmMessageBox.GetHeader());
-                Assert::AreEqual(std::wstring(L"Clipboard did not contain valid trigger conditions."),
+                Assert::AreEqual(std::wstring(L"Clipboard did not contain valid value conditions."),
                                  vmMessageBox.GetMessage());
 
                 return DialogResult::OK;
             });
 
-        vmTrigger.mockClipboard.SetText(L"M:0xH1234");
-        vmTrigger.PasteFromClipboard();
-
-        Assert::IsTrue(bDialogShown);
-
         // Measured does not require a comparison for values
-        vmTrigger.SetIsValue(true);
-        bDialogShown = false;
-
         vmTrigger.mockClipboard.SetText(L"M:0xH1234");
         vmTrigger.PasteFromClipboard();
 
         Assert::IsFalse(bDialogShown);
+
+        // Values do not allow conditions without flags - but allow the paste so the user can add a flag
+        vmTrigger.mockClipboard.SetText(L"0xH1234=7");
+        vmTrigger.PasteFromClipboard();
+
+        Assert::IsFalse(bDialogShown);
+
+        // cannot paste unparseable value
+        vmTrigger.mockClipboard.SetText(L"banana");
+        vmTrigger.PasteFromClipboard();
+
+        Assert::IsTrue(bDialogShown);
     }
 
     TEST_METHOD(TestPasteFromClipboardInvalidSyntax)
@@ -964,6 +973,30 @@ public:
 
         Assert::AreEqual(std::wstring(L"0x0007 (indirect 0x0002+0x05)\r\n[No code note]"),
             vmTrigger.Conditions().GetItemAt(2)->GetTooltip(TriggerConditionViewModel::SourceValueProperty));
+    }
+
+    TEST_METHOD(TestNewConditionFromIndirectNote)
+    {
+        std::array<uint8_t, 10> pMemory = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+        ra::data::context::mocks::MockConsoleContext mockConsoleContext;
+        TriggerViewModelHarness vmTrigger;
+        Parse(vmTrigger, "0xH1234=16");
+        Assert::AreEqual({1U}, vmTrigger.Conditions().Count());
+        vmTrigger.Conditions().GetItemAt(0)->SetSelected(true);
+
+        vmTrigger.InitializeMemory(&pMemory.at(0), pMemory.size());
+        vmTrigger.mockGameContext.SetCodeNote({4U}, L"[8-bit pointer] test\n+4=[16-bit] note");
+        vmTrigger.mockGameContext.DoFrame();
+
+        vmTrigger.mockWindowManager.MemoryInspector.Viewer().SetAddress(8);
+        vmTrigger.mockWindowManager.MemoryInspector.Viewer().SetSize(MemSize::EightBit);
+        Assert::AreEqual(
+            std::wstring(L"[Indirect from 0x0004]\r\n[16-bit] note"),
+            vmTrigger.mockWindowManager.MemoryInspector.GetCurrentAddressNote());
+
+        vmTrigger.NewCondition();
+        Assert::AreEqual({3U}, vmTrigger.Conditions().Count());
+        Assert::AreEqual(std::string("0xH1234=16_I:0xH0004_0x 0004=2312"), vmTrigger.Serialize());
     }
 
     TEST_METHOD(TestNewConditionValue)


### PR DESCRIPTION
When pressing "New Condition" on the achievement editor with an indirect note address selected in the memory inspector, the whole chain will be copied to the achievement.