### PR TITLE
don't highlight ResetIf that is true if it's part of an AndNext chain that's not entirely true

### DIFF
--- a/src/ui/viewmodels/TriggerConditionViewModel.cpp
+++ b/src/ui/viewmodels/TriggerConditionViewModel.cpp
@@ -975,7 +975,10 @@ void TriggerConditionViewModel::UpdateRowColor(const rc_condition_t* pCondition)
         switch (pCondition->type)
         {
             case RC_CONDITION_RESET_IF:
-                SetRowColor(pTheme.ColorTriggerResetTrue());
+                if (pCondition->is_true & 0x02)
+                    SetRowColor(pTheme.ColorTriggerResetTrue());
+                else
+                    SetRowColor(pTheme.ColorTriggerIsTrue());
                 return;
 
             case RC_CONDITION_PAUSE_IF:

--- a/src/ui/viewmodels/TriggerViewModel.cpp
+++ b/src/ui/viewmodels/TriggerViewModel.cpp
@@ -1494,14 +1494,17 @@ void TriggerViewModel::UpdateGroupColors(const rc_trigger_t* pTrigger)
                 continue;
 
             bool bIsReset = false;
-            rc_condition_t* pCondition = pGroup->m_pConditionSet->conditions;
-            for (; pCondition != nullptr; pCondition = pCondition->next)
+            if (pGroup->m_pConditionSet->num_reset_conditions > 0)
             {
-                // a reset condition cannot remain true with a target hitcount, so only check if it's currently true
-                if (pCondition->is_true && pCondition->type == RC_CONDITION_RESET_IF)
+                rc_condition_t* pCondition = pGroup->m_pConditionSet->conditions;
+                for (; pCondition != nullptr; pCondition = pCondition->next)
                 {
-                    bIsReset = true;
-                    break;
+                    // if the second is_true bit is non-zero, the condition was responsible for resetting the trigger.
+                    if (pCondition->type == RC_CONDITION_RESET_IF && (pCondition->is_true & 0x02))
+                    {
+                        bIsReset = true;
+                        break;
+                    }
                 }
             }
 

--- a/tests/ui/viewmodels/TriggerConditionViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/TriggerConditionViewModel_Tests.cpp
@@ -1873,13 +1873,17 @@ public:
         condition.UpdateRowColor(pCondition);
         Assert::AreEqual(nDefaultColor, condition.GetRowColor().ARGB);
 
-        pCondition->is_true = 1;
+        pCondition->is_true = 3;
         condition.UpdateRowColor(pCondition);
         Assert::AreEqual(pTheme.ColorTriggerResetTrue().ARGB, condition.GetRowColor().ARGB);
 
         pCondition->is_true = 0;
         condition.UpdateRowColor(pCondition);
         Assert::AreEqual(nDefaultColor, condition.GetRowColor().ARGB);
+
+        pCondition->is_true = 1; // condition itself is true, but reset did not occur - assume false exists in AndNext chain
+        condition.UpdateRowColor(pCondition);
+        Assert::AreEqual(pTheme.ColorTriggerIsTrue().ARGB, condition.GetRowColor().ARGB);
 
         // PauseIf
         pCondition = pCondition->next;


### PR DESCRIPTION
```
AndNext A=1
ResetIf B=2
```
The ResetIf would be highlighted in yellow if it was true, even if the AndNext was not true. Yellow is supposed to help the developer find the condition that cause the reset, and would be misleading. Now it will be green like any other true condition. It will turn yellow when the AndNext is also true and the Reset occurs.