### PR TITLE
dispatch pause message to UI thread

### DIFF
--- a/src/services/FrameEventQueue.cpp
+++ b/src/services/FrameEventQueue.cpp
@@ -3,6 +3,7 @@
 #include "RA_Defs.h"
 #include "util\Strings.hh"
 
+#include "ui\IDesktop.hh"
 #include "ui\viewmodels\MessageBoxViewModel.hh"
 #include "ui\viewmodels\WindowManager.hh"
 
@@ -59,7 +60,9 @@ void FrameEventQueue::DoFrame()
         const auto& pEmulatorContext = ra::services::ServiceLocator::Get<ra::data::context::EmulatorContext>();
         pEmulatorContext.Pause();
 
-        ra::ui::viewmodels::MessageBoxViewModel::ShowWarningMessage(L"The emulator has been paused.", sPauseMessage);
+        ra::services::ServiceLocator::Get<ra::ui::IDesktop>().InvokeOnUIThread([sPauseMessage]() {
+            ra::ui::viewmodels::MessageBoxViewModel::ShowWarningMessage(L"The emulator has been paused.", sPauseMessage);
+        });
     }
 }
 


### PR DESCRIPTION
https://discord.com/channels/310192285306454017/1149693430306447380/1468399873257771204

Instead of posting the SHOW_MESSAGE for the dialog to the UI thread and then waiting for the dialog to close, this moves the entire process of showing the dialog to the UI thread so it doesn't block the secondary thread.