### PR TITLE
fix note modifications being discarded on reset all

### DIFF
--- a/src/ui/viewmodels/AssetListViewModel.cpp
+++ b/src/ui/viewmodels/AssetListViewModel.cpp
@@ -1478,8 +1478,19 @@ void AssetListViewModel::ResetSelected()
             }
         }
 
+        // if the current address note hasn't been flushed to disk, capture it and
+        // restore it after we refresh from disk.
+        auto& pMemoryInspector = ra::services::ServiceLocator::GetMutable<ra::ui::viewmodels::WindowManager>().MemoryInspector;
+        std::wstring sCurrentNoteValue;
+        const bool bIsNoteUncommitted = pMemoryInspector.IsNoteUncommitted();
+        if (bIsNoteUncommitted)
+            sCurrentNoteValue = pMemoryInspector.GetCurrentAddressNote();
+
         // when resetting all, always read the file to pick up new items
         pGameContext.Assets().ReloadAssets(vAssetsToReset);
+
+        if (bIsNoteUncommitted)
+            pMemoryInspector.SetCurrentAddressNote(sCurrentNoteValue);
     }
     else
     {

--- a/src/ui/viewmodels/MemoryInspectorViewModel.hh
+++ b/src/ui/viewmodels/MemoryInspectorViewModel.hh
@@ -79,7 +79,7 @@ public:
     /// <summary>
     /// Sets the current address's note.
     /// </summary>
-    void SetCurrentAddressNote(const std::wstring& sValue);
+    void SetCurrentAddressNote(const std::wstring& sValue) { SetValue(CurrentAddressNoteProperty, sValue); }
 
     /// <summary>
     /// The <see cref="ModelProperty" /> for whether or not the current address note is editable.
@@ -165,6 +165,8 @@ public:
 
     void ToggleBit(int nBit);
 
+    bool IsNoteUncommitted() const noexcept { return m_nUncommittedNoteAddress != 0xFFFFFFFF; }
+
 protected:
     void OnValueChanged(const IntModelProperty::ChangeArgs& args) override;
     void OnValueChanged(const StringModelProperty::ChangeArgs& args) override;
@@ -183,8 +185,9 @@ private:
     static const IntModelProperty CurrentAddressValueProperty;
     void OnCurrentAddressChanged(ra::ByteAddress nNewAddress);
 
+    void SetCurrentAddressNoteInternal(const std::wstring& sValue);
     void UpdateNoteButtons();
-    void SaveNotes();
+    void SaveUncommittedNote();
 
     MemorySearchViewModel m_pSearch;
     MemoryViewerViewModel m_pViewer;
@@ -192,8 +195,8 @@ private:
     bool m_bSyncingAddress = false;
     bool m_bSyncingCodeNote = false;
     bool m_bNoteIsIndirect = false;
-    ra::ByteAddress m_nSavedNoteAddress = 0xFFFFFFFF;
-    std::wstring m_sSavedNote;
+    ra::ByteAddress m_nUncommittedNoteAddress = 0xFFFFFFFF;
+    std::wstring m_sOriginalNoteValue;
 };
 
 } // namespace viewmodels


### PR DESCRIPTION
Note modifications aren't written to the XXX-User.txt file until the address changes in case multiple modifications are made.

When pressing Reset All, unpublished data is read from the XXX-User.txt file, which would overwrite the uncommitted data in the currently selected note.

Solution: if the currently selected note is modified, capture it before resetting all, and restore it after.