### PR TITLE
don't write frozen values if bookmark contains invalid addresses in chain

### DIFF
--- a/src/ui/viewmodels/MemoryBookmarksViewModel.hh
+++ b/src/ui/viewmodels/MemoryBookmarksViewModel.hh
@@ -109,7 +109,9 @@ public:
         /// <summary>
         /// Updates the current address from the indirect address chain.
         /// </summary>
-        void UpdateCurrentAddress();
+        /// <returns><c>true</c> if the indirect address chain was valid, <c>false</c> if not.</returns>
+        /// <remarks>Address will be updated to whatever the chain evaluates to, regardless of the chain's validity</remarks>
+        bool UpdateCurrentAddress();
 
         /// <summary>
         /// The <see cref="ModelProperty" /> for the bookmark size.

--- a/src/ui/viewmodels/PointerInspectorViewModel.cpp
+++ b/src/ui/viewmodels/PointerInspectorViewModel.cpp
@@ -80,7 +80,15 @@ void PointerInspectorViewModel::OnValueChanged(const StringModelProperty::Change
 void PointerInspectorViewModel::OnActiveGameChanged()
 {
     const auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::context::GameContext>();
-    if (pGameContext.GameId() == 0)
+    ra::ByteAddress nAddress = 0;
+
+    if (pGameContext.GameId() != 0)
+    {
+        if (m_vPointers.Count() > 0)
+            nAddress = gsl::narrow_cast<ra::ByteAddress>(m_vPointers.GetItemAt(0)->GetId());
+    }
+
+    if (nAddress == 0)
     {
 
         m_vPointers.Clear();
@@ -102,7 +110,7 @@ void PointerInspectorViewModel::OnActiveGameChanged()
     }
     else
     {
-        OnCurrentAddressChanged(GetCurrentAddress());
+        OnCurrentAddressChanged(nAddress);
     }
 }
 

--- a/src/ui/viewmodels/PointerInspectorViewModel.cpp
+++ b/src/ui/viewmodels/PointerInspectorViewModel.cpp
@@ -746,7 +746,29 @@ void PointerInspectorViewModel::UpdateValues()
         auto* pField = Bookmarks().GetItemAt<StructFieldViewModel>(nIndex);
         if (pField != nullptr)
         {
-            pField->SetAddress(nBaseAddress + pField->m_nOffset);
+            if (pField->GetBehavior() == BookmarkBehavior::Frozen)
+            {
+                pField->SetAddressWithoutUpdatingValue(nBaseAddress + pField->m_nOffset);
+
+                bool bIsPointerChainValid = true;
+                for (gsl::index nChainIndex = 0; nChainIndex < gsl::narrow_cast<gsl::index>(PointerChain().Count()); ++nChainIndex)
+                {
+                    if (PointerChain().GetItemValue(nChainIndex, MemoryBookmarkViewModel::RowColorProperty) != MemoryBookmarkViewModel::RowColorProperty.GetDefaultValue())
+                    {
+                        bIsPointerChainValid = false;
+                        break;
+                    }
+                }
+
+                pField->SetRowColor(ra::ui::Color(bIsPointerChainValid ? 0xFFFFFFC0 : 0xFFFFF0C0));
+                if (!bIsPointerChainValid)
+                    continue;
+            }
+            else
+            {
+                pField->SetAddress(nBaseAddress + pField->m_nOffset);
+            }
+
             UpdateBookmark(*pField);
         }
     }

--- a/tests/ui/viewmodels/MemoryBookmarksViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/MemoryBookmarksViewModel_Tests.cpp
@@ -8,6 +8,7 @@
 
 #include "tests\mocks\MockAchievementRuntime.hh"
 #include "tests\mocks\MockConfiguration.hh"
+#include "tests\mocks\MockConsoleContext.hh"
 #include "tests\mocks\MockDesktop.hh"
 #include "tests\mocks\MockEmulatorContext.hh"
 #include "tests\mocks\MockFileSystem.hh"
@@ -58,6 +59,7 @@ private:
     {
     public:
         ra::data::context::mocks::MockEmulatorContext mockEmulatorContext;
+        ra::data::context::mocks::MockConsoleContext mockConsoleContext;
         ra::data::context::mocks::MockGameContext mockGameContext;
         ra::data::context::mocks::MockUserContext mockUserContext;
         ra::services::mocks::MockAchievementRuntime mockAchievementRuntime;
@@ -1796,6 +1798,69 @@ public:
 
         bookmark.SetSize(MemSize::TwentyFourBit);
         Assert::AreEqual(std::wstring(L"883efa"), bookmark.GetCurrentValue());
+    }
+
+    TEST_METHOD(TestDoFrameFrozenBookmarks)
+    {
+        MemoryBookmarksViewModelHarness bookmarks;
+        std::array<unsigned char, 32> memory{};
+        bookmarks.mockEmulatorContext.MockMemory(memory);
+        bookmarks.mockConsoleContext.AddMemoryRegion(0U, 16,
+                                                     ra::data::context::ConsoleContext::AddressType::SystemRAM);
+
+        bookmarks.AddBookmark("M:0xX0000");
+        bookmarks.AddBookmark("I:0xX0004_M:0xH0008");
+        auto* pBookmark1 = bookmarks.Bookmarks().GetItemAt(0);
+        Expects(pBookmark1 != nullptr);
+        auto* pBookmark2 = bookmarks.Bookmarks().GetItemAt(1);
+        Expects(pBookmark2 != nullptr);
+
+        memory.at(0) = 6;
+        memory.at(1) = 1;
+        memory.at(4) = 4;
+        memory.at(12) = 7;
+        bookmarks.DoFrame();
+
+        Assert::AreEqual(0U, pBookmark1->GetAddress());
+        Assert::IsFalse(pBookmark1->HasIndirectAddress());
+        Assert::AreEqual(std::wstring(L"00000106"), pBookmark1->GetCurrentValue());
+
+        Assert::AreEqual(12U, pBookmark2->GetAddress());
+        Assert::IsTrue(pBookmark2->HasIndirectAddress());
+        Assert::AreEqual(std::wstring(L"07"), pBookmark2->GetCurrentValue());
+
+        pBookmark1->SetBehavior(ra::ui::viewmodels::MemoryBookmarksViewModel::BookmarkBehavior::Frozen);
+        pBookmark2->SetBehavior(ra::ui::viewmodels::MemoryBookmarksViewModel::BookmarkBehavior::Frozen);
+
+        memory.at(0) = 3;
+        memory.at(12) = 4;
+
+        bookmarks.DoFrame();
+
+        // frozen values should be written back to memory
+        Assert::AreEqual(0U, pBookmark1->GetAddress());
+        Assert::AreEqual(std::wstring(L"00000106"), pBookmark1->GetCurrentValue());
+        Assert::AreEqual({6}, memory.at(0));
+
+        Assert::AreEqual(12U, pBookmark2->GetAddress());
+        Assert::AreEqual(std::wstring(L"07"), pBookmark2->GetCurrentValue());
+        Assert::AreEqual({7}, memory.at(12));
+
+        // console says only 16 bytes are valid. if pointer points beyond that, it shouldn't write
+        memory.at(4) = 20;
+        Assert::AreEqual({0}, memory.at(28));
+
+        bookmarks.DoFrame();
+        Assert::AreEqual({28}, pBookmark2->GetAddress()); // address updated
+        Assert::AreEqual({0}, memory.at(28));             // but not memory
+
+        // null is implicitly invalid
+        memory.at(4) = 0;
+        Assert::AreEqual({0}, memory.at(8));
+
+        bookmarks.DoFrame();
+        Assert::AreEqual({8}, pBookmark2->GetAddress()); // address updated
+        Assert::AreEqual({0}, memory.at(8));             // but not memory
     }
 };
 


### PR DESCRIPTION
If a bookmark is made for an indirect chain and frozen, the value will be written to the calculated address every frame. This adds logic to not write the value to the calculated address if any link in the chain is NULL or not in the system memory map.

Visually, the value will still appear frozen, it just won't be getting written to the calculated address. I've altered the frozen row color to be slightly more orange when an invalid address is detected in the chain.