### PR TITLE
open IPE for bookmark label with F2 key

### DIFF
--- a/src/ui/win32/MemoryBookmarksDialog.cpp
+++ b/src/ui/win32/MemoryBookmarksDialog.cpp
@@ -122,6 +122,7 @@ MemoryBookmarksDialog::MemoryBookmarksDialog(MemoryBookmarksViewModel& vmMemoryB
     m_bindBookmarks.SetShowGridLines(true);
     m_bindBookmarks.BindIsSelected(MemoryBookmarksViewModel::MemoryBookmarkViewModel::IsSelectedProperty);
     m_bindBookmarks.BindRowColor(MemoryBookmarksViewModel::MemoryBookmarkViewModel::RowColorProperty);
+    m_bindBookmarks.SetPrimaryEditColumn(0);
 
     auto pDescriptionColumn = std::make_unique<ra::ui::win32::bindings::GridTextColumnBinding>(
         MemoryBookmarksViewModel::MemoryBookmarkViewModel::DescriptionProperty);

--- a/src/ui/win32/bindings/GridBinding.cpp
+++ b/src/ui/win32/bindings/GridBinding.cpp
@@ -1382,11 +1382,11 @@ void GridBinding::OnLvnKeyDown(const LPNMLVKEYDOWN pnmKeyDown)
                 m_pDoubleClickHandler(gsl::narrow_cast<gsl::index>(nFirstSelectedItem));
         }
 
-        // if F2 is pressed, and the first column is a text column, open the in-place editor
-        if (pnmKeyDown->wVKey == VK_F2)
+        // if F2 is pressed, and a primary edit column is specified, open the in-place editor for that column
+        if (pnmKeyDown->wVKey == VK_F2 && m_nPrimaryEditColumn != -1 && m_nPrimaryEditColumn < m_vColumns.size())
         {
-            const auto pTextColumn = dynamic_cast<const GridTextColumnBinding*>(m_vColumns.at(0).get());
-            if (pTextColumn && !pTextColumn->IsReadOnly())
+            const auto& pColumn = m_vColumns.at(m_nPrimaryEditColumn);
+            if (!pColumn->IsReadOnly())
             {
                 const int nFirstSelectedItem = ListView_GetNextItem(m_hWnd, -1, LVNI_SELECTED);
                 if (nFirstSelectedItem != -1)

--- a/src/ui/win32/bindings/GridBinding.cpp
+++ b/src/ui/win32/bindings/GridBinding.cpp
@@ -1383,7 +1383,7 @@ void GridBinding::OnLvnKeyDown(const LPNMLVKEYDOWN pnmKeyDown)
         }
 
         // if F2 is pressed, and a primary edit column is specified, open the in-place editor for that column
-        if (pnmKeyDown->wVKey == VK_F2 && m_nPrimaryEditColumn != -1 && m_nPrimaryEditColumn < m_vColumns.size())
+        if (pnmKeyDown->wVKey == VK_F2 && m_nPrimaryEditColumn != -1 && ra::to_unsigned(m_nPrimaryEditColumn) < m_vColumns.size())
         {
             const auto& pColumn = m_vColumns.at(m_nPrimaryEditColumn);
             if (!pColumn->IsReadOnly())
@@ -1395,7 +1395,6 @@ void GridBinding::OnLvnKeyDown(const LPNMLVKEYDOWN pnmKeyDown)
                     pInfo->nItemIndex = gsl::narrow_cast<gsl::index>(nFirstSelectedItem);
                     pInfo->nColumnIndex = 0;
 
-                    const auto& pColumn = m_vColumns.at(0);
                     OpenIPE(pInfo, *pColumn);
                 }
             }

--- a/src/ui/win32/bindings/GridBinding.hh
+++ b/src/ui/win32/bindings/GridBinding.hh
@@ -52,6 +52,10 @@ public:
     void OnLvnGetDispInfo(NMLVDISPINFO& pnmDispInfo);
     void OnTooltipGetDispInfo(NMTTDISPINFO& pnmTtDispInfo);
     virtual void OnNmClick(const NMITEMACTIVATE* pnmItemActivate);
+    void OpenIPE(
+        std::unique_ptr<ra::ui::win32::bindings::GridColumnBinding::InPlaceEditorInfo,
+                        std::default_delete<ra::ui::win32::bindings::GridColumnBinding::InPlaceEditorInfo>>& pInfo,
+        ra::ui::win32::bindings::GridColumnBinding& pColumn);
     virtual void OnNmRClick(const NMITEMACTIVATE* pnmItemActivate);
     virtual void OnNmDblClick(const NMITEMACTIVATE* pnmItemActivate);
     LRESULT OnCustomDraw(NMLVCUSTOMDRAW* pCustomDraw) override;

--- a/src/ui/win32/bindings/GridBinding.hh
+++ b/src/ui/win32/bindings/GridBinding.hh
@@ -41,6 +41,7 @@ public:
     void SetDoubleClickHandler(std::function<void(gsl::index)> pHandler);
     void SetCopyHandler(std::function<void()> pHandler);
     void SetPasteHandler(std::function<void()> pHandler);
+    void SetPrimaryEditColumn(gsl::index nIndex) noexcept { m_nPrimaryEditColumn = nIndex; }
 
     void InitializeTooltips(std::chrono::milliseconds nDisplayTime);
 
@@ -146,6 +147,7 @@ private:
     std::function<void()> m_pPasteHandler = nullptr;
 
     gsl::index m_nSortIndex = -1;
+    gsl::index m_nPrimaryEditColumn = -1;
 
     std::chrono::steady_clock::time_point m_tFocusTime{};
     std::chrono::steady_clock::time_point m_tIPECloseTime{};


### PR DESCRIPTION
Mimics the Edit Cell functionality provided by Excel and Google docs wherein pressing F2 will open the in-place editor for the cell. As grid navigation is still limited to up/down (rows), only the first column can be edited in this way, and only if it's an editable text field.