### PR TITLE
don't discard float attribute if raw size found

### DIFF
--- a/src/data/models/CodeNoteModel.cpp
+++ b/src/data/models/CodeNoteModel.cpp
@@ -854,7 +854,6 @@ void CodeNoteModel::ExtractSize(const std::wstring& sNote, bool bIsPointer)
                 {
                     const auto nBits = _wtoi(sPreviousWord.c_str());
                     m_nBytes = (nBits + 7) / 8;
-                    m_nMemSize = MemSize::Unknown;
                     bBytesFromBits = true;
                     bWordIsSize = true;
                     bFoundSize = true;
@@ -865,14 +864,15 @@ void CodeNoteModel::ExtractSize(const std::wstring& sNote, bool bIsPointer)
                 if (!bFoundSize || (bBytesFromBits && !bIsPointer))
                 {
                     m_nBytes = _wtoi(sPreviousWord.c_str());
-                    m_nMemSize = MemSize::Unknown;
                     bBytesFromBits = false;
                     bWordIsSize = true;
                     bFoundSize = true;
                 }
             }
 
-            if (bWordIsSize)
+            if (bWordIsSize &&
+                (m_nMemSize == MemSize::Unknown ||      // size not yet determined
+                 MemSizeBytes(m_nMemSize) != m_nBytes)) // size mismatch
             {
                 switch (m_nBytes)
                 {

--- a/tests/data/models/CodeNoteModel_Tests.cpp
+++ b/tests/data/models/CodeNoteModel_Tests.cpp
@@ -111,6 +111,9 @@ public:
         TestCodeNoteSize(L"[2 Byte] Test", 2U, MemSize::SixteenBit);
         TestCodeNoteSize(L"[4 Byte] Test", 4U, MemSize::ThirtyTwoBit);
         TestCodeNoteSize(L"[4 Byte - Float] Test", 4U, MemSize::Float);
+        TestCodeNoteSize(L"[Float - 4 Byte] Test", 4U, MemSize::Float);
+        TestCodeNoteSize(L"[32-bit Float] Test", 4U, MemSize::Float);
+        TestCodeNoteSize(L"[Float 32-bit] Test", 4U, MemSize::Float);
         TestCodeNoteSize(L"[8 Byte] Test", 8U, MemSize::Array);
         TestCodeNoteSize(L"[0x80 Bytes] Test", 128U, MemSize::Array);
         TestCodeNoteSize(L"[0xa8 bytes] Test", 168U, MemSize::Array);


### PR DESCRIPTION
https://discord.com/channels/310192285306454017/310195377993416714/1430270301609922641

The `32-bit` appearing after `float` was taking priority over the `float`.