### PR TITLE
add helper function to modify non-visible virtualized items

### DIFF
--- a/src/ui/viewmodels/TriggerConditionViewModel.cpp
+++ b/src/ui/viewmodels/TriggerConditionViewModel.cpp
@@ -992,6 +992,11 @@ void TriggerConditionViewModel::UpdateRowColor(const rc_condition_t* pCondition)
     }
 }
 
+void TriggerConditionViewModel::PushValue(const ra::data::IntModelProperty& pProperty, int nNewValue)
+{
+    SetValue(pProperty, nNewValue);
+}
+
 } // namespace viewmodels
 } // namespace ui
 } // namespace ra

--- a/src/ui/viewmodels/TriggerConditionViewModel.hh
+++ b/src/ui/viewmodels/TriggerConditionViewModel.hh
@@ -111,6 +111,8 @@ public:
     void SetRowColor(Color value) { SetValue(RowColorProperty, ra::to_signed(value.ARGB)); }
     void UpdateRowColor(const rc_condition_t* pCondition);
 
+    void PushValue(const ra::data::IntModelProperty& pProperty, int nNewValue);
+
 private:
     void OnValueChanged(const IntModelProperty::ChangeArgs& args) override;
     void OnValueChanged(const BoolModelProperty::ChangeArgs& args) override;

--- a/src/ui/viewmodels/TriggerViewModel.hh
+++ b/src/ui/viewmodels/TriggerViewModel.hh
@@ -99,6 +99,7 @@ public:
     void UpdateFrom(const rc_value_t& pValue);
     
     void SelectRange(gsl::index nFrom, gsl::index nTo, bool bValue);
+    int SetSelectedItemValues(const IntModelProperty& pProperty, int nNewValue);
 
     void SuspendConditionMonitor() const noexcept;
     void ResumeConditionMonitor() const;
@@ -151,7 +152,7 @@ public:
 
     void DoFrame();
     void UpdateColors(const rc_trigger_t* pTrigger);
-    void UpdateCurrentGroup(bool bRememberHits);
+    void UpdateCurrentGroup(bool bRememberHits, const IntModelProperty* pProperty, int nNewValue);
     void UpdateConditions();
     void ToggleDecimal();
 

--- a/src/ui/win32/AssetEditorDialog.cpp
+++ b/src/ui/win32/AssetEditorDialog.cpp
@@ -986,6 +986,9 @@ AssetEditorDialog::AssetEditorDialog(AssetEditorViewModel& vmAssetEditor)
     m_bindConditions.Virtualize(TriggerViewModel::ScrollOffsetProperty, TriggerViewModel::ScrollMaximumProperty,
         [&vmAssetEditor](gsl::index nFrom, gsl::index nTo, bool bIsSelected) {
             vmAssetEditor.Trigger().SelectRange(nFrom, nTo, bIsSelected);
+        },
+        [&vmAssetEditor](const ra::data::IntModelProperty& pProperty, int nNewValue) {
+            return vmAssetEditor.Trigger().SetSelectedItemValues(pProperty, nNewValue);
         });
 
     using namespace ra::bitwise_ops;

--- a/src/ui/win32/MemoryInspectorDialog.cpp
+++ b/src/ui/win32/MemoryInspectorDialog.cpp
@@ -214,10 +214,13 @@ MemoryInspectorDialog::MemoryInspectorDialog(MemoryInspectorViewModel& vmMemoryI
     m_bindSearchResults.BindRowColor(MemorySearchViewModel::SearchResultViewModel::RowColorProperty);
     m_bindSearchResults.BindIsSelected(MemorySearchViewModel::SearchResultViewModel::IsSelectedProperty);
     m_bindSearchResults.Virtualize(MemorySearchViewModel::ScrollOffsetProperty,
-        MemorySearchViewModel::ScrollMaximumProperty, [&vmMemoryInspector](gsl::index nFrom, gsl::index nTo, bool bIsSelected)
-    {
-        vmMemoryInspector.Search().SelectRange(nFrom, nTo, bIsSelected);
-    });
+        MemorySearchViewModel::ScrollMaximumProperty,
+        [&vmMemoryInspector](gsl::index nFrom, gsl::index nTo, bool bIsSelected)
+        {
+            vmMemoryInspector.Search().SelectRange(nFrom, nTo, bIsSelected);
+        },
+        nullptr // Search results are readonly, no need to multi-set values
+    );
 
     // Code Notes
     m_bindAddress.BindText(MemoryInspectorViewModel::CurrentAddressTextProperty, ra::ui::win32::bindings::TextBoxBinding::UpdateMode::KeyPress);

--- a/src/ui/win32/bindings/GridBinding.cpp
+++ b/src/ui/win32/bindings/GridBinding.cpp
@@ -471,18 +471,22 @@ void GridBinding::DeselectAll() noexcept
 
 int GridBinding::UpdateSelected(const IntModelProperty& pProperty, int nNewValue)
 {
-    if (m_pIsSelectedProperty == nullptr)
-        return 0;
-
     int nUpdated = 0;
 
-    const auto nCount = ra::to_signed(m_vmItems->Count());
-    for (gsl::index nIndex = 0; nIndex < nCount; ++nIndex)
+    if (m_fSetSelectedItemValues != nullptr)
     {
-        if (m_vmItems->GetItemValue(nIndex, *m_pIsSelectedProperty))
+        return m_fSetSelectedItemValues(pProperty, nNewValue);
+    }
+    else if (m_pIsSelectedProperty != nullptr)
+    {
+        const auto nCount = ra::to_signed(m_vmItems->Count());
+        for (gsl::index nIndex = 0; nIndex < nCount; ++nIndex)
         {
-            m_vmItems->SetItemValue(nIndex, pProperty, nNewValue);
-            ++nUpdated;
+            if (m_vmItems->GetItemValue(nIndex, *m_pIsSelectedProperty))
+            {
+                m_vmItems->SetItemValue(nIndex, pProperty, nNewValue);
+                ++nUpdated;
+            }
         }
     }
 
@@ -755,7 +759,8 @@ void GridBinding::SetPasteHandler(std::function<void()> pHandler)
 }
 
 void GridBinding::Virtualize(const IntModelProperty& pScrollOffsetProperty, const IntModelProperty& pScrollMaximumProperty,
-    std::function<void(gsl::index, gsl::index, bool)> fUpdateSelectedItems)
+    std::function<void(gsl::index, gsl::index, bool)> fUpdateSelectedItems,
+    std::function<int(const IntModelProperty& pProperty, int nNewValue)> fSetSelectedItemValues)
 {
     if (m_hWnd)
     {
@@ -765,6 +770,7 @@ void GridBinding::Virtualize(const IntModelProperty& pScrollOffsetProperty, cons
     m_pScrollOffsetProperty = &pScrollOffsetProperty;
     m_pScrollMaximumProperty = &pScrollMaximumProperty;
     m_fUpdateSelectedItems = fUpdateSelectedItems;
+    m_fSetSelectedItemValues = fSetSelectedItemValues;
 
     m_nScrollOffset = GetValue(pScrollOffsetProperty);
 }

--- a/src/ui/win32/bindings/GridBinding.hh
+++ b/src/ui/win32/bindings/GridBinding.hh
@@ -32,7 +32,8 @@ public:
     ViewModelCollectionBase& GetItems() noexcept { return *m_vmItems; }
 
     void Virtualize(const IntModelProperty& pScrollOffsetProperty, const IntModelProperty& pScrollMaximumProperty,
-        std::function<void(gsl::index, gsl::index, bool)> fUpdateSelectedItems);
+                    std::function<void(gsl::index, gsl::index, bool)> fUpdateSelectedItems,
+                    std::function<int(const IntModelProperty& pProperty, int nNewValue)> fSetSelectedItemValues);
 
     void BindIsSelected(const BoolModelProperty& pIsSelectedProperty);
     void BindEnsureVisible(const IntModelProperty& pEnsureVisibleProperty) noexcept;
@@ -142,6 +143,7 @@ private:
     const IntModelProperty* m_pVisibleItemCountProperty = nullptr;
     ra::tstring m_sDispInfo;
     std::function<void(gsl::index, gsl::index, bool)> m_fUpdateSelectedItems = nullptr;
+    std::function<int(const IntModelProperty& pProperty, int nNewValue)> m_fSetSelectedItemValues = nullptr;
 
     HWND m_hInPlaceEditor = nullptr;
 


### PR DESCRIPTION
Fixes first part of https://discord.com/channels/310192285306454017/1149693430306447380/1395985705422815283

The multi-edit functionality was only writing to the visible rows.