### PR TITLE
change author on cloned assets

### DIFF
--- a/src/ui/viewmodels/AssetListViewModel.cpp
+++ b/src/ui/viewmodels/AssetListViewModel.cpp
@@ -1835,6 +1835,8 @@ void AssetListViewModel::CloneSelected()
     }
 
     auto& pGameContext = ra::services::ServiceLocator::GetMutable<ra::data::context::GameContext>();
+    const auto& pUserContext = ra::services::ServiceLocator::Get<ra::data::context::UserContext>();
+    const auto pAuthor = ra::Widen(pUserContext.GetDisplayName());
 
     FilteredAssets().BeginUpdate();
 
@@ -1849,6 +1851,7 @@ void AssetListViewModel::CloneSelected()
             auto& vmAchievement = pGameContext.Assets().NewAchievement();
             vmAchievement.SetSubsetID(pSourceAchievement->GetSubsetID());
             vmAchievement.SetCategory(ra::data::models::AssetCategory::Local);
+            vmAchievement.SetAuthor(pAuthor);
             vmAchievement.UpdateServerCheckpoint();
 
             vmAchievement.SetName(pSourceAchievement->GetName() + L" (copy)");
@@ -1869,6 +1872,7 @@ void AssetListViewModel::CloneSelected()
             auto& vmLeaderboard = pGameContext.Assets().NewLeaderboard();
             vmLeaderboard.SetSubsetID(pSourceLeaderboard->GetSubsetID());
             vmLeaderboard.SetCategory(ra::data::models::AssetCategory::Local);
+            vmLeaderboard.SetAuthor(pAuthor);
             vmLeaderboard.UpdateServerCheckpoint();
 
             vmLeaderboard.SetName(pSourceLeaderboard->GetName() + L" (copy)");

--- a/tests/ui/viewmodels/AssetListViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/AssetListViewModel_Tests.cpp
@@ -3810,11 +3810,13 @@ public:
     TEST_METHOD(TestCloneSingle)
     {
         AssetListViewModelHarness vmAssetList;
+        vmAssetList.mockUserContext.Initialize("Username", "DisplayName", "ApiToken");
         vmAssetList.SetGameId(22U);
         vmAssetList.mockGameContext.SetActiveGameId(22U);
         vmAssetList.SetSubsetFilter(22U);
         vmAssetList.AddAchievement(AssetCategory::Core, 5, L"Test1", L"Desc1", L"12345", "0xH1234=1");
         vmAssetList.AddAchievement(AssetCategory::Core, 7, L"Test2", L"Desc2", L"11111", "0xH1111=1");
+        vmAssetList.mockGameContext.Assets().FindAchievement(2)->SetAuthor(L"OriginalAuthor");
 
         Assert::AreEqual({ 2U }, vmAssetList.mockGameContext.Assets().Count());
         Assert::AreEqual({ 2U }, vmAssetList.FilteredAssets().Count());
@@ -3853,6 +3855,7 @@ public:
         Assert::AreEqual(std::wstring(L"Desc2"), pAchievement->GetDescription());
         Assert::AreEqual(std::wstring(L"11111"), pAchievement->GetBadge());
         Assert::AreEqual(std::string("0xH1111=1"), pAchievement->GetTrigger());
+        Assert::AreEqual(std::wstring(L"DisplayName"), pAchievement->GetAuthor());
 
         // and loaded in the editor, which should be shown (local achievement will always have ID 0)
         Assert::AreEqual({ 0U }, vmAssetList.mockWindowManager.AssetEditor.GetID());
@@ -4446,6 +4449,7 @@ public:
     TEST_METHOD(TestCloneLeaderboard)
     {
         AssetListViewModelHarness vmAssetList;
+        vmAssetList.mockUserContext.Initialize("Username", "DisplayName", "ApiToken");
         vmAssetList.SetGameId(22U);
         vmAssetList.mockGameContext.SetActiveGameId(22U);
         vmAssetList.SetSubsetFilter(22U);
@@ -4461,6 +4465,7 @@ public:
         vmLeaderboard->SetValueDefinition("0xH5555*2");
         vmLeaderboard->SetValueFormat(ra::data::ValueFormat::Score);
         vmLeaderboard->SetLowerIsBetter(true);
+        vmLeaderboard->SetAuthor(L"OriginalAuthor");
 
         Assert::AreEqual({ 1U }, vmAssetList.mockGameContext.Assets().Count());
         Assert::AreEqual({ 1U }, vmAssetList.FilteredAssets().Count());
@@ -4501,6 +4506,7 @@ public:
         Assert::AreEqual(std::string("0xH5555*2"), pLeaderboard->GetValueDefinition());
         Assert::AreEqual(ra::data::ValueFormat::Score, pLeaderboard->GetValueFormat());
         Assert::IsTrue(pLeaderboard->IsLowerBetter());
+        Assert::AreEqual(std::wstring(L"DisplayName"), pLeaderboard->GetAuthor());
 
         // and loaded in the editor, which should be shown (local achievement will always have ID 0)
         Assert::AreEqual({ 0U }, vmAssetList.mockWindowManager.AssetEditor.GetID());


### PR DESCRIPTION
Update the author when cloning an achievement/leaderboard so they appear in the Authored filter.