### PR TITLE
ensure subset id gets set on cloned assets

### DIFF
--- a/src/data/context/GameAssets.cpp
+++ b/src/data/context/GameAssets.cpp
@@ -111,23 +111,6 @@ ra::data::models::AssetCategory GameAssets::MostPublishedAssetCategory() const
     return ra::data::models::AssetCategory::None;
 }
 
-void GameAssets::OnItemsAdded(const std::vector<gsl::index>& vNewIndices)
-{
-    auto* pLocalBadges = dynamic_cast<ra::data::models::LocalBadgesModel*>(FindAsset(ra::data::models::AssetType::LocalBadges, 0));
-    if (pLocalBadges)
-    {
-        for (const auto nIndex : vNewIndices)
-        {
-            const auto* pAsset = GetItemAt(nIndex);
-            const auto* pAchievement = dynamic_cast<const ra::data::models::AchievementModel*>(pAsset);
-            if (pAchievement && ra::StringStartsWith(pAchievement->GetBadge(), L"local\\"))
-                pLocalBadges->AddReference(pAchievement->GetBadge(), pAchievement->IsBadgeCommitted());
-        }
-    }
-
-    ra::data::DataModelCollection<ra::data::models::AssetModelBase>::OnItemsAdded(vNewIndices);
-}
-
 void GameAssets::OnBeforeItemRemoved(ModelBase& pModel)
 {
     auto* pLocalBadges = dynamic_cast<ra::data::models::LocalBadgesModel*>(FindAsset(ra::data::models::AssetType::LocalBadges, 0));
@@ -309,8 +292,7 @@ void GameAssets::ReloadAssets(const std::vector<ra::data::models::AssetModelBase
 
             if (pAsset)
             {
-                pAsset->Deserialize(pTokenizer);
-                pAsset->CreateLocalCheckpoint();
+                pAsset->DeserializeLocalCheckpoint(pTokenizer);
 
                 if (nId == 0)
                     vUnnumberedAssets.push_back(pAsset);

--- a/src/data/context/GameAssets.hh
+++ b/src/data/context/GameAssets.hh
@@ -141,7 +141,6 @@ public:
 
 protected:
     void OnBeforeItemRemoved(ModelBase& pModel) override;
-    void OnItemsAdded(const std::vector<gsl::index>& vNewIndices) override;
 
     uint32_t m_nNextLocalId = FirstLocalId;
 };

--- a/src/data/models/AssetModelBase.cpp
+++ b/src/data/models/AssetModelBase.cpp
@@ -267,6 +267,17 @@ void AssetModelBase::ResetLocalCheckpoint(ra::Tokenizer& pTokenizer)
     EndUpdate();             // re-enable notifications
 }
 
+void AssetModelBase::DeserializeLocalCheckpoint(ra::Tokenizer& pTokenizer)
+{
+    Expects(m_pTransaction != nullptr);
+    Expects(m_pTransaction->m_pNext == nullptr);
+
+    BeginUpdate();           // disable notifications while rebuilding
+    Deserialize(pTokenizer); // load unpublished changes
+    CreateLocalCheckpoint(); // start transaction for in-memory changes
+    EndUpdate();             // re-enable notifications
+}
+
 void AssetModelBase::SetNew()
 {
     SetValue(ChangesProperty, ra::etoi(AssetChanges::New));

--- a/src/data/models/AssetModelBase.hh
+++ b/src/data/models/AssetModelBase.hh
@@ -276,6 +276,8 @@ public:
     virtual void Serialize(ra::services::TextWriter& pWriter) const = 0;
     virtual bool Deserialize(ra::Tokenizer& pTokenizer) = 0;
 
+    void DeserializeLocalCheckpoint(ra::Tokenizer& pTokenizer);
+
     /// <summary>
     /// Captures the current state of the asset as a reflection of the state on the server.
     /// </summary>

--- a/src/ui/viewmodels/AssetListViewModel.cpp
+++ b/src/ui/viewmodels/AssetListViewModel.cpp
@@ -1840,6 +1840,7 @@ void AssetListViewModel::CloneSelected()
     FilteredAssets().BeginUpdate();
 
     // add the cloned items
+    pGameContext.Assets().BeginUpdate();
     std::vector<int> vNewIDs;
     for (const auto* pAsset : vSelectedAssets)
     {
@@ -1847,6 +1848,7 @@ void AssetListViewModel::CloneSelected()
         if (pSourceAchievement != nullptr)
         {
             auto& vmAchievement = pGameContext.Assets().NewAchievement();
+            vmAchievement.SetSubsetID(pSourceAchievement->GetSubsetID());
             vmAchievement.SetCategory(ra::data::models::AssetCategory::Local);
             vmAchievement.UpdateServerCheckpoint();
 
@@ -1866,6 +1868,7 @@ void AssetListViewModel::CloneSelected()
         if (pSourceLeaderboard != nullptr)
         {
             auto& vmLeaderboard = pGameContext.Assets().NewLeaderboard();
+            vmLeaderboard.SetSubsetID(pSourceLeaderboard->GetSubsetID());
             vmLeaderboard.SetCategory(ra::data::models::AssetCategory::Local);
             vmLeaderboard.UpdateServerCheckpoint();
 
@@ -1884,6 +1887,7 @@ void AssetListViewModel::CloneSelected()
             vNewIDs.push_back(vmLeaderboard.GetID());
         }
     }
+    pGameContext.Assets().EndUpdate();
 
     // select the new items and deselect everything else
     gsl::index nIndex = -1;

--- a/tests/data/context/GameAssets_Tests.cpp
+++ b/tests/data/context/GameAssets_Tests.cpp
@@ -156,12 +156,12 @@ public:
             auto pLocalBadges = std::make_unique<ra::data::models::LocalBadgesModel>();
             pLocalBadges->CreateServerCheckpoint();
             pLocalBadges->CreateLocalCheckpoint();
-            Append(std::move(pLocalBadges));
+            mockGameContext.Assets().Append(std::move(pLocalBadges));
         }
 
         ra::data::models::LocalBadgesModel& GetLocalBadgesModel()
         {
-            return *(dynamic_cast<ra::data::models::LocalBadgesModel*>(FindAsset(ra::data::models::AssetType::LocalBadges, 0)));
+            return *(dynamic_cast<ra::data::models::LocalBadgesModel*>(mockGameContext.Assets().FindAsset(ra::data::models::AssetType::LocalBadges, 0)));
         }
 
         void AddRichPresenceModel()

--- a/tests/ui/viewmodels/AssetListViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/AssetListViewModel_Tests.cpp
@@ -409,6 +409,7 @@ private:
         void AddAchievement(AssetCategory nCategory, unsigned nPoints, const std::wstring& sTitle)
         {
             auto vmAchievement = std::make_unique<MockAchievementModel>();
+            vmAchievement->BeginUpdate();
             vmAchievement->SetID(gsl::narrow_cast<unsigned int>(mockGameContext.Assets().Count() + 1));
             vmAchievement->SetCategory(nCategory);
             vmAchievement->SetPoints(nPoints);
@@ -417,6 +418,7 @@ private:
             vmAchievement->CreateServerCheckpoint();
             vmAchievement->CreateLocalCheckpoint();
             vmAchievement->AttachAndInitialize(*vmAchievement->m_pInfo);
+            vmAchievement->EndUpdate();
             mockGameContext.Assets().Append(std::move(vmAchievement));
 
             EnsureCoreSubset();
@@ -426,6 +428,7 @@ private:
             const std::wstring& sDescription, const std::wstring& sBadge, const std::string& sTrigger)
         {
             auto vmAchievement = std::make_unique<MockAchievementModel>();
+            vmAchievement->BeginUpdate();
             vmAchievement->SetID(gsl::narrow_cast<unsigned int>(mockGameContext.Assets().Count() + 1));
             vmAchievement->SetCategory(nCategory);
             vmAchievement->SetPoints(nPoints);
@@ -437,6 +440,7 @@ private:
             vmAchievement->CreateServerCheckpoint();
             vmAchievement->CreateLocalCheckpoint();
             vmAchievement->AttachAndInitialize(*vmAchievement->m_pInfo);
+            vmAchievement->EndUpdate();
             mockGameContext.Assets().Append(std::move(vmAchievement));
 
             EnsureCoreSubset();
@@ -446,6 +450,7 @@ private:
             const std::wstring& sDescription, const std::wstring& sBadge, const std::string& sTrigger)
         {
             auto vmAchievement = std::make_unique<MockAchievementModel>();
+            vmAchievement->BeginUpdate();
             vmAchievement->CreateServerCheckpoint();
             vmAchievement->SetID(gsl::narrow_cast<unsigned int>(mockGameContext.Assets().Count() + 1));
             vmAchievement->SetCategory(AssetCategory::Local);
@@ -458,6 +463,7 @@ private:
             vmAchievement->CreateLocalCheckpoint();
             vmAchievement->SetNew();
             vmAchievement->AttachAndInitialize(*vmAchievement->m_pInfo);
+            vmAchievement->EndUpdate();
             mockGameContext.Assets().Append(std::move(vmAchievement));
 
             EnsureCoreSubset();
@@ -615,6 +621,9 @@ private:
             }
 
             std::unique_ptr<rc_client_achievement_info_t> m_pInfo;
+
+            using ra::data::models::AchievementModel::BeginUpdate;
+            using ra::data::models::AchievementModel::EndUpdate;
         };
 
         std::map<ra::AchievementID, std::wstring> m_mValidationErrors;
@@ -3790,6 +3799,8 @@ public:
     {
         AssetListViewModelHarness vmAssetList;
         vmAssetList.SetGameId(22U);
+        vmAssetList.mockGameContext.SetActiveGameId(22U);
+        vmAssetList.SetSubsetFilter(22U);
         vmAssetList.AddAchievement(AssetCategory::Core, 5, L"Test1", L"Desc1", L"12345", "0xH1234=1");
         vmAssetList.AddAchievement(AssetCategory::Core, 7, L"Test2", L"Desc2", L"11111", "0xH1111=1");
 
@@ -3826,6 +3837,7 @@ public:
 
         const auto* pAchievement = vmAssetList.mockGameContext.Assets().FindAchievement(pAsset->GetId());
         Expects(pAchievement != nullptr);
+        Assert::AreEqual(22U, pAchievement->GetSubsetID());
         Assert::AreEqual(std::wstring(L"Desc2"), pAchievement->GetDescription());
         Assert::AreEqual(std::wstring(L"11111"), pAchievement->GetBadge());
         Assert::AreEqual(std::string("0xH1111=1"), pAchievement->GetTrigger());
@@ -3856,6 +3868,8 @@ public:
         AssetListViewModelHarness vmAssetList;
         vmAssetList.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, true);
         vmAssetList.SetGameId(22U);
+        vmAssetList.mockGameContext.SetActiveGameId(22U);
+        vmAssetList.SetSubsetFilter(22U);
         vmAssetList.AddAchievement(AssetCategory::Core, 5, L"Test1", L"Desc1", L"12345", "0xH1234=1");
         vmAssetList.AddAchievement(AssetCategory::Core, 7, L"Test2", L"Desc2", L"11111", "0xH1111=1");
 
@@ -3926,11 +3940,14 @@ public:
         const std::wstring sLocalBadgeName = L"local\\1234.png";
 
         vmAssetList.SetGameId(22U);
+        vmAssetList.mockGameContext.SetActiveGameId(22U);
+        vmAssetList.SetSubsetFilter(22U);
         vmAssetList.SetCategoryFilter(AssetListViewModel::CategoryFilter::Local);
         vmAssetList.AddAchievement(AssetCategory::Local, 5, L"Test1", L"Desc1", L"12345", "0xH1234=1");
         auto* pSourceAchievement = vmAssetList.mockGameContext.Assets().FindAchievement(2);
         Expects(pSourceAchievement != nullptr);
         pSourceAchievement->SetBadge(sLocalBadgeName);
+        Assert::AreEqual(1, pLocalBadges->GetReferenceCount(sLocalBadgeName, false));
 
         Assert::AreEqual({ 2U }, vmAssetList.mockGameContext.Assets().Count());
         Assert::AreEqual({ 1U }, vmAssetList.FilteredAssets().Count());
@@ -3981,6 +3998,8 @@ public:
     {
         AssetListViewModelHarness vmAssetList;
         vmAssetList.SetGameId(22U);
+        vmAssetList.mockGameContext.SetActiveGameId(22U);
+        vmAssetList.SetSubsetFilter(22U);
         vmAssetList.AddAchievement(AssetCategory::Core, 5, L"Test1", L"Desc1", L"12345", "0xH1234=1");
         vmAssetList.AddAchievement(AssetCategory::Core, 7, L"Test2", L"Desc2", L"11111", "0xH1111=1");
         vmAssetList.SetCategoryFilter(AssetListViewModel::CategoryFilter::All);
@@ -4016,6 +4035,8 @@ public:
         AssetListViewModelHarness vmAssetList;
 
         vmAssetList.SetGameId(22U);
+        vmAssetList.mockGameContext.SetActiveGameId(22U);
+        vmAssetList.SetSubsetFilter(22U);
         vmAssetList.SetCategoryFilter(AssetListViewModel::CategoryFilter::Local);
         vmAssetList.AddAchievement(AssetCategory::Local, 5, L"Test1", L"Desc1", L"12345", "0xH1234=1");
         auto* pSourceAchievement = vmAssetList.mockGameContext.Assets().FindAchievement(1);
@@ -4056,6 +4077,8 @@ public:
     {
         AssetListViewModelHarness vmAssetList;
         vmAssetList.SetGameId(22U);
+        vmAssetList.mockGameContext.SetActiveGameId(22U);
+        vmAssetList.SetSubsetFilter(22U);
         vmAssetList.AddAchievement(AssetCategory::Core, 5, L"Test1", L"Desc1", L"12345", "0xH1234=1");
         vmAssetList.AddAchievement(AssetCategory::Core, 7, L"Test2", L"Desc2", L"11111", "0xH1111=1");
         vmAssetList.AddAchievement(AssetCategory::Core, 9, L"Test3", L"Desc3", L"12321", "0xH5342=1");
@@ -4120,6 +4143,8 @@ public:
     {
         AssetListViewModelHarness vmAssetList;
         vmAssetList.SetGameId(22U);
+        vmAssetList.mockGameContext.SetActiveGameId(22U);
+        vmAssetList.SetSubsetFilter(22U);
         vmAssetList.AddAchievement(AssetCategory::Core, 5, L"Test1", L"Desc1", L"12345", "0xH1234=1");
         vmAssetList.AddAchievement(AssetCategory::Core, 7, L"Test2", L"Desc2", L"11111", "0xH1111=1");
 
@@ -4152,6 +4177,8 @@ public:
     {
         AssetListViewModelHarness vmAssetList;
         vmAssetList.SetGameId(22U);
+        vmAssetList.mockGameContext.SetActiveGameId(22U);
+        vmAssetList.SetSubsetFilter(22U);
         vmAssetList.AddAchievement(AssetCategory::Core, 5, L"Test1", L"Desc1", L"12345", "0xH1234=1");
         vmAssetList.AddAchievement(AssetCategory::Core, 7, L"Test2", L"Desc2", L"11111", "0xH1111=1");
 
@@ -4209,6 +4236,8 @@ public:
     {
         AssetListViewModelHarness vmAssetList;
         vmAssetList.SetGameId(22U);
+        vmAssetList.mockGameContext.SetActiveGameId(22U);
+        vmAssetList.SetSubsetFilter(22U);
         const auto* pLocalBadges = vmAssetList.AddLocalBadgesModel();
         Expects(pLocalBadges != nullptr);
         vmAssetList.AddAchievement(AssetCategory::Core, 5, L"Test1", L"Desc1", L"12345", "0xH1234=1");
@@ -4300,6 +4329,8 @@ public:
     {
         AssetListViewModelHarness vmAssetList;
         vmAssetList.SetGameId(22U);
+        vmAssetList.mockGameContext.SetActiveGameId(22U);
+        vmAssetList.SetSubsetFilter(22U);
         const auto* pLocalBadges = vmAssetList.AddLocalBadgesModel();
         Expects(pLocalBadges != nullptr);
         vmAssetList.AddAchievement(AssetCategory::Core, 5, L"Test1", L"Desc1", L"12345", "0xH1234=1");
@@ -4404,6 +4435,8 @@ public:
     {
         AssetListViewModelHarness vmAssetList;
         vmAssetList.SetGameId(22U);
+        vmAssetList.mockGameContext.SetActiveGameId(22U);
+        vmAssetList.SetSubsetFilter(22U);
         vmAssetList.SetAssetTypeFilter(ra::data::models::AssetType::Leaderboard);
         vmAssetList.AddLeaderboard(ra::data::models::AssetCategory::Core, L"Leaderboard1");
         auto* vmLeaderboard = dynamic_cast<ra::data::models::LeaderboardModel*>(vmAssetList.mockGameContext.Assets().GetItemAt(0));


### PR DESCRIPTION
Fixes https://discord.com/channels/310192285306454017/1149693430306447380/1395632699980513281

In addition to ensuring the subsetid gets set correctly so the item appears in the filtered list, I've added some BeginUpdate/EndUpdate blocks to prevent the item from being compared against the filter as it's being initialized. That resulted in detangling some of the logic around reference counting the local badge files. (OnValueChanged was not being raised properly if the achievement hadn't been fully initialized yet).