### PR TITLE
support achievementsets api from cache

### DIFF
--- a/src/services/GameIdentifier.cpp
+++ b/src/services/GameIdentifier.cpp
@@ -258,6 +258,11 @@ void GameIdentifier::LoadKnownHashes(std::map<std::string, unsigned>& mHashes)
     }
 }
 
+void GameIdentifier::AddHash(const std::string& sHash, unsigned nGameId)
+{
+    m_mKnownHashes.insert_or_assign(sHash, nGameId);
+}
+
 void GameIdentifier::SaveKnownHashes(std::map<std::string, unsigned>& mHashes)
 {
     auto& pLocalStorage = ra::services::ServiceLocator::GetMutable<ra::services::ILocalStorage>();

--- a/src/services/GameIdentifier.hh
+++ b/src/services/GameIdentifier.hh
@@ -41,6 +41,9 @@ public:
     /// </summary>
     void SaveKnownHashes() const;
 
+protected:
+    void AddHash(const std::string& sHash, unsigned nGameId);
+
 private:
     static void LoadKnownHashes(std::map<std::string, unsigned>& mHashes);
     static void SaveKnownHashes(std::map<std::string, unsigned>& mHashes);

--- a/tests/RA_Integration.Tests.vcxproj
+++ b/tests/RA_Integration.Tests.vcxproj
@@ -450,6 +450,7 @@
     <ClInclude Include="mocks\MockFileSystem.hh" />
     <ClInclude Include="mocks\MockFrameEventQueue.hh" />
     <ClInclude Include="mocks\MockGameContext.hh" />
+    <ClInclude Include="mocks\MockGameIdentifier.hh" />
     <ClInclude Include="mocks\MockHttpRequester.hh" />
     <ClInclude Include="mocks\MockImageRepository.hh" />
     <ClInclude Include="mocks\MockLocalStorage.hh" />

--- a/tests/RA_Integration.Tests.vcxproj.filters
+++ b/tests/RA_Integration.Tests.vcxproj.filters
@@ -590,5 +590,8 @@
     <ClInclude Include="..\src\data\models\CodeNoteModel.hh">
       <Filter>Code</Filter>
     </ClInclude>
+    <ClInclude Include="mocks\MockGameIdentifier.hh">
+      <Filter>Mocks</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/tests/mocks/MockGameIdentifier.hh
+++ b/tests/mocks/MockGameIdentifier.hh
@@ -1,0 +1,31 @@
+#ifndef RA_DATA_MOCK_GAMEIDENTIFIER_HH
+#define RA_DATA_MOCK_GAMEIDENTIFIER_HH
+#pragma once
+
+#include "services\GameIdentifier.hh"
+
+#include "services\ServiceLocator.hh"
+
+namespace ra {
+namespace services {
+namespace mocks {
+
+class MockGameIdentifier : public GameIdentifier
+{
+public:
+    MockGameIdentifier() noexcept
+        : m_Override(this)
+    {
+    }
+
+    using GameIdentifier::AddHash;
+
+private:
+    ra::services::ServiceLocator::ServiceOverride<ra::services::GameIdentifier> m_Override;
+};
+
+} // namespace mocks
+} // namespace services
+} // namespace ra
+
+#endif // !RA_DATA_MOCK_GAMEIDENTIFIER_HH


### PR DESCRIPTION
allows cached achievement data to be loaded via alternate API when server is unreachable.