### PR TITLE
move KeepActive logic into AssetListViewModel

### DIFF
--- a/src/services/AchievementRuntime.cpp
+++ b/src/services/AchievementRuntime.cpp
@@ -1772,11 +1772,6 @@ static void HandleAchievementTriggeredEvent(const rc_client_achievement_t& pAchi
     // this captures the unlock time and rich presence state, even if KeepActive it selected.
     vmAchievement->SetState(ra::data::models::AssetState::Triggered);
 
-    // if KeepActive is selected, set the achievement back to Waiting
-    const auto& pAssetList = ra::services::ServiceLocator::Get<ra::ui::viewmodels::WindowManager>().AssetList;
-    if (pAssetList.KeepActive())
-        vmAchievement->SetState(ra::data::models::AssetState::Waiting);
-
     if (vmAchievement->IsPauseOnTrigger())
     {
         auto& pFrameEventQueue = ra::services::ServiceLocator::GetMutable<ra::services::FrameEventQueue>();

--- a/tests/services/AchievementRuntime_Tests.cpp
+++ b/tests/services/AchievementRuntime_Tests.cpp
@@ -2184,42 +2184,6 @@ public:
         Assert::IsTrue(runtime.mockAudioSystem.WasAudioFilePlayed(L"Overlay\\acherror.wav"));
     }
 
-    TEST_METHOD(TestHandleAchievementTriggeredKeepActive)
-    {
-        AchievementRuntimeHarness runtime;
-        runtime.mockWindowManager.AssetList.SetKeepActive(true);
-        auto* pAch6 = runtime.MockAchievement(6U, "0xH0000=1");
-        pAch6->public_.rarity = 23.45f;
-        pAch6->public_.rarity_hardcore = 12.34f;
-        memcpy(pAch6->public_.badge_name, "012345", 7);
-        auto* vmAch6 = runtime.WrapAchievement(pAch6);
-        runtime.mockGameContext.SetRichPresenceDisplayString(L"Titles");
-        runtime.mockGameContext.Assets().FindRichPresence()->Activate();
-        runtime.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, false);
-        runtime.mockConfiguration.SetPopupLocation(ra::ui::viewmodels::Popup::AchievementTriggered,
-                                                   ra::ui::viewmodels::PopupLocation::BottomLeft);
-
-        rc_client_event_t event;
-        memset(&event, 0, sizeof(event));
-        event.type = RC_CLIENT_EVENT_ACHIEVEMENT_TRIGGERED;
-        event.achievement = &pAch6->public_;
-        runtime.RaiseEvent(event);
-
-        Assert::AreEqual(ra::data::models::AssetState::Waiting, vmAch6->GetState());
-        Assert::AreEqual(std::wstring(L"Titles"), vmAch6->GetUnlockRichPresence());
-
-        auto* pPopup = runtime.mockOverlayManager.GetMessage(1);
-        Expects(pPopup != nullptr);
-        Assert::AreEqual(ra::ui::viewmodels::Popup::AchievementTriggered, pPopup->GetPopupType());
-        Assert::AreEqual(std::wstring(L"Achievement Unlocked - 23.45%"), pPopup->GetTitle());
-        Assert::AreEqual(std::wstring(L"Ach6 (5)"), pPopup->GetDescription());
-        Assert::AreEqual(std::wstring(L"Description 6"), pPopup->GetDetail());
-        Assert::AreEqual(ra::ui::ImageType::Badge, pPopup->GetImage().Type());
-        Assert::AreEqual(std::string("012345"), pPopup->GetImage().Name());
-        Assert::AreEqual({0U}, runtime.mockFrameEventQueue.NumTriggeredTriggers());
-        Assert::IsTrue(runtime.mockAudioSystem.WasAudioFilePlayed(L"Overlay\\unlock.wav"));
-    }
-
     TEST_METHOD(TestHandleChallengeIndicatorShowEvent)
     {
         AchievementRuntimeHarness runtime;

--- a/tests/ui/viewmodels/AssetListViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/AssetListViewModel_Tests.cpp
@@ -5690,6 +5690,48 @@ public:
                                       ResetButtonState::ResetDisabled, RevertButtonState::Revert,
                                       CreateButtonState::Enabled, CloneButtonState::Disabled);
     }
+
+    TEST_METHOD(TestKeepActive)
+    {
+        AssetListViewModelHarness vmAssetList;
+        vmAssetList.SetGameId(1U);
+        vmAssetList.SetCategoryFilter(AssetListViewModel::CategoryFilter::Core);
+        vmAssetList.AddThreeAchievements();
+        vmAssetList.SetKeepActive(true);
+
+        Assert::AreEqual({ 2U }, vmAssetList.FilteredAssets().Count());
+        auto* pAchievement1 = vmAssetList.mockGameContext.Assets().FindAchievement(1);
+        Expects(pAchievement1 != nullptr);
+        Assert::AreEqual(AssetState::Inactive, vmAssetList.FilteredAssets().GetItemAt(0)->GetState());
+        pAchievement1->SetState(ra::data::models::AssetState::Active);
+
+        Assert::AreEqual(AssetState::Active, vmAssetList.FilteredAssets().GetItemAt(0)->GetState());
+        pAchievement1->SetState(ra::data::models::AssetState::Triggered);
+
+        Assert::AreEqual(AssetState::Waiting, vmAssetList.FilteredAssets().GetItemAt(0)->GetState());
+        Assert::AreEqual(AssetState::Waiting, pAchievement1->GetState());
+    }
+
+    TEST_METHOD(TestKeepActiveNonVisible)
+    {
+        AssetListViewModelHarness vmAssetList;
+        vmAssetList.SetGameId(1U);
+        vmAssetList.SetCategoryFilter(AssetListViewModel::CategoryFilter::Unofficial);
+        vmAssetList.AddThreeAchievements();
+        vmAssetList.SetKeepActive(true);
+
+        Assert::AreEqual({ 1U }, vmAssetList.FilteredAssets().Count());
+        auto* pAchievement1 = vmAssetList.mockGameContext.Assets().FindAchievement(1);
+        Expects(pAchievement1 != nullptr);
+        Assert::AreEqual(AssetState::Inactive, vmAssetList.FilteredAssets().GetItemAt(0)->GetState());
+        pAchievement1->SetState(ra::data::models::AssetState::Active);
+
+        Assert::AreEqual(AssetState::Inactive, vmAssetList.FilteredAssets().GetItemAt(0)->GetState()); // not achievement 1 - shouldn't change
+        pAchievement1->SetState(ra::data::models::AssetState::Triggered);
+
+        Assert::AreEqual(AssetState::Inactive, vmAssetList.FilteredAssets().GetItemAt(0)->GetState());
+        Assert::AreEqual(AssetState::Waiting, pAchievement1->GetState()); // should still get set to waiting even if not visible
+    }
 };
 
 } // namespace tests


### PR DESCRIPTION
fixes KeepActive not working when routing events through the rc_client_external interface