### PR TITLE
allow entry of up to 64k characters in code note field

### DIFF
--- a/src/ui/win32/MemoryInspectorDialog.cpp
+++ b/src/ui/win32/MemoryInspectorDialog.cpp
@@ -327,6 +327,11 @@ BOOL MemoryInspectorDialog::OnInitDialog()
     SetWindowFont(GetDlgItem(GetHWND(), IDC_RA_MEMBITS), GetStockObject(SYSTEM_FIXED_FONT), TRUE);
     SetWindowFont(GetDlgItem(GetHWND(), IDC_RA_MEMBITS_TITLE), GetStockObject(SYSTEM_FIXED_FONT), TRUE);
 
+    // NOTE: This is the number of Unicode characters allowed. The database stores data
+    //       in UTF-8, so this is the upper bound and less will actually be allowed if
+    //       non-ASCII characters are used.
+    SendMessage(GetDlgItem(GetHWND(), IDC_RA_NOTE_TEXT), EM_SETLIMITTEXT, 65530, 0);
+
     return DialogBase::OnInitDialog();
 }
 


### PR DESCRIPTION
Addresses https://discord.com/channels/310192285306454017/310195377993416714/1372409861857480848

The control [defaults to 32K](https://learn.microsoft.com/en-us/windows/win32/controls/em-setlimittext).

> Before EM_SETLIMITTEXT is called, the default limit for the amount of text a user can enter in an edit control is 32,767 characters.