### PR TITLE
improve stability when loading rapidly

### DIFF
--- a/src/data/context/GameAssets.cpp
+++ b/src/data/context/GameAssets.cpp
@@ -127,6 +127,9 @@ void GameAssets::OnBeforeItemRemoved(ModelBase& pModel)
 void GameAssets::ReloadAssets(const std::vector<ra::data::models::AssetModelBase*>& vAssetsToReload)
 {
     const auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::context::GameContext>();
+    if (pGameContext.Subsets().empty()) // server assets haven't been loaded yet
+        return;
+
     const auto nPrimarySubsetId = pGameContext.Subsets().front().AchievementSetID();
 
     auto* pRichPresence = dynamic_cast<ra::data::models::RichPresenceModel*>(FindAsset(ra::data::models::AssetType::RichPresence, 0));

--- a/src/ui/viewmodels/AssetListViewModel.cpp
+++ b/src/ui/viewmodels/AssetListViewModel.cpp
@@ -106,6 +106,8 @@ void AssetListViewModel::OnActiveGameChanged()
     const auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::context::GameContext>();
     SetGameId(pGameContext.ActiveGameId());
 
+    m_bInitializingFilter = true;
+
     switch (pGameContext.Assets().MostPublishedAssetCategory())
     {
         case ra::data::models::AssetCategory::Core:
@@ -133,6 +135,8 @@ void AssetListViewModel::OnActiveGameChanged()
         SetSubsetFilter(0);
     else
         SetSubsetFilter(pGameContext.Subsets().front().AchievementSetID());
+
+    m_bInitializingFilter = false;
 
     ApplyFilter();
 }
@@ -386,6 +390,9 @@ void AssetListViewModel::OnValueChanged(const BoolModelProperty::ChangeArgs& arg
 
 void AssetListViewModel::ApplyFilter()
 {
+    if (m_bInitializingFilter)
+        return;
+
     const auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::context::GameContext>();
     m_vFilteredAssets.BeginUpdate();
 

--- a/src/ui/viewmodels/AssetListViewModel.hh
+++ b/src/ui/viewmodels/AssetListViewModel.hh
@@ -337,6 +337,7 @@ private:
     static void SyncAsset(AssetSummaryViewModel& vmSummary, const ra::data::models::AssetModelBase& pAsset);
     gsl::index GetFilteredAssetIndex(const ra::data::models::AssetModelBase& pAsset) const;
     void ApplyFilter();
+    bool m_bInitializingFilter = false;
 
     ViewModelCollection<AssetSummaryViewModel> m_vFilteredAssets;
 

--- a/src/ui/viewmodels/MemoryInspectorViewModel.cpp
+++ b/src/ui/viewmodels/MemoryInspectorViewModel.cpp
@@ -205,17 +205,15 @@ void MemoryInspectorViewModel::OnCodeNoteChanged(ra::ByteAddress nAddress, const
     {
         // call the override that asks for an author to see if there's a non-indirect note at
         // the address. if so, use it.
-        std::string sAuthor;
         const auto& pGameContext = ra::services::ServiceLocator::Get<ra::data::context::GameContext>();
         const auto* pCodeNotes = pGameContext.Assets().FindCodeNotes();
-        Expects(pCodeNotes != nullptr);
-        const auto* pDirectNote = pCodeNotes->FindCodeNote(nAddress, sAuthor);
+        const auto* pDirectNote = pCodeNotes ? pCodeNotes->FindCodeNoteModel(nAddress, false) : nullptr;
         if (pDirectNote)
         {
             // non indirect note found. normally, this will match sNewNote, but sometimes sNewNote
-            // will be for an indirect note sharing the addres, so always use the direct note
+            // will be for an indirect note sharing the address, so always use the direct note
             m_bNoteIsIndirect = false;
-            SetCurrentAddressNote(*pDirectNote);
+            SetCurrentAddressNote(pDirectNote->GetNote());
         }
         else
         {
@@ -223,7 +221,7 @@ void MemoryInspectorViewModel::OnCodeNoteChanged(ra::ByteAddress nAddress, const
             if (sNewNote.length() == 0)
             {
                 // empty note notification is probably a deleted note, but check to be sure
-                const auto* pIndirectNote = pCodeNotes->FindCodeNote(nAddress);
+                const auto* pIndirectNote = pCodeNotes ? pCodeNotes->FindCodeNoteModel(nAddress, true) : nullptr;
                 m_bNoteIsIndirect = (pIndirectNote != nullptr);
             }
             else


### PR DESCRIPTION
Possible improvement for https://discord.com/channels/310192285306454017/1149693430306447380/1410649883488293056

When rapidly switching between games, I would occasionally encounter one game trying to finish loading while another had already started replacing the data with its own.

Added a couple logic checks to ensure the game being initialized was still being loaded.