### PR TITLE
use mutex when sync'ing state

### DIFF
--- a/src/data/models/AchievementModel.cpp
+++ b/src/data/models/AchievementModel.cpp
@@ -268,7 +268,6 @@ void AchievementModel::SyncState()
                 const auto& pClock = ra::services::ServiceLocator::Get<ra::services::IClock>();
                 m_tUnlock = pClock.Now();
 
-                auto& pRuntime = ra::services::ServiceLocator::GetMutable<ra::services::AchievementRuntime>();
                 if (pRuntime.HasRichPresence())
                     SetUnlockRichPresence(pRuntime.GetRichPresenceDisplayString());
             }

--- a/src/data/models/LeaderboardModel.cpp
+++ b/src/data/models/LeaderboardModel.cpp
@@ -223,7 +223,7 @@ void LeaderboardModel::HandleStateChanged(AssetState nOldState, AssetState nNewS
     SyncState(nNewState);
 }
 
-void LeaderboardModel::SyncState(AssetState nNewState) noexcept
+void LeaderboardModel::SyncState(AssetState nNewState)
 {
     auto& pRuntime = ra::services::ServiceLocator::GetMutable<ra::services::AchievementRuntime>();
     auto* pClient = pRuntime.GetClient();

--- a/src/data/models/LeaderboardModel.hh
+++ b/src/data/models/LeaderboardModel.hh
@@ -225,7 +225,7 @@ private:
     void HandleStateChanged(AssetState nOldState, AssetState nNewState);
     void SyncTitle();
     void SyncDescription();
-    void SyncState(AssetState nNewState) noexcept;
+    void SyncState(AssetState nNewState);
     void SyncValueFormat();
     void SyncTracker();
     void SyncDefinition();


### PR DESCRIPTION
https://discord.com/channels/310192285306454017/1149693430306447380/1420543542551642272

If the UI thread tries to activate an achievement while the do_frame thread is attempting to process it, it's possible for the do_frame thread to deactivate the achievement before the UI thread finishes, leading to the reported exception.