### PR TITLE
fix indirect bookmark description changing when pointer changes

### DIFF
--- a/src/data/Types.hh
+++ b/src/data/Types.hh
@@ -51,6 +51,7 @@ enum class MemFormat : uint8_t
 {
     Hex,
     Dec,
+    Unknown,
 };
 
 using ByteAddress = uint32_t;

--- a/src/data/context/GameContext.cpp
+++ b/src/data/context/GameContext.cpp
@@ -250,6 +250,9 @@ void GameContext::EndLoadGame(int nResult, bool bWasPaused, bool bShowSoftcoreWa
                 [this](ra::ByteAddress nAddress, const std::wstring& sNewNote) {
                     OnCodeNoteChanged(nAddress, sNewNote);
                 },
+                [this](ra::ByteAddress nOldAddress, ra::ByteAddress nNewAddress, const std::wstring sNote) {
+                    OnCodeNoteMoved(nOldAddress, nNewAddress, sNote);
+                },
                 [this]() { EndLoad(); });
 
             m_vAssets.Append(std::move(pCodeNotes));
@@ -691,6 +694,20 @@ void GameContext::OnCodeNoteChanged(ra::ByteAddress nAddress, const std::wstring
         {
             Expects(target != nullptr);
             target->OnCodeNoteChanged(nAddress, sNewNote);
+        }
+    }
+}
+
+void GameContext::OnCodeNoteMoved(ra::ByteAddress nOldAddress, ra::ByteAddress nNewAddress, const std::wstring& sNote)
+{
+    if (!m_vNotifyTargets.empty())
+    {
+        // create a copy of the list of pointers in case it's modified by one of the callbacks
+        NotifyTargetSet vNotifyTargets(m_vNotifyTargets);
+        for (NotifyTarget* target : vNotifyTargets)
+        {
+            Expects(target != nullptr);
+            target->OnCodeNoteMoved(nOldAddress, nNewAddress, sNote);
         }
     }
 }

--- a/src/data/context/GameContext.hh
+++ b/src/data/context/GameContext.hh
@@ -150,6 +150,7 @@ public:
         virtual void OnBeginGameLoad() noexcept(false) {}
         virtual void OnEndGameLoad() noexcept(false) {}
         virtual void OnCodeNoteChanged(ra::ByteAddress, const std::wstring&) noexcept(false) {}
+        virtual void OnCodeNoteMoved(ra::ByteAddress, ra::ByteAddress, const std::wstring&) noexcept(false) {}
     };
 
     void AddNotifyTarget(NotifyTarget& pTarget) noexcept { GSL_SUPPRESS_F6 m_vNotifyTargets.insert(&pTarget); }
@@ -206,6 +207,7 @@ protected:
     void OnBeforeActiveGameChanged();
     void OnActiveGameChanged();
     void OnCodeNoteChanged(ra::ByteAddress nAddress, const std::wstring& sNewNote);
+    void OnCodeNoteMoved(ra::ByteAddress nOldAddress, ra::ByteAddress nNewAddress, const std::wstring& sNote);
     void BeginLoad();
     void EndLoad();
 

--- a/src/data/models/CodeNotesModel.hh
+++ b/src/data/models/CodeNotesModel.hh
@@ -25,14 +25,16 @@ public:
     bool IsShownInList() const noexcept override { return false; }
 
     typedef std::function<void(ra::ByteAddress nAddress, const std::wstring& sNewNote)> CodeNoteChangedFunction;
+    typedef std::function<void(ra::ByteAddress nOldAddress, ra::ByteAddress nNewAddress, const std::wstring& sNewNote)> CodeNoteMovedFunction;
 
     /// <summary>
     /// Repopulates with code notes from the server.
     /// </summary>
     /// <param name="nGameId">Unique identifier of the game to load code notes for.</param>
     /// <param name="fCodeNoteChanged">Callback to call when a code note is changed.</param>
+    /// <param name="fCodeMovedChanged">Callback to call when a code note is moved.</param>
     /// <param name="callback">Callback to call when the loading completes.</param>
-    void Refresh(unsigned int nGameId, CodeNoteChangedFunction fCodeNoteChanged, std::function<void()> callback);
+    void Refresh(unsigned int nGameId, CodeNoteChangedFunction fCodeNoteChanged, CodeNoteMovedFunction fCodeNoteMoved, std::function<void()> callback);
 
     /// <summary>
     /// Returns the note associated with the specified address.
@@ -215,6 +217,7 @@ protected:
     bool m_bRefreshing = false;
 
     CodeNoteChangedFunction m_fCodeNoteChanged;
+    CodeNoteMovedFunction m_fCodeNoteMoved;
 
 private:
     static std::wstring BuildCodeNoteSized(ra::ByteAddress nAddress, unsigned nCheckBytes, ra::ByteAddress nNoteAddress, const CodeNoteModel& pNote);

--- a/src/ui/viewmodels/MemoryBookmarksViewModel.hh
+++ b/src/ui/viewmodels/MemoryBookmarksViewModel.hh
@@ -163,6 +163,7 @@ protected:
 
     // ra::data::context::GameContext::NotifyTarget
     void OnActiveGameChanged() override;
+    void OnEndGameLoad() override;
 
     // ra::ui::ViewModelCollectionBase::NotifyTarget
     void OnViewModelBoolValueChanged(gsl::index nIndex, const BoolModelProperty::ChangeArgs& args) override;

--- a/src/ui/viewmodels/MemoryInspectorViewModel.cpp
+++ b/src/ui/viewmodels/MemoryInspectorViewModel.cpp
@@ -190,6 +190,15 @@ void MemoryInspectorViewModel::UpdateNoteButtons()
     }
 }
 
+void MemoryInspectorViewModel::OnCodeNoteMoved(ra::ByteAddress nOldAddress, ra::ByteAddress nNewAddress, const std::wstring& sNote)
+{
+    const auto nCurrentAddress = GetCurrentAddress();
+    if (nNewAddress == nCurrentAddress)
+        OnCodeNoteChanged(nCurrentAddress, sNote);
+    else if (nOldAddress == nCurrentAddress)
+        OnCodeNoteChanged(nCurrentAddress, L"");
+}
+
 void MemoryInspectorViewModel::OnCodeNoteChanged(ra::ByteAddress nAddress, const std::wstring& sNewNote)
 {
     if (nAddress == GetCurrentAddress())

--- a/src/ui/viewmodels/MemoryInspectorViewModel.hh
+++ b/src/ui/viewmodels/MemoryInspectorViewModel.hh
@@ -177,6 +177,7 @@ protected:
     void OnActiveGameChanged() override;
     void OnEndGameLoad() override;
     void OnCodeNoteChanged(ra::ByteAddress nAddress, const std::wstring& sNewNote) override;
+    void OnCodeNoteMoved(ra::ByteAddress nOldAddress, ra::ByteAddress nNewAddress, const std::wstring& sNote) override;
 
 private:
     static const IntModelProperty CurrentAddressValueProperty;

--- a/src/ui/viewmodels/MemorySearchViewModel.cpp
+++ b/src/ui/viewmodels/MemorySearchViewModel.cpp
@@ -1014,6 +1014,27 @@ void MemorySearchViewModel::OnCodeNoteChanged(ra::ByteAddress nAddress, const st
     }
 }
 
+void MemorySearchViewModel::OnCodeNoteMoved(ra::ByteAddress nOldAddress, ra::ByteAddress nNewAddress, const std::wstring& sNote)
+{
+    for (gsl::index i = 0; i < ra::to_signed(m_vResults.Count()); ++i)
+    {
+        auto* pRow = m_vResults.GetItemAt(i);
+        if (pRow != nullptr)
+        {
+            if (pRow->nAddress == nOldAddress)
+            {
+                pRow->UpdateCodeNote(L"");
+                break;
+            }
+            else if (pRow->nAddress == nNewAddress)
+            {
+                pRow->UpdateCodeNote(sNote);
+                break;
+            }
+        }
+    }
+}
+
 static constexpr bool CanEditFilterValue(ra::services::SearchFilterType nFilterType)
 {
     switch (nFilterType)

--- a/src/ui/viewmodels/MemorySearchViewModel.hh
+++ b/src/ui/viewmodels/MemorySearchViewModel.hh
@@ -499,6 +499,7 @@ protected:
 
     // GameContext::NotifyTarget
     void OnCodeNoteChanged(ra::ByteAddress nAddress, const std::wstring& sNote) override;
+    void OnCodeNoteMoved(ra::ByteAddress nOldAddress, ra::ByteAddress nNewAddress, const std::wstring& sNote) override;
 
     void SaveResults(ra::services::TextWriter& sFile, std::function<bool(int)> pProgressCallback) const;
 

--- a/src/ui/viewmodels/MemoryViewerViewModel.hh
+++ b/src/ui/viewmodels/MemoryViewerViewModel.hh
@@ -187,6 +187,7 @@ protected:
     // GameContext::NotifyTarget
     void OnActiveGameChanged() override;
     void OnCodeNoteChanged(ra::ByteAddress, const std::wstring&) override;
+    void OnCodeNoteMoved(ra::ByteAddress nOldAddress, ra::ByteAddress nNewAddress, const std::wstring& sNote) override;
 
     // EmulatorContext::NotifyTarget
     void OnTotalMemorySizeChanged() override;

--- a/src/ui/viewmodels/MemoryWatchListViewModel.cpp
+++ b/src/ui/viewmodels/MemoryWatchListViewModel.cpp
@@ -67,12 +67,28 @@ void MemoryWatchListViewModel::InitializeNotifyTargets(bool syncNotes)
     pEmulatorContext.AddNotifyTarget(*this);
 }
 
+void MemoryWatchListViewModel::OnCodeNoteMoved(ra::ByteAddress nOldAddress, ra::ByteAddress nNewAddress, const std::wstring& sNote)
+{
+    for (gsl::index nIndex = 0; ra::to_unsigned(nIndex) < m_vItems.Count(); ++nIndex)
+    {
+        auto* pItem = m_vItems.GetItemAt(nIndex);
+        if (pItem && !pItem->IsIndirectAddress()) // ignore move events for indirect notes
+        {
+            const auto nCurrentAddress = pItem->GetAddress();
+            if (nCurrentAddress == nNewAddress)
+                pItem->SetRealNote(sNote);
+            else if (nCurrentAddress == nOldAddress)
+                pItem->SetRealNote(L"");
+        }
+    }
+}
+
 void MemoryWatchListViewModel::OnCodeNoteChanged(ra::ByteAddress nAddress, const std::wstring& sNewNote)
 {
     for (gsl::index nIndex = 0; ra::to_unsigned(nIndex) < m_vItems.Count(); ++nIndex)
     {
         auto* pItem = m_vItems.GetItemAt(nIndex);
-        if (pItem && pItem->GetAddress() == nAddress)
+        if (pItem && !pItem->IsIndirectAddress() && pItem->GetAddress() == nAddress)
             pItem->SetRealNote(sNewNote);
     }
 }

--- a/src/ui/viewmodels/MemoryWatchListViewModel.hh
+++ b/src/ui/viewmodels/MemoryWatchListViewModel.hh
@@ -85,6 +85,7 @@ public:
 protected:
     // ra::data::context::GameContext::NotifyTarget
     void OnCodeNoteChanged(ra::ByteAddress nAddress, const std::wstring& sNewNote) override;
+    void OnCodeNoteMoved(ra::ByteAddress nOldAddress, ra::ByteAddress nNewAddress, const std::wstring& sNote) override;
 
     // ra::data::context::EmulatorContext::NotifyTarget
     void OnByteWritten(ra::ByteAddress, uint8_t) override;

--- a/tests/data/models/CodeNotesModel_Tests.cpp
+++ b/tests/data/models/CodeNotesModel_Tests.cpp
@@ -44,6 +44,11 @@ private:
                 [this](ra::ByteAddress nAddress, const std::wstring& sNewNote) {
                     mNewNotes[nAddress] = sNewNote;
                 },
+                [this](ra::ByteAddress nOldAddress, ra::ByteAddress nNewAddress, const std::wstring& sNote) {
+                    if (nOldAddress != 0xFFFFFFFF)
+                        mNewNotes[nOldAddress] = L"";
+                    mNewNotes[nNewAddress] = sNote;
+                },
                 []() {});
 
             mockThreadPool.ExecuteNextTask(); // FetchCodeNotes is async
@@ -53,6 +58,11 @@ private:
         {
             m_fCodeNoteChanged = [this](ra::ByteAddress nAddress, const std::wstring& sNewNote) {
                 mNewNotes[nAddress] = sNewNote;
+            };
+            m_fCodeNoteMoved = [this](ra::ByteAddress nOldAddress, ra::ByteAddress nNewAddress, const std::wstring& sNote) {
+                if (nOldAddress != 0xFFFFFFFF)
+                    mNewNotes[nOldAddress] = L"";
+                mNewNotes[nNewAddress] = sNote;
             };
         }
 

--- a/tests/mocks/MockGameContext.hh
+++ b/tests/mocks/MockGameContext.hh
@@ -107,6 +107,9 @@ public:
                 }
 
                 OnCodeNoteChanged(nAddress, sNote);
+            },
+            [this](ra::ByteAddress nOldAddress, ra::ByteAddress nNewAddress, const std::wstring& sNote) {
+                OnCodeNoteMoved(nOldAddress, nNewAddress, sNote);
             });
         Assets().Append(std::move(pCodeNotes));
     }
@@ -155,10 +158,11 @@ private:
     class MockCodeNotesModel : public ra::data::models::CodeNotesModel
     {
     public:
-        void Initialize(unsigned nGameId, CodeNoteChangedFunction fCodeNoteChanged)
+        void Initialize(unsigned nGameId, CodeNoteChangedFunction fCodeNoteChanged, CodeNoteMovedFunction fCodeNoteMoved)
         {
             m_nGameId = nGameId;
             m_fCodeNoteChanged = fCodeNoteChanged;
+            m_fCodeNoteMoved = fCodeNoteMoved;
         }
     };
 

--- a/tests/ui/viewmodels/MemoryBookmarksViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/MemoryBookmarksViewModel_Tests.cpp
@@ -108,6 +108,7 @@ public:
 
         Assert::AreEqual({ 0U }, bookmarks.Bookmarks().Items().Count());
         bookmarks.mockGameContext.NotifyActiveGameChanged();
+        bookmarks.mockGameContext.NotifyGameLoad();
 
         Assert::AreEqual({ 1U }, bookmarks.Bookmarks().Items().Count());
         const auto& bookmark = *bookmarks.GetBookmark(0);
@@ -133,6 +134,7 @@ public:
 
         Assert::AreEqual({ 0U }, bookmarks.Bookmarks().Items().Count());
         bookmarks.mockGameContext.NotifyActiveGameChanged();
+        bookmarks.mockGameContext.NotifyGameLoad();
 
         Assert::AreEqual({ 1U }, bookmarks.Bookmarks().Items().Count());
         const auto& bookmark = *bookmarks.GetBookmark(0);
@@ -158,6 +160,7 @@ public:
 
         Assert::AreEqual({ 0U }, bookmarks.Bookmarks().Items().Count());
         bookmarks.mockGameContext.NotifyActiveGameChanged();
+        bookmarks.mockGameContext.NotifyGameLoad();
 
         Assert::AreEqual({ 1U }, bookmarks.Bookmarks().Items().Count());
         const auto& bookmark = *bookmarks.GetBookmark(0);
@@ -183,6 +186,7 @@ public:
                             "{\"Description\":\"desc2\",\"Address\":1235,\"Type\":3,\"Decimal\":false}]}");
 
         bookmarks.mockGameContext.NotifyActiveGameChanged();
+        bookmarks.mockGameContext.NotifyGameLoad();
         Assert::AreEqual({ 2U }, bookmarks.Bookmarks().Items().Count());
 
         Assert::IsTrue(bookmarks.HasBookmark(1234U));
@@ -193,6 +197,7 @@ public:
             "{\"Bookmarks\":[{\"Description\":\"desc3\",\"Address\":5555,\"Type\":2,\"Decimal\":false}]}");
 
         bookmarks.mockGameContext.NotifyActiveGameChanged();
+        bookmarks.mockGameContext.NotifyGameLoad();
         Assert::AreEqual({ 1U }, bookmarks.Bookmarks().Items().Count());
         const auto& bookmark = *bookmarks.GetBookmark(0);
         Assert::AreEqual(std::wstring(L""), bookmark.GetRealNote());
@@ -219,10 +224,12 @@ public:
             "{\"Bookmarks\":[{\"Description\":\"desc\",\"Address\":1234,\"Type\":2,\"Decimal\":false}]}");
 
         bookmarks.mockGameContext.NotifyActiveGameChanged();
+        bookmarks.mockGameContext.NotifyGameLoad();
         Assert::AreEqual({ 1U }, bookmarks.Bookmarks().Items().Count());
 
         bookmarks.mockGameContext.SetGameId(4U);
         bookmarks.mockGameContext.NotifyActiveGameChanged();
+        bookmarks.mockGameContext.NotifyGameLoad();
         Assert::AreEqual({ 0U }, bookmarks.Bookmarks().Items().Count());
     }
 
@@ -236,6 +243,7 @@ public:
             "{\"Bookmarks\":[{\"Address\":1234,\"Size\":10}]}");
 
         bookmarks.mockGameContext.NotifyActiveGameChanged();
+        bookmarks.mockGameContext.NotifyGameLoad();
 
         Assert::AreEqual({ 1U }, bookmarks.Bookmarks().Items().Count());
         const auto& bookmark = *bookmarks.GetBookmark(0);
@@ -257,6 +265,7 @@ public:
                                                   "{\"Bookmarks\":[{\"MemAddr\":\"0xH4D2\"}]}");
 
         bookmarks.mockGameContext.NotifyActiveGameChanged();
+        bookmarks.mockGameContext.NotifyGameLoad();
 
         Assert::AreEqual({1U}, bookmarks.Bookmarks().Items().Count());
         auto& bookmark = *bookmarks.GetBookmark(0);
@@ -295,6 +304,7 @@ public:
             "{\"Bookmarks\":[{\"Address\":1234,\"Size\":10,\"Description\":\"desc\"}]}");
 
         bookmarks.mockGameContext.NotifyActiveGameChanged();
+        bookmarks.mockGameContext.NotifyGameLoad();
 
         Assert::AreEqual({ 1U }, bookmarks.Bookmarks().Items().Count());
         const auto& bookmark = *bookmarks.GetBookmark(0);
@@ -316,6 +326,7 @@ public:
             "{\"Bookmarks\":[{\"Address\":1234,\"Size\":10,\"Description\":\"desc\"}]}");
 
         bookmarks.mockGameContext.NotifyActiveGameChanged();
+        bookmarks.mockGameContext.NotifyGameLoad();
 
         Assert::AreEqual({ 1U }, bookmarks.Bookmarks().Items().Count());
         const auto& bookmark = *bookmarks.GetBookmark(0);
@@ -337,6 +348,7 @@ public:
             "{\"Bookmarks\":[{\"Address\":1234,\"Size\":10,\"Description\":\"Note description\"}]}");
 
         bookmarks.mockGameContext.NotifyActiveGameChanged();
+        bookmarks.mockGameContext.NotifyGameLoad();
 
         Assert::AreEqual({ 1U }, bookmarks.Bookmarks().Items().Count());
         const auto& bookmark = *bookmarks.GetBookmark(0);
@@ -395,12 +407,14 @@ public:
             "{\"Bookmarks\":[{\"Address\":1234,\"Size\":10}]}");
 
         bookmarks.mockGameContext.NotifyActiveGameChanged();
+        bookmarks.mockGameContext.NotifyGameLoad();
 
         bookmarks.AddBookmark(2345U, MemSize::SixteenBit);
         Assert::IsTrue(bookmarks.IsModified());
 
         bookmarks.mockGameContext.SetGameId(0U);
         bookmarks.mockGameContext.NotifyActiveGameChanged();
+        bookmarks.mockGameContext.NotifyGameLoad();
 
         Assert::IsFalse(bookmarks.IsModified());
         const std::string& sContents = bookmarks.mockLocalStorage.GetStoredData(ra::services::StorageItemType::Bookmarks, L"3");
@@ -417,6 +431,7 @@ public:
             "{\"Bookmarks\":[{\"Address\":1234,\"Description\":\"Old\",\"Size\":10}]}");
 
         bookmarks.mockGameContext.NotifyActiveGameChanged();
+        bookmarks.mockGameContext.NotifyGameLoad();
 
         bookmarks.AddBookmark(2345U, MemSize::SixteenBit);
         bookmarks.GetBookmark(0)->SetDescription(L"");        // explicit blank resets to default note
@@ -425,6 +440,7 @@ public:
 
         bookmarks.mockGameContext.SetGameId(0U);
         bookmarks.mockGameContext.NotifyActiveGameChanged();
+        bookmarks.mockGameContext.NotifyGameLoad();
 
         Assert::IsFalse(bookmarks.IsModified());
         const std::string& sContents = bookmarks.mockLocalStorage.GetStoredData(ra::services::StorageItemType::Bookmarks, L"3");
@@ -442,12 +458,14 @@ public:
             "{\"Bookmarks\":[{\"Address\":1234,\"Size\":10}]}");
 
         bookmarks.mockGameContext.NotifyActiveGameChanged();
+        bookmarks.mockGameContext.NotifyGameLoad();
 
         bookmarks.GetBookmark(0)->SetFormat(MemFormat::Dec);
         Assert::IsTrue(bookmarks.IsModified());
 
         bookmarks.mockGameContext.SetGameId(0U);
         bookmarks.mockGameContext.NotifyActiveGameChanged();
+        bookmarks.mockGameContext.NotifyGameLoad();
 
         Assert::IsFalse(bookmarks.IsModified());
         const std::string& sContents = bookmarks.mockLocalStorage.GetStoredData(ra::services::StorageItemType::Bookmarks, L"3");
@@ -464,6 +482,7 @@ public:
             "{\"Bookmarks\":[{\"Address\":1234,\"Size\":10}]}");
 
         bookmarks.mockGameContext.NotifyActiveGameChanged();
+        bookmarks.mockGameContext.NotifyGameLoad();
 
         Assert::AreEqual({ 1U }, bookmarks.Bookmarks().Items().Count());
         const auto* bookmark = bookmarks.GetBookmark(0);
@@ -498,6 +517,7 @@ public:
             "{\"Bookmarks\":[{\"Address\":1234,\"Size\":10,\"Description\":\"My Description\"}]}");
 
         bookmarks.mockGameContext.NotifyActiveGameChanged();
+        bookmarks.mockGameContext.NotifyGameLoad();
 
         Assert::AreEqual({ 1U }, bookmarks.Bookmarks().Items().Count());
         const auto* bookmark = bookmarks.GetBookmark(0);
@@ -560,6 +580,7 @@ public:
         bookmarks.mockEmulatorContext.MockMemory(memory);
 
         bookmarks.mockGameContext.NotifyActiveGameChanged();
+        bookmarks.mockGameContext.NotifyGameLoad();
         Assert::AreEqual({ 1U }, bookmarks.Bookmarks().Items().Count());
 
         auto& bookmark = *bookmarks.GetBookmark(0);
@@ -924,6 +945,7 @@ public:
             "{\"Bookmarks\":[{\"MemAddr\":\"0xH04d2\"}]}");
 
         bookmarks.mockGameContext.NotifyActiveGameChanged();
+        bookmarks.mockGameContext.NotifyGameLoad();
 
         bookmarks.AddBookmark(2345U, MemSize::SixteenBit);
         Assert::IsTrue(bookmarks.IsModified());
@@ -962,6 +984,7 @@ public:
             "{\"Bookmarks\":[{\"Address\":1234,\"Size\":10}]}");
 
         bookmarks.mockGameContext.NotifyActiveGameChanged();
+        bookmarks.mockGameContext.NotifyGameLoad();
 
         bookmarks.AddBookmark(2345U, MemSize::SixteenBit);
         Assert::IsTrue(bookmarks.IsModified());
@@ -1187,6 +1210,7 @@ public:
         bookmarks.mockEmulatorContext.MockMemory(memory);
 
         bookmarks.mockGameContext.NotifyActiveGameChanged();
+        bookmarks.mockGameContext.NotifyGameLoad();
         bookmarks.AddBookmark(1, MemSize::ThirtyTwoBit);
         bookmarks.AddBookmark(2, MemSize::TwentyFourBit);
         bookmarks.AddBookmark(3, MemSize::SixteenBit);
@@ -1632,6 +1656,7 @@ public:
                                                   "{\"Bookmarks\":[{\"MemAddr\":\"0xH04d2\"}]}");
 
         bookmarks.mockGameContext.NotifyActiveGameChanged();
+        bookmarks.mockGameContext.NotifyGameLoad();
 
         bookmarks.AddBookmark("I:0x 0020_M:0xW0008");
         Assert::IsTrue(bookmarks.IsModified());

--- a/tests/ui/viewmodels/MemoryWatchListViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/MemoryWatchListViewModel_Tests.cpp
@@ -35,6 +35,7 @@ private:
         ra::data::context::mocks::MockGameContext mockGameContext;
         ra::data::context::mocks::MockUserContext mockUserContext;
         ra::services::mocks::MockAchievementRuntime mockAchievementRuntime;
+        ra::services::mocks::MockConfiguration mockConfiguration;
         ra::ui::mocks::MockDesktop mockDesktop;
         ra::ui::viewmodels::mocks::MockOverlayManager mockOverlayManager;
 
@@ -129,7 +130,7 @@ public:
         Assert::AreEqual(std::wstring(L"Note description"), pItem->GetDescription());
         Assert::AreEqual(1234U, pItem->GetAddress());
         Assert::AreEqual(MemSize::EightBit, pItem->GetSize());
-        Assert::AreEqual(MemFormat::Dec, pItem->GetFormat());
+        Assert::AreEqual(MemFormat::Hex, pItem->GetFormat());
         Assert::IsFalse(pItem->IsCustomDescription());
 
         watchList.mockGameContext.SetCodeNote(1234U, L"New description");
@@ -141,7 +142,7 @@ public:
         Assert::AreEqual(std::wstring(L"New description"), pItem->GetDescription());
         Assert::AreEqual(1234U, pItem->GetAddress());
         Assert::AreEqual(MemSize::EightBit, pItem->GetSize());
-        Assert::AreEqual(MemFormat::Dec, pItem->GetFormat());
+        Assert::AreEqual(MemFormat::Hex, pItem->GetFormat());
         Assert::IsFalse(pItem->IsCustomDescription());
     }
 
@@ -160,7 +161,7 @@ public:
         Assert::AreEqual(std::wstring(L"My Description"), pItem->GetDescription());
         Assert::AreEqual(1234U, pItem->GetAddress());
         Assert::AreEqual(MemSize::EightBit, pItem->GetSize());
-        Assert::AreEqual(MemFormat::Dec, pItem->GetFormat());
+        Assert::AreEqual(MemFormat::Hex, pItem->GetFormat());
         Assert::IsTrue(pItem->IsCustomDescription());
 
         watchList.mockGameContext.SetCodeNote(1234U, L"New description");
@@ -172,7 +173,7 @@ public:
         Assert::AreEqual(std::wstring(L"My Description"), pItem->GetDescription());
         Assert::AreEqual(1234U, pItem->GetAddress());
         Assert::AreEqual(MemSize::EightBit, pItem->GetSize());
-        Assert::AreEqual(MemFormat::Dec, pItem->GetFormat());
+        Assert::AreEqual(MemFormat::Hex, pItem->GetFormat());
         Assert::IsTrue(pItem->IsCustomDescription());
 
         watchList.mockGameContext.SetCodeNote(1234U, L"My Description");
@@ -184,7 +185,7 @@ public:
         Assert::AreEqual(std::wstring(L"My Description"), pItem->GetDescription());
         Assert::AreEqual(1234U, pItem->GetAddress());
         Assert::AreEqual(MemSize::EightBit, pItem->GetSize());
-        Assert::AreEqual(MemFormat::Dec, pItem->GetFormat());
+        Assert::AreEqual(MemFormat::Hex, pItem->GetFormat());
         Assert::IsFalse(pItem->IsCustomDescription());
 
         watchList.mockGameContext.SetCodeNote(1234U, L"New description");
@@ -196,7 +197,7 @@ public:
         Assert::AreEqual(std::wstring(L"New description"), pItem->GetDescription());
         Assert::AreEqual(1234U, pItem->GetAddress());
         Assert::AreEqual(MemSize::EightBit, pItem->GetSize());
-        Assert::AreEqual(MemFormat::Dec, pItem->GetFormat());
+        Assert::AreEqual(MemFormat::Hex, pItem->GetFormat());
         Assert::IsFalse(pItem->IsCustomDescription());
     }
 
@@ -453,7 +454,7 @@ public:
         Assert::AreEqual(std::wstring(L"[double] Note description"), pItem2.GetRealNote());
         Assert::AreEqual(12U, pItem2.GetAddress()); // adjusted to significant bytes
         Assert::AreEqual(MemSize::Double32, pItem2.GetSize());
-        Assert::AreEqual(MemFormat::Dec, pItem2.GetFormat()); // implied from note
+        Assert::AreEqual(MemFormat::Hex, pItem2.GetFormat());
         Assert::AreEqual(std::wstring(L"0.0"), pItem2.GetCurrentValue());
         Assert::AreEqual(std::wstring(L"0.0"), pItem2.GetPreviousValue());
         Assert::AreEqual(0U, pItem2.GetChanges());


### PR DESCRIPTION
Provides a separate callback when a note moves instead of trying to set the old address to blank and the new address to the note description.