### PR TITLE
fix potential memory leaks and undefined behavior

### DIFF
--- a/src/data/context/EmulatorContext.cpp
+++ b/src/data/context/EmulatorContext.cpp
@@ -154,7 +154,7 @@ void EmulatorContext::UpdateUserAgent()
     if (!m_sVersion.empty() && (m_sVersion.at(0) == 'v' || m_sVersion.at(0) == 'V'))
     {
         /* version string starts with a "v". assume it's part of a prefix (i.e. "v1.2", or "version 1.2") and ignore it */
-        while (nOffset < m_sVersion.length() && (isalpha(m_sVersion.at(nOffset)) || isspace(m_sVersion.at(nOffset))))
+        while (nOffset < m_sVersion.length() && (ra::util::String::IsAlpha(m_sVersion.at(nOffset)) || ra::util::String::IsSpace(m_sVersion.at(nOffset))))
             ++nOffset;
     }
 
@@ -188,7 +188,7 @@ static unsigned long long ParseVersion(const char* sVersion)
 {
     Expects(sVersion != nullptr);
 
-    while (isalpha(*sVersion) || isspace(*sVersion))
+    while (ra::util::String::IsAlpha(*sVersion) || ra::util::String::IsSpace(*sVersion))
         ++sVersion;
 
     char* pPart{};
@@ -323,7 +323,7 @@ bool EmulatorContext::ValidateClientVersion(bool& bHardcore)
 
     // remove leading prefix and any trailing ".0"s off the client version
     std::string sClientVersion = m_sVersion;
-    while (!sClientVersion.empty() && (isalpha(sClientVersion.at(0)) || isspace(sClientVersion.at(0))))
+    while (!sClientVersion.empty() && (ra::util::String::IsAlpha(sClientVersion.at(0)) || ra::util::String::IsSpace(sClientVersion.at(0))))
         sClientVersion.erase(0, 1);
     while (ra::util::String::EndsWith(sClientVersion, ".0"))
         sClientVersion.resize(sClientVersion.length() - 2);

--- a/src/data/context/GameContext.cpp
+++ b/src/data/context/GameContext.cpp
@@ -593,7 +593,7 @@ void GameContext::MigrateSubsetUserFiles()
             {
                 if (!sLine.empty())
                 {
-                    if (isdigit(sLine.at(0)) || sLine.at(0) == 'L')
+                    if (ra::util::String::IsDigit(sLine.at(0)) || sLine.at(0) == 'L')
                     {
                         // found a local achievement or leaderboard. inject subset id
                         const auto nIndex = sLine.find(':');

--- a/src/data/models/RichPresenceModel.cpp
+++ b/src/data/models/RichPresenceModel.cpp
@@ -126,7 +126,7 @@ void RichPresenceModel::SetScript(const std::string& sScript)
     bool bIsOnlyWhitespace = true;
     for (const char c : sScript)
     {
-        if (!isspace(static_cast<int>(c)))
+        if (!ra::util::String::IsSpace(c))
         {
             bIsOnlyWhitespace = false;
             break;

--- a/src/devkit/context/impl/RcClient.cpp
+++ b/src/devkit/context/impl/RcClient.cpp
@@ -100,13 +100,18 @@ static void ConvertHttpResponseToApiServerResponse(rc_api_server_response_t& pRe
 static std::string_view FindParameter(const std::string& sInput, const std::string& sParameter)
 {
     auto nIndex = sInput.find(sParameter);
-    if (nIndex != std::string::npos)
+    while (nIndex != std::string::npos)
     {
-        nIndex += 3;
-        auto nIndex2 = sInput.find('&', nIndex);
-        if (nIndex2 == std::string::npos)
-            nIndex2 = sInput.length();
-        return std::string_view(&sInput.at(nIndex), nIndex2 - nIndex);
+        if (nIndex == 0 || sInput.at(nIndex - 1) == '&')
+        {
+            nIndex += sParameter.length();
+            auto nIndex2 = sInput.find('&', nIndex);
+            if (nIndex2 == std::string::npos)
+                nIndex2 = sInput.length();
+            return std::string_view(&sInput.at(nIndex), nIndex2 - nIndex);
+        }
+
+        nIndex = sInput.find(sParameter, nIndex + sParameter.length());
     }
 
     return {};
@@ -120,30 +125,23 @@ void RcClient::DispatchRequest(const rc_api_request_t& pRequest,
     httpRequest.SetPostData(pRequest.post_data);
     httpRequest.SetContentType(pRequest.content_type);
 
-    std::string sApi;
-    auto nIndex = httpRequest.GetPostData().find("r=", 0, 2);
-    if (nIndex != std::string::npos)
-    {
-        nIndex += 2;
-        for (; nIndex < httpRequest.GetPostData().length(); ++nIndex)
-        {
-            const char c = httpRequest.GetPostData().at(nIndex);
-            if (c == '&')
-                break;
+    std::string sParams = httpRequest.GetPostData();
 
-            sApi.push_back(c);
-        }
+    std::string sApi;
+    const auto svApi = FindParameter(sParams, "r=");
+    if (!svApi.empty())
+    {
+        sApi = svApi;
 
         if (ra::services::ServiceLocator::Exists<ra::services::ILogger>())
         {
-            std::string sParams = httpRequest.GetPostData();
-            const auto svToken = FindParameter(sParams, "&t=");
+            const auto svToken = FindParameter(sParams, "t=");
             if (!svToken.empty())
                 sParams.replace(svToken.data() - sParams.data(), svToken.length(), "[redacted]");
 
             if (ra::util::String::StartsWith(sApi, "login"))
             {
-                const auto svPassword = FindParameter(sParams, "&p=");
+                const auto svPassword = FindParameter(sParams, "p=");
                 if (!svPassword.empty())
                     sParams.replace(svPassword.data() - sParams.data(), svPassword.length(), "[redacted]");
             }
@@ -177,7 +175,7 @@ void RcClient::CallApi(const std::string& sApi, const ra::services::Http::Reques
 {
     std::wstring sParameter;
     if (sApi == "codenotes2") {
-        const auto svGameId = FindParameter(pRequest.GetPostData(), "&g=");
+        const auto svGameId = FindParameter(pRequest.GetPostData(), "g=");
         if (!svGameId.empty())
             sParameter = ra::util::String::Widen(svGameId);
     }

--- a/src/devkit/data/Memory.cpp
+++ b/src/devkit/data/Memory.cpp
@@ -298,7 +298,7 @@ bool Memory::TryParseAddressRange(const std::wstring& sRange, ra::data::ByteAddr
     }
 
     ptr += nAddressLength;
-    while (iswspace(*ptr))
+    while (ra::util::String::IsSpace(*ptr))
         ++ptr;
 
     if (*ptr == '\0')
@@ -315,7 +315,7 @@ bool Memory::TryParseAddressRange(const std::wstring& sRange, ra::data::ByteAddr
     }
 
     ++ptr;
-    while (iswspace(*ptr))
+    while (ra::util::String::IsSpace(*ptr))
         ++ptr;
 
     nAddressLength = TryParseAddressInternal(ptr, nEnd);

--- a/src/devkit/data/models/MemoryNoteModel.cpp
+++ b/src/devkit/data/models/MemoryNoteModel.cpp
@@ -1,10 +1,10 @@
 #include "MemoryNoteModel.hh"
 
-#include "context\IConsoleContext.hh"
+#include "context/IConsoleContext.hh"
 
-#include "services\ServiceLocator.hh"
+#include "services/ServiceLocator.hh"
 
-#include "util\Strings.hh"
+#include "util/Strings.hh"
 
 namespace ra {
 namespace data {
@@ -376,7 +376,7 @@ void MemoryNoteModel::SetNote(const std::wstring& sNote, bool bImpliedPointer)
                 // "pointer" not found
                 ExtractSize(sLine, false);
             }
-            else if (sLine.length() > nPointerIndex + 8 && iswalpha(sLine.at(nPointerIndex + 7)))
+            else if (sLine.length() > nPointerIndex + 8 && ra::util::String::IsAlpha(sLine.at(nPointerIndex + 7)))
             {
                 // extra trailing letters - assume "pointers"
                 ExtractSize(sLine, false);
@@ -441,17 +441,6 @@ Memory::Size MemoryNoteModel::GetImpliedPointerSize()
     return Memory::Size::ThirtyTwoBit;
 }
 
-static constexpr bool IsHexDigit(wchar_t c)
-{
-    if (c >= '0' && c <= '9')
-        return true;
-    if (c >= 'a' && c <= 'f')
-        return true;
-    if (c >= 'A' && c <= 'F')
-        return true;
-    return false;
-}
-
 MemoryNoteModel::Parser::TokenType MemoryNoteModel::Parser::NextToken(std::wstring& sWord) const
 {
     wchar_t cFirstLetter = '\0';
@@ -466,14 +455,12 @@ MemoryNoteModel::Parser::TokenType MemoryNoteModel::Parser::NextToken(std::wstri
         // find the next word
         if (c > 255)
         {
-            // ignore unicode characters - isalpha with the default locale would return false,
-            // but it also likes to pop up asserts in a debug build.
-
+            // ignore unicode characters
             // if we've found any alphanumeric characters, process them.
             if (!sWord.empty())
                 break;
         }
-        else if (isalpha(c))
+        else if (ra::util::String::IsAlpha(c))
         {
             if (sWord.empty())
             {
@@ -484,7 +471,7 @@ MemoryNoteModel::Parser::TokenType MemoryNoteModel::Parser::NextToken(std::wstri
             }
             else if (bWordIsHexNumber)
             {
-                if (IsHexDigit(c))
+                if (ra::util::String::IsHexDigit(c))
                 {
                     // continue hex number
                     sWord.push_back(gsl::narrow_cast<wchar_t>(tolower(c)));
@@ -506,7 +493,7 @@ MemoryNoteModel::Parser::TokenType MemoryNoteModel::Parser::NextToken(std::wstri
                 break;
             }
         }
-        else if (isdigit(c))
+        else if (ra::util::String::IsDigit(c))
         {
             if (sWord.empty())
             {
@@ -515,7 +502,7 @@ MemoryNoteModel::Parser::TokenType MemoryNoteModel::Parser::NextToken(std::wstri
 
                 if (c == '0' && m_nIndex < m_sNote.size() - 2 &&
                     m_sNote.at(m_nIndex + 1) == 'x' &&
-                    IsHexDigit(m_sNote.at(m_nIndex + 2)))
+                    ra::util::String::IsHexDigit(m_sNote.at(m_nIndex + 2)))
                 {
                     sWord.push_back(m_sNote.at(++m_nIndex));
                     sWord.push_back(m_sNote.at(++m_nIndex));
@@ -791,7 +778,7 @@ void MemoryNoteModel::ExtractSize(const std::wstring& sNote, bool bIsPointer)
         nLastTokenType = nTokenType;
 
         const wchar_t c = parser.Peek();
-        if (c < 256 && isalnum(c))
+        if (ra::util::String::IsAlNum(c))
         {
             // number next to word [32bit]
             std::swap(sPreviousWord, sWord);
@@ -831,7 +818,7 @@ static void RemoveIndentPrefix(std::wstring& sNote)
         }
 
         c = sNote.at(nIndent + 1);
-        if (isdigit(c)) // found +N
+        if (ra::util::String::IsDigit(c)) // found +N
         {
             if (nIndent > nLineIndex + 1)
             {
@@ -871,7 +858,7 @@ void MemoryNoteModel::ProcessIndirectNotes(const std::wstring& sNote, size_t nIn
             //   +0x20 [32-bit pointer] user data
             //   ++0x08 [16-bit] points
             //
-            while (nNextIndex + 2 < sNote.length() && !isdigit(sNote.at(nNextIndex + 2)))
+            while (nNextIndex + 2 < sNote.length() && !ra::util::String::IsDigit(sNote.at(nNextIndex + 2)))
             {
                 nNextIndex = nStopIndex = sNote.find(L"\n+", nNextIndex + 2);
                 if (nNextIndex == std::wstring::npos)
@@ -884,7 +871,7 @@ void MemoryNoteModel::ProcessIndirectNotes(const std::wstring& sNote, size_t nIn
                 while (nStopIndex > 0)
                 {
                     const wchar_t c = sNote.at(nStopIndex - 1);
-                    if (c >= 256 || !isspace(c))
+                    if (!ra::util::String::IsSpace(c))
                         break;
                     --nStopIndex;
                 }
@@ -910,12 +897,12 @@ void MemoryNoteModel::ProcessIndirectNotes(const std::wstring& sNote, size_t nIn
         }
 
         // if there are any error processing offsets, don't treat this as a pointer note
-        if (!pEnd || iswalnum(*pEnd))
+        if (!pEnd || ra::util::String::IsAlNum(*pEnd))
             return;
 
         // skip over [whitespace] [optional separator] [whitespace]
         const wchar_t* pStop = sNextNote.c_str() + sNextNote.length();
-        while (pEnd < pStop && *pEnd < 256 && isspace(*pEnd) && *pEnd != '\n')
+        while (pEnd < pStop && ra::util::String::IsSpace(*pEnd) && *pEnd != '\n')
             ++pEnd;
 
         if (pEnd < pStop)
@@ -925,12 +912,12 @@ void MemoryNoteModel::ProcessIndirectNotes(const std::wstring& sNote, size_t nIn
                 // no separator. found an unannotated note
                 ++pEnd;
             }
-            else if (!iswalnum(*pEnd) && *pEnd != '[' && *pEnd != '(') // assume brackets are not a separator
+            else if (!ra::util::String::IsAlNum(*pEnd) && *pEnd != '[' && *pEnd != '(') // assume brackets are not a separator
             {
                 // found a separator. skip it and any following whitespace
                 ++pEnd;
 
-                while (pEnd < pStop && *pEnd < 256 && isspace(*pEnd))
+                while (pEnd < pStop && ra::util::String::IsSpace(*pEnd))
                     ++pEnd;
             }
         }
@@ -1040,7 +1027,7 @@ std::wstring MemoryNoteModel::TrimSize(const std::wstring& sNote, bool bKeepPoin
     while (nStartIndex > 0)
     {
         const wchar_t c = sNote.at(nStartIndex - 1);
-        if (c >= 256 || !isspace(c))
+        if (!ra::util::String::IsSpace(c))
             break;
         --nStartIndex;
     }
@@ -1048,16 +1035,16 @@ std::wstring MemoryNoteModel::TrimSize(const std::wstring& sNote, bool bKeepPoin
     while (nEndIndex < sNote.length() - 1)
     {
         const wchar_t c = sNote.at(nEndIndex + 1);
-        if (c >= 256 || !isspace(c))
+        if (!ra::util::String::IsSpace(c))
             break;
         ++nEndIndex;
     }
 
     if (nStartIndex > 0 && nEndIndex < sNote.length() - 1)
     {
-        if (isspace(sNote.at(nStartIndex)))
+        if (ra::util::String::IsSpace(sNote.at(nStartIndex)))
             ++nStartIndex;
-        else if (isspace(sNote.at(nEndIndex - 1)))
+        else if (!ra::util::String::IsSpace(sNote.at(nEndIndex - 1)))
             --nEndIndex;
     }
 
@@ -1131,7 +1118,7 @@ static size_t MatchBitPrefix(std::wstring_view svRange)
     if (svRange.at(0) != 'b' && svRange.at(0) != 'B')
         return std::wstring::npos;
 
-    if (isdigit(svRange.at(1)))
+    if (ra::util::String::IsDigit(svRange.at(1)))
         return 1;
 
     if (svRange.size() < 4)
@@ -1143,13 +1130,13 @@ static size_t MatchBitPrefix(std::wstring_view svRange)
     if (svRange.at(2) != 't' && svRange.at(2) != 'T')
         return std::wstring::npos;
 
-    if (isdigit(svRange.at(3)))
+    if (ra::util::String::IsDigit(svRange.at(3)))
         return 3;
 
     if (svRange.size() < 5 || (svRange.at(3) != 's' && svRange.at(3) != 'S'))
         return std::wstring::npos;
 
-    if (isdigit(svRange.at(4)))
+    if (ra::util::String::IsDigit(svRange.at(4)))
         return 4;
 
     return std::wstring::npos;
@@ -1176,13 +1163,13 @@ static bool ParseBitRange(std::wstring_view svRange, uint32_t& nLow, uint32_t& n
     }
 
     size_t nStart = nIndex;
-    while (nIndex < svRange.size() && isdigit(svRange.at(nIndex)))
+    while (nIndex < svRange.size() && ra::util::String::IsDigit(svRange.at(nIndex)))
         ++nIndex;
 
     const auto svLow = svRange.substr(nStart, nIndex - nStart);
     std::wstring_view svHigh;
 
-    while (nIndex < svRange.size() && isspace(svRange.at(nIndex)))
+    while (nIndex < svRange.size() && ra::util::String::IsSpace(svRange.at(nIndex)))
         ++nIndex;
 
     if (nIndex < svRange.size())
@@ -1199,10 +1186,10 @@ static bool ParseBitRange(std::wstring_view svRange, uint32_t& nLow, uint32_t& n
         }
 
         ++nIndex;
-        while (nIndex < svRange.size() && isspace(svRange.at(nIndex)))
+        while (nIndex < svRange.size() && ra::util::String::IsSpace(svRange.at(nIndex)))
             ++nIndex;
 
-        if (nIndex < svRange.size() && !isdigit(svRange.at(nIndex)))
+        if (nIndex < svRange.size() && !ra::util::String::IsDigit(svRange.at(nIndex)))
         {
             nStart = nIndex;
             nIndex = MatchBitPrefix(svRange.substr(nIndex));
@@ -1212,7 +1199,7 @@ static bool ParseBitRange(std::wstring_view svRange, uint32_t& nLow, uint32_t& n
         }
 
         nStart = nIndex;
-        while (nIndex < svRange.size() && isdigit(svRange.at(nIndex)))
+        while (nIndex < svRange.size() && ra::util::String::IsDigit(svRange.at(nIndex)))
             ++nIndex;
 
         svHigh = svRange.substr(nStart, nIndex - nStart);
@@ -1234,7 +1221,7 @@ static bool ParseRange(std::wstring_view svRange, uint32_t& nLow, uint32_t& nHig
         svRange = svRange.substr(0, svRange.size() - 1);
 
     size_t nIndex = 0;
-    while (nIndex < svRange.size() && IsHexDigit(svRange.at(nIndex)))
+    while (nIndex < svRange.size() && ra::util::String::IsHexDigit(svRange.at(nIndex)))
         ++nIndex;
 
     if (nIndex == 0)
@@ -1243,7 +1230,7 @@ static bool ParseRange(std::wstring_view svRange, uint32_t& nLow, uint32_t& nHig
     const auto svLow = svRange.substr(0, nIndex);
     std::wstring_view svHigh;
 
-    while (nIndex < svRange.size() && isspace(svRange.at(nIndex)))
+    while (nIndex < svRange.size() && ra::util::String::IsSpace(svRange.at(nIndex)))
         ++nIndex;
 
     if (nIndex < svRange.size())
@@ -1251,11 +1238,11 @@ static bool ParseRange(std::wstring_view svRange, uint32_t& nLow, uint32_t& nHig
         if (svRange.at(nIndex++) != '-')
             return false;
 
-        while (nIndex < svRange.size() && isspace(svRange.at(nIndex)))
+        while (nIndex < svRange.size() && ra::util::String::IsSpace(svRange.at(nIndex)))
             ++nIndex;
 
         const auto nStart = nIndex;
-        while (nIndex < svRange.size() && IsHexDigit(svRange.at(nIndex)))
+        while (nIndex < svRange.size() && ra::util::String::IsHexDigit(svRange.at(nIndex)))
             ++nIndex;
 
         if (nIndex == nStart)
@@ -1311,11 +1298,11 @@ static std::wstring_view GetValues(const std::wstring_view svLine)
     }
 
     // skip over any leading non-alphanumeric characters
-    if (!isalnum(svLine.at(0)))
+    if (!ra::util::String::IsAlNum(svLine.at(0)))
     {
         for (size_t nScan = 1; nScan < nSplit; ++nScan)
         {
-            if (isalnum(svLine.at(nScan)))
+            if (ra::util::String::IsAlNum(svLine.at(nScan)))
                 return GetValues(svLine.substr(nScan));
         }
 
@@ -1331,7 +1318,7 @@ static std::wstring_view GetValues(const std::wstring_view svLine)
 
     // scan backwards from the splitter to find the first non-alphanumeric non-whitespace character
     auto nIndex = nSplit;
-    while (nIndex > 0 && (isalnum(svLine.at(nIndex - 1)) || isspace(svLine.at(nIndex - 1))))
+    while (nIndex > 0 && (ra::util::String::IsAlNum(svLine.at(nIndex - 1)) || ra::util::String::IsSpace(svLine.at(nIndex - 1))))
         --nIndex;
 
     // if nIndex is 0, we should have matched mapped values earlier. must be invalid. ignore.
@@ -1339,7 +1326,7 @@ static std::wstring_view GetValues(const std::wstring_view svLine)
         return {};
 
     // ignore leading whitespace
-    while (isspace(svLine.at(nIndex)))
+    while (ra::util::String::IsSpace(svLine.at(nIndex)))
         ++nIndex;
 
     // return remainder of line
@@ -1371,7 +1358,7 @@ static std::wstring_view MatchSubNote(std::wstring_view svNote, std::function<bo
                         break;
 
                     nFront = nComma + 1;
-                    while (nFront < svValues.size() && isspace(svValues.at(nFront)))
+                    while (nFront < svValues.size() && ra::util::String::IsSpace(svValues.at(nFront)))
                         ++nFront;
                 } while (nFront < svValues.size());
             }
@@ -1440,7 +1427,7 @@ static bool MatchEnumText(const std::wstring_view svValue, uint32_t nValue, bool
     else if (svValue.at(nSplit) == L'=')
     {
         auto svRight = svValue.substr(nSplit + 1);
-        while (!svRight.empty() && isspace(svRight.at(0)))
+        while (!svRight.empty() && ra::util::String::IsSpace(svRight.at(0)))
             svRight.remove_prefix(1);
 
         if (ParseRange(svRight, nLow, nHigh, isHex))
@@ -1560,13 +1547,13 @@ std::wstring MemoryNoteModel::GetSummary() const
             {
                 // ignore bracket and whitespace between summary and enum values
                 --nIndex;
-                while (nIndex > 0 && isspace(svNote.at(nIndex - 1)))
+                while (nIndex > 0 && ra::util::String::IsSpace(svNote.at(nIndex - 1)))
                     --nIndex;
 
-                if (nIndex > 0 && !isalnum(svNote.at(nIndex - 1)))
+                if (nIndex > 0 && !ra::util::String::IsAlNum(svNote.at(nIndex - 1)))
                 {
                     --nIndex;
-                    while (nIndex > 0 && isspace(svNote.at(nIndex - 1)))
+                    while (nIndex > 0 && ra::util::String::IsSpace(svNote.at(nIndex - 1)))
                         --nIndex;
                 }
             }
@@ -1617,7 +1604,7 @@ static ra::data::Memory::Format GetNumberFormat(std::wstring_view svValue)
         // did not match any digits
         nFormat = ra::data::Memory::Format::Unknown;
     }
-    else if (nIndex < svValue.size() && isalpha(svValue.at(nIndex)))
+    else if (nIndex < svValue.size() && ra::util::String::IsAlpha(svValue.at(nIndex)))
     {
         // trailing alphabetic characters after matching digits
         nFormat = ra::data::Memory::Format::Unknown;

--- a/src/devkit/data/models/MemoryNoteModel.cpp
+++ b/src/devkit/data/models/MemoryNoteModel.cpp
@@ -1565,7 +1565,7 @@ std::wstring MemoryNoteModel::GetSummary() const
     return TrimSize(std::wstring(svNote), false);
 }
 
-static ra::data::Memory::Format GetNumberFormat(std::wstring_view svValue)
+static constexpr ra::data::Memory::Format GetNumberFormat(std::wstring_view svValue)
 {
     auto nFormat = ra::data::Memory::Format::Dec;
 

--- a/src/devkit/data/models/MemoryNotesModel.cpp
+++ b/src/devkit/data/models/MemoryNotesModel.cpp
@@ -88,6 +88,8 @@ void MemoryNotesModel::Refresh(unsigned int nGameId,
             }
         }
 
+        rc_api_destroy_fetch_code_notes_response(&response);
+
         std::map<ra::data::ByteAddress, std::wstring> mPendingNotes;
         {
             std::unique_lock<std::mutex> lock(m_oMutex);

--- a/src/devkit/services/Http.cpp
+++ b/src/devkit/services/Http.cpp
@@ -66,10 +66,10 @@ void Http::UrlEncodeAppend(std::string& sOutput, const std::string& sInput)
     if (sOutput.capacity() < nNeeded)
         sOutput.reserve(nNeeded);
 
-    for (const unsigned char c : sInput)
+    for (const char c : sInput)
     {
         // unreserved characters per RFC3986 (section 2.3)
-        if (isalnum(c) || c == '-' || c == '.' || c == '_' || c == '~')
+        if (ra::util::String::IsAlNum(c) || c == '-' || c == '.' || c == '_' || c == '~')
         {
             sOutput.push_back(c);
         }

--- a/src/devkit/util/StringBuilder.cpp
+++ b/src/devkit/util/StringBuilder.cpp
@@ -278,7 +278,7 @@ std::wstring StringBuilder::Widen(std::string_view str)
         {
             *pOut++ = 0xFFFD;
         }
-        else if (nAccumulator < 0xFFFF)
+        else if (nAccumulator < 0x10000)
         {
             *pOut++ = gsl::narrow_cast<uint16_t>(nAccumulator & 0xFFFF);
         }

--- a/src/devkit/util/StringBuilder.hh
+++ b/src/devkit/util/StringBuilder.hh
@@ -158,7 +158,7 @@ public:
                 oss << arg;
             else
             {
-                if (std::isdigit(ra::to_unsigned(sFormat.front())))
+                if (sFormat.front() >= '0' && sFormat.front() <= '9')
                 {
                     if (sFormat.front() == '0')
                         oss << std::setfill('0');
@@ -305,7 +305,7 @@ public:
                 {
                     const char c = gsl::narrow<char>(*pScan);
                     sFormat.push_back(c);
-                    if (isalpha(to_unsigned(c)))
+                    if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z'))
                         break;
 
                     ++pScan;

--- a/src/devkit/util/Strings.cpp
+++ b/src/devkit/util/Strings.cpp
@@ -22,11 +22,11 @@ std::string& String::TrimLineEnding(std::string& str) noexcept
 _Use_decl_annotations_
 std::wstring& String::Trim(std::wstring& str)
 {
-    while (!str.empty() && iswspace(str.back()))
+    while (!str.empty() && IsSpace(str.back()))
         str.pop_back();
 
     size_t nIndex = 0;
-    while (nIndex < str.length() && iswspace(str.at(nIndex)))
+    while (nIndex < str.length() && IsSpace(str.at(nIndex)))
         ++nIndex;
 
     if (nIndex > 0)

--- a/src/devkit/util/Strings.hh
+++ b/src/devkit/util/Strings.hh
@@ -212,6 +212,58 @@ public:
     /// Encodes a string to Base64.
     /// </summary>
     static std::string EncodeBase64(const std::string& sString);
+
+    /// <summary>
+    /// Determines if a given character is considered whitespace.
+    /// </summary>
+    template<typename CharT, typename = std::enable_if_t<is_char_v<CharT>>>
+    static constexpr bool IsSpace(CharT c)
+    {
+        // 9=tab (\t), 10=newline (\n), 11=vertical tab (\v), 12=form feed (\f), 13=carriage return (\r)
+        return c == ' ' || (c >= 9 && c <= 13);
+    }
+
+    /// <summary>
+    /// Determines if a given character is considered alphabetic.
+    /// </summary>
+    template<typename CharT, typename = std::enable_if_t<is_char_v<CharT>>>
+    static constexpr bool IsAlpha(CharT c)
+    {
+        return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+    }
+
+    /// <summary>
+    /// Determines if a given character is considered alphabetic or numeric.
+    /// </summary>
+    template<typename CharT, typename = std::enable_if_t<is_char_v<CharT>>>
+    static constexpr bool IsAlNum(CharT c)
+    {
+        return IsAlpha(c) || IsDigit(c);
+    }
+
+    /// <summary>
+    /// Determines if a given character is considered numeric.
+    /// </summary>
+    template<typename CharT, typename = std::enable_if_t<is_char_v<CharT>>>
+    static constexpr bool IsDigit(CharT c)
+    {
+        return c >= '0' && c <= '9';
+    }
+
+    /// <summary>
+    /// Determines if a given character is considered a hexadecimal digit.
+    /// </summary>
+    template<typename CharT, typename = std::enable_if_t<is_char_v<CharT>>>
+    static constexpr bool IsHexDigit(CharT c)
+    {
+        if (c >= '0' && c <= '9')
+            return true;
+        if (c >= 'a' && c <= 'f')
+            return true;
+        if (c >= 'A' && c <= 'F')
+            return true;
+        return false;
+    }
 };
 
 } // namespace util

--- a/src/services/AchievementRuntime.cpp
+++ b/src/services/AchievementRuntime.cpp
@@ -2521,6 +2521,8 @@ static bool LoadProgressV2(rc_client_t* pClient, ra::services::TextReader& pFile
         }
     }
 
+    rc_destroy_preparse_state(&pParseState);
+
     return true;
 }
 

--- a/src/services/AchievementRuntimeExports.cpp
+++ b/src/services/AchievementRuntimeExports.cpp
@@ -695,6 +695,7 @@ public:
                 }
 
                 pMenuItem->checked = pItem.IsSelected() ? 1 : 0;
+                ++pMenuItem;
             }
 
             if (!bChanged)

--- a/src/services/impl/WindowsHttpRequester.cpp
+++ b/src/services/impl/WindowsHttpRequester.cpp
@@ -328,7 +328,7 @@ std::string WindowsHttpRequester::GetStatusCodeText(unsigned int nStatusCode) co
             message = ra::util::String::Narrow(szMessageBuffer);
 
             // trim trailing whitespace
-            while (isspace(message.back()))
+            while (ra::util::String::IsSpace(message.back()))
                 message.pop_back();
         }
     }

--- a/src/ui/viewmodels/TriggerSummaryViewModel.cpp
+++ b/src/ui/viewmodels/TriggerSummaryViewModel.cpp
@@ -286,13 +286,9 @@ bool TriggerSummaryViewModel::MergeClauses(
 
 static constexpr bool IsValueCharacter(wchar_t c)
 {
-    if (c >= '0' && c <= '9')
+    if (ra::util::String::IsHexDigit(c))
         return true;
-    if (c >= 'a' && c <= 'f')
-        return true;
-    if (c >= 'A' && c <= 'F')
-        return true;
-    if (isspace(c))
+    if (ra::util::String::IsSpace(c))
         return true;
     if (c == 'h' || c == 'H' || c == 'x' || c == '-')
         return true;

--- a/src/ui/viewmodels/UnknownGameViewModel.cpp
+++ b/src/ui/viewmodels/UnknownGameViewModel.cpp
@@ -99,6 +99,8 @@ void UnknownGameViewModel::InitializeGameTitles(ConsoleID consoleId)
             m_vGameTitles.EndUpdate();
         }
 
+        rc_api_destroy_fetch_games_list_response(&response);
+
         SetValue(FilterResultsProperty, ra::util::String::Printf(L"%u/%u",
             gsl::narrow_cast<uint32_t>(m_vAllGameTitles.size()),
             gsl::narrow_cast<uint32_t>(m_vAllGameTitles.size())));

--- a/src/ui/win32/bindings/ImageBinding.hh
+++ b/src/ui/win32/bindings/ImageBinding.hh
@@ -17,11 +17,16 @@ class ImageBinding : public ControlBinding, protected IImageRepository::NotifyTa
 public:
     explicit ImageBinding(ViewModelBase& vmViewModel) noexcept : ControlBinding(vmViewModel) {}
 
-    ~ImageBinding()
+    ~ImageBinding() noexcept
     {
-        auto& pImageRepository = ra::services::ServiceLocator::GetMutable<ra::ui::IImageRepository>();
+        GSL_SUPPRESS_F6 auto& pImageRepository = ra::services::ServiceLocator::GetMutable<ra::ui::IImageRepository>();
         pImageRepository.RemoveNotifyTarget(*this);
     }
+
+    ImageBinding(const ImageBinding&) noexcept = delete;
+    ImageBinding& operator=(const ImageBinding&) noexcept = delete;
+    ImageBinding(ImageBinding&&) noexcept = delete;
+    ImageBinding& operator=(ImageBinding&&) noexcept = delete;
 
     void SetHWND(DialogBase& pDialog, HWND hControl) override
     {

--- a/src/ui/win32/bindings/ImageBinding.hh
+++ b/src/ui/win32/bindings/ImageBinding.hh
@@ -17,6 +17,12 @@ class ImageBinding : public ControlBinding, protected IImageRepository::NotifyTa
 public:
     explicit ImageBinding(ViewModelBase& vmViewModel) noexcept : ControlBinding(vmViewModel) {}
 
+    ~ImageBinding()
+    {
+        auto& pImageRepository = ra::services::ServiceLocator::GetMutable<ra::ui::IImageRepository>();
+        pImageRepository.RemoveNotifyTarget(*this);
+    }
+
     void SetHWND(DialogBase& pDialog, HWND hControl) override
     {
         ControlBinding::SetHWND(pDialog, hControl);

--- a/src/ui/win32/bindings/MultiLineGridBinding.cpp
+++ b/src/ui/win32/bindings/MultiLineGridBinding.cpp
@@ -306,8 +306,7 @@ void MultiLineGridBinding::UpdateCellContents(const ItemMetrics& pItemMetrics,
             for (auto nIndex : pIter->second)
             {
                 auto nIndex2 = gsl::narrow_cast<size_t>(nIndex) - 1;
-                wchar_t c = 0; // isspace throws a debug assertion if c > 255
-                while (nIndex2 > nStop && (c = sText.at(nIndex2 - 1)) < 255 && isspace(c))
+                while (nIndex2 > nStop && ra::util::String::IsSpace(sText.at(nIndex2 - 1)))
                     --nIndex2;
                 sText.at(nIndex2) = '\0';
 


### PR DESCRIPTION
The c `isX` functions (like `isalpha`) have undefined behavior for unicode characters. `iswX` functions are provided, but the default implementation of those is just to check ranges. Since range checks can be constexpr, and I'm likely to forget about the `iswX` functions, I've added helper functions in `ra::util::String` for the `isX` functions. This eliminates the undefined behavior, and potentially encourages some compiler optimization.

Some missing `rc_api_destroy` function calls were added, which would eliminate memory leaks in some paths.

Ensures an ImageBinding waiting for an image isn't called if the image arrives after the ImageBinding is destroyed.

Fixes a potential issue with the sensitive parameter logging code if the `r=` parameter is not the first parameter in the query params.
