### PR TITLE
prevent uploading rich presence that would be truncated

### DIFF
--- a/src/data/models/RichPresenceModel.cpp
+++ b/src/data/models/RichPresenceModel.cpp
@@ -72,6 +72,20 @@ void RichPresenceModel::OnValueChanged(const IntModelProperty::ChangeArgs& args)
     AssetModelBase::OnValueChanged(args);
 }
 
+bool RichPresenceModel::ValidateAsset(std::wstring& sError)
+{
+    const auto& sScript = GetScript();
+    if (sScript.length() > MaxScriptLength)
+    {
+        sError = ra::util::String::Printf(L"Script length exceeds limit: %d/%d", sScript.length(), MaxScriptLength);
+        return false;
+    }
+
+    // TODO: validate parse and validate logic
+
+    return true;
+}
+
 void RichPresenceModel::SetScript(const std::string& sScript)
 {
     bool bIsOnlyWhitespace = true;
@@ -103,6 +117,8 @@ void RichPresenceModel::SetScript(const std::string& sScript)
         sNormalizedScript.push_back('\n');
 
     SetAssetDefinition(m_pScript, sNormalizedScript);
+
+    // TODO: parse and load into runtime
 }
 
 void RichPresenceModel::ReloadRichPresenceScript()

--- a/src/data/models/RichPresenceModel.hh
+++ b/src/data/models/RichPresenceModel.hh
@@ -16,17 +16,17 @@ public:
     RichPresenceModel() noexcept;
 
     /// <summary>
-    /// The <see cref="ModelProperty" /> for the start trigger version.
+    /// The <see cref="ModelProperty" /> for the rich presence script.
     /// </summary>
     static const IntModelProperty ScriptProperty;
 
     /// <summary>
-    /// Gets the start trigger definition.
+    /// Gets the rich presence script.
     /// </summary>
     const std::string& GetScript() const { return GetAssetDefinition(m_pScript); }
 
     /// <summary>
-    /// Sets the start trigger definition.
+    /// Sets the rich presence script.
     /// </summary>
     void SetScript(const std::string& sScript);
 
@@ -38,8 +38,19 @@ public:
     void Serialize(ra::services::TextWriter& pWriter) const noexcept override;
     bool Deserialize(ra::util::Tokenizer& pTokenizer) noexcept override;
 
+    /// <summary>
+    /// Gets the maximum size of the rich presence script.
+    /// </summary>
+    /// <remarks>
+    /// This is the absolute maximum number of bytes (in UTF-8).
+    /// There's a soft limit of 60000 characters due to the way the webpage validates length.
+    /// </remarks>
+    static constexpr size_t MaxScriptLength = 65535;
+
 protected:
     void OnValueChanged(const IntModelProperty::ChangeArgs& args) override;
+
+    bool ValidateAsset(std::wstring& sError) override;
 
 private:
     void WriteRichPresenceScript();

--- a/src/ui/viewmodels/AssetListViewModel.cpp
+++ b/src/ui/viewmodels/AssetListViewModel.cpp
@@ -1345,6 +1345,14 @@ void AssetListViewModel::ValidateLeaderboardForCore(std::wstring& sError, const 
         sError.append(ra::util::String::Printf(L"\n* %s: %s: %s", pLeaderboard.GetName(), L"Value", sValueError));
 }
 
+
+void AssetListViewModel::ValidateRichPresenceForCore(std::wstring& sError, const ra::data::models::RichPresenceModel& pRichPresence) const
+{
+    const auto& sScript = pRichPresence.GetScript();
+    if (sScript.length() > ra::data::models::RichPresenceModel::MaxScriptLength)
+        sError.append(ra::util::String::Printf(L"\n* %s: %s", L"Rich Presence", pRichPresence.GetValidationError()));
+}
+
 bool AssetListViewModel::ValidateAssetsForCore(std::vector<ra::data::models::AssetModelBase*>& vAssets, bool bCoreOnly)
 {
     std::wstring sError;
@@ -1371,6 +1379,14 @@ bool AssetListViewModel::ValidateAssetsForCore(std::vector<ra::data::models::Ass
                     sError.append(ra::util::String::Printf(L"\n* %s: No Value definition", pLeaderboard->GetName()));
 
                 ValidateLeaderboardForCore(sError, *pLeaderboard);
+            }
+            else
+            {
+                const auto* pRichPresence = dynamic_cast<const ra::data::models::RichPresenceModel*>(pAsset);
+                if (pRichPresence != nullptr)
+                {
+                    ValidateRichPresenceForCore(sError, *pRichPresence);
+                }
             }
         }
     }

--- a/src/ui/viewmodels/AssetListViewModel.hh
+++ b/src/ui/viewmodels/AssetListViewModel.hh
@@ -293,6 +293,8 @@ protected:
     bool ValidateAssetsForCore(std::vector<ra::data::models::AssetModelBase*>& vAssets, bool bCoreOnly);
     virtual void ValidateAchievementForCore(std::wstring& sError, const ra::data::models::AchievementModel& pAchievement) const noexcept(false);
     virtual void ValidateLeaderboardForCore(std::wstring& sError, const ra::data::models::LeaderboardModel& pAchievement) const noexcept(false);
+    virtual void ValidateRichPresenceForCore(std::wstring& sError, const ra::data::models::RichPresenceModel& pRichPresence) const noexcept(false);
+
     virtual bool SelectionContainsInvalidAsset(const std::vector<ra::data::models::AssetModelBase*>& vSelectedAssets, _Out_ std::wstring& sErrorMessage) const;
 
 private:


### PR DESCRIPTION
Shows an error when trying to publish a rich presence script that exceeds the maximum length.

https://discord.com/channels/310192285306454017/1419772152240144506/1480213336401645589

I've chosen to use the 64K byte limitation rather than the 60K character limitation, which was originally provided due to the fact that the web interface could only count characters.

Similar errors are already reported for achievements and leaderboards - but only as warnings. They don't prevent publishing the assets. They probably should.