### PR TITLE
ensure custom regions from previous session make it to next session

### DIFF
--- a/src/data/models/MemoryRegionsModel.cpp
+++ b/src/data/models/MemoryRegionsModel.cpp
@@ -67,14 +67,17 @@ void MemoryRegionsModel::AddCustomRegion(ra::ByteAddress nStartAddress, ra::Byte
     pRegion.nEndAddress = nEndAddress;
 
     m_vRegions.push_back(pRegion);
+
+    // setting changes to Unpublished forces a write without attempting to consolidate modifications
+    SetValue(ChangesProperty, ra::etoi(AssetChanges::Unpublished));
 }
 
 void MemoryRegionsModel::ResetCustomRegions()
 {
     m_vRegions.clear();
 
-    // setting changes to Unpublished forces a write without attempting to consolidate modifications
-    SetValue(ChangesProperty, ra::etoi(AssetChanges::Unpublished));
+    // nothing should be written if custom regions is empty
+    SetValue(ChangesProperty, ra::etoi(AssetChanges::None));
 }
 
 static bool ParseAddress(const wchar_t** pointer, ra::ByteAddress& address) noexcept

--- a/tests/data/models/MemoryRegionsModel_Tests.cpp
+++ b/tests/data/models/MemoryRegionsModel_Tests.cpp
@@ -92,7 +92,7 @@ public:
         pTokenizer.Consume(':');
 
         Assert::IsTrue(regions.Deserialize(pTokenizer));
-        Assert::AreEqual(AssetChanges::None, regions.GetChanges());
+        Assert::AreEqual(AssetChanges::Unpublished, regions.GetChanges());
         regions.AssertRegion(0x1234, 0x2345, L"My region");
     }
 
@@ -106,7 +106,7 @@ public:
         pTokenizer.Consume(':');
 
         Assert::IsTrue(regions.Deserialize(pTokenizer));
-        Assert::AreEqual(AssetChanges::None, regions.GetChanges());
+        Assert::AreEqual(AssetChanges::Unpublished, regions.GetChanges());
         regions.AssertRegion(0x1234, 0x2345, L"My \"region\"");
     }
 


### PR DESCRIPTION
When custom regions were read from disk, they were considered unmodified, and therefore not written back to disk when other assets were saved. They need to be classified as Unpublished to be written back to disk.