### PR TITLE
fix keyboard navigation outside virtualized search results

### DIFF
--- a/src/ui/viewmodels/MemorySearchViewModel.cpp
+++ b/src/ui/viewmodels/MemorySearchViewModel.cpp
@@ -949,6 +949,20 @@ void MemorySearchViewModel::UpdateResult(SearchResultViewModel& vmResult,
     }
 }
 
+bool MemorySearchViewModel::GetResult(gsl::index nIndex, ra::services::SearchResult& pResult) const
+{
+    memset(&pResult, 0, sizeof(pResult));
+
+    std::lock_guard lock(m_oMutex);
+
+    if (m_vSearchResults.size() < 2)
+        return false;
+
+    const auto& pCurrentResults = *m_vSearchResults.at(m_nSelectedSearchResult).get();
+    return pCurrentResults.pResults.GetMatchingAddress(nIndex, pResult);
+}
+
+
 std::wstring MemorySearchViewModel::GetTooltip(const SearchResultViewModel& vmResult) const
 {
     std::wstring sTooltip = ra::StringPrintf(L"%s\n%s | Current\n",

--- a/src/ui/viewmodels/MemorySearchViewModel.hh
+++ b/src/ui/viewmodels/MemorySearchViewModel.hh
@@ -367,6 +367,11 @@ public:
     const std::wstring& GetResultCountText() const { return GetValue(ResultCountTextProperty); }
 
     /// <summary>
+    /// Gets the unprocessed result at the specified index.
+    /// </summary>
+    bool GetResult(gsl::index nIndex, ra::services::SearchResult& pResult) const;
+
+    /// <summary>
     /// The <see cref="ModelProperty" /> for the scroll offset.
     /// </summary>
     static const IntModelProperty ScrollOffsetProperty;
@@ -497,7 +502,7 @@ private:
     bool m_bScrolling = false;
     bool m_bSelectingFilter = false;
 
-    std::mutex m_oMutex;
+    mutable std::mutex m_oMutex;
 
     struct SearchResult
     {

--- a/src/ui/win32/MemoryInspectorDialog.cpp
+++ b/src/ui/win32/MemoryInspectorDialog.cpp
@@ -56,18 +56,14 @@ void MemoryInspectorDialog::SearchResultsGridBinding::OnLvnItemChanged(const LPN
     {
         if (ListView_GetItemState(m_hWnd, pnmListView->iItem, LVIS_FOCUSED))
         {
-            auto& vmMemory = GetViewModel<MemorySearchViewModel>();
-            const auto nIndex = GetVisibleItemIndex(pnmListView->iItem);
-            auto sValue = vmMemory.Results().GetItemValue(gsl::narrow_cast<gsl::index>(nIndex),
-                MemorySearchViewModel::SearchResultViewModel::AddressProperty);
+            ra::services::SearchResult pResult{};
 
-            // in 4-bit mode, remove the "L" or "U"
-            if (vmMemory.ResultMemSize() == MemSize::Nibble_Lower)
-                sValue.pop_back();
+            auto& vmSearch = GetViewModel<MemorySearchViewModel>();
+            if (!vmSearch.GetResult(pnmListView->iItem, pResult))
+                return;
 
-            const auto nAddress = ra::ByteAddressFromString(ra::Narrow(sValue));
-
-            ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::WindowManager>().MemoryInspector.SetCurrentAddress(nAddress);
+            auto& pMemoryInspector = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::WindowManager>().MemoryInspector;
+            pMemoryInspector.SetCurrentAddress(pResult.nAddress);
         }
     }
 }


### PR DESCRIPTION
Addresses https://discord.com/channels/310192285306454017/1149693430306447380/1395563884995149844

When moving the selection up past the first visible search result, the query to fetch the next (hidden) result returned null, so it defaulted to address 0.

Solution: query search results directly, instead of relying of populated control.