### PR TITLE
prevent exception processing ui-thread specific action after binding destroyed

### DIFF
--- a/src/ui/win32/bindings/ControlBinding.cpp
+++ b/src/ui/win32/bindings/ControlBinding.cpp
@@ -26,6 +26,8 @@ ControlBinding::~ControlBinding() noexcept
     DisableBinding();
 
     UnsubclassWndProc();
+
+    BeginDestruction();
 }
 
 void ControlBinding::ForceRepaint(HWND hWnd)

--- a/src/ui/win32/bindings/ControlBinding.hh
+++ b/src/ui/win32/bindings/ControlBinding.hh
@@ -2,6 +2,7 @@
 #define RA_UI_WIN32_CONTROLBINDING_H
 #pragma once
 
+#include "data\AsyncObject.hh"
 #include "ui\BindingBase.hh"
 #include "ui\win32\DialogBase.hh"
 
@@ -10,7 +11,7 @@ namespace ui {
 namespace win32 {
 namespace bindings {
 
-class ControlBinding : protected BindingBase
+class ControlBinding : protected BindingBase, protected ra::data::AsyncObject
 {
 public:
     explicit ControlBinding(ViewModelBase& vmViewModel) noexcept : BindingBase(vmViewModel) {}
@@ -153,7 +154,7 @@ protected:
 
     void InvokeOnUIThread(std::function<void()> fAction)
     {
-        WindowBinding::InvokeOnUIThread(fAction);
+        WindowBinding::InvokeOnUIThread(fAction, this);
     }
 
     void InvokeOnUIThreadAndWait(std::function<void()> fAction)

--- a/src/ui/win32/bindings/GridBinding.cpp
+++ b/src/ui/win32/bindings/GridBinding.cpp
@@ -617,7 +617,7 @@ void GridBinding::OnEndViewModelCollectionUpdate()
     {
         if (!WindowBinding::IsOnUIThread())
         {
-            WindowBinding::InvokeOnUIThread([this]() { OnEndViewModelCollectionUpdate(); });
+            WindowBinding::InvokeOnUIThread([this]() { OnEndViewModelCollectionUpdate(); }, this);
             return;
         }
 

--- a/src/ui/win32/bindings/WindowBinding.cpp
+++ b/src/ui/win32/bindings/WindowBinding.cpp
@@ -570,7 +570,7 @@ void WindowBinding::EnableInvokeOnUIThread()
     }
 }
 
-void WindowBinding::InvokeOnUIThread(std::function<void()> fAction)
+void WindowBinding::InvokeOnUIThread(std::function<void()> fAction, ra::data::AsyncObject* pAsyncObject)
 {
     if (s_pDispatchingWindow == nullptr)
     {
@@ -581,6 +581,14 @@ void WindowBinding::InvokeOnUIThread(std::function<void()> fAction)
     {
         // already on the UI thread
         fAction();
+    }
+    else if (pAsyncObject)
+    {
+        s_pDispatchingWindow->QueueFunction([fAction, pAsyncHandle = pAsyncObject->CreateAsyncHandle()] {
+            ra::data::AsyncKeepAlive asyncKeepAlive(*pAsyncHandle);
+            if (!pAsyncHandle->IsDestroyed())
+                fAction();
+        });
     }
     else
     {

--- a/src/ui/win32/bindings/WindowBinding.hh
+++ b/src/ui/win32/bindings/WindowBinding.hh
@@ -2,6 +2,8 @@
 #define RA_UI_WIN32_WINDOWBINDING_H
 #pragma once
 
+#include "data/AsyncObject.hh"
+
 #include "ui/BindingBase.hh"
 #include "ui/WindowViewModelBase.hh"
 
@@ -145,7 +147,7 @@ public:
     /// <summary>
     /// Dispatches a function to the UI thread.
     /// </summary>
-    static void InvokeOnUIThread(std::function<void()> fAction);
+    static void InvokeOnUIThread(std::function<void()> fAction, ra::data::AsyncObject* pAsyncObject = nullptr);
 
     /// <summary>
     /// Executes a function on the UI thread and waits for it to complete.


### PR DESCRIPTION
Fixes a multi-threaded issue where a binding tries to update the UI from a non-UI thread and then gets destroyed before the UI thread can handle the request.

https://discord.com/channels/310192285306454017/1149693430306447380/1366772907287642204