### PR TITLE
prevent exception evaluating recall tooltip for recall chain without a remember

### DIFF
--- a/src/ui/viewmodels/TriggerConditionViewModel.cpp
+++ b/src/ui/viewmodels/TriggerConditionViewModel.cpp
@@ -979,9 +979,12 @@ std::wstring TriggerConditionViewModel::GetRecallTooltip(bool bOperand2) const
                 break;
         }
 
-        const auto* pOperand1 = rc_condition_get_real_operand1(pCondition);
-        if ((pOperand1 && pOperand1->type == RC_OPERAND_RECALL) || pCondition->operand2.type == RC_OPERAND_RECALL)
-            mRememberRef[nConditionIndex] = { nLastRememberIndex, pLastRememberCondition };
+        if (pLastRememberCondition) // if something has been remembered, check for recalls that might map to it.
+        {
+            const auto* pOperand1 = rc_condition_get_real_operand1(pCondition);
+            if ((pOperand1 && pOperand1->type == RC_OPERAND_RECALL) || pCondition->operand2.type == RC_OPERAND_RECALL)
+                mRememberRef[nConditionIndex] = { nLastRememberIndex, pLastRememberCondition };
+        }
 
         if (pCondition->type == RC_CONDITION_REMEMBER)
         {

--- a/tests/devkit/data/models/CodeNoteModel_Tests.cpp
+++ b/tests/devkit/data/models/CodeNoteModel_Tests.cpp
@@ -132,6 +132,7 @@ public:
         TestCodeNoteSize(L"[be float] Test", 4U, Memory::Size::FloatBigEndian);
         TestCodeNoteSize(L"[bigendian float] Test", 4U, Memory::Size::FloatBigEndian);
         TestCodeNoteSize(L"[32-bit] pointer to float", 4U, Memory::Size::ThirtyTwoBit);
+        TestCodeNoteSize(L"[8-bit] can double down", 1U, Memory::Size::EightBit);
 
         TestCodeNoteSize(L"[64-bit double] Test", 8U, Memory::Size::Double32);
         TestCodeNoteSize(L"[64-bit double BE] Test", 8U, Memory::Size::Double32BigEndian);

--- a/tests/ui/viewmodels/TriggerConditionViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/TriggerConditionViewModel_Tests.cpp
@@ -1629,6 +1629,25 @@ public:
         Assert::AreEqual(std::wstring(L"0x00000000 (recall)\r\n[invalid recall]"), pCondition1->GetTooltip(TriggerConditionViewModel::SourceTypeProperty));
     }
 
+    TEST_METHOD(TestTooltipRecallChainInvalid)
+    {
+        IndirectAddressTriggerViewModelHarness vmTrigger;
+        vmTrigger.mockGameContext.InitializeCodeNotes();
+        vmTrigger.Parse("K:{recall}+6_A:{recall}_0xH0000=1");
+        vmTrigger.mockConfiguration.SetFeatureEnabled(ra::services::Feature::PreferDecimal, true);
+
+        // there is no Remember for the first condition to point to
+        const auto* pCondition1 = vmTrigger.Conditions().GetItemAt(0);
+        Expects(pCondition1 != nullptr);
+        Assert::AreEqual(std::wstring(L"0x00000000 (recall)\r\n[invalid recall]"), pCondition1->GetTooltip(TriggerConditionViewModel::SourceTypeProperty));
+
+        // the second condition points to the first one, but it's broken too
+        const auto* pCondition2 = vmTrigger.Conditions().GetItemAt(1);
+        Expects(pCondition2 != nullptr);
+        Assert::AreEqual(std::wstring(L"0x00000006 (recall)\r\n1: 0x00000000 + 0x00000006 -> 0x00000006"),
+            pCondition2->GetTooltip(TriggerConditionViewModel::SourceTypeProperty));
+    }
+
     TEST_METHOD(TestTooltipRecallInvalidInPauseIf)
     {
         IndirectAddressTriggerViewModelHarness vmTrigger;


### PR DESCRIPTION
Fixes an error showing the tooltip for a `{recall}` that points at a `Remembered` value that is using a `{recall}` that isn't pointing at anything.

When a `{recall}` doesn't point at anything, the tooltip shows `[Invalid recall]`, but when the missing `Remember` is further up the chain, an exception was occurring. Now, the broken `Remember` will report `0` as being remembered and that will appear in the tooltip for the latter nodes.