### PR TITLE
Queue memory reads on doframe thread

### DIFF
--- a/src/data/context/EmulatorContext.cpp
+++ b/src/data/context/EmulatorContext.cpp
@@ -711,8 +711,15 @@ bool EmulatorContext::IsValidAddress(ra::ByteAddress nAddress) const noexcept
     return false;
 }
 
+static int g_threadId = 0;
+
 uint8_t EmulatorContext::ReadMemoryByte(ra::ByteAddress nAddress) const noexcept
 {
+    if (g_threadId > 1000)
+    {
+        Expects(g_threadId == __threadid());
+    }
+
     for (const auto& pBlock : m_vMemoryBlocks)
     {
         if (nAddress < pBlock.size)
@@ -732,6 +739,15 @@ uint8_t EmulatorContext::ReadMemoryByte(ra::ByteAddress nAddress) const noexcept
 _Use_decl_annotations_
 uint32_t EmulatorContext::ReadMemory(ra::ByteAddress nAddress, uint8_t pBuffer[], size_t nCount) const
 {
+    if (g_threadId < 1000)
+        g_threadId++;
+    else if (g_threadId == 1000)
+        g_threadId = __threadid();
+    if (g_threadId > 1000)
+    {
+        Expects(g_threadId == __threadid());
+    }
+
     uint32_t nBytesRead = 0;
     Expects(pBuffer != nullptr);
 

--- a/src/data/context/EmulatorContext.cpp
+++ b/src/data/context/EmulatorContext.cpp
@@ -711,13 +711,14 @@ bool EmulatorContext::IsValidAddress(ra::ByteAddress nAddress) const noexcept
     return false;
 }
 
-uint8_t EmulatorContext::ReadMemoryByte(ra::ByteAddress nAddress) const noexcept
+uint8_t EmulatorContext::ReadMemoryByte(ra::ByteAddress nAddress) const
 {
 #if !defined(_NDEBUG) && !defined(RA_UTEST)
     const auto& pRuntime = ra::services::ServiceLocator::Get<ra::services::AchievementRuntime>();
     if (!pRuntime.IsOnDoFrameThread())
     {
-        Expects(ra::services::ServiceLocator::Get<ra::data::context::GameContext>().IsGameLoading());
+        const auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::context::GameContext>();
+        Expects(pGameContext.GameId() == 0 || pGameContext.IsGameLoading());
     }
 #endif
 

--- a/src/data/context/EmulatorContext.cpp
+++ b/src/data/context/EmulatorContext.cpp
@@ -711,14 +711,15 @@ bool EmulatorContext::IsValidAddress(ra::ByteAddress nAddress) const noexcept
     return false;
 }
 
-static int g_threadId = 0;
-
 uint8_t EmulatorContext::ReadMemoryByte(ra::ByteAddress nAddress) const noexcept
 {
-    if (g_threadId > 1000)
+#if !defined(_NDEBUG) && !defined(RA_UTEST)
+    const auto& pRuntime = ra::services::ServiceLocator::Get<ra::services::AchievementRuntime>();
+    if (!pRuntime.IsOnDoFrameThread())
     {
-        Expects(g_threadId == __threadid());
+        Expects(ra::services::ServiceLocator::Get<ra::data::context::GameContext>().IsGameLoading());
     }
+#endif
 
     for (const auto& pBlock : m_vMemoryBlocks)
     {
@@ -739,14 +740,13 @@ uint8_t EmulatorContext::ReadMemoryByte(ra::ByteAddress nAddress) const noexcept
 _Use_decl_annotations_
 uint32_t EmulatorContext::ReadMemory(ra::ByteAddress nAddress, uint8_t pBuffer[], size_t nCount) const
 {
-    if (g_threadId < 1000)
-        g_threadId++;
-    else if (g_threadId == 1000)
-        g_threadId = __threadid();
-    if (g_threadId > 1000)
+#if !defined(_NDEBUG) && !defined(RA_UTEST)
+    const auto& pRuntime = ra::services::ServiceLocator::Get<ra::services::AchievementRuntime>();
+    if (!pRuntime.IsOnDoFrameThread())
     {
-        Expects(g_threadId == __threadid());
+        Expects(ra::services::ServiceLocator::Get<ra::data::context::GameContext>().IsGameLoading());
     }
+#endif
 
     uint32_t nBytesRead = 0;
     Expects(pBuffer != nullptr);

--- a/src/data/context/EmulatorContext.cpp
+++ b/src/data/context/EmulatorContext.cpp
@@ -744,7 +744,8 @@ uint32_t EmulatorContext::ReadMemory(ra::ByteAddress nAddress, uint8_t pBuffer[]
     const auto& pRuntime = ra::services::ServiceLocator::Get<ra::services::AchievementRuntime>();
     if (!pRuntime.IsOnDoFrameThread())
     {
-        Expects(ra::services::ServiceLocator::Get<ra::data::context::GameContext>().IsGameLoading());
+        const auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::context::GameContext>();
+        Expects(pGameContext.GameId() == 0 || pGameContext.IsGameLoading());
     }
 #endif
 
@@ -1070,13 +1071,23 @@ void EmulatorContext::RebuildMenu() const
 void EmulatorContext::Reset() const
 {
     if (m_fResetEmulator)
-        ra::services::ServiceLocator::Get<ra::ui::IDesktop>().InvokeOnUIThread(m_fResetEmulator);
+    {
+        if (IsExternalRcheevosClient()) // AchievementRuntimeExports will determine which thread to notify
+            m_fResetEmulator();
+        else
+            ra::services::ServiceLocator::Get<ra::ui::IDesktop>().InvokeOnUIThread(m_fResetEmulator);
+    }
 }
 
 void EmulatorContext::Pause() const
 {
     if (m_fPauseEmulator)
-        ra::services::ServiceLocator::Get<ra::ui::IDesktop>().InvokeOnUIThread(m_fPauseEmulator);
+    {
+        if (IsExternalRcheevosClient()) // AchievementRuntimeExports will determine which thread to notify
+            m_fPauseEmulator();
+        else
+            ra::services::ServiceLocator::Get<ra::ui::IDesktop>().InvokeOnUIThread(m_fPauseEmulator);
+    }
 }
 
 void EmulatorContext::Unpause() const

--- a/src/data/context/EmulatorContext.cpp
+++ b/src/data/context/EmulatorContext.cpp
@@ -1085,6 +1085,20 @@ void EmulatorContext::Unpause() const
         ra::services::ServiceLocator::Get<ra::ui::IDesktop>().InvokeOnUIThread(m_fUnpauseEmulator);
 }
 
+void EmulatorContext::DispatchesReadMemory::DispatchMemoryRead(std::function<void()>&& fFunction)
+{
+    if (ra::services::ServiceLocator::Exists<ra::services::AchievementRuntime>())
+    {
+        const auto& pRuntime = ra::services::ServiceLocator::Get<ra::services::AchievementRuntime>();
+        pRuntime.QueueMemoryRead(std::move(fFunction));
+    }
+    else
+    {
+        fFunction();
+    }
+}
+
+
 } // namespace context
 } // namespace data
 } // namespace ra

--- a/src/data/context/EmulatorContext.hh
+++ b/src/data/context/EmulatorContext.hh
@@ -235,6 +235,12 @@ public:
     /// </summary>
     void WriteMemory(ra::ByteAddress nAddress, MemSize nSize, uint32_t nValue) const;
 
+    class DispatchesReadMemory
+    {
+    protected:
+        static void DispatchMemoryRead(std::function<void()>&& fFunction);
+    };
+
     /// <summary>
     /// Converts an address to a displayable string.
     /// </summary>

--- a/src/data/context/EmulatorContext.hh
+++ b/src/data/context/EmulatorContext.hh
@@ -218,7 +218,7 @@ public:
     /// <summary>
     /// Reads memory from the emulator.
     /// </summary>
-    uint8_t ReadMemoryByte(ra::ByteAddress nAddress) const noexcept;
+    uint8_t ReadMemoryByte(ra::ByteAddress nAddress) const;
 
     /// <summary>
     /// Reads memory from the emulator.

--- a/src/data/models/CodeNoteModel.cpp
+++ b/src/data/models/CodeNoteModel.cpp
@@ -16,10 +16,10 @@ struct CodeNoteModel::PointerData
 {
     uint32_t RawPointerValue = 0xFFFFFFFF;       // last raw value of pointer captured
     ra::ByteAddress PointerAddress = 0xFFFFFFFF; // raw pointer value converted to RA address
-    ra::ByteAddress NoteAddress = 0xFFFFFFFF;    // RA address where RawPointerValue was read from
     unsigned int OffsetRange = 0;                // highest offset captured within pointer block
     unsigned int HeaderLength = 0;               // length of note text not associated to OffsetNotes
     bool HasPointers = false;                    // true if there are nested pointers
+    bool PointerRead = false;                    // true the first time RawPointerValue is updated
 
     enum OffsetType
     {
@@ -65,6 +65,11 @@ ra::ByteAddress CodeNoteModel::GetPointerAddress() const noexcept
     return m_pPointerData != nullptr ? m_pPointerData->PointerAddress : 0xFFFFFFFF;
 }
 
+bool CodeNoteModel::HasRawPointerValue() const noexcept
+{
+    return m_pPointerData != nullptr ? m_pPointerData->PointerRead : false;
+}
+
 uint32_t CodeNoteModel::GetRawPointerValue() const noexcept
 {
     return m_pPointerData != nullptr ? m_pPointerData->RawPointerValue : 0xFFFFFFFF;
@@ -91,7 +96,7 @@ void CodeNoteModel::UpdateRawPointerValue(ra::ByteAddress nAddress, const ra::da
     if (m_pPointerData == nullptr)
         return;
 
-    m_pPointerData->NoteAddress = nAddress;
+    m_pPointerData->PointerRead = true;
 
     const uint32_t nValue = pEmulatorContext.ReadMemory(nAddress, GetMemSize());
     if (nValue != m_pPointerData->RawPointerValue)

--- a/src/data/models/CodeNoteModel.hh
+++ b/src/data/models/CodeNoteModel.hh
@@ -34,6 +34,7 @@ public:
     bool IsPointer() const noexcept { return m_pPointerData != nullptr; }
     std::wstring GetPointerDescription() const;
     ra::ByteAddress GetPointerAddress() const noexcept;
+    bool HasRawPointerValue() const noexcept;
     uint32_t GetRawPointerValue() const noexcept;
     bool HasNestedPointers() const noexcept;
     const CodeNoteModel* GetPointerNoteAtOffset(int nOffset) const;

--- a/src/data/models/CodeNotesModel.cpp
+++ b/src/data/models/CodeNotesModel.cpp
@@ -26,6 +26,7 @@ void CodeNotesModel::Refresh(unsigned int nGameId, CodeNoteChangedFunction fCode
 {
     m_nGameId = nGameId;
     m_vCodeNotes.clear();
+    m_bHasPointers = false;
 
     if (nGameId == 0)
     {
@@ -82,6 +83,15 @@ void CodeNotesModel::Refresh(unsigned int nGameId, CodeNoteChangedFunction fCode
         for (const auto pNote : mPendingCodeNotes)
             SetCodeNote(pNote.first, pNote.second);
 
+        for (const auto& pNote : m_vCodeNotes)
+        {
+            if (pNote->IsPointer())
+            {
+                m_bHasPointers = true;
+                break;
+            }
+        }
+
         callback();
     });
 }
@@ -102,14 +112,8 @@ void CodeNotesModel::AddCodeNote(ra::ByteAddress nAddress, const std::string& sA
     note->SetAddress(nAddress);
 
     const bool bIsPointer = note->IsPointer();
-    if (bIsPointer)
-    {
+    if (bIsPointer && !m_bRefreshing)
         m_bHasPointers = true;
-
-        // capture the initial value of the pointer
-        const auto& pEmulatorContext = ra::services::ServiceLocator::Get<ra::data::context::EmulatorContext>();
-        note->UpdateRawPointerValue(nAddress, pEmulatorContext, nullptr);
-    }
 
     {
         std::unique_lock<std::mutex> lock(m_oMutex);
@@ -122,18 +126,7 @@ void CodeNotesModel::AddCodeNote(ra::ByteAddress nAddress, const std::string& sA
 
     OnCodeNoteChanged(nAddress, sNote);
 
-    // also raise CodeNoteChanged events for each indirect child note
-    if (bIsPointer && m_fCodeNoteChanged)
-    {
-        const auto* pCodeNote = FindCodeNoteModel(nAddress);
-        if (pCodeNote != nullptr)
-        {
-            pCodeNote->EnumeratePointerNotes([this](ra::ByteAddress nAddress, const CodeNoteModel& pOffsetNote) {
-                m_fCodeNoteChanged(nAddress, pOffsetNote.GetNote());
-                return true;
-            });
-        }
-    }
+    // CodeNoteChanged events for indirect child notes will be raised by first call to DoFrame
 }
 
 void CodeNotesModel::OnCodeNoteChanged(ra::ByteAddress nAddress, const std::wstring& sNewNote)
@@ -511,11 +504,27 @@ void CodeNotesModel::DoFrame()
     {
         if (pCodeNote->IsPointer())
         {
-            pCodeNote->UpdateRawPointerValue(pCodeNote->GetAddress(), pEmulatorContext,
-                [this](ra::ByteAddress nOldAddress, ra::ByteAddress nNewAddress, const CodeNoteModel& pOffsetNote) {
-                    m_fCodeNoteChanged(nOldAddress, L"");
-                    m_fCodeNoteChanged(nNewAddress, pOffsetNote.GetNote());
-                });
+            if (!m_fCodeNoteChanged)
+            {
+                pCodeNote->UpdateRawPointerValue(pCodeNote->GetAddress(), pEmulatorContext, nullptr);
+            }
+            else if (pCodeNote->HasRawPointerValue())
+            {
+                pCodeNote->UpdateRawPointerValue(pCodeNote->GetAddress(), pEmulatorContext,
+                    [this](ra::ByteAddress nOldAddress, ra::ByteAddress nNewAddress, const CodeNoteModel& pOffsetNote) {
+                        const auto* pNote = FindCodeNoteModel(nOldAddress, false);
+                        m_fCodeNoteChanged(nOldAddress, pNote ? pNote->GetNote() : L"");
+                        m_fCodeNoteChanged(nNewAddress, pOffsetNote.GetNote());
+                    });
+            }
+            else
+            {
+                // pointer hasn't been read before, only raise event for new address
+                pCodeNote->UpdateRawPointerValue(pCodeNote->GetAddress(), pEmulatorContext,
+                    [this](ra::ByteAddress nOldAddress, ra::ByteAddress nNewAddress, const CodeNoteModel& pOffsetNote) {
+                        m_fCodeNoteChanged(nNewAddress, pOffsetNote.GetNote());
+                    });
+            }
         }
     }
 }

--- a/src/data/models/CodeNotesModel.cpp
+++ b/src/data/models/CodeNotesModel.cpp
@@ -521,7 +521,7 @@ void CodeNotesModel::DoFrame()
             {
                 // pointer hasn't been read before, only raise event for new address
                 pCodeNote->UpdateRawPointerValue(pCodeNote->GetAddress(), pEmulatorContext,
-                    [this](ra::ByteAddress nOldAddress, ra::ByteAddress nNewAddress, const CodeNoteModel& pOffsetNote) {
+                    [this](ra::ByteAddress, ra::ByteAddress nNewAddress, const CodeNoteModel& pOffsetNote) {
                         m_fCodeNoteChanged(nNewAddress, pOffsetNote.GetNote());
                     });
             }

--- a/src/services/AchievementRuntime.cpp
+++ b/src/services/AchievementRuntime.cpp
@@ -440,7 +440,7 @@ typedef struct QueueMemoryReadData
 static void DispatchMemoryRead(struct rc_client_scheduled_callback_data_t* callback_data,
                                rc_client_t*, rc_clock_t)
 {
-    QueueMemoryReadData* data = (QueueMemoryReadData*)callback_data->data;
+    QueueMemoryReadData* data = static_cast<QueueMemoryReadData*>(callback_data->data);
     data->fCallback();
 
     delete data;
@@ -466,7 +466,7 @@ void AchievementRuntime::QueueMemoryRead(std::function<void()>&& fCallback) cons
     data->fCallback = std::move(fCallback);
 
     rc_client_scheduled_callback_data_t* scheduled_callback =
-        (rc_client_scheduled_callback_data_t*)calloc(1, sizeof(rc_client_scheduled_callback_data_t));
+        static_cast<rc_client_scheduled_callback_data_t*>(calloc(1, sizeof(rc_client_scheduled_callback_data_t)));
     Expects(scheduled_callback != nullptr);
     scheduled_callback->callback = DispatchMemoryRead;
     scheduled_callback->data = data;

--- a/src/services/AchievementRuntime.cpp
+++ b/src/services/AchievementRuntime.cpp
@@ -438,7 +438,7 @@ typedef struct QueueMemoryReadData
 } QueueMemoryReadData;
 
 static void DispatchMemoryRead(struct rc_client_scheduled_callback_data_t* callback_data,
-                               rc_client_t* client, rc_clock_t now)
+                               rc_client_t*, rc_clock_t)
 {
     QueueMemoryReadData* data = (QueueMemoryReadData*)callback_data->data;
     data->fCallback();
@@ -449,6 +449,12 @@ static void DispatchMemoryRead(struct rc_client_scheduled_callback_data_t* callb
 
 void AchievementRuntime::QueueMemoryRead(std::function<void()>&& fCallback) const
 {
+    if (GetClient()->state.allow_background_memory_reads)
+    {
+        fCallback();
+        return;
+    }
+
     if (m_hDoFrameThread == 0 || IsOnDoFrameThread())
     {
         fCallback();
@@ -467,40 +473,8 @@ void AchievementRuntime::QueueMemoryRead(std::function<void()>&& fCallback) cons
 
     rc_client_schedule_callback(GetClient(), scheduled_callback);
 
-    // schedule an rc_client_idle() call for 200ms from now. if another read gets queued
-    // before rc_client_idle() is called, it'll use the same queued rc_client_idle().
-    // if no "when=0" items are queued when the callback is called, rc_client_idle will
-    // not be called
-    static std::atomic<bool> bIdleQueued = false;
-    bool bWantToQueue = true;
-    const bool bWasQueued = bIdleQueued.exchange(bWantToQueue);
-    if (!bWasQueued)
-    {
-        ra::services::ServiceLocator::GetMutable<ra::services::IThreadPool>().
-            ScheduleAsync(std::chrono::milliseconds(200), [this]()
-            {
-                bIdleQueued = false;
-
-                auto* pClient = GetClient();
-                if (!pClient)
-                    return;
-
-                const auto* pScheduledCallback = pClient->state.scheduled_callbacks;
-                if (pScheduledCallback)
-                {
-                    bool bShouldIdle = false;
-                    {
-                        rc_mutex_lock(&pClient->state.mutex);
-                        pScheduledCallback = pClient->state.scheduled_callbacks;
-                        bShouldIdle = pScheduledCallback && pScheduledCallback->when == 0;
-                        rc_mutex_unlock(&pClient->state.mutex);
-                    }
-
-                    if (bShouldIdle)
-                        rc_client_idle(pClient);
-                }
-            });
-    }
+    // We have to assume the client will call rc_client_do_frame or rc_client_idle in a
+    // timely manner or the callback won't get called and the UI will appear unresponsive.
 }
 
 /* ---- ClientSynchronizer ----- */
@@ -1441,17 +1415,17 @@ void AchievementRuntime::LoadGameCallback(int nResult, const char* sErrorMessage
     delete wrapper;
 }
 
-rc_client_async_handle_t* AchievementRuntime::BeginChangeMedia(const char* file_path,
+rc_client_async_handle_t* AchievementRuntime::BeginIdentifyAndChangeMedia(const char* file_path,
     const uint8_t* data, size_t data_size, CallbackWrapper* pCallbackWrapper) noexcept
 {
     auto* client = GetClient();
-    return rc_client_begin_change_media(client, file_path, data, data_size, AchievementRuntime::ChangeMediaCallback, pCallbackWrapper);
+    return rc_client_begin_identify_and_change_media(client, file_path, data, data_size, AchievementRuntime::ChangeMediaCallback, pCallbackWrapper);
 }
 
-rc_client_async_handle_t* AchievementRuntime::BeginChangeMediaFromHash(const char* sHash, CallbackWrapper* pCallbackWrapper) noexcept
+rc_client_async_handle_t* AchievementRuntime::BeginChangeMedia(const char* sHash, CallbackWrapper* pCallbackWrapper) noexcept
 {
     auto* client = GetClient();
-    return rc_client_begin_change_media_from_hash(client, sHash, AchievementRuntime::ChangeMediaCallback, pCallbackWrapper);
+    return rc_client_begin_change_media(client, sHash, AchievementRuntime::ChangeMediaCallback, pCallbackWrapper);
 }
 
 GSL_SUPPRESS_CON3

--- a/src/services/AchievementRuntime.hh
+++ b/src/services/AchievementRuntime.hh
@@ -160,6 +160,8 @@ public:
     /// </summary>
     void AsyncServerCall(const rc_api_request_t* pRequest, AsyncServerCallCallback fCallback, void* pCallbackData) const;
 
+    void QueueMemoryRead(std::function<void()>&& fCallback) const;
+
     class Synchronizer
     {
     public:

--- a/src/services/AchievementRuntime.hh
+++ b/src/services/AchievementRuntime.hh
@@ -161,7 +161,7 @@ public:
     void AsyncServerCall(const rc_api_request_t* pRequest, AsyncServerCallCallback fCallback, void* pCallbackData) const;
 
     void QueueMemoryRead(std::function<void()>&& fCallback) const;
-    bool IsOnDoFrameThread() const { return GetCurrentThreadId() == m_hDoFrameThread; }
+    bool IsOnDoFrameThread() const { return m_hDoFrameThread && GetCurrentThreadId() == m_hDoFrameThread; }
 
     class Synchronizer
     {
@@ -281,9 +281,9 @@ private:
                                                        const uint8_t* data, size_t data_size,
                                                        CallbackWrapper* pCallbackWrapper) noexcept;
 
-    rc_client_async_handle_t* BeginChangeMedia(const char* file_path, const uint8_t* data, size_t data_size,
-                                               CallbackWrapper* pCallbackWrapper) noexcept;
-    rc_client_async_handle_t* BeginChangeMediaFromHash(const char* sHash, CallbackWrapper* pCallbackWrapper) noexcept;
+    rc_client_async_handle_t* BeginIdentifyAndChangeMedia(const char* file_path, const uint8_t* data, size_t data_size,
+                                                          CallbackWrapper* pCallbackWrapper) noexcept;
+    rc_client_async_handle_t* BeginChangeMedia(const char* sHash, CallbackWrapper* pCallbackWrapper) noexcept;
     static void ChangeMediaCallback(int nResult, const char* sErrorMessage, rc_client_t*, void* pUserdata);
 
     static void PostProcessGameDataResponse(const rc_api_server_response_t* server_response,

--- a/src/services/AchievementRuntime.hh
+++ b/src/services/AchievementRuntime.hh
@@ -110,7 +110,7 @@ public:
     /// <summary>
     /// Processes stuff not related to a frame.
     /// </summary>
-    void Idle() noexcept;
+    void Idle() const noexcept;
 
     /// <summary>
     /// Loads HitCount data for active achievements from a save state file.
@@ -161,6 +161,7 @@ public:
     void AsyncServerCall(const rc_api_request_t* pRequest, AsyncServerCallCallback fCallback, void* pCallbackData) const;
 
     void QueueMemoryRead(std::function<void()>&& fCallback) const;
+    bool IsOnDoFrameThread() const { return GetCurrentThreadId() == m_hDoFrameThread; }
 
     class Synchronizer
     {
@@ -211,6 +212,7 @@ public:
 
 private:
     bool m_bPaused = false;
+    DWORD m_hDoFrameThread = 0;
     std::unique_ptr<rc_client_t> m_pClient;
 
     class ClientSynchronizer;

--- a/src/services/AchievementRuntime.hh
+++ b/src/services/AchievementRuntime.hh
@@ -161,7 +161,7 @@ public:
     void AsyncServerCall(const rc_api_request_t* pRequest, AsyncServerCallCallback fCallback, void* pCallbackData) const;
 
     void QueueMemoryRead(std::function<void()>&& fCallback) const;
-    bool IsOnDoFrameThread() const { return m_hDoFrameThread && GetCurrentThreadId() == m_hDoFrameThread; }
+    bool IsOnDoFrameThread() const noexcept { return m_hDoFrameThread && GetCurrentThreadId() == m_hDoFrameThread; }
 
     class Synchronizer
     {

--- a/src/services/AchievementRuntimeExports.cpp
+++ b/src/services/AchievementRuntimeExports.cpp
@@ -848,10 +848,10 @@ private:
         return 0;
     }
     
-    static void RaisePauseEvent() noexcept
+    static void RaisePauseEvent()
     {
         // not actually a memory read, but we want it to occur in the DoFrame loop
-        ra::services::ServiceLocator::Get<ra::services::AchievementRuntime>().QueueMemoryRead([]() {
+        ra::services::ServiceLocator::Get<ra::services::AchievementRuntime>().QueueMemoryRead([]() noexcept {
             RaiseIntegrationEvent(RC_CLIENT_RAINTEGRATION_EVENT_PAUSE);
         });
     }

--- a/src/ui/viewmodels/MemoryBookmarksViewModel.hh
+++ b/src/ui/viewmodels/MemoryBookmarksViewModel.hh
@@ -20,6 +20,7 @@ namespace viewmodels {
 class MemoryBookmarksViewModel : public WindowViewModelBase,
     protected ra::data::context::GameContext::NotifyTarget,
     protected ra::data::context::EmulatorContext::NotifyTarget,
+    protected ra::data::context::EmulatorContext::DispatchesReadMemory,
     protected ra::ui::ViewModelCollectionBase::NotifyTarget
 {
 public:

--- a/src/ui/viewmodels/MemoryBookmarksViewModel.hh
+++ b/src/ui/viewmodels/MemoryBookmarksViewModel.hh
@@ -163,6 +163,11 @@ public:
         uint32_t GetCurrentValueRaw() const noexcept { return m_nValue; }
 
         /// <summary>
+        /// Sets the current value of the bookmarked address.
+        /// </summary>
+        void SetCurrentValueRaw(unsigned nValue);
+
+        /// <summary>
         /// The <see cref="ModelProperty" /> for the previous value of the bookmarked address.
         /// </summary>
         static const StringModelProperty PreviousValueProperty;

--- a/src/ui/viewmodels/MemoryInspectorViewModel.cpp
+++ b/src/ui/viewmodels/MemoryInspectorViewModel.cpp
@@ -453,7 +453,7 @@ void MemoryInspectorViewModel::ToggleBit(int nBit)
 
     // push the updated value to the emulator
     const auto& pEmulatorContext = ra::services::ServiceLocator::Get<ra::data::context::EmulatorContext>();
-    pEmulatorContext.WriteMemoryByte(nAddress, nValue);
+    pEmulatorContext.WriteMemoryByte(nAddress, gsl::narrow_cast<uint8_t>(nValue));
 
     // update the local value, which will cause the bits string to get updated
     SetValue(CurrentAddressValueProperty, nValue);

--- a/src/ui/viewmodels/MemoryInspectorViewModel.cpp
+++ b/src/ui/viewmodels/MemoryInspectorViewModel.cpp
@@ -282,8 +282,7 @@ void MemoryInspectorViewModel::OnCurrentAddressChanged(ra::ByteAddress nNewAddre
 
     UpdateNoteButtons();
 
-    const auto& pEmulatorContext = ra::services::ServiceLocator::Get<ra::data::context::EmulatorContext>();
-    const auto nValue = pEmulatorContext.ReadMemoryByte(nNewAddress);
+    const auto nValue = Viewer().GetValueAtAddress(nNewAddress);
     SetValue(CurrentAddressValueProperty, nValue);
 
     m_pViewer.SetAddress(nNewAddress);
@@ -449,11 +448,11 @@ bool MemoryInspectorViewModel::PreviousNote()
 void MemoryInspectorViewModel::ToggleBit(int nBit)
 {
     const auto nAddress = GetCurrentAddress();
+    auto nValue = GetValue(CurrentAddressValueProperty);
+    nValue ^= (1 << nBit);
 
     // push the updated value to the emulator
     const auto& pEmulatorContext = ra::services::ServiceLocator::Get<ra::data::context::EmulatorContext>();
-    auto nValue = pEmulatorContext.ReadMemoryByte(nAddress);
-    nValue ^= (1 << nBit);
     pEmulatorContext.WriteMemoryByte(nAddress, nValue);
 
     // update the local value, which will cause the bits string to get updated

--- a/src/ui/viewmodels/MemorySearchViewModel.cpp
+++ b/src/ui/viewmodels/MemorySearchViewModel.cpp
@@ -3,7 +3,6 @@
 #include "data\context\ConsoleContext.hh"
 #include "data\context\EmulatorContext.hh"
 
-#include "services\AchievementRuntime.hh"
 #include "services\IClock.hh"
 #include "services\IFileSystem.hh"
 #include "services\ServiceLocator.hh"
@@ -551,19 +550,6 @@ void MemorySearchViewModel::AddNewPage(std::unique_ptr<SearchResult>&& pNewPage)
     else
     {
         ++m_nSelectedSearchResult;
-    }
-}
-
-void MemorySearchViewModel::DispatchMemoryRead(std::function<void()>&& fFunction)
-{
-    if (ra::services::ServiceLocator::Exists<ra::services::AchievementRuntime>())
-    {
-        const auto& pRuntime = ra::services::ServiceLocator::Get<ra::services::AchievementRuntime>();
-        pRuntime.QueueMemoryRead(std::move(fFunction));
-    }
-    else
-    {
-        fFunction();
     }
 }
 

--- a/src/ui/viewmodels/MemorySearchViewModel.hh
+++ b/src/ui/viewmodels/MemorySearchViewModel.hh
@@ -21,6 +21,7 @@ namespace viewmodels {
 class MemorySearchViewModel : public ViewModelBase,
     protected ViewModelCollectionBase::NotifyTarget,
     protected ra::data::context::EmulatorContext::NotifyTarget,
+    protected ra::data::context::EmulatorContext::DispatchesReadMemory,
     protected ra::data::context::GameContext::NotifyTarget
 {
 public:
@@ -482,8 +483,6 @@ private:
 
     void OnPredefinedFilterRangeChanged();
     void OnFilterRangeChanged();
-
-    static void DispatchMemoryRead(std::function<void()>&& fFunction);
 
     ViewModelCollection<PredefinedFilterRangeViewModel> m_vPredefinedFilterRanges;
     LookupItemViewModelCollection m_vSearchTypes;

--- a/src/ui/viewmodels/MemorySearchViewModel.hh
+++ b/src/ui/viewmodels/MemorySearchViewModel.hh
@@ -429,6 +429,7 @@ public:
     void ToggleContinuousFilter();
     static const BoolModelProperty CanContinuousFilterProperty;
     static const StringModelProperty ContinuousFilterLabelProperty;
+    bool IsContinuousFiltering() const noexcept { return m_bIsContinuousFiltering; }
 
     /// <summary>
     /// Excludes the currently selected items from the search results.
@@ -471,15 +472,20 @@ protected:
 
 private:
     bool ParseFilterRange(_Out_ ra::ByteAddress& nStart, _Out_ ra::ByteAddress& nEnd);
+    void BeginNewSearch(ra::ByteAddress nStart, ra::ByteAddress nEnd);
     void ApplyContinuousFilter();
     void UpdateResults();
     void DoUpdateResults();
+    void DoApplyFilter();
+    void DoExcludeSelected();
     void UpdateResult(SearchResultViewModel& pRow, const ra::services::SearchResults& pResults,
         ra::services::SearchResults::Result& pResult, bool bForceFilterCheck,
         const ra::data::context::EmulatorContext& pEmulatorContext);
 
     void OnPredefinedFilterRangeChanged();
     void OnFilterRangeChanged();
+
+    void DispatchMemoryRead(std::function<void()>&& fFunction);
 
     ViewModelCollection<PredefinedFilterRangeViewModel> m_vPredefinedFilterRanges;
     LookupItemViewModelCollection m_vSearchTypes;

--- a/src/ui/viewmodels/MemorySearchViewModel.hh
+++ b/src/ui/viewmodels/MemorySearchViewModel.hh
@@ -475,9 +475,7 @@ private:
     void BeginNewSearch(ra::ByteAddress nStart, ra::ByteAddress nEnd);
     void ApplyContinuousFilter();
     void UpdateResults();
-    void DoUpdateResults();
     void DoApplyFilter();
-    void DoExcludeSelected();
     void UpdateResult(SearchResultViewModel& pRow, const ra::services::SearchResults& pResults,
         ra::services::SearchResults::Result& pResult, bool bForceFilterCheck,
         const ra::data::context::EmulatorContext& pEmulatorContext);
@@ -485,7 +483,7 @@ private:
     void OnPredefinedFilterRangeChanged();
     void OnFilterRangeChanged();
 
-    void DispatchMemoryRead(std::function<void()>&& fFunction);
+    static void DispatchMemoryRead(std::function<void()>&& fFunction);
 
     ViewModelCollection<PredefinedFilterRangeViewModel> m_vPredefinedFilterRanges;
     LookupItemViewModelCollection m_vSearchTypes;
@@ -498,7 +496,6 @@ private:
     std::chrono::steady_clock::time_point m_tLastContinuousFilterCheck;
     bool m_bScrolling = false;
     bool m_bSelectingFilter = false;
-    bool m_bUpdateResultsPending = false;
 
     std::mutex m_oMutex;
 

--- a/src/ui/viewmodels/MemoryViewerViewModel.cpp
+++ b/src/ui/viewmodels/MemoryViewerViewModel.cpp
@@ -672,7 +672,7 @@ uint8_t MemoryViewerViewModel::GetValueAtAddress(ra::ByteAddress nAddress) const
     if (nAddress < nFirstAddress)
         return 0;
     const auto nOffset = nAddress - nFirstAddress;
-    const auto nVisibleLines = GetNumVisibleLines();
+    const auto nVisibleLines = ra::to_unsigned(GetNumVisibleLines());
     if (nOffset >= nVisibleLines * 16)
         return 0;
 

--- a/src/ui/viewmodels/MemoryViewerViewModel.cpp
+++ b/src/ui/viewmodels/MemoryViewerViewModel.cpp
@@ -5,9 +5,6 @@
 #include "data\context\EmulatorContext.hh"
 #include "data\context\GameContext.hh"
 
-#include "services\AchievementRuntime.hh"
-#include "services\ServiceLocator.hh"
-
 #include "ui\EditorTheme.hh"
 #include "ui\viewmodels\WindowManager.hh"
 
@@ -450,19 +447,6 @@ void MemoryViewerViewModel::OnValueChanged(const IntModelProperty::ChangeArgs& a
     }
 
     ViewModelBase::OnValueChanged(args);
-}
-
-void MemoryViewerViewModel::DispatchMemoryRead(std::function<void()>&& fFunction)
-{
-    if (ra::services::ServiceLocator::Exists<ra::services::AchievementRuntime>())
-    {
-        const auto& pRuntime = ra::services::ServiceLocator::Get<ra::services::AchievementRuntime>();
-        pRuntime.QueueMemoryRead(std::move(fFunction));
-    }
-    else
-    {
-        fFunction();
-    }
 }
 
 void MemoryViewerViewModel::ReadMemory(ra::ByteAddress nFirstAddress, int nNumVisibleLines)

--- a/src/ui/viewmodels/MemoryViewerViewModel.hh
+++ b/src/ui/viewmodels/MemoryViewerViewModel.hh
@@ -176,8 +176,9 @@ public:
     void AdvanceCursorPage();
     void RetreatCursorPage();
 
-    bool IncreaseCurrentValue(uint32_t nModifier);
-    bool DecreaseCurrentValue(uint32_t nModifier);
+    uint8_t GetValueAtAddress(ra::ByteAddress nAddress) const;
+    void IncreaseCurrentValue(uint32_t nModifier);
+    void DecreaseCurrentValue(uint32_t nModifier);
 
 protected:
     void OnValueChanged(const IntModelProperty::ChangeArgs& args) override;
@@ -227,6 +228,8 @@ private:
     void UpdateInvalidRegions();
     void UpdateHighlight(ra::ByteAddress nAddress, int nNewLength, int nOldLength);
 
+    static void DispatchMemoryRead(std::function<void()>&& fFunction);
+    void ReadMemory(ra::ByteAddress nFirstAddress, int nNumVisibleLines);
     int NibblesPerWord() const;
     int GetSelectedNibbleOffset() const;
     void UpdateSelectedNibble(int nNewNibble);

--- a/src/ui/viewmodels/MemoryViewerViewModel.hh
+++ b/src/ui/viewmodels/MemoryViewerViewModel.hh
@@ -18,7 +18,8 @@ namespace viewmodels {
 
 class MemoryViewerViewModel : public ViewModelBase,
                               protected ra::data::context::GameContext::NotifyTarget,
-                              protected ra::data::context::EmulatorContext::NotifyTarget
+                              protected ra::data::context::EmulatorContext::NotifyTarget,
+                              protected ra::data::context::EmulatorContext::DispatchesReadMemory
 {
 public:
     GSL_SUPPRESS_F6 MemoryViewerViewModel();
@@ -228,7 +229,6 @@ private:
     void UpdateInvalidRegions();
     void UpdateHighlight(ra::ByteAddress nAddress, int nNewLength, int nOldLength);
 
-    static void DispatchMemoryRead(std::function<void()>&& fFunction);
     void ReadMemory(ra::ByteAddress nFirstAddress, int nNumVisibleLines);
     int NibblesPerWord() const;
     int GetSelectedNibbleOffset() const;

--- a/src/ui/viewmodels/PointerFinderViewModel.cpp
+++ b/src/ui/viewmodels/PointerFinderViewModel.cpp
@@ -87,11 +87,13 @@ void PointerFinderViewModel::StateViewModel::Capture()
         }
     }
 
-    const auto& pEmulatorContext = ra::services::ServiceLocator::GetMutable<ra::data::context::EmulatorContext>();
-    const auto nMemorySize = gsl::narrow<ra::ByteAddress>(pEmulatorContext.TotalMemorySize());
+    DispatchMemoryRead([this]() {
+        const auto& pEmulatorContext = ra::services::ServiceLocator::GetMutable<ra::data::context::EmulatorContext>();
+        const auto nMemorySize = gsl::narrow<ra::ByteAddress>(pEmulatorContext.TotalMemorySize());
 
-    m_pCapture.reset(new ra::services::SearchResults());
-    m_pCapture->Initialize(0, nMemorySize, m_pOwner->GetSearchType());
+        m_pCapture.reset(new ra::services::SearchResults());
+        m_pCapture->Initialize(0, nMemorySize, m_pOwner->GetSearchType());
+    });
 
     SetValue(CaptureButtonTextProperty, L"Release");
     SetValue(CanCaptureProperty, false);

--- a/src/ui/viewmodels/PointerFinderViewModel.hh
+++ b/src/ui/viewmodels/PointerFinderViewModel.hh
@@ -67,7 +67,8 @@ public:
     /// </summary>
     void BookmarkSelected();
 
-    class StateViewModel : public ViewModelBase
+    class StateViewModel : public ViewModelBase,
+                           protected ra::data::context::EmulatorContext::DispatchesReadMemory
     {
     public:
         /// <summary>

--- a/src/ui/win32/bindings/MemoryViewerControlBinding.cpp
+++ b/src/ui/win32/bindings/MemoryViewerControlBinding.cpp
@@ -258,9 +258,10 @@ bool MemoryViewerControlBinding::HandleShortcut(UINT nChar)
                 nModifier *= 16;
 
             if (nChar == VK_ADD)
-                return m_pViewModel.IncreaseCurrentValue(nModifier);
+                m_pViewModel.IncreaseCurrentValue(nModifier);
             else
-                return m_pViewModel.DecreaseCurrentValue(nModifier);
+                m_pViewModel.DecreaseCurrentValue(nModifier);
+            return true;
         }
 
         default:

--- a/tests/data/models/CodeNotesModel_Tests.cpp
+++ b/tests/data/models/CodeNotesModel_Tests.cpp
@@ -394,6 +394,7 @@ public:
             L"+03 - Bombs Defused\n"
             L"+04 - Bomb Timer";
         notes.AddCodeNote(1234, "Author", sNote);
+        notes.DoFrame();
 
         notes.AssertNote(1234U, sNote, MemSize::TwentyFourBit); // full note for pointer address
 
@@ -411,6 +412,7 @@ public:
             L"---DEFAULT_HEAD = Barry's Head\n"
             L"---FRAGGER_HEAD = Fragger Helmet";
         notes.AddCodeNote(1234, "Author", sNote);
+        notes.DoFrame();
 
         notes.AssertNote(1234U, sNote, MemSize::ThirtyTwoBit); // full note for pointer address
 
@@ -429,6 +431,7 @@ public:
             L"+0x8000 = [8-bit] Current lap\n"
             L"+0x8033 = [16-bit] Total race time";
         notes.AddCodeNote(1234, "Author", sNote);
+        notes.DoFrame();
 
         notes.AssertNote(1234U, sNote, MemSize::ThirtyTwoBit); // full note for pointer address
 
@@ -450,6 +453,7 @@ public:
             L"+0x1B5BE = Seconds 0x\n"
             L"+0x1B5CE = Lap";
         notes.AddCodeNote(1234, "Author", sNote);
+        notes.DoFrame();
 
         notes.AssertNote(1234U, sNote, MemSize::SixteenBit); // full note for pointer address
 
@@ -472,6 +476,7 @@ public:
             L"+20 = Stat Points (16-bit)\r\n"
             L"+22 = Skill Points (8-bit)";
         notes.AddCodeNote(1234, "Author", sNote);
+        notes.DoFrame();
 
         notes.AssertNote(1234U, sNote, MemSize::ThirtyTwoBit, 4); // full note for pointer address (assume 32-bit if not specified)
 
@@ -493,6 +498,7 @@ public:
             L"+0x438 | Pointer - Award - Pretty Woman (32bit)\n"
             L"--- +0x24C | Flag";
         notes.AddCodeNote(1234, "Author", sNote);
+        notes.DoFrame();
 
         notes.AssertNote(1234U, sNote, MemSize::ThirtyTwoBit); // full note for pointer address
 
@@ -513,6 +519,7 @@ public:
             L"+5C = Right Leg Health {16-bit}\n"
             L"+5E = Left Leg Health {16-bit}";
         notes.AddCodeNote(1234, "Author", sNote);
+        notes.DoFrame();
 
         // offset parse failure results in a non-pointer note
         notes.AssertNote(1234U, sNote, MemSize::TwentyFourBit);
@@ -531,6 +538,7 @@ public:
             L"+0x1B56E = Seconds 0x\n"
             L"+0x1B5CE = Lap";
         notes.AddCodeNote(1234, "Author", sNote);
+        notes.DoFrame();
 
         notes.AssertNote(1234U, sNote, MemSize::SixteenBit); // full note for pointer address
 
@@ -552,6 +560,7 @@ public:
             L"+6 = Large (32-bit)\n"
             L"+10 = Very Large (8 bytes)";
         notes.AddCodeNote(1234, "Author", sNote);
+        notes.DoFrame();
 
         Assert::AreEqual(std::wstring(), notes.FindCodeNote(0, MemSize::EightBit));
         Assert::AreEqual(std::wstring(L"Unknown [indirect]"), notes.FindCodeNote(1, MemSize::EightBit));
@@ -594,6 +603,7 @@ public:
         notes.AddCodeNote(40, "Author", L"After [32-bit]");
         notes.AddCodeNote(1, "Author", L"Before");
         notes.AddCodeNote(20, "Author", L"In the middle");
+        notes.DoFrame();
 
         Assert::AreEqual(std::wstring(), notes.FindCodeNote(0, MemSize::EightBit));
         Assert::AreEqual(std::wstring(L"Before"), notes.FindCodeNote(1, MemSize::EightBit));
@@ -627,6 +637,7 @@ public:
         notes.AddCodeNote(20, "Author", L"After [32-bit]");
         notes.AddCodeNote(4, "Author", L"Before");
         notes.AddCodeNote(12, "Author", L"In the middle");
+        notes.DoFrame();
 
         int i = 0;
         notes.EnumerateCodeNotes([&i, &sPointerNote](ra::ByteAddress nAddress, unsigned nBytes, const std::wstring& sNote) {
@@ -671,6 +682,7 @@ public:
         notes.AddCodeNote(20, "Author", L"After [32-bit]");
         notes.AddCodeNote(4, "Author", L"Before");
         notes.AddCodeNote(12, "Author", L"In the middle");
+        notes.DoFrame();
 
         int i = 0;
         notes.EnumerateCodeNotes([&i, &sPointerNote](ra::ByteAddress nAddress, unsigned nBytes, const std::wstring& sNote) {
@@ -731,6 +743,7 @@ public:
         notes.AddCodeNote(40, "Author", L"After [32-bit]");
         notes.AddCodeNote(1, "Author", L"Before");
         notes.AddCodeNote(20, "Author", L"In the middle");
+        notes.DoFrame();
 
         int i = 0;
         notes.EnumerateCodeNotes([&i, &sPointerNote](ra::ByteAddress nAddress, unsigned nBytes, const std::wstring& sNote) {
@@ -796,6 +809,7 @@ public:
             L"+2 = Medium (16-bit)\n"
             L"+4 = Large (32-bit)";
         notes.AddCodeNote(0x0000, "Author", sNote);
+        notes.DoFrame();
 
         // should receive notifications for the pointer note, and for each subnote
         Assert::AreEqual({4U}, notes.mNewNotes.size());
@@ -868,6 +882,7 @@ public:
             L"+2 = Medium (16-bit)\n"
             L"+4 = Large (32-bit)";
         notes.AddCodeNote(0x0000, "Author", sNote);
+        notes.DoFrame();
 
         // should receive notifications for the pointer note, and for each subnote
         Assert::AreEqual({4U}, notes.mNewNotes.size());
@@ -915,6 +930,7 @@ public:
             L"+2 = Medium (16-bit)\n"
             L"+4 = Large (32-bit)";
         notes.AddCodeNote(0x0000, "Author", sNote);
+        notes.DoFrame();
 
         // should receive notifications for the pointer note, and for each subnote
         Assert::AreEqual({4U}, notes.mNewNotes.size());
@@ -962,6 +978,7 @@ public:
             L"+0xFFFFFF82 = Medium (16-bit)\n"
             L"+0xFFFFFF84 = Large (32-bit)";
         notes.AddCodeNote(0x0000, "Author", sNote);
+        notes.DoFrame();
 
         // should receive notifications for the pointer note, and for each subnote
         Assert::AreEqual({4U}, notes.mNewNotes.size());
@@ -1008,6 +1025,7 @@ public:
             L"+2 = Medium (16-bit)\n"
             L"+4 = Large (32-bit)";
         notes.AddCodeNote(0x0000, "Author", sNote);
+        notes.DoFrame();
 
         // indirect notes are at 0x11 (byte), 0x12 (word), and 0x14 (dword)
         Assert::AreEqual(0xFFFFFFFF, notes.FindCodeNoteStart(0x10));
@@ -1035,6 +1053,7 @@ public:
             L"+0xFFFFFF90 = Medium (16-bit)\n" // 16+8=24
             L"+0xFFFFFF98 = Large (32-bit)";   // 24+8=32
         notes.AddCodeNote(4, "Author", sPointerNote);
+        notes.DoFrame();
 
         // indirect notes are at 16 (byte), 24 (word), and 32 (dword)
         Assert::AreEqual(0xFFFFFFFF, notes.FindCodeNoteStart(15));
@@ -1069,6 +1088,7 @@ public:
             L"+4 = Large (32-bit)";
         notes.AddCodeNote(0x0000, "Author", sNote);
         notes.AddCodeNote(0x0008, "Author", L"Not indirect");
+        notes.DoFrame();
 
         // indirect notes are at 0x11 (byte), 0x12 (word), and 0x14 (dword)
         Assert::AreEqual(0xFFFFFFFF, notes.GetIndirectSource(0x10));
@@ -1100,6 +1120,7 @@ public:
             L"+0xFFFFFF84 = Large (32-bit)";
         notes.AddCodeNote(0x0004, "Author", sNote);
         notes.AddCodeNote(0x0008, "Author", L"Not indirect");
+        notes.DoFrame();
 
         // indirect notes are at 0x11 (byte), 0x12 (word), and 0x14 (dword)
         Assert::AreEqual(0xFFFFFFFF, notes.GetIndirectSource(0x10));
@@ -1253,6 +1274,7 @@ public:
         notes.AddCodeNote(20, "Author", L"After [32-bit]");
         notes.AddCodeNote(4, "Author", L"Before");
         notes.AddCodeNote(12, "Author", L"In the middle");
+        notes.DoFrame();
 
         Assert::AreEqual({4U}, notes.GetNextNoteAddress({0U}));
         Assert::AreEqual({12U}, notes.GetNextNoteAddress({4U}));
@@ -1286,6 +1308,7 @@ public:
         notes.AddCodeNote(40, "Author", L"After [32-bit]");
         notes.AddCodeNote(1, "Author", L"Before");
         notes.AddCodeNote(20, "Author", L"In the middle");
+        notes.DoFrame();
 
         Assert::AreEqual({1U}, notes.GetNextNoteAddress({0U}));
         Assert::AreEqual({4U}, notes.GetNextNoteAddress({1U}));
@@ -1314,6 +1337,7 @@ public:
         notes.AddCodeNote(20, "Author", L"After [32-bit]");
         notes.AddCodeNote(4, "Author", L"Before");
         notes.AddCodeNote(12, "Author", L"In the middle");
+        notes.DoFrame();
 
         Assert::AreEqual({1234U}, notes.GetPreviousNoteAddress({0xFFFFFFFFU}));
         Assert::AreEqual({20U}, notes.GetPreviousNoteAddress({1234U}));
@@ -1347,6 +1371,7 @@ public:
         notes.AddCodeNote(40, "Author", L"After [32-bit]");
         notes.AddCodeNote(1, "Author", L"Before");
         notes.AddCodeNote(20, "Author", L"In the middle");
+        notes.DoFrame();
 
         Assert::AreEqual({40U}, notes.GetPreviousNoteAddress({0xFFFFFFFFU}));
         Assert::AreEqual({20U}, notes.GetPreviousNoteAddress({40U}));

--- a/tests/ui/viewmodels/MemoryInspectorViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/MemoryInspectorViewModel_Tests.cpp
@@ -60,6 +60,8 @@ private:
             mockUserContext.SetUsername("Author");
 
             mockGameContext.InitializeCodeNotes();
+
+            Viewer().DoFrame(); // load memory into viewer so CurrentAddress value can be read
         }
 
         ~MemoryInspectorViewModelHarness()
@@ -739,6 +741,7 @@ public:
             L"[32-bit pointer] Player data\n"
             L"+4: [32-bit] Current HP\n"
             L"+8: [32-bit] Max HP");
+        inspector.mockGameContext.DoFrame(); // force indirect code note initialization
 
         inspector.SetCurrentAddress(16U);
         inspector.BookmarkCurrentAddress();

--- a/tests/ui/viewmodels/MemoryViewerViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/MemoryViewerViewModel_Tests.cpp
@@ -1928,11 +1928,6 @@ public:
         MemoryViewerViewModelHarness viewer;
         viewer.InitializeMemory(256);
 
-        // ignore if readonly
-        viewer.SetReadOnly(true);
-        Assert::IsTrue(viewer.IsReadOnly());
-        Assert::IsFalse(viewer.IncreaseCurrentValue(1));
-
         viewer.SetReadOnly(false);
         Assert::IsFalse(viewer.IsReadOnly());
 
@@ -1940,28 +1935,35 @@ public:
         Assert::AreEqual({ 0U }, viewer.GetAddress());
         Assert::AreEqual({ 0x0U }, viewer.mockEmulatorContext.ReadMemoryByte(0U));
 
-        // Increase by 1 from 0x0 should result to 0X1
-        Assert::IsTrue(viewer.IncreaseCurrentValue(1));
+        // Increase by 1 from 0x0 should result to 0x1
+        viewer.IncreaseCurrentValue(1);
         Assert::AreEqual({ 0x1U }, viewer.mockEmulatorContext.ReadMemoryByte(0U));
 
-        // Increase by 1 from 0xFE should result to 0XFF
+        // Increase by 1 from 0xFE should result to 0xFF
         viewer.mockEmulatorContext.WriteMemoryByte(0x0U, 0XFEU);
-        Assert::IsTrue(viewer.IncreaseCurrentValue(1));
+        viewer.IncreaseCurrentValue(1);
         Assert::AreEqual({ 0xFFU }, viewer.mockEmulatorContext.ReadMemoryByte(0U));
 
         // Increase by 1 from 0xFF should not change the value
-        Assert::IsFalse(viewer.IncreaseCurrentValue(1));
+        viewer.IncreaseCurrentValue(1);
         Assert::AreEqual({ 0xFFU }, viewer.mockEmulatorContext.ReadMemoryByte(0U));
 
-        // Increase by 1 from 0x0 should result to 0X0001
-        viewer.mockEmulatorContext.WriteMemory(0x0U, MemSize::SixteenBit, 0X0U);
-        Assert::IsTrue(viewer.IncreaseCurrentValue(1));
+        // Increase by 1 from 0x0 should result to 0x0001
+        viewer.mockEmulatorContext.WriteMemory(0x0U, MemSize::SixteenBit, 0x0U);
+        viewer.IncreaseCurrentValue(1);
         Assert::AreEqual({ 0x1U }, viewer.mockEmulatorContext.ReadMemory(0U, MemSize::SixteenBit));
 
         // Increase by 1 from 0xFFFF should not change the value
-        viewer.mockEmulatorContext.WriteMemory(0x0U, MemSize::SixteenBit, 0XFFFFU);
-        Assert::IsFalse(viewer.IncreaseCurrentValue(1));
+        viewer.mockEmulatorContext.WriteMemory(0x0U, MemSize::SixteenBit, 0xFFFFU);
+        viewer.IncreaseCurrentValue(1);
         Assert::AreEqual({ 0xFFFFU }, viewer.mockEmulatorContext.ReadMemory(0U, MemSize::SixteenBit));
+
+        // ignore if readonly
+        viewer.mockEmulatorContext.WriteMemory(0x0U, MemSize::SixteenBit, 0x0U);
+        viewer.SetReadOnly(true);
+        Assert::IsTrue(viewer.IsReadOnly());
+        viewer.IncreaseCurrentValue(1);
+        Assert::AreEqual({ 0x0U }, viewer.mockEmulatorContext.ReadMemory(0U, MemSize::SixteenBit));
     }
 
     TEST_METHOD(TestIncreaseCurrentValueBySixTeen)
@@ -1969,11 +1971,6 @@ public:
         MemoryViewerViewModelHarness viewer;
         viewer.InitializeMemory(256);
 
-        // ignore if readonly
-        viewer.SetReadOnly(true);
-        Assert::IsTrue(viewer.IsReadOnly());
-        Assert::IsFalse(viewer.IncreaseCurrentValue(16));
-
         viewer.SetReadOnly(false);
         Assert::IsFalse(viewer.IsReadOnly());
 
@@ -1981,28 +1978,35 @@ public:
         Assert::AreEqual({ 0U }, viewer.GetAddress());
         Assert::AreEqual({ 0x0U }, viewer.mockEmulatorContext.ReadMemoryByte(0U));
 
-        // Increase by 16 from 0x0 should result to 0X10
-        Assert::IsTrue(viewer.IncreaseCurrentValue(16));
+        // Increase by 16 from 0x0 should result to 0x10
+        viewer.IncreaseCurrentValue(16);
         Assert::AreEqual({ 0x10U }, viewer.mockEmulatorContext.ReadMemoryByte(0U));
 
-        // Increase by 16 from 0xFE should result to 0XFF
+        // Increase by 16 from 0xFE should result to 0xFF
         viewer.mockEmulatorContext.WriteMemoryByte(0x0U, 0XFEU);
-        Assert::IsTrue(viewer.IncreaseCurrentValue(16));
+        viewer.IncreaseCurrentValue(16);
         Assert::AreEqual({ 0xFFU }, viewer.mockEmulatorContext.ReadMemoryByte(0U));
 
         // Increase by 16 from 0xFF should not change the value
-        Assert::IsFalse(viewer.IncreaseCurrentValue(16));
+        viewer.IncreaseCurrentValue(16);
         Assert::AreEqual({ 0xFFU }, viewer.mockEmulatorContext.ReadMemoryByte(0U));
 
-        // Increase by 16 from 0x0 should result to 0X0010
-        viewer.mockEmulatorContext.WriteMemory(0x0U, MemSize::SixteenBit, 0X0U);
-        Assert::IsTrue(viewer.IncreaseCurrentValue(16));
+        // Increase by 16 from 0x0 should result to 0x0010
+        viewer.mockEmulatorContext.WriteMemory(0x0U, MemSize::SixteenBit, 0x0U);
+        viewer.IncreaseCurrentValue(16);
         Assert::AreEqual({ 0x10U }, viewer.mockEmulatorContext.ReadMemory(0U, MemSize::SixteenBit));
 
         // Increase by 16 from 0xFFFF should not change the value
-        viewer.mockEmulatorContext.WriteMemory(0x0U, MemSize::SixteenBit, 0XFFFFU);
-        Assert::IsFalse(viewer.IncreaseCurrentValue(16));
+        viewer.mockEmulatorContext.WriteMemory(0x0U, MemSize::SixteenBit, 0xFFFFU);
+        viewer.IncreaseCurrentValue(16);
         Assert::AreEqual({ 0xFFFFU }, viewer.mockEmulatorContext.ReadMemory(0U, MemSize::SixteenBit));
+
+        // ignore if readonly
+        viewer.mockEmulatorContext.WriteMemory(0x0U, MemSize::SixteenBit, 0x0U);
+        viewer.SetReadOnly(true);
+        Assert::IsTrue(viewer.IsReadOnly());
+        viewer.IncreaseCurrentValue(16);
+        Assert::AreEqual({ 0x0U }, viewer.mockEmulatorContext.ReadMemory(0U, MemSize::SixteenBit));
     }
 
     TEST_METHOD(TestDecreaseCurrentValueByOne)
@@ -2010,11 +2014,6 @@ public:
         MemoryViewerViewModelHarness viewer;
         viewer.InitializeMemory(256);
 
-        // ignore if readonly
-        viewer.SetReadOnly(true);
-        Assert::IsTrue(viewer.IsReadOnly());
-        Assert::IsFalse(viewer.DecreaseCurrentValue(1));
-
         viewer.SetReadOnly(false);
         Assert::IsFalse(viewer.IsReadOnly());
 
@@ -2023,27 +2022,33 @@ public:
         Assert::AreEqual({ 0x0U }, viewer.mockEmulatorContext.ReadMemoryByte(0U));
 
         // Decrease by 1 from 0x0 should not change the value
-        Assert::IsFalse(viewer.DecreaseCurrentValue(1));
+        viewer.DecreaseCurrentValue(1);
         Assert::AreEqual({ 0x0U }, viewer.mockEmulatorContext.ReadMemoryByte(0U));
 
         // Decrease by 1 from 0xFF should result to 0XFE
         viewer.mockEmulatorContext.WriteMemoryByte(0x0U, 0XFFU);
-        Assert::IsTrue(viewer.DecreaseCurrentValue(1));
+        viewer.DecreaseCurrentValue(1);
         Assert::AreEqual({ 0xFEU }, viewer.mockEmulatorContext.ReadMemoryByte(0U));
 
         // Decrease by 1 from 0x1 should result to 0X0
         viewer.mockEmulatorContext.WriteMemoryByte(0x0U, 0X1U);
-        Assert::IsTrue(viewer.DecreaseCurrentValue(1));
+        viewer.DecreaseCurrentValue(1);
         Assert::AreEqual({ 0x0U }, viewer.mockEmulatorContext.ReadMemoryByte(0U));
 
         // Decrease by 1 from 0x0 should not change the value
         viewer.mockEmulatorContext.WriteMemory(0x0U, MemSize::SixteenBit, 0X0U);
-        Assert::IsFalse(viewer.DecreaseCurrentValue(1));
+        viewer.DecreaseCurrentValue(1);
         Assert::AreEqual({ 0x0U }, viewer.mockEmulatorContext.ReadMemory(0U, MemSize::SixteenBit));
 
         // Decrease by 1 from 0xFFFF should result to 0XFFFE
         viewer.mockEmulatorContext.WriteMemory(0x0U, MemSize::SixteenBit, 0XFFFFU);
-        Assert::IsTrue(viewer.DecreaseCurrentValue(1));
+        viewer.DecreaseCurrentValue(1);
+        Assert::AreEqual({ 0xFFFEU }, viewer.mockEmulatorContext.ReadMemory(0U, MemSize::SixteenBit));
+
+        // ignore if readonly
+        viewer.SetReadOnly(true);
+        Assert::IsTrue(viewer.IsReadOnly());
+        viewer.DecreaseCurrentValue(1);
         Assert::AreEqual({ 0xFFFEU }, viewer.mockEmulatorContext.ReadMemory(0U, MemSize::SixteenBit));
     }
 
@@ -2052,11 +2057,6 @@ public:
         MemoryViewerViewModelHarness viewer;
         viewer.InitializeMemory(256);
 
-        // ignore if readonly
-        viewer.SetReadOnly(true);
-        Assert::IsTrue(viewer.IsReadOnly());
-        Assert::IsFalse(viewer.DecreaseCurrentValue(16));
-
         viewer.SetReadOnly(false);
         Assert::IsFalse(viewer.IsReadOnly());
 
@@ -2065,27 +2065,33 @@ public:
         Assert::AreEqual({ 0x0U }, viewer.mockEmulatorContext.ReadMemoryByte(0U));
 
         // Decrease by 16 from 0x0 should not change the value
-        Assert::IsFalse(viewer.DecreaseCurrentValue(16));
+        viewer.DecreaseCurrentValue(16);
         Assert::AreEqual({ 0x0U }, viewer.mockEmulatorContext.ReadMemoryByte(0U));
 
         // Decrease by 16 from 0xFF should result to 0XEF
-        viewer.mockEmulatorContext.WriteMemoryByte(0x0U, 0XFFU);
-        Assert::IsTrue(viewer.DecreaseCurrentValue(16));
+        viewer.mockEmulatorContext.WriteMemoryByte(0x0U, 0xFFU);
+        viewer.DecreaseCurrentValue(16);
         Assert::AreEqual({ 0xEFU }, viewer.mockEmulatorContext.ReadMemoryByte(0U));
 
         // Decrease by 16 from 0x1 should result to 0X0
-        viewer.mockEmulatorContext.WriteMemoryByte(0x0U, 0X1U);
-        Assert::IsTrue(viewer.DecreaseCurrentValue(16));
+        viewer.mockEmulatorContext.WriteMemoryByte(0x0U, 0x1U);
+        viewer.DecreaseCurrentValue(16);
         Assert::AreEqual({ 0x0U }, viewer.mockEmulatorContext.ReadMemoryByte(0U));
 
         // Decrease by 16 from 0x0 should not change the value
-        viewer.mockEmulatorContext.WriteMemory(0x0U, MemSize::SixteenBit, 0X0U);
-        Assert::IsFalse(viewer.DecreaseCurrentValue(16));
+        viewer.mockEmulatorContext.WriteMemory(0x0U, MemSize::SixteenBit, 0x0U);
+        viewer.DecreaseCurrentValue(16);
         Assert::AreEqual({ 0x0U }, viewer.mockEmulatorContext.ReadMemory(0U, MemSize::SixteenBit));
 
         // Decrease by 16 from 0xFFFF should result to 0XFFEF
-        viewer.mockEmulatorContext.WriteMemory(0x0U, MemSize::SixteenBit, 0XFFFFU);
-        Assert::IsTrue(viewer.DecreaseCurrentValue(16));
+        viewer.mockEmulatorContext.WriteMemory(0x0U, MemSize::SixteenBit, 0xFFFFU);
+        viewer.DecreaseCurrentValue(16);
+        Assert::AreEqual({ 0xFFEFU }, viewer.mockEmulatorContext.ReadMemory(0U, MemSize::SixteenBit));
+
+        // ignore if readonly
+        viewer.SetReadOnly(true);
+        Assert::IsTrue(viewer.IsReadOnly());
+        viewer.DecreaseCurrentValue(16);
         Assert::AreEqual({ 0xFFEFU }, viewer.mockEmulatorContext.ReadMemory(0U, MemSize::SixteenBit));
     }
 };


### PR DESCRIPTION
When `rc_client_set_allow_background_memory_reads` (https://github.com/RetroAchievements/rcheevos/pull/439) is set to false, any attempt to call the `read_memory_handler` from a thread other than whichever thread last called `rc_client_do_frame` will asynchronously queue up the `read_memory_handler` logic to be dispatched by the next call to `rc_client_do_frame` or `rc_client_idle`.

If `rc_client_set_allow_background_memory_reads` is not set to false, `read_memory_handler` will be continue to be called immediately in reaction to whatever triggered the need to read memory (typically the user clicking on something in the UI). That matches the current behavior, and provides the most responsive user interaction.

-----

**Notes regarding calling `rc_client_idle` while using this feature when emulation is paused:**
* `rc_client_idle` should be called at least once every 500ms, preferably once every 200ms or less.
  - not doing so may make the UI appear laggy when emulation is paused.
* `rc_client_idle` should be called on the same thread as `rc_client_do_frame` would be called from.
  - memory reads are dispatched by `rc_client_idle` and will occur on whichever thread calls `rc_client_idle`
  - if `rc_client_set_allow_background_memory_reads` is called with `false`, the client only wants reads on the `rc_client_do_frame` thread, so that should be the same thread `rc_client_idle` is called from.
  
