### PR TITLE
fix delta/prior not showing up for last element of a chain

### DIFF
--- a/src/ui/viewmodels/TriggerConditionViewModel.cpp
+++ b/src/ui/viewmodels/TriggerConditionViewModel.cpp
@@ -244,6 +244,16 @@ void TriggerConditionViewModel::InitializeFrom(const rc_condition_t& pCondition)
     const auto* pOperand = rc_condition_get_real_operand1(&pCondition);
     Expects(pOperand != nullptr);
     SetOperand(SourceTypeProperty, SourceSizeProperty, SourceValueProperty, *pOperand);
+
+    // if the runtime has optimized a delta into a delta read of a non-delta chain, we
+    // have to select the delta value manually
+    if (pOperand != &pCondition.operand1 &&
+        (pCondition.operand1.type == RC_OPERAND_DELTA || pCondition.operand1.type == RC_OPERAND_PRIOR))
+    {
+        const auto nType = static_cast<TriggerOperandType>(pCondition.operand1.type);
+        SetSourceType(nType);
+    }
+
     SetOperand(TargetTypeProperty, TargetSizeProperty, TargetValueProperty, pCondition.operand2);
 
     SetOperator(static_cast<TriggerOperatorType>(pCondition.oper));

--- a/tests/ui/viewmodels/TriggerConditionViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/TriggerConditionViewModel_Tests.cpp
@@ -59,7 +59,7 @@ private:
 
     void ParseAndRegenerate(const std::string& sInput)
     {
-        unsigned char pBuffer[512] = {0};
+        unsigned char pBuffer[2048] = {0};
         const auto nSize = rc_trigger_size(sInput.c_str());
         Assert::IsTrue(nSize > 0 && nSize < sizeof(pBuffer));
 
@@ -580,7 +580,7 @@ public:
         Assert::AreEqual(std::string("K:0xH1234"), sSerialized);
     }
 
-    TEST_METHOD(TestSizes)
+    TEST_METHOD(TestParseAndRegenerateSizes)
     {
         ParseAndRegenerate("0xH1234=0xH2345"); // 8-bit
         ParseAndRegenerate("0x 1234=0x 2345"); // 16-bit
@@ -605,7 +605,7 @@ public:
         ParseAndRegenerate("fL1234=fL2345"); // mbf32le
     }
 
-    TEST_METHOD(TestOperandTypes)
+    TEST_METHOD(TestParseAndRegenerateOperandTypes)
     {
         ParseAndRegenerate("0xH1234=0xH1234"); // address
         ParseAndRegenerate("0xH1234=d0xH1234"); // delta
@@ -617,7 +617,7 @@ public:
         ParseAndRegenerate("0xH1234=f12.34"); // float
     }
 
-    TEST_METHOD(TestOperators)
+    TEST_METHOD(TestParseAndRegenerateOperators)
     {
         ParseAndRegenerate("0xH1234=5"); // equals
         ParseAndRegenerate("0xH1234!=5"); // not equals
@@ -634,7 +634,7 @@ public:
         ParseAndRegenerate("A:0xH1234&5"); // bitwise and
     }
 
-    TEST_METHOD(TestConditionTypes)
+    TEST_METHOD(TestParseAndRegenerateConditionTypes)
     {
         ParseAndRegenerate("0xH1234=5"); // none
         ParseAndRegenerate("R:0xH1234=5"); // reset if
@@ -653,10 +653,13 @@ public:
         ParseAndRegenerate("T:0xH1234=5"); // trigger
     }
 
-    TEST_METHOD(TestParseAndRegenerate)
+    TEST_METHOD(TestParseAndRegenerateHits)
     {
-        ParseAndRegenerate("0xH1234=5"); // simple
         ParseAndRegenerate("R:0xH1234=5.100."); // flag and 100 hits
+    }
+
+    TEST_METHOD(TestParseAndRegenerateValue)
+    {
         ParseAndRegenerateValue("M:0xH1234=5"); // measured without hit target
         ParseAndRegenerateValue("M:0xH1234"); // measured without comparison
         ParseAndRegenerateValue("M:0xH1234/5"); // measured with modifier

--- a/tests/ui/viewmodels/TriggerViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/TriggerViewModel_Tests.cpp
@@ -268,6 +268,15 @@ public:
         ParseAndRegenerate("0xH1234=0xH2345SI:0x 1234_A:0xH2345_0xH7777=345"); // addsource/addaddress chain
     }
 
+    TEST_METHOD(TestParseAndRegenerateComplex)
+    {
+        ParseAndRegenerate("R:0xH1234=5.100.");                               // flag and 100 hits
+        ParseAndRegenerate("A:0xH1234_A:0xH1236_A:0xH1237_M:0xH1238=99");     // addsource chain
+        ParseAndRegenerate("A:d0xH1234_A:d0xH1236_A:d0xH1237_M:d0xH1238=99"); // addsource delta chain
+        ParseAndRegenerate("A:p0xH1234_A:p0xH1236_A:p0xH1237_M:p0xH1238=99"); // addsource prior chain
+        ParseAndRegenerate("I:0xX1234_0xH0010=1");                            // addaddress chain
+    }
+
     TEST_METHOD(TestParseAndRegenerateValue)
     {
         ParseAndRegenerateValue(""); // empty


### PR DESCRIPTION
fixes https://discord.com/channels/310192285306454017/1149693430306447380/1373404810312945804

The new runtime is optimizing an AddSource chain of deltas to just use the delta of the AddSource chain of non-deltas. As a result, the final element of the chain doesn't appear as a delta when extracting the non-combining operand and needs to be massaged back into a delta.