### PR TITLE
revalidate achievement with code note warning when code notes change

### DIFF
--- a/src/ui/viewmodels/AssetListViewModel.cpp
+++ b/src/ui/viewmodels/AssetListViewModel.cpp
@@ -141,6 +141,22 @@ void AssetListViewModel::OnActiveGameChanged()
     ApplyFilter();
 }
 
+void AssetListViewModel::OnCodeNoteChanged(ra::ByteAddress, const std::wstring&)
+{
+    RevalidateNoteAssetValidationWarnings();
+}
+
+void AssetListViewModel::RevalidateNoteAssetValidationWarnings()
+{
+    auto& pGameContext = ra::services::ServiceLocator::GetMutable<ra::data::context::GameContext>();
+    for (auto& pAsset : pGameContext.Assets())
+    {
+        const auto& sValidationError = pAsset.GetValidationError();
+        if (sValidationError.find(L"code note") != std::wstring::npos)
+            pAsset.Validate();
+    }
+}
+
 void AssetListViewModel::OnDataModelStringValueChanged(gsl::index nIndex, const StringModelProperty::ChangeArgs& args)
 {
     // sync this property through to the summary view model

--- a/src/ui/viewmodels/AssetListViewModel.hh
+++ b/src/ui/viewmodels/AssetListViewModel.hh
@@ -306,6 +306,7 @@ private:
 
     // GameContext::NotifyTarget
     void OnActiveGameChanged() override;
+    void OnCodeNoteChanged(ra::ByteAddress, const std::wstring&) override;
 
     void OnValueChanged(const IntModelProperty::ChangeArgs& args) override;
     void OnValueChanged(const BoolModelProperty::ChangeArgs& args) override;
@@ -338,6 +339,8 @@ private:
     gsl::index GetFilteredAssetIndex(const ra::data::models::AssetModelBase& pAsset) const;
     void ApplyFilter();
     bool m_bInitializingFilter = false;
+
+    void RevalidateNoteAssetValidationWarnings();
 
     ViewModelCollection<AssetSummaryViewModel> m_vFilteredAssets;
 


### PR DESCRIPTION
https://discord.com/channels/310192285306454017/310195377993416714/1427604851654791188

Validation normally only occurs when saving changes to an achievement. If the validation warning is related to code notes, the only way to clear it after fixing the code note is to modify and reset the achievement.

This change will automatically revalidate the achievement if the validation warning contains "code note" and a code note is changed.