### PR TITLE
don't reset MemoryRegionsModel when only resetting single asset

### DIFF
--- a/src/data/context/GameAssets.cpp
+++ b/src/data/context/GameAssets.cpp
@@ -146,6 +146,8 @@ void GameAssets::ReloadAssets(const std::vector<ra::data::models::AssetModelBase
         return;
     }
 
+    auto* pMemoryRegions = FindMemoryRegions();
+
     std::vector<ra::data::models::AssetModelBase*> vRemainingAssetsToReload(vAssetsToReload);
     const bool bReloadAll = vAssetsToReload.empty();
     if (bReloadAll)
@@ -180,11 +182,12 @@ void GameAssets::ReloadAssets(const std::vector<ra::data::models::AssetModelBase
                 vRemainingAssetsToReload.push_back(&pAsset);
             }
         }
-    }
 
-    auto* pMemoryRegions = FindMemoryRegions();
-    if (pMemoryRegions)
-        pMemoryRegions->ResetCustomRegions();
+        // memory regions are only refreshed when reloading all.
+        // to prevent duplicate entries, clear out the existing ones.
+        if (pMemoryRegions)
+            pMemoryRegions->ResetCustomRegions();
+    }
 
     std::string sLine;
     pData->GetLine(sLine); // version used to create the file


### PR DESCRIPTION
fixes issue where custom memory regions are lost after resetting an achievement