### PR TITLE
only show first line of code note in unmodified bookmark description

### DIFF
--- a/src/data/models/CodeNoteModel.hh
+++ b/src/data/models/CodeNoteModel.hh
@@ -83,6 +83,7 @@ public:
         size_t m_nEndIndex;
     };
 
+    static std::wstring TrimSize(const std::wstring& sNote, bool bKeepPointer);
 
 private:
     std::string m_sAuthor;

--- a/src/ui/viewmodels/MemoryBookmarksViewModel.cpp
+++ b/src/ui/viewmodels/MemoryBookmarksViewModel.cpp
@@ -33,8 +33,9 @@ namespace ra {
 namespace ui {
 namespace viewmodels {
 
-const StringModelProperty MemoryBookmarksViewModel::MemoryBookmarkViewModel::DescriptionProperty("MemoryBookmarkViewModel", "Description", L"");
+const StringModelProperty MemoryBookmarksViewModel::MemoryBookmarkViewModel::DescriptionProperty("MemoryBookmarkViewModel", "DescriptionHeader", L"");
 const BoolModelProperty MemoryBookmarksViewModel::MemoryBookmarkViewModel::IsCustomDescriptionProperty("MemoryBookmarkViewModel", "IsCustomDescription", false);
+const StringModelProperty MemoryBookmarksViewModel::MemoryBookmarkViewModel::RealNoteProperty("MemoryBookmarkViewModel", "Description", L"");
 const IntModelProperty MemoryBookmarksViewModel::MemoryBookmarkViewModel::AddressProperty("MemoryBookmarkViewModel", "Address", 0);
 const IntModelProperty MemoryBookmarksViewModel::MemoryBookmarkViewModel::SizeProperty("MemoryBookmarkViewModel", "Size", ra::etoi(MemSize::EightBit));
 const IntModelProperty MemoryBookmarksViewModel::MemoryBookmarkViewModel::FormatProperty("MemoryBookmarkViewModel", "Format", ra::etoi(MemFormat::Hex));
@@ -151,31 +152,55 @@ void MemoryBookmarksViewModel::MemoryBookmarkViewModel::OnValueChanged(const Int
 
 void MemoryBookmarksViewModel::MemoryBookmarkViewModel::OnValueChanged(const StringModelProperty::ChangeArgs& args)
 {
-    if (args.Property == MemoryBookmarkViewModel::DescriptionProperty)
+    if (args.Property == MemoryBookmarkViewModel::RealNoteProperty)
     {
-        if (m_bInitialized)
+        const auto sNewHeader = ExtractDescriptionHeader(args.tNewValue);
+        if (sNewHeader == GetDescription())
         {
-            m_bModified = true;
-
-            const auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::context::GameContext>();
-            const auto* pCodeNotes = pGameContext.Assets().FindCodeNotes();
-            const auto* pNote = (pCodeNotes != nullptr) ? pCodeNotes->FindCodeNote(m_nAddress) : nullptr;
-
-            bool bIsCustomDescription = false;
-            if (pNote)
-            {
-                if (*pNote != args.tNewValue)
-                    bIsCustomDescription = true;
-            }
-            else if (!args.tNewValue.empty())
-            {
-                bIsCustomDescription = true;
-            }
-            SetIsCustomDescription(bIsCustomDescription);
+            SetIsCustomDescription(false);
+        }
+        else if (!IsCustomDescription())
+        {
+            m_bSyncingDescriptionHeader = true;
+            SetDescription(sNewHeader);
+            m_bSyncingDescriptionHeader = false;
+        }
+    }
+    else if (args.Property == MemoryBookmarkViewModel::DescriptionProperty && !m_bSyncingDescriptionHeader)
+    {
+        const auto& sFullNote = GetRealNote();
+        const auto sHeader = ExtractDescriptionHeader(sFullNote);
+        if (args.tNewValue.empty() && !sHeader.empty())
+        {
+            // custom description was cleared out - reset to default
+            m_bSyncingDescriptionHeader = true;
+            SetDescription(sHeader);
+            m_bSyncingDescriptionHeader = false;
+            SetIsCustomDescription(false);
+        }
+        else
+        {
+            SetIsCustomDescription(sHeader != args.tNewValue);
         }
     }
 
     LookupItemViewModel::OnValueChanged(args);
+}
+
+std::wstring MemoryBookmarksViewModel::MemoryBookmarkViewModel::ExtractDescriptionHeader(const std::wstring& sFullNote)
+{
+    // extract the first line into DescriptionHeader
+    const auto nIndex = sFullNote.find('\n');
+    if (nIndex == std::string::npos)
+        return ra::data::models::CodeNoteModel::TrimSize(sFullNote, true);
+
+    std::wstring sNote = sFullNote;
+    sNote.resize(nIndex);
+
+    if (sNote.back() == '\r')
+        sNote.pop_back();
+
+    return ra::data::models::CodeNoteModel::TrimSize(sNote, true);
 }
 
 static rc_condition_t* FindMeasuredCondition(rc_value_t* pValue) noexcept
@@ -512,23 +537,14 @@ void MemoryBookmarksViewModel::OnCodeNoteChanged(ra::ByteAddress nAddress, const
     {
         auto* pBookmark = m_vBookmarks.GetItemAt(nIndex);
         if (pBookmark && pBookmark->GetAddress() == nAddress)
-        {
-            if (!pBookmark->IsCustomDescription())
-            {
-                pBookmark->SetDescription(sNewNote);
-            }
-            else
-            {
-                if (pBookmark->GetDescription() == sNewNote)
-                    pBookmark->SetIsCustomDescription(false);
-            }
-        }
+            pBookmark->SetRealNote(sNewNote);
     }
 }
 
 void MemoryBookmarksViewModel::LoadBookmarks(ra::services::TextReader& sBookmarksFile)
 {
     const auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::context::GameContext>();
+    const auto* pCodeNotes = pGameContext.Assets().FindCodeNotes();
     gsl::index nIndex = 0;
 
     m_vBookmarks.BeginUpdate();
@@ -600,22 +616,16 @@ void MemoryBookmarksViewModel::LoadBookmarks(ra::services::TextReader& sBookmark
                     vmBookmark->SetAddress(bookmark["Address"].GetUint());
                 }
 
-                const auto* pCodeNotes = pGameContext.Assets().FindCodeNotes();
-                const auto* pNote = (pCodeNotes != nullptr) ? pCodeNotes->FindCodeNote(vmBookmark->GetAddress()) : nullptr;
 
                 std::wstring sDescription;
+                const auto* pNote = (pCodeNotes != nullptr) ? pCodeNotes->FindCodeNote(vmBookmark->GetAddress()) : nullptr;
+                vmBookmark->SetRealNote(pNote ? *pNote : std::wstring(L""));
+
                 if (bookmark.HasMember("Description"))
                 {
                     sDescription = ra::Widen(bookmark["Description"].GetString());
-                    vmBookmark->SetIsCustomDescription(!pNote || sDescription != *pNote);
+                    vmBookmark->SetDescription(sDescription);
                 }
-                else
-                {
-                    vmBookmark->SetIsCustomDescription(false);
-                    if (pNote)
-                        sDescription = *pNote;
-                }
-                vmBookmark->SetDescription(sDescription);
 
                 if (bookmark.HasMember("Decimal") && bookmark["Decimal"].GetBool())
                     vmBookmark->SetFormat(ra::MemFormat::Dec);
@@ -757,7 +767,7 @@ void MemoryBookmarksViewModel::UpdateBookmark(MemoryBookmarksViewModel::MemoryBo
             if (isspace(sMessage.at(0)))
                 sMessage.erase(0, 1);
 
-            const auto& pDescription = pBookmark.GetDescription();
+            const auto& pDescription = pBookmark.GetRealNote();
             if (!pDescription.empty())
             {
                 auto nDescriptionLength = pDescription.find(L'\n');
@@ -844,7 +854,7 @@ void MemoryBookmarksViewModel::InitializeBookmark(MemoryBookmarksViewModel::Memo
     const auto* pNote = (pCodeNotes != nullptr) ? pCodeNotes->FindCodeNote(nAddress) : nullptr;
     if (pNote)
     {
-        vmBookmark.SetDescription(*pNote);
+        vmBookmark.SetRealNote(*pNote);
 
         // if bookmarking an 8-byte double, automatically adjust the bookmark for the significant bytes
         if (vmBookmark.GetSize() == MemSize::Double32 && pCodeNotes->GetCodeNoteBytes(nAddress) == 8)

--- a/src/ui/viewmodels/MemoryBookmarksViewModel.hh
+++ b/src/ui/viewmodels/MemoryBookmarksViewModel.hh
@@ -46,17 +46,17 @@ public:
     {
     public:
         /// <summary>
-        /// The <see cref="ModelProperty" /> for the bookmark description.
+        /// The <see cref="ModelProperty" /> for bookmark summary.
         /// </summary>
         static const StringModelProperty DescriptionProperty;
 
         /// <summary>
-        /// Gets the bookmark description.
+        /// Gets the bookmark summary.
         /// </summary>
         const std::wstring& GetDescription() const { return GetValue(DescriptionProperty); }
 
         /// <summary>
-        /// Sets the bookmark description.
+        /// Sets the bookmark summary.
         /// </summary>
         void SetDescription(const std::wstring& sValue) { SetValue(DescriptionProperty, sValue); }
 
@@ -74,6 +74,21 @@ public:
         /// Sets whether the bookmark description is custom.
         /// </summary>
         void SetIsCustomDescription(bool bValue) { SetValue(IsCustomDescriptionProperty, bValue); }
+
+        /// <summary>
+        /// The <see cref="ModelProperty" /> for the note supporting the bookmark.
+        /// </summary>
+        static const StringModelProperty RealNoteProperty;
+
+        /// <summary>
+        /// Gets the note supporting the bookmark.
+        /// </summary>
+        const std::wstring& GetRealNote() const { return GetValue(RealNoteProperty); }
+
+        /// <summary>
+        /// Sets the note supporting the bookmark.
+        /// </summary>
+        void SetRealNote(const std::wstring& sValue) { SetValue(RealNoteProperty, sValue); }
 
         /// <summary>
         /// The <see cref="ModelProperty" /> for the bookmark address.
@@ -295,6 +310,7 @@ public:
 
     private:
         std::wstring BuildCurrentValue() const;
+        static std::wstring ExtractDescriptionHeader(const std::wstring& sFullNote);
 
         // keep address/size/value fields directly accessible for speed - also keep in ValueProperty for binding
         ra::ByteAddress m_nAddress = 0;
@@ -302,6 +318,7 @@ public:
         MemSize m_nSize = MemSize::EightBit;
         bool m_bModified = false;
         bool m_bInitialized = false;
+        bool m_bSyncingDescriptionHeader = false;
 
         std::string m_sIndirectAddress;
         std::unique_ptr<uint8_t[]> m_pBuffer;

--- a/src/ui/viewmodels/PointerInspectorViewModel.cpp
+++ b/src/ui/viewmodels/PointerInspectorViewModel.cpp
@@ -82,7 +82,6 @@ void PointerInspectorViewModel::OnActiveGameChanged()
     const auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::context::GameContext>();
     if (pGameContext.GameId() == 0)
     {
-
         m_vPointers.Clear();
         m_vNodes.Clear();
         m_vPointerChain.Clear();
@@ -123,7 +122,8 @@ void PointerInspectorViewModel::OnEndGameLoad()
                 {
                     m_vPointers.Add(nAddress,
                                     ra::StringPrintf(L"%s | %s", pEmulatorContext.FormatAddress(nAddress),
-                                                     TrimSize(pNote.GetPointerDescription(), false)));
+                                                     ra::data::models::CodeNoteModel::TrimSize(
+                                                         pNote.GetPointerDescription(), false)));
                 }
 
                 return true;
@@ -188,7 +188,7 @@ void PointerInspectorViewModel::UpdatePointerVisibility(ra::ByteAddress nAddress
         m_vPointers.BeginUpdate();
         m_vPointers.Add(nAddress,
                         ra::StringPrintf(L"%s | %s", pEmulatorContext.FormatAddress(nAddress),
-                                         TrimSize(pNote->GetPointerDescription(), false)));
+                             ra::data::models::CodeNoteModel::TrimSize(pNote->GetPointerDescription(), false)));
         m_vPointers.MoveItem(nCount, nIndex);
         m_vPointers.EndUpdate();
     }
@@ -348,12 +348,12 @@ const ra::data::models::CodeNoteModel* PointerInspectorViewModel::UpdatePointerC
 
         if (pNote)
         {
-            pItem->SetDescription(pNote->GetPointerDescription());
+            pItem->SetRealNote(pNote->GetPointerDescription());
             pItem->SetSize(pNote->GetMemSize());
         }
         else
         {
-            pItem->SetDescription(L"");
+            pItem->SetRealNote(L"");
             pItem->SetSize(MemSize::EightBit);
         }
 
@@ -375,58 +375,6 @@ const ra::data::models::CodeNoteModel* PointerInspectorViewModel::UpdatePointerC
     return pNote;
 }
 
-std::wstring PointerInspectorViewModel::TrimSize(const std::wstring& sNote, bool bKeepPointer)
-{
-    size_t nEndIndex = 0;
-    size_t nStartIndex = sNote.find('[');
-    if (nStartIndex != std::string::npos)
-    {
-        nEndIndex = sNote.find(']', nStartIndex + 1);
-        if (nEndIndex == std::string::npos)
-            return sNote;
-    }
-    else
-    {
-        nStartIndex = sNote.find('(');
-        if (nStartIndex == std::string::npos)
-            return sNote;
-
-        nEndIndex = sNote.find(')', nStartIndex + 1);
-        if (nEndIndex == std::string::npos)
-            return sNote;
-    }
-
-    bool bPointer = false;
-    std::wstring sWord;
-    ra::data::models::CodeNoteModel::Parser::TokenType nTokenType;
-    const ra::data::models::CodeNoteModel::Parser parser(sNote, nStartIndex + 1, nEndIndex);
-    do
-    {
-        nTokenType = parser.NextToken(sWord);
-        if (nTokenType == ra::data::models::CodeNoteModel::Parser::TokenType::Other)
-        {
-            if (sWord == L"pointer")
-                bPointer = true;
-            else
-                return sNote;
-        }
-    } while (nTokenType != ra::data::models::CodeNoteModel::Parser::TokenType::None);
-
-    while (nStartIndex > 0 && isspace(sNote.at(nStartIndex - 1)))
-        nStartIndex--;
-
-    while (nEndIndex < sNote.length() - 1 && isspace(sNote.at(nEndIndex + 1)))
-        nEndIndex++;
-
-    std::wstring sNoteCopy = sNote;
-    sNoteCopy.erase(nStartIndex, nEndIndex - nStartIndex + 1);
-
-    if (bPointer && bKeepPointer)
-        sNoteCopy.insert(0, L"[pointer] ");
-
-    return sNoteCopy;
-}
-
 void PointerInspectorViewModel::SyncField(PointerInspectorViewModel::StructFieldViewModel& pFieldViewModel, const ra::data::models::CodeNoteModel& pOffsetNote)
 {
     const auto nSize = pOffsetNote.GetMemSize();
@@ -438,14 +386,14 @@ void PointerInspectorViewModel::SyncField(PointerInspectorViewModel::StructField
     auto nIndex = sNote.find('\n');
     if (nIndex == std::string::npos)
     {
-        pFieldViewModel.SetDescription(TrimSize(sNote, true));
+        pFieldViewModel.SetRealNote(ra::data::models::CodeNoteModel::TrimSize(sNote, true));
     }
     else
     {
         if (nIndex > 0 && sNote.at(nIndex - 1) == '\r')
             --nIndex;
 
-        pFieldViewModel.SetDescription(TrimSize(sNote.substr(0, nIndex), true));
+        pFieldViewModel.SetRealNote(ra::data::models::CodeNoteModel::TrimSize(sNote.substr(0, nIndex), true));
     }
 }
 
@@ -601,13 +549,13 @@ void PointerInspectorViewModel::BuildNote(ra::StringBuilder& builder,
         }
 
         if (isCurrentField)
-            builder.Append(TrimSize(GetCurrentFieldNote(), false));
+            builder.Append(ra::data::models::CodeNoteModel::TrimSize(GetCurrentFieldNote(), false));
         else if (!pOffsetNote.IsPointer())
-            builder.Append(TrimSize(pOffsetNote.GetNote(), false));
+            builder.Append(ra::data::models::CodeNoteModel::TrimSize(pOffsetNote.GetNote(), false));
         else if (&pOffsetNote == m_pCurrentNote)
-            builder.Append(TrimSize(GetCurrentAddressNote(), false));
+            builder.Append(ra::data::models::CodeNoteModel::TrimSize(GetCurrentAddressNote(), false));
         else
-            builder.Append(TrimSize(pOffsetNote.GetPointerDescription(), false));
+            builder.Append(ra::data::models::CodeNoteModel::TrimSize(pOffsetNote.GetPointerDescription(), false));
 
         if (pOffsetNote.IsPointer())
             BuildNote(builder, sChain, nDepth + 1, pOffsetNote);

--- a/src/ui/viewmodels/PointerInspectorViewModel.hh
+++ b/src/ui/viewmodels/PointerInspectorViewModel.hh
@@ -226,7 +226,6 @@ private:
     void UpdatePointerChainValues();
     void UpdateValues();
     std::string GetMemRefChain(bool bMeasured) const;
-    static std::wstring TrimSize(const std::wstring& sNote, bool bKeepPointer);
 
     void BuildNote(ra::StringBuilder& builder,
                    std::stack<const PointerInspectorViewModel::PointerNodeViewModel*>& sChain, gsl::index nDepth,

--- a/src/ui/win32/MemoryBookmarksDialog.cpp
+++ b/src/ui/win32/MemoryBookmarksDialog.cpp
@@ -136,6 +136,7 @@ MemoryBookmarksDialog::MemoryBookmarksDialog(MemoryBookmarksViewModel& vmMemoryB
     pAddressColumn->SetHeader(L"Address");
     pAddressColumn->UpdateWidth();
     pAddressColumn->SetAlignment(ra::ui::RelativePosition::Far);
+    pAddressColumn->BindTooltip(MemoryBookmarksViewModel::MemoryBookmarkViewModel::RealNoteProperty);
     m_bindBookmarks.BindColumn(1, std::move(pAddressColumn));
 
     auto pSizeColumn = std::make_unique<ra::ui::win32::bindings::GridLookupColumnBinding>(
@@ -201,6 +202,7 @@ MemoryBookmarksDialog::MemoryBookmarksDialog(MemoryBookmarksViewModel& vmMemoryB
 BOOL MemoryBookmarksDialog::OnInitDialog()
 {
     m_bindBookmarks.SetControl(*this, IDC_RA_LBX_ADDRESSES);
+    m_bindBookmarks.InitializeTooltips(std::chrono::seconds(30));
 
     return DialogBase::OnInitDialog();
 }

--- a/src/ui/win32/PointerInspectorDialog.cpp
+++ b/src/ui/win32/PointerInspectorDialog.cpp
@@ -80,7 +80,7 @@ PointerInspectorDialog::PointerInspectorDialog(PointerInspectorViewModel& vmPoin
     m_bindFields.BindColumn(0, std::move(pOffsetColumn));
 
     auto pDescriptionColumn = std::make_unique<ra::ui::win32::bindings::GridTextColumnBinding>(
-        PointerInspectorViewModel::StructFieldViewModel::DescriptionProperty);
+        PointerInspectorViewModel::StructFieldViewModel::RealNoteProperty);
     pDescriptionColumn->SetHeader(L"Description");
     pDescriptionColumn->SetWidth(GridColumnBinding::WidthType::Fill, 80);
     m_bindFields.BindColumn(1, std::move(pDescriptionColumn));
@@ -140,7 +140,7 @@ PointerInspectorDialog::PointerInspectorDialog(PointerInspectorViewModel& vmPoin
     m_bindPointerChain.BindColumn(2, std::move(pValueColumn));
 
     pDescriptionColumn = std::make_unique<ra::ui::win32::bindings::GridTextColumnBinding>(
-        PointerInspectorViewModel::StructFieldViewModel::DescriptionProperty);
+        PointerInspectorViewModel::StructFieldViewModel::RealNoteProperty);
     pDescriptionColumn->SetHeader(L"Description");
     pDescriptionColumn->SetWidth(GridColumnBinding::WidthType::Fill, 80);
     m_bindPointerChain.BindColumn(3, std::move(pDescriptionColumn));

--- a/src/ui/win32/bindings/GridColumnBinding.hh
+++ b/src/ui/win32/bindings/GridColumnBinding.hh
@@ -46,7 +46,14 @@ public:
         return GetText(vmItems, nIndex);
     }
 
-    virtual std::wstring GetTooltip(_UNUSED const ra::ui::ViewModelCollectionBase& vmItems, _UNUSED gsl::index nIndex) const { return L""; }
+    void BindTooltip(const ra::ui::StringModelProperty& pProperty) noexcept { m_pBoundTooltipProperty = &pProperty; }
+    virtual std::wstring GetTooltip(const ra::ui::ViewModelCollectionBase& vmItems, gsl::index nIndex) const
+    {
+        if (m_pBoundTooltipProperty)
+            return vmItems.GetItemValue(nIndex, *m_pBoundTooltipProperty);
+
+        return L"";
+    }
 
     virtual bool DependsOn(const ra::ui::BoolModelProperty&) const noexcept(false) { return false; }
     virtual bool DependsOn(const ra::ui::IntModelProperty& pProperty) const noexcept(false)
@@ -91,6 +98,7 @@ protected:
     ra::ui::RelativePosition m_nAlignment = ra::ui::RelativePosition::Near;
     bool m_bReadOnly = true;
     const IntModelProperty* m_pTextColorProperty = nullptr;
+    const StringModelProperty* m_pBoundTooltipProperty = nullptr;
 };
 
 } // namespace bindings

--- a/tests/ui/viewmodels/MemoryBookmarksViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/MemoryBookmarksViewModel_Tests.cpp
@@ -148,6 +148,7 @@ public:
 
         Assert::AreEqual({ 1U }, bookmarks.Bookmarks().Count());
         const auto& bookmark = *bookmarks.Bookmarks().GetItemAt(0);
+        Assert::AreEqual(std::wstring(L""), bookmark.GetRealNote());
         Assert::AreEqual(std::wstring(L"desc"), bookmark.GetDescription());
         Assert::AreEqual(1234U, bookmark.GetAddress());
         Assert::AreEqual(MemSize::EightBit, bookmark.GetSize());
@@ -172,6 +173,7 @@ public:
 
         Assert::AreEqual({ 1U }, bookmarks.Bookmarks().Count());
         const auto& bookmark = *bookmarks.Bookmarks().GetItemAt(0);
+        Assert::AreEqual(std::wstring(L""), bookmark.GetRealNote());
         Assert::AreEqual(std::wstring(L"desc"), bookmark.GetDescription());
         Assert::AreEqual(1234U, bookmark.GetAddress());
         Assert::AreEqual(MemSize::EightBit, bookmark.GetSize());
@@ -196,6 +198,7 @@ public:
 
         Assert::AreEqual({ 1U }, bookmarks.Bookmarks().Count());
         const auto& bookmark = *bookmarks.Bookmarks().GetItemAt(0);
+        Assert::AreEqual(std::wstring(L""), bookmark.GetRealNote());
         Assert::AreEqual(std::wstring(L"desc"), bookmark.GetDescription());
         Assert::AreEqual(1234U, bookmark.GetAddress());
         Assert::AreEqual(MemSize::EightBit, bookmark.GetSize());
@@ -229,6 +232,7 @@ public:
         bookmarks.mockGameContext.NotifyActiveGameChanged();
         Assert::AreEqual({ 1U }, bookmarks.Bookmarks().Count());
         const auto& bookmark = *bookmarks.Bookmarks().GetItemAt(0);
+        Assert::AreEqual(std::wstring(L""), bookmark.GetRealNote());
         Assert::AreEqual(std::wstring(L"desc3"), bookmark.GetDescription());
         Assert::AreEqual(5555U, bookmark.GetAddress());
         Assert::AreEqual(MemSize::SixteenBit, bookmark.GetSize());
@@ -272,7 +276,47 @@ public:
 
         Assert::AreEqual({ 1U }, bookmarks.Bookmarks().Count());
         const auto& bookmark = *bookmarks.Bookmarks().GetItemAt(0);
+        Assert::AreEqual(std::wstring(L"Note description"), bookmark.GetRealNote());
         Assert::AreEqual(std::wstring(L"Note description"), bookmark.GetDescription());
+        Assert::AreEqual(1234U, bookmark.GetAddress());
+        Assert::AreEqual(MemSize::EightBit, bookmark.GetSize());
+        Assert::AreEqual((int)MemFormat::Hex, (int)bookmark.GetFormat());
+        Assert::IsFalse(bookmark.IsCustomDescription());
+    }
+
+    TEST_METHOD(TestLoadBookmarksDescriptionFromMultilineCodeNotes)
+    {
+        MemoryBookmarksViewModelHarness bookmarks;
+        bookmarks.SetIsVisible(true);
+        bookmarks.mockGameContext.SetGameId(3U);
+        bookmarks.mockGameContext.SetCodeNote(1234U, L"[8-bit] Selected Character\r\n1=Bob\r\n2=Jane");
+        bookmarks.mockLocalStorage.MockStoredData(ra::services::StorageItemType::Bookmarks, L"3",
+                                                  "{\"Bookmarks\":[{\"MemAddr\":\"0xH4D2\"}]}");
+
+        bookmarks.mockGameContext.NotifyActiveGameChanged();
+
+        Assert::AreEqual({1U}, bookmarks.Bookmarks().Count());
+        auto& bookmark = *bookmarks.Bookmarks().GetItemAt(0);
+        Assert::AreEqual(std::wstring(L"[8-bit] Selected Character\r\n1=Bob\r\n2=Jane"), bookmark.GetRealNote());
+        Assert::AreEqual(std::wstring(L"Selected Character"), bookmark.GetDescription());
+        Assert::AreEqual(1234U, bookmark.GetAddress());
+        Assert::AreEqual(MemSize::EightBit, bookmark.GetSize());
+        Assert::AreEqual((int)MemFormat::Hex, (int)bookmark.GetFormat());
+        Assert::IsFalse(bookmark.IsCustomDescription());
+
+        bookmark.SetDescription(L"Primary Character");
+
+        Assert::AreEqual(std::wstring(L"[8-bit] Selected Character\r\n1=Bob\r\n2=Jane"), bookmark.GetRealNote());
+        Assert::AreEqual(std::wstring(L"Primary Character"), bookmark.GetDescription());
+        Assert::AreEqual(1234U, bookmark.GetAddress());
+        Assert::AreEqual(MemSize::EightBit, bookmark.GetSize());
+        Assert::AreEqual((int)MemFormat::Hex, (int)bookmark.GetFormat());
+        Assert::IsTrue(bookmark.IsCustomDescription());
+
+        bookmark.SetDescription(L"Selected Character");
+
+        Assert::AreEqual(std::wstring(L"[8-bit] Selected Character\r\n1=Bob\r\n2=Jane"), bookmark.GetRealNote());
+        Assert::AreEqual(std::wstring(L"Selected Character"), bookmark.GetDescription());
         Assert::AreEqual(1234U, bookmark.GetAddress());
         Assert::AreEqual(MemSize::EightBit, bookmark.GetSize());
         Assert::AreEqual((int)MemFormat::Hex, (int)bookmark.GetFormat());
@@ -291,6 +335,7 @@ public:
 
         Assert::AreEqual({ 1U }, bookmarks.Bookmarks().Count());
         const auto& bookmark = *bookmarks.Bookmarks().GetItemAt(0);
+        Assert::AreEqual(std::wstring(L""), bookmark.GetRealNote());
         Assert::AreEqual(std::wstring(L"desc"), bookmark.GetDescription());
         Assert::AreEqual(1234U, bookmark.GetAddress());
         Assert::AreEqual(MemSize::EightBit, bookmark.GetSize());
@@ -311,6 +356,7 @@ public:
 
         Assert::AreEqual({ 1U }, bookmarks.Bookmarks().Count());
         const auto& bookmark = *bookmarks.Bookmarks().GetItemAt(0);
+        Assert::AreEqual(std::wstring(L"Note description"), bookmark.GetRealNote());
         Assert::AreEqual(std::wstring(L"desc"), bookmark.GetDescription());
         Assert::AreEqual(1234U, bookmark.GetAddress());
         Assert::AreEqual(MemSize::EightBit, bookmark.GetSize());
@@ -331,6 +377,7 @@ public:
 
         Assert::AreEqual({ 1U }, bookmarks.Bookmarks().Count());
         const auto& bookmark = *bookmarks.Bookmarks().GetItemAt(0);
+        Assert::AreEqual(std::wstring(L"Note description"), bookmark.GetRealNote());
         Assert::AreEqual(std::wstring(L"Note description"), bookmark.GetDescription());
         Assert::AreEqual(1234U, bookmark.GetAddress());
         Assert::AreEqual(MemSize::EightBit, bookmark.GetSize());
@@ -404,12 +451,12 @@ public:
         bookmarks.mockGameContext.SetGameId(3U);
         bookmarks.mockGameContext.SetCodeNote(1234U, L"Note description");
         bookmarks.mockLocalStorage.MockStoredData(ra::services::StorageItemType::Bookmarks, L"3",
-            "{\"Bookmarks\":[{\"Address\":1234,\"Size\":10}]}");
+            "{\"Bookmarks\":[{\"Address\":1234,\"Description\":\"Old\",\"Size\":10}]}");
 
         bookmarks.mockGameContext.NotifyActiveGameChanged();
 
         bookmarks.AddBookmark(2345U, MemSize::SixteenBit);
-        bookmarks.Bookmarks().GetItemAt(0)->SetDescription(L""); // explicit blank hides existing note
+        bookmarks.Bookmarks().GetItemAt(0)->SetDescription(L"");        // explicit blank resets to default note
         bookmarks.Bookmarks().GetItemAt(1)->SetDescription(L"Custom2"); // no backing note
         Assert::IsTrue(bookmarks.IsModified());
 
@@ -419,7 +466,7 @@ public:
         Assert::IsFalse(bookmarks.IsModified());
         const std::string& sContents = bookmarks.mockLocalStorage.GetStoredData(ra::services::StorageItemType::Bookmarks, L"3");
         Assert::AreEqual(std::string("{\"Bookmarks\":["
-            "{\"MemAddr\":\"0xH04d2\",\"Description\":\"\"},"
+            "{\"MemAddr\":\"0xH04d2\"},"
             "{\"MemAddr\":\"0x 0929\",\"Description\":\"Custom2\"}]}"), sContents);
     }
 
@@ -458,6 +505,7 @@ public:
         Assert::AreEqual({ 1U }, bookmarks.Bookmarks().Count());
         const auto* bookmark = bookmarks.Bookmarks().GetItemAt(0);
         Expects(bookmark != nullptr);
+        Assert::AreEqual(std::wstring(L"Note description"), bookmark->GetRealNote());
         Assert::AreEqual(std::wstring(L"Note description"), bookmark->GetDescription());
         Assert::AreEqual(1234U, bookmark->GetAddress());
         Assert::AreEqual(MemSize::EightBit, bookmark->GetSize());
@@ -469,6 +517,7 @@ public:
         Assert::AreEqual({ 1U }, bookmarks.Bookmarks().Count());
         bookmark = bookmarks.Bookmarks().GetItemAt(0);
         Expects(bookmark != nullptr);
+        Assert::AreEqual(std::wstring(L"New description"), bookmark->GetRealNote());
         Assert::AreEqual(std::wstring(L"New description"), bookmark->GetDescription());
         Assert::AreEqual(1234U, bookmark->GetAddress());
         Assert::AreEqual(MemSize::EightBit, bookmark->GetSize());
@@ -490,6 +539,7 @@ public:
         Assert::AreEqual({ 1U }, bookmarks.Bookmarks().Count());
         const auto* bookmark = bookmarks.Bookmarks().GetItemAt(0);
         Expects(bookmark != nullptr);
+        Assert::AreEqual(std::wstring(L"Note description"), bookmark->GetRealNote());
         Assert::AreEqual(std::wstring(L"My Description"), bookmark->GetDescription());
         Assert::AreEqual(1234U, bookmark->GetAddress());
         Assert::AreEqual(MemSize::EightBit, bookmark->GetSize());
@@ -501,6 +551,7 @@ public:
         Assert::AreEqual({ 1U }, bookmarks.Bookmarks().Count());
         bookmark = bookmarks.Bookmarks().GetItemAt(0);
         Expects(bookmark != nullptr);
+        Assert::AreEqual(std::wstring(L"New description"), bookmark->GetRealNote());
         Assert::AreEqual(std::wstring(L"My Description"), bookmark->GetDescription());
         Assert::AreEqual(1234U, bookmark->GetAddress());
         Assert::AreEqual(MemSize::EightBit, bookmark->GetSize());
@@ -512,6 +563,7 @@ public:
         Assert::AreEqual({ 1U }, bookmarks.Bookmarks().Count());
         bookmark = bookmarks.Bookmarks().GetItemAt(0);
         Expects(bookmark != nullptr);
+        Assert::AreEqual(std::wstring(L"My Description"), bookmark->GetRealNote());
         Assert::AreEqual(std::wstring(L"My Description"), bookmark->GetDescription());
         Assert::AreEqual(1234U, bookmark->GetAddress());
         Assert::AreEqual(MemSize::EightBit, bookmark->GetSize());
@@ -523,6 +575,7 @@ public:
         Assert::AreEqual({ 1U }, bookmarks.Bookmarks().Count());
         bookmark = bookmarks.Bookmarks().GetItemAt(0);
         Expects(bookmark != nullptr);
+        Assert::AreEqual(std::wstring(L"New description"), bookmark->GetRealNote());
         Assert::AreEqual(std::wstring(L"New description"), bookmark->GetDescription());
         Assert::AreEqual(1234U, bookmark->GetAddress());
         Assert::AreEqual(MemSize::EightBit, bookmark->GetSize());
@@ -591,7 +644,7 @@ public:
 
         Assert::AreEqual({ 1U }, bookmarks.Bookmarks().Count());
         const auto& bookmark = *bookmarks.Bookmarks().GetItemAt(0);
-        Assert::AreEqual(std::wstring(L""), bookmark.GetDescription());
+        Assert::AreEqual(std::wstring(L""), bookmark.GetRealNote());
         Assert::AreEqual(1234U, bookmark.GetAddress());
         Assert::AreEqual(MemSize::EightBit, bookmark.GetSize());
         Assert::AreEqual((int)MemFormat::Hex, (int)bookmark.GetFormat());
@@ -612,7 +665,7 @@ public:
 
         Assert::AreEqual({ 1U }, bookmarks.Bookmarks().Count());
         const auto& bookmark = *bookmarks.Bookmarks().GetItemAt(0);
-        Assert::AreEqual(std::wstring(L"NOTE"), bookmark.GetDescription());
+        Assert::AreEqual(std::wstring(L"NOTE"), bookmark.GetRealNote());
         Assert::AreEqual(2345U, bookmark.GetAddress());
         Assert::AreEqual(MemSize::SixteenBit, bookmark.GetSize());
         Assert::AreEqual((int)MemFormat::Hex, (int)bookmark.GetFormat());
@@ -632,7 +685,7 @@ public:
 
         Assert::AreEqual({ 1U }, bookmarks.Bookmarks().Count());
         const auto& bookmark = *bookmarks.Bookmarks().GetItemAt(0);
-        Assert::AreEqual(std::wstring(L""), bookmark.GetDescription());
+        Assert::AreEqual(std::wstring(L""), bookmark.GetRealNote());
         Assert::AreEqual(5678U, bookmark.GetAddress());
         Assert::AreEqual(MemSize::ThirtyTwoBit, bookmark.GetSize());
         Assert::AreEqual((int)MemFormat::Dec, (int)bookmark.GetFormat());
@@ -860,6 +913,7 @@ public:
         Assert::IsTrue(bDialogSeen);
         Assert::AreEqual({ 1U }, bookmarks.Bookmarks().Count());
         const auto& bookmark = *bookmarks.Bookmarks().GetItemAt(0);
+        Assert::AreEqual(std::wstring(L"Note description"), bookmark.GetRealNote());
         Assert::AreEqual(std::wstring(L"Note description"), bookmark.GetDescription());
         Assert::AreEqual(1234U, bookmark.GetAddress());
         Assert::AreEqual(MemSize::EightBit, bookmark.GetSize());
@@ -1094,7 +1148,7 @@ public:
         MemoryBookmarksViewModelHarness bookmarks;
         bookmarks.AddBookmark(4U, MemSize::EightBit);
         auto& bookmark1 = *bookmarks.Bookmarks().GetItemAt(0);
-        bookmark1.SetDescription(L"Short Description");
+        bookmark1.SetRealNote(L"Short Description");
 
         std::array<uint8_t, 64> memory = {};
         for (uint8_t i = 0; i < memory.size(); ++i)
@@ -1117,7 +1171,7 @@ public:
         MemoryBookmarksViewModelHarness bookmarks;
         bookmarks.AddBookmark(4U, MemSize::EightBit);
         auto& bookmark1 = *bookmarks.Bookmarks().GetItemAt(0);
-        bookmark1.SetDescription(L"This description is long enough that it will be truncated at the nearest word");
+        bookmark1.SetRealNote(L"This description is long enough that it will be truncated at the nearest word");
 
         std::array<uint8_t, 64> memory = {};
         for (uint8_t i = 0; i < memory.size(); ++i)
@@ -1140,7 +1194,7 @@ public:
         MemoryBookmarksViewModelHarness bookmarks;
         bookmarks.AddBookmark(4U, MemSize::EightBit);
         auto& bookmark1 = *bookmarks.Bookmarks().GetItemAt(0);
-        bookmark1.SetDescription(L"Level:\n0x0F=1-1\n0x13=1-2\n0x14=1-3");
+        bookmark1.SetRealNote(L"Level:\n0x0F=1-1\n0x13=1-2\n0x14=1-3");
 
         std::array<uint8_t, 64> memory = {};
         for (uint8_t i = 0; i < memory.size(); ++i)
@@ -1319,7 +1373,7 @@ public:
 
         Assert::AreEqual({ 1U }, bookmarks.Bookmarks().Count());
         const auto& bookmark = *bookmarks.Bookmarks().GetItemAt(0);
-        Assert::AreEqual(std::wstring(L""), bookmark.GetDescription());
+        Assert::AreEqual(std::wstring(L""), bookmark.GetRealNote());
         Assert::AreEqual(1U, bookmark.GetAddress());
         Assert::AreEqual(MemSize::Float, bookmark.GetSize());
         Assert::AreEqual((int)MemFormat::Hex, (int)bookmark.GetFormat());
@@ -1356,7 +1410,7 @@ public:
         // without a code note, assume the user is bookmarking the 4 significant bytes
         Assert::AreEqual({1U}, bookmarks.Bookmarks().Count());
         const auto& bookmark = *bookmarks.Bookmarks().GetItemAt(0);
-        Assert::AreEqual(std::wstring(L""), bookmark.GetDescription());
+        Assert::AreEqual(std::wstring(L""), bookmark.GetRealNote());
         Assert::AreEqual(4U, bookmark.GetAddress());
         Assert::AreEqual(MemSize::Double32, bookmark.GetSize());
         Assert::AreEqual((int)MemFormat::Hex, (int)bookmark.GetFormat());
@@ -1377,7 +1431,7 @@ public:
         bookmarks.AddBookmark(8U, MemSize::Double32);
         Assert::AreEqual({2U}, bookmarks.Bookmarks().Count());
         const auto& bookmark2 = *bookmarks.Bookmarks().GetItemAt(1);
-        Assert::AreEqual(std::wstring(L"[double] Note description"), bookmark2.GetDescription());
+        Assert::AreEqual(std::wstring(L"[double] Note description"), bookmark2.GetRealNote());
         Assert::AreEqual(12U, bookmark2.GetAddress()); // adjusted to significant bytes
         Assert::AreEqual(MemSize::Double32, bookmark2.GetSize());
         Assert::AreEqual((int)MemFormat::Hex, (int)bookmark2.GetFormat());
@@ -1396,7 +1450,7 @@ public:
         bookmarks.AddBookmark(12U, MemSize::Double32);
         Assert::AreEqual({3U}, bookmarks.Bookmarks().Count());
         const auto& bookmark3 = *bookmarks.Bookmarks().GetItemAt(2);
-        Assert::AreEqual(std::wstring(L""), bookmark3.GetDescription());
+        Assert::AreEqual(std::wstring(L""), bookmark3.GetRealNote());
         Assert::AreEqual(12U, bookmark3.GetAddress()); // adjusted to significant bytes
         Assert::AreEqual(MemSize::Double32, bookmark3.GetSize());
         Assert::AreEqual((int)MemFormat::Hex, (int)bookmark3.GetFormat());
@@ -1417,7 +1471,7 @@ public:
 
         Assert::AreEqual({ 1U }, bookmarks.Bookmarks().Count());
         const auto& bookmark = *bookmarks.Bookmarks().GetItemAt(0);
-        Assert::AreEqual(std::wstring(L""), bookmark.GetDescription());
+        Assert::AreEqual(std::wstring(L""), bookmark.GetRealNote());
         Assert::AreEqual(1U, bookmark.GetAddress());
         Assert::AreEqual(MemSize::Text, bookmark.GetSize());
         Assert::AreEqual(MemoryBookmarksViewModel::BookmarkBehavior::None, bookmark.GetBehavior());
@@ -1577,7 +1631,7 @@ public:
 
         Assert::AreEqual({1U}, bookmarks.Bookmarks().Count());
         const auto& bookmark = *bookmarks.Bookmarks().GetItemAt(0);
-        Assert::AreEqual(std::wstring(L"data here"), bookmark.GetDescription());
+        Assert::AreEqual(std::wstring(L"data here"), bookmark.GetRealNote());
         Assert::AreEqual(0x28U, bookmark.GetAddress()); // $0020=0x20, 0x20+8 = 0x28
         Assert::AreEqual(MemSize::TwentyFourBit, bookmark.GetSize());
         Assert::AreEqual((int)MemFormat::Hex, (int)bookmark.GetFormat());
@@ -1589,7 +1643,7 @@ public:
         memory.at(0x18) = 0xAB;
         bookmarks.DoFrame();
 
-        Assert::AreEqual(std::wstring(L"data here"), bookmark.GetDescription());
+        Assert::AreEqual(std::wstring(L"data here"), bookmark.GetRealNote());
         Assert::AreEqual(0x18U, bookmark.GetAddress()); // $0020=0x10, 0x10+8 = 0x18
         Assert::AreEqual(std::wstring(L"1a00ab"), bookmark.GetCurrentValue());
     }
@@ -1623,6 +1677,7 @@ public:
         Assert::IsTrue(bDialogSeen);
         Assert::AreEqual({1U}, bookmarks.Bookmarks().Count());
         const auto& bookmark = *bookmarks.Bookmarks().GetItemAt(0);
+        Assert::AreEqual(std::wstring(L"data here"), bookmark.GetRealNote());
         Assert::AreEqual(std::wstring(L"data here"), bookmark.GetDescription());
         Assert::AreEqual(8U, bookmark.GetAddress());
         Assert::AreEqual(MemSize::TwentyFourBit, bookmark.GetSize());

--- a/tests/ui/viewmodels/MemoryInspectorViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/MemoryInspectorViewModel_Tests.cpp
@@ -748,7 +748,7 @@ public:
         Assert::AreEqual({16U}, pBookmarks.GetItemAt(0)->GetAddress());
         Assert::AreEqual(MemSize::ThirtyTwoBit, pBookmarks.GetItemAt(0)->GetSize());
         Assert::AreEqual(std::string("I:0xX0004_M:0xX0004"), pBookmarks.GetItemAt(0)->GetIndirectAddress());
-        Assert::AreEqual(std::wstring(L"[32-bit] Current HP"), pBookmarks.GetItemAt(0)->GetDescription());
+        Assert::AreEqual(std::wstring(L"[32-bit] Current HP"), pBookmarks.GetItemAt(0)->GetRealNote());
     }
 };
 

--- a/tests/ui/viewmodels/PointerInspectorViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/PointerInspectorViewModel_Tests.cpp
@@ -84,7 +84,7 @@ private:
             Assert::AreEqual(nOffset, pField->m_nOffset);
             Assert::AreEqual(nAddress, pField->GetAddress());
             Assert::AreEqual(sOffset, pField->GetOffset());
-            Assert::AreEqual(sDescription, pField->GetDescription());
+            Assert::AreEqual(sDescription, pField->GetRealNote());
             Assert::AreEqual(nSize, pField->GetSize());
             Assert::AreEqual(nFormat, pField->GetFormat());
             Assert::AreEqual(sCurrentValue, pField->GetCurrentValue());
@@ -107,7 +107,7 @@ private:
             Ensures(pPointer != nullptr);
             Assert::AreEqual(sOffset, pPointer->GetOffset());
             Assert::AreEqual(nAddress, pPointer->GetAddress());
-            Assert::AreEqual(sDescription, pPointer->GetDescription());
+            Assert::AreEqual(sDescription, pPointer->GetRealNote());
             Assert::AreEqual(sValue, pPointer->GetCurrentValue());
         }
 


### PR DESCRIPTION
closes #1183 

When populating the default description for a bookmark, only the first line of the code note is used. The entire code note can be found as a tooltip on the address column.

Before:
![image](https://github.com/user-attachments/assets/0aaa0194-82fb-47bd-86a1-34ebab55fb72)

After:
![image](https://github.com/user-attachments/assets/b5a18092-2d1b-44b0-86a2-ac02fbccda3c)
