### PR TITLE
extract value assignments for display in tooltip for comparison value

### DIFF
--- a/src/data/models/CodeNoteModel.hh
+++ b/src/data/models/CodeNoteModel.hh
@@ -26,6 +26,7 @@ public:
     const unsigned int GetBytes() const noexcept { return m_nBytes; }
     const MemSize GetMemSize() const noexcept { return m_nMemSize; }
     const MemFormat GetDefaultMemFormat() const noexcept { return m_nMemFormat; }
+    std::wstring_view GetEnumText(uint32_t nValue) const;
 
     void SetAuthor(const std::string& sAuthor) { m_sAuthor = sAuthor; }
     void SetAddress(ra::ByteAddress nAddress) noexcept { m_nAddress = nAddress; }
@@ -98,6 +99,15 @@ private:
     unsigned int m_nBytes = 1;
     MemSize m_nMemSize = MemSize::Unknown;
     MemFormat m_nMemFormat = MemFormat::Dec;
+
+    enum EnumState {
+        None,
+        Hex,
+        Dec,
+        Unknown,
+    };
+    mutable EnumState m_nEnumState = EnumState::Unknown;
+    static EnumState DetermineEnumState(const std::wstring_view svNote);
 
     struct PointerData;
     std::unique_ptr<PointerData> m_pPointerData;

--- a/src/ui/viewmodels/TriggerConditionViewModel.hh
+++ b/src/ui/viewmodels/TriggerConditionViewModel.hh
@@ -119,6 +119,7 @@ private:
 
     void SerializeAppendOperand(std::string& sBuffer, TriggerOperandType nType, MemSize nSize, const std::wstring& nValue) const;
 
+    std::wstring GetPotentialEnumValueTooltip(unsigned int nValue, ra::ByteAddress nCompareAddress) const;
     static std::wstring GetValueTooltip(unsigned int nValue);
     std::wstring GetAddressTooltip(ra::ByteAddress nAddress, const std::wstring& sPointerChain, const ra::data::models::CodeNoteModel* pNote) const;
     std::wstring GetRecallTooltip(bool bOperand2) const;

--- a/tests/data/models/CodeNoteModel_Tests.cpp
+++ b/tests/data/models/CodeNoteModel_Tests.cpp
@@ -728,6 +728,150 @@ public:
         Assert::IsNotNull(pObj2Note);
         Assert::AreEqual(28U, pObj2Note->GetPointerAddress());
     }
+
+    TEST_METHOD(TestGetEnumTextSimple)
+    {
+        CodeNoteModelHarness note;
+        const std::wstring sNote =
+            L"[8-bit] Color\r\n"
+            L"0=None\r\n"
+            L"1=Red\r\n"
+            L"2=Green\r\n"
+            L"3=Blue\r\n";
+        note.SetNote(sNote);
+
+        Assert::AreEqual(std::wstring_view(L"0=None"), note.GetEnumText(0));
+        Assert::AreEqual(std::wstring_view(L"1=Red"), note.GetEnumText(1));
+        Assert::AreEqual(std::wstring_view(L"2=Green"), note.GetEnumText(2));
+        Assert::AreEqual(std::wstring_view(L"3=Blue"), note.GetEnumText(3));
+        Assert::AreEqual(std::wstring_view(), note.GetEnumText(4));
+    }
+
+    TEST_METHOD(TestGetEnumTextSingleLine)
+    {
+        CodeNoteModelHarness note;
+        const std::wstring sNote = L"Color (0=None, 1=Red, 2=Green, 3=Blue)";
+        note.SetNote(sNote);
+
+        Assert::AreEqual(std::wstring_view(L"0=None"), note.GetEnumText(0));
+        Assert::AreEqual(std::wstring_view(L"1=Red"), note.GetEnumText(1));
+        Assert::AreEqual(std::wstring_view(L"2=Green"), note.GetEnumText(2));
+        Assert::AreEqual(std::wstring_view(L"3=Blue"), note.GetEnumText(3));
+        Assert::AreEqual(std::wstring_view(), note.GetEnumText(4));
+    }
+
+    TEST_METHOD(TestGetEnumTextSingleLineAlternateFormat)
+    {
+        CodeNoteModelHarness note;
+        const std::wstring sNote = L"Color [0: None, 1: Red, 2: Green, 3: Blue]";
+        note.SetNote(sNote);
+
+        Assert::AreEqual(std::wstring_view(L"0: None"), note.GetEnumText(0));
+        Assert::AreEqual(std::wstring_view(L"1: Red"), note.GetEnumText(1));
+        Assert::AreEqual(std::wstring_view(L"2: Green"), note.GetEnumText(2));
+        Assert::AreEqual(std::wstring_view(L"3: Blue"), note.GetEnumText(3));
+        Assert::AreEqual(std::wstring_view(), note.GetEnumText(4));
+    }
+
+    TEST_METHOD(TestGetEnumTextHexPrefix0x)
+    {
+        CodeNoteModelHarness note;
+        const std::wstring sNote =
+            L"[8-bit] Color\r\n"
+            L"0x00=None\r\n"
+            L"0x10=Red\r\n"
+            L"0x4C=Green\r\n"
+            L"0xA3=Blue\r\n";
+        note.SetNote(sNote);
+
+        Assert::AreEqual(std::wstring_view(L"0x00=None"), note.GetEnumText(0x00));
+        Assert::AreEqual(std::wstring_view(L"0x10=Red"), note.GetEnumText(0x10));
+        Assert::AreEqual(std::wstring_view(L"0x4C=Green"), note.GetEnumText(0x4C));
+        Assert::AreEqual(std::wstring_view(L"0xA3=Blue"), note.GetEnumText(0xA3));
+        Assert::AreEqual(std::wstring_view(), note.GetEnumText(0x2A));
+    }
+
+    TEST_METHOD(TestGetEnumTextHexPrefixH)
+    {
+        CodeNoteModelHarness note;
+        const std::wstring sNote =
+            L"[8-bit] Color\r\n"
+            L"h00=None\r\n"
+            L"h10=Red\r\n"
+            L"h4c=Green\r\n"
+            L"ha3=Blue\r\n";
+        note.SetNote(sNote);
+
+        Assert::AreEqual(std::wstring_view(L"h00=None"), note.GetEnumText(0x00));
+        Assert::AreEqual(std::wstring_view(L"h10=Red"), note.GetEnumText(0x10));
+        Assert::AreEqual(std::wstring_view(L"h4c=Green"), note.GetEnumText(0x4C));
+        Assert::AreEqual(std::wstring_view(L"ha3=Blue"), note.GetEnumText(0xA3));
+        Assert::AreEqual(std::wstring_view(), note.GetEnumText(0x2A));
+    }
+
+    TEST_METHOD(TestGetEnumTextHexPrefixNone)
+    {
+        CodeNoteModelHarness note;
+        const std::wstring sNote =
+            L"[8-bit] Color\r\n"
+            L"00=None\r\n"
+            L"10=Red\r\n"
+            L"4C=Green\r\n"
+            L"A3=Blue\r\n";
+        note.SetNote(sNote);
+
+        Assert::AreEqual(std::wstring_view(L"00=None"), note.GetEnumText(0x00));
+        Assert::AreEqual(std::wstring_view(L"10=Red"), note.GetEnumText(0x10));
+        Assert::AreEqual(std::wstring_view(L"4C=Green"), note.GetEnumText(0x4C));
+        Assert::AreEqual(std::wstring_view(L"A3=Blue"), note.GetEnumText(0xA3));
+        Assert::AreEqual(std::wstring_view(), note.GetEnumText(0x2A));
+    }
+
+    TEST_METHOD(TestGetEnumTextRange)
+    {
+        CodeNoteModelHarness note;
+        const std::wstring sNote =
+            L"[8-bit] Color\r\n"
+            L"0-3=None\r\n"
+            L"4-7=Red\r\n"
+            L"9-12=Green\r\n"
+            L"15-18=Blue\r\n";
+        note.SetNote(sNote);
+
+        Assert::AreEqual(std::wstring_view(L"0-3=None"), note.GetEnumText(0));
+        Assert::AreEqual(std::wstring_view(L"4-7=Red"), note.GetEnumText(4));
+        Assert::AreEqual(std::wstring_view(L"4-7=Red"), note.GetEnumText(5));
+        Assert::AreEqual(std::wstring_view(L"4-7=Red"), note.GetEnumText(6));
+        Assert::AreEqual(std::wstring_view(L"4-7=Red"), note.GetEnumText(7));
+        Assert::AreEqual(std::wstring_view(L"9-12=Green"), note.GetEnumText(10));
+        Assert::AreEqual(std::wstring_view(L"15-18=Blue"), note.GetEnumText(17));
+        Assert::AreEqual(std::wstring_view(), note.GetEnumText(8));
+        Assert::AreEqual(std::wstring_view(), note.GetEnumText(20));
+    }
+
+    TEST_METHOD(TestGetEnumTextIndirect)
+    {
+        CodeNoteModelHarness note;
+        const std::wstring sNote =
+            L"[32-bit pointer] Data\r\n"
+            L"0=NULL\r\n"
+            L"+0x02|Color\r\n"
+            L"1=Red\r\n"
+            L"2=Green\r\n"
+            L"+0x04|Alternate Color\r\n"
+            L"3=Blue\r\n";
+        note.SetNote(sNote);
+
+        Assert::AreEqual(std::wstring_view(L"0=NULL"), note.GetEnumText(0));
+        Assert::AreEqual(std::wstring_view(), note.GetEnumText(2));
+
+        const auto* pSubNote = note.GetPointerNoteAtOffset(0x02);
+        Assert::IsNotNull(pSubNote);
+        Assert::AreEqual(std::wstring_view(), pSubNote->GetEnumText(0));
+        Assert::AreEqual(std::wstring_view(L"1=Red"), pSubNote->GetEnumText(1));
+        Assert::AreEqual(std::wstring_view(L"2=Green"), pSubNote->GetEnumText(2));
+        Assert::AreEqual(std::wstring_view(), pSubNote->GetEnumText(3));
+    }
 };
 
 } // namespace tests

--- a/tests/ui/viewmodels/TriggerConditionViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/TriggerConditionViewModel_Tests.cpp
@@ -732,6 +732,17 @@ public:
         Assert::AreEqual(std::wstring(L""), condition.GetTooltip(TriggerConditionViewModel::TargetValueProperty));
     }
 
+    TEST_METHOD(TestTooltipValueEnum)
+    {
+        TriggerConditionViewModelHarness condition;
+        condition.mockGameContext.SetCodeNote({ 0x0099U }, L"Color {02=Red, 06=Brown}");
+        condition.mockConfiguration.SetFeatureEnabled(ra::services::Feature::PreferDecimal, true);
+        condition.Parse("0xH0099=2");
+
+        Assert::AreEqual(std::wstring(L"0x0099\r\nColor {02=Red, 06=Brown}"), condition.GetTooltip(TriggerConditionViewModel::SourceValueProperty));
+        Assert::AreEqual(std::wstring(L"02=Red"), condition.GetTooltip(TriggerConditionViewModel::TargetValueProperty));
+    }
+
     TEST_METHOD(TestTooltipValueHex)
     {
         TriggerConditionViewModelHarness condition;


### PR DESCRIPTION
When hovering over a value, if the other side of the equation is a memory reference with a note, the note will be processed to see if a matching value can be extracted.

<img width="681" height="229" alt="image" src="https://github.com/user-attachments/assets/e065ef26-a20f-47af-b199-74c5f9f35256" />

<img width="721" height="43" alt="image" src="https://github.com/user-attachments/assets/481b32b5-f54f-4207-abdb-2dc2b89bd323" />
