### PR TITLE
Eliminate NewAchievement and NewLeaderboard from GameAssets

### DIFF
--- a/src/devkit/data/models/AchievementModel.cpp
+++ b/src/devkit/data/models/AchievementModel.cpp
@@ -148,7 +148,7 @@ void AchievementModel::CommitTransaction()
 bool AchievementModel::IsShownInList() const
 {
     // don't show warning achievements in asset list
-    if (GetID() > 101000000 && GetCategory() == AssetCategory::Core)
+    if (GetID() >= FirstWarningAchievementId && GetCategory() == AssetCategory::Core)
         return false;
 
     return true;

--- a/src/devkit/data/models/AchievementModel.hh
+++ b/src/devkit/data/models/AchievementModel.hh
@@ -193,6 +193,11 @@ public:
     /// </summary>
     static constexpr size_t MaxSerializedLength = 65535;
 
+    /// <summary>
+    /// Gets the unique ientifier of the first warning achievement.
+    /// </summary>
+    static constexpr uint32_t FirstWarningAchievementId = 101000001;
+
 protected:
     void OnValueChanged(const IntModelProperty::ChangeArgs& args) override;
     void OnValueChanged(const StringModelProperty::ChangeArgs& args) override;

--- a/src/devkit/data/models/GameAssets.cpp
+++ b/src/devkit/data/models/GameAssets.cpp
@@ -46,18 +46,6 @@ const ra::data::models::AssetModelBase* GameAssets::FindAsset(ra::data::models::
     return nullptr;
 }
 
-ra::data::models::AchievementModel& GameAssets::NewAchievement()
-{
-    auto vmAchievement = std::make_unique<ra::data::models::AchievementModel>();
-    vmAchievement->SetID(m_nNextLocalId++);
-    vmAchievement->SetPoints(0);
-    vmAchievement->SetNew();
-    vmAchievement->CreateServerCheckpoint();
-    vmAchievement->CreateLocalCheckpoint();
-
-    return dynamic_cast<ra::data::models::AchievementModel&>(AddItem(std::move(vmAchievement)));
-}
-
 ra::data::models::AssetCategory GameAssets::MostPublishedAssetCategory() const
 {
     bool bHasLocalAssets = false;

--- a/src/devkit/data/models/GameAssets.cpp
+++ b/src/devkit/data/models/GameAssets.cpp
@@ -58,17 +58,6 @@ ra::data::models::AchievementModel& GameAssets::NewAchievement()
     return dynamic_cast<ra::data::models::AchievementModel&>(AddItem(std::move(vmAchievement)));
 }
 
-ra::data::models::LeaderboardModel& GameAssets::NewLeaderboard()
-{
-    auto vmLeaderboard = std::make_unique<ra::data::models::LeaderboardModel>();
-    vmLeaderboard->SetID(m_nNextLocalId++);
-    vmLeaderboard->SetNew();
-    vmLeaderboard->CreateServerCheckpoint();
-    vmLeaderboard->CreateLocalCheckpoint();
-
-    return dynamic_cast<ra::data::models::LeaderboardModel&>(AddItem(std::move(vmLeaderboard)));
-}
-
 ra::data::models::AssetCategory GameAssets::MostPublishedAssetCategory() const
 {
     bool bHasLocalAssets = false;

--- a/src/devkit/data/models/GameAssets.hh
+++ b/src/devkit/data/models/GameAssets.hh
@@ -57,11 +57,6 @@ public:
     }
 
     /// <summary>
-    /// Creates a new achievement asset.
-    /// </summary>
-    ra::data::models::AchievementModel& NewAchievement();
-
-    /// <summary>
     /// Finds the leaderboard asset for the specified ID.
     /// </summary>
     ra::data::models::LeaderboardModel* FindLeaderboard(uint32_t nId)

--- a/src/devkit/data/models/GameAssets.hh
+++ b/src/devkit/data/models/GameAssets.hh
@@ -78,11 +78,6 @@ public:
     }
 
     /// <summary>
-    /// Creates a new leaderboard asset.
-    /// </summary>
-    ra::data::models::LeaderboardModel& NewLeaderboard();
-
-    /// <summary>
     /// Finds the rich presence asset.
     /// </summary>
     ra::data::models::RichPresenceModel* FindRichPresence()

--- a/src/ui/viewmodels/AssetListViewModel.cpp
+++ b/src/ui/viewmodels/AssetListViewModel.cpp
@@ -1933,22 +1933,26 @@ void AssetListViewModel::CloneSelected()
         const auto* pSourceAchievement = dynamic_cast<const ra::data::models::AchievementModel*>(pAsset);
         if (pSourceAchievement != nullptr)
         {
-            auto& vmAchievement = pGameContext.Assets().NewAchievement();
-            vmAchievement.SetSubsetID(pSourceAchievement->GetSubsetID());
-            vmAchievement.SetCategory(ra::data::models::AssetCategory::Local);
-            vmAchievement.SetAuthor(pAuthor);
-            vmAchievement.UpdateServerCheckpoint();
+            auto pAchievement = std::make_unique<ra::data::models::AchievementModel>();
+            pAchievement->SetID(pGameContext.Assets().GetNextLocalId());
+            pAchievement->SetSubsetID(pSourceAchievement->GetSubsetID());
+            pAchievement->SetCategory(ra::data::models::AssetCategory::Local);
+            pAchievement->SetAuthor(pAuthor);
+            pAchievement->CreateServerCheckpoint();
+            pAchievement->CreateLocalCheckpoint();
 
-            vmAchievement.SetName(pSourceAchievement->GetTitle() + L" (copy)");
-            vmAchievement.SetDescription(pSourceAchievement->GetDescription());
-            vmAchievement.SetBadge(pSourceAchievement->GetBadge());
-            vmAchievement.SetPoints(pSourceAchievement->GetPoints());
-            vmAchievement.SetTrigger(pSourceAchievement->GetTrigger());
-            vmAchievement.SetAchievementType(pSourceAchievement->GetAchievementType());
-            vmAchievement.SetNew();
+            pAchievement->SetName(pSourceAchievement->GetTitle() + L" (copy)");
+            pAchievement->SetDescription(pSourceAchievement->GetDescription());
+            pAchievement->SetBadge(pSourceAchievement->GetBadge());
+            pAchievement->SetPoints(pSourceAchievement->GetPoints());
+            pAchievement->SetTrigger(pSourceAchievement->GetTrigger());
+            pAchievement->SetAchievementType(pSourceAchievement->GetAchievementType());
+            pAchievement->SetNew();
 
+            pAchievement->Validate(); // force re-validation now that everything is set
+
+            const auto& vmAchievement = dynamic_cast<ra::data::models::AchievementModel&>(pGameContext.Assets().Append(std::move(pAchievement)));
             EnsureAppearsInFilteredList(vmAchievement);
-
             vNewIDs.push_back(vmAchievement.GetID());
         }
 
@@ -1961,6 +1965,7 @@ void AssetListViewModel::CloneSelected()
             pLeaderboard->SetCategory(ra::data::models::AssetCategory::Local);
             pLeaderboard->SetAuthor(pAuthor);
             pLeaderboard->CreateServerCheckpoint();
+            pLeaderboard->CreateLocalCheckpoint();
 
             pLeaderboard->SetName(pSourceLeaderboard->GetTitle() + L" (copy)");
             pLeaderboard->SetDescription(pSourceLeaderboard->GetDescription());
@@ -1970,10 +1975,11 @@ void AssetListViewModel::CloneSelected()
             pLeaderboard->SetValueDefinition(pSourceLeaderboard->GetValueDefinition());
             pLeaderboard->SetValueFormat(pSourceLeaderboard->GetValueFormat());
             pLeaderboard->SetLowerIsBetter(pSourceLeaderboard->IsLowerBetter());
-            pLeaderboard->CreateLocalCheckpoint();
             pLeaderboard->SetNew();
 
-            auto& vmLeaderboard = dynamic_cast<ra::data::models::LeaderboardModel&>(pGameContext.Assets().Append(std::move(pLeaderboard)));
+            pLeaderboard->Validate(); // force re-validation now that everything is set
+
+            const auto& vmLeaderboard = dynamic_cast<ra::data::models::LeaderboardModel&>(pGameContext.Assets().Append(std::move(pLeaderboard)));
             EnsureAppearsInFilteredList(vmLeaderboard);
             vNewIDs.push_back(vmLeaderboard.GetID());
         }

--- a/src/ui/viewmodels/AssetListViewModel.cpp
+++ b/src/ui/viewmodels/AssetListViewModel.cpp
@@ -1955,24 +1955,26 @@ void AssetListViewModel::CloneSelected()
         const auto* pSourceLeaderboard = dynamic_cast<const ra::data::models::LeaderboardModel*>(pAsset);
         if (pSourceLeaderboard != nullptr)
         {
-            auto& vmLeaderboard = pGameContext.Assets().NewLeaderboard();
-            vmLeaderboard.SetSubsetID(pSourceLeaderboard->GetSubsetID());
-            vmLeaderboard.SetCategory(ra::data::models::AssetCategory::Local);
-            vmLeaderboard.SetAuthor(pAuthor);
-            vmLeaderboard.UpdateServerCheckpoint();
+            auto pLeaderboard = std::make_unique<ra::data::models::LeaderboardModel>();
+            pLeaderboard->SetID(pGameContext.Assets().GetNextLocalId());
+            pLeaderboard->SetSubsetID(pSourceLeaderboard->GetSubsetID());
+            pLeaderboard->SetCategory(ra::data::models::AssetCategory::Local);
+            pLeaderboard->SetAuthor(pAuthor);
+            pLeaderboard->CreateServerCheckpoint();
 
-            vmLeaderboard.SetName(pSourceLeaderboard->GetTitle() + L" (copy)");
-            vmLeaderboard.SetDescription(pSourceLeaderboard->GetDescription());
-            vmLeaderboard.SetStartTrigger(pSourceLeaderboard->GetStartTrigger());
-            vmLeaderboard.SetSubmitTrigger(pSourceLeaderboard->GetSubmitTrigger());
-            vmLeaderboard.SetCancelTrigger(pSourceLeaderboard->GetCancelTrigger());
-            vmLeaderboard.SetValueDefinition(pSourceLeaderboard->GetValueDefinition());
-            vmLeaderboard.SetValueFormat(pSourceLeaderboard->GetValueFormat());
-            vmLeaderboard.SetLowerIsBetter(pSourceLeaderboard->IsLowerBetter());
-            vmLeaderboard.SetNew();
+            pLeaderboard->SetName(pSourceLeaderboard->GetTitle() + L" (copy)");
+            pLeaderboard->SetDescription(pSourceLeaderboard->GetDescription());
+            pLeaderboard->SetStartTrigger(pSourceLeaderboard->GetStartTrigger());
+            pLeaderboard->SetSubmitTrigger(pSourceLeaderboard->GetSubmitTrigger());
+            pLeaderboard->SetCancelTrigger(pSourceLeaderboard->GetCancelTrigger());
+            pLeaderboard->SetValueDefinition(pSourceLeaderboard->GetValueDefinition());
+            pLeaderboard->SetValueFormat(pSourceLeaderboard->GetValueFormat());
+            pLeaderboard->SetLowerIsBetter(pSourceLeaderboard->IsLowerBetter());
+            pLeaderboard->CreateLocalCheckpoint();
+            pLeaderboard->SetNew();
 
+            auto& vmLeaderboard = dynamic_cast<ra::data::models::LeaderboardModel&>(pGameContext.Assets().Append(std::move(pLeaderboard)));
             EnsureAppearsInFilteredList(vmLeaderboard);
-
             vNewIDs.push_back(vmLeaderboard.GetID());
         }
     }

--- a/tests/Exports_Tests.cpp
+++ b/tests/Exports_Tests.cpp
@@ -441,17 +441,6 @@ private:
         MockWindowManager mockWindowManager;
         MockClock mockClock;
 
-        ra::data::models::AchievementModel& MockAchievement(unsigned int nId)
-        {
-            auto& pAch = mockGameContext.Assets().NewAchievement();
-            pAch.SetCategory(ra::data::models::AssetCategory::Core);
-            pAch.SetID(nId);
-            pAch.SetTrigger("1=1");
-            pAch.UpdateServerCheckpoint();
-            pAch.SetState(ra::data::models::AssetState::Active);
-            return pAch;
-        }
-
     private:
         MockThreadPool mockThreadPool;
         MockServer mockServer;

--- a/tests/data/context/EmulatorContext_Tests.cpp
+++ b/tests/data/context/EmulatorContext_Tests.cpp
@@ -76,20 +76,6 @@ private:
             MockVersions(sClientVersion, sServerVersion, sServerVersion);
         }
 
-        ra::data::models::AchievementModel& MockAchievement()
-        {
-            auto& pAch = mockGameContext.Assets().NewAchievement();
-            pAch.SetCategory(ra::data::models::AssetCategory::Core);
-            pAch.SetID(1U);
-            pAch.SetName(L"AchievementTitle");
-            pAch.SetDescription(L"AchievementDescription");
-            pAch.SetBadge(L"12345");
-            pAch.SetPoints(5);
-            pAch.SetState(ra::data::models::AssetState::Active);
-            pAch.UpdateServerCheckpoint();
-            return pAch;
-        }
-
     private:
         ra::services::ServiceLocator::ServiceOverride<EmulatorContext> m_Override;
     };

--- a/tests/data/context/GameContext_Tests.cpp
+++ b/tests/data/context/GameContext_Tests.cpp
@@ -33,6 +33,7 @@
 #include "tests\mocks\MockConfiguration.hh"
 #include "tests\mocks\MockDesktop.hh"
 #include "tests\mocks\MockFrameEventQueue.hh"
+#include "tests\mocks\MockGameContext.hh"
 #include "tests\mocks\MockOverlayManager.hh"
 #include "tests\mocks\MockServer.hh"
 #include "tests\mocks\MockSessionTracker.hh"
@@ -122,27 +123,12 @@ public:
 
         ra::data::models::AchievementModel& MockAchievement()
         {
-            auto& pAch = Assets().NewAchievement();
-            pAch.SetCategory(ra::data::models::AssetCategory::Core);
-            pAch.SetID(1U);
-            pAch.SetName(L"AchievementTitle");
-            pAch.SetDescription(L"AchievementDescription");
-            pAch.SetBadge(L"12345");
-            pAch.SetPoints(5);
-            pAch.SetState(ra::data::models::AssetState::Active);
-            pAch.UpdateServerCheckpoint();
-            return pAch;
+            return ra::data::context::mocks::MockGameContext::MockAchievement(Assets(), ra::data::models::AssetCategory::Core);
         }
 
         ra::data::models::LeaderboardModel& MockLeaderboard()
         {
-            auto vmLeaderboard = std::make_unique<ra::data::models::LeaderboardModel>();
-            vmLeaderboard->SetID(1U);
-            vmLeaderboard->SetName(L"LeaderboardTitle");
-            vmLeaderboard->SetDescription(L"LeaderboardDescription");
-            vmLeaderboard->CreateServerCheckpoint();
-            vmLeaderboard->CreateLocalCheckpoint();
-            return dynamic_cast<ra::data::models::LeaderboardModel&>(Assets().Append(std::move(vmLeaderboard)));
+            return ra::data::context::mocks::MockGameContext::MockLeaderboard(Assets(), ra::data::models::AssetCategory::Core);
         }
 
         void RemoveNonAchievementAssets()
@@ -922,7 +908,7 @@ public:
 
         // new achievement should be allocated an ID higher than the largest existing local
         // ID, even if intermediate values are available
-        const auto& pAch2 = game.Assets().NewAchievement();
+        const auto& pAch2 = ra::data::context::mocks::MockGameContext::MockAchievement(game.Assets(), ra::data::models::AssetCategory::Local);
         Assert::AreEqual(999000004U, pAch2.GetID());
     }
 

--- a/tests/data/context/GameContext_Tests.cpp
+++ b/tests/data/context/GameContext_Tests.cpp
@@ -136,12 +136,13 @@ public:
 
         ra::data::models::LeaderboardModel& MockLeaderboard()
         {
-            auto& pLeaderboard = Assets().NewLeaderboard();
-            pLeaderboard.SetID(1U);
-            pLeaderboard.SetName(L"LeaderboardTitle");
-            pLeaderboard.SetDescription(L"LeaderboardDescription");
-            pLeaderboard.UpdateServerCheckpoint();
-            return pLeaderboard;
+            auto vmLeaderboard = std::make_unique<ra::data::models::LeaderboardModel>();
+            vmLeaderboard->SetID(1U);
+            vmLeaderboard->SetName(L"LeaderboardTitle");
+            vmLeaderboard->SetDescription(L"LeaderboardDescription");
+            vmLeaderboard->CreateServerCheckpoint();
+            vmLeaderboard->CreateLocalCheckpoint();
+            return dynamic_cast<ra::data::models::LeaderboardModel&>(Assets().Append(std::move(vmLeaderboard)));
         }
 
         void RemoveNonAchievementAssets()

--- a/tests/devkit/data/models/GameAssets_Tests.cpp
+++ b/tests/devkit/data/models/GameAssets_Tests.cpp
@@ -72,29 +72,35 @@ public:
         ra::data::models::AchievementModel& AddAchievement(AssetCategory nCategory, unsigned nPoints, const std::wstring& sTitle,
             const std::wstring& sDescription, const std::wstring& sBadge, const std::string& sTrigger)
         {
-            auto& pAchievement = NewAchievement();
-            pAchievement.SetCategory(nCategory);
-            pAchievement.SetPoints(nPoints);
-            pAchievement.SetName(sTitle);
-            pAchievement.SetDescription(sDescription);
-            pAchievement.SetBadge(sBadge);
-            pAchievement.SetTrigger(sTrigger);
-
-            std::wstring sAuthor = L"Auth";
-            sAuthor.push_back(sBadge.front());
-            pAchievement.SetAuthor(sAuthor);
+            auto vmAchievement = std::make_unique<ra::data::models::AchievementModel>();
 
             if (nCategory == AssetCategory::Local)
             {
-                pAchievement.UpdateLocalCheckpoint();
+                vmAchievement->CreateServerCheckpoint();
+                vmAchievement->SetID(m_nNextLocalId++);
             }
             else
             {
-                pAchievement.SetID(gsl::narrow_cast<uint32_t>(Count()));
-                pAchievement.UpdateServerCheckpoint();
+                vmAchievement->SetID(gsl::narrow_cast<uint32_t>(Count() + 1));
             }
 
-            return pAchievement;
+            vmAchievement->SetCategory(nCategory);
+            vmAchievement->SetPoints(nPoints);
+            vmAchievement->SetName(sTitle);
+            vmAchievement->SetDescription(sDescription);
+            vmAchievement->SetBadge(sBadge);
+            vmAchievement->SetTrigger(sTrigger);
+
+            std::wstring sAuthor = L"Auth";
+            sAuthor.push_back(sBadge.front());
+            vmAchievement->SetAuthor(sAuthor);
+
+            if (nCategory != AssetCategory::Local)
+                vmAchievement->CreateServerCheckpoint();
+
+            vmAchievement->CreateLocalCheckpoint();
+
+            return dynamic_cast<ra::data::models::AchievementModel&>(Append(std::move(vmAchievement)));
         }
 
         ra::data::models::AchievementModel& AddAchievement()
@@ -205,12 +211,12 @@ public:
     {
         GameAssetsHarness gameAssets;
         gameAssets.AddAchievement(AssetCategory::Core, 5, L"Ach1", L"Desc1", L"11111", "1=1");
-        gameAssets.AddAchievement(AssetCategory::Local, 5, L"Ach2", L"Desc2", L"22222", "2=2");
+        const auto& vmAchievement = gameAssets.AddAchievement(AssetCategory::Local, 5, L"Ach2", L"Desc2", L"22222", "2=2");
         gameAssets.AddAchievement(AssetCategory::Unofficial, 5, L"Ach3", L"Desc3", L"33333", "3=3");
 
         gameAssets.SaveAllAssets();
 
-        const auto& sExpected = ra::util::String::Printf("0.0.0.0\nGame Title\n%u:\"2=2\":Ach2:Desc2::::Auth2:5:::::22222\n", GameAssets::FirstLocalId + 1);
+        const auto& sExpected = ra::util::String::Printf("0.0.0.0\nGame Title\n%u:\"2=2\":Ach2:Desc2::::Auth2:5:::::22222\n", vmAchievement.GetID());
         Assert::AreEqual(sExpected, gameAssets.GetUserFile());
     }
 
@@ -746,11 +752,11 @@ public:
     {
         GameAssetsHarness gameAssets;
         gameAssets.AddLeaderboard(AssetCategory::Core, L"LB1", L"Desc1", "0xH1234=1", "0xH1234=2", "0xH1234=3", "M:0xH1235", Value::Format::Seconds);
-        gameAssets.AddLeaderboard(AssetCategory::Local, L"LB2", L"Desc2", "0xH2234=1", "0xH2234=2", "0xH2234=3", "M:0xH2235", Value::Format::Minutes);
+        const auto& vmLeaderboard2 = gameAssets.AddLeaderboard(AssetCategory::Local, L"LB2", L"Desc2", "0xH2234=1", "0xH2234=2", "0xH2234=3", "M:0xH2235", Value::Format::Minutes);
 
         gameAssets.SaveAllAssets();
 
-        const auto& sExpected = ra::util::String::Printf("0.0.0.0\nGame Title\nL%u:\"0xH2234=1\":\"0xH2234=2\":\"0xH2234=3\":\"M:0xH2235\":MINUTES:LB2:Desc2:0\n", GameAssets::FirstLocalId + 1);
+        const auto& sExpected = ra::util::String::Printf("0.0.0.0\nGame Title\nL%u:\"0xH2234=1\":\"0xH2234=2\":\"0xH2234=3\":\"M:0xH2235\":MINUTES:LB2:Desc2:0\n", vmLeaderboard2.GetID());
         Assert::AreEqual(sExpected, gameAssets.GetUserFile());
     }
 

--- a/tests/devkit/data/models/GameAssets_Tests.cpp
+++ b/tests/devkit/data/models/GameAssets_Tests.cpp
@@ -122,27 +122,33 @@ public:
             const std::wstring& sTitle, const std::wstring& sDescription, const std::string& sStart,
             const std::string& sCancel, const std::string& sSubmit, const std::string& sValue, Value::Format nFormat)
         {
-            auto& pLeaderboard = NewLeaderboard();
-            pLeaderboard.SetCategory(nCategory);
-            pLeaderboard.SetName(sTitle);
-            pLeaderboard.SetDescription(sDescription);
-            pLeaderboard.SetStartTrigger(sStart);
-            pLeaderboard.SetSubmitTrigger(sSubmit);
-            pLeaderboard.SetCancelTrigger(sCancel);
-            pLeaderboard.SetValueDefinition(sValue);
-            pLeaderboard.SetValueFormat(nFormat);
+            auto vmLeaderboard = std::make_unique<ra::data::models::LeaderboardModel>();
 
             if (nCategory == AssetCategory::Local)
             {
-                pLeaderboard.UpdateLocalCheckpoint();
+                vmLeaderboard->CreateServerCheckpoint();
+                vmLeaderboard->SetID(m_nNextLocalId++);
             }
             else
             {
-                pLeaderboard.SetID(gsl::narrow_cast<uint32_t>(Count()));
-                pLeaderboard.UpdateServerCheckpoint();
+                vmLeaderboard->SetID(gsl::narrow_cast<uint32_t>(Count()));
             }
 
-            return pLeaderboard;
+            vmLeaderboard->SetCategory(nCategory);
+            vmLeaderboard->SetName(sTitle);
+            vmLeaderboard->SetDescription(sDescription);
+            vmLeaderboard->SetStartTrigger(sStart);
+            vmLeaderboard->SetSubmitTrigger(sSubmit);
+            vmLeaderboard->SetCancelTrigger(sCancel);
+            vmLeaderboard->SetValueDefinition(sValue);
+            vmLeaderboard->SetValueFormat(nFormat);
+
+            if (nCategory != AssetCategory::Local)
+                vmLeaderboard->CreateServerCheckpoint();
+
+            vmLeaderboard->CreateLocalCheckpoint();
+
+            return dynamic_cast<ra::data::models::LeaderboardModel&>(Append(std::move(vmLeaderboard)));
         }
 
         void MockUserFile(const std::string& sContents)

--- a/tests/mocks/MockGameContext.hh
+++ b/tests/mocks/MockGameContext.hh
@@ -39,7 +39,7 @@ public:
         m_nGameId = m_nActiveGameId = nGameId;
 
         // MockRuntime may have populated an AchievementSet. Update it too
-        auto* pPrimarySet = const_cast<ra::data::models::AchievementSetModel*>(Assets().AchievementSets().GetItemAt(0));
+        GSL_SUPPRESS_TYPE3 auto* pPrimarySet = const_cast<ra::data::models::AchievementSetModel*>(Assets().AchievementSets().GetItemAt(0));
         if (pPrimarySet)
         {
             pPrimarySet->SetID(nGameId);
@@ -150,6 +150,91 @@ public:
 
     GSL_SUPPRESS_C128
     void InitializeFromAchievementRuntime();
+
+    static ra::data::models::AchievementModel& MockAchievement(ra::data::models::GameAssets& pAssets, ra::data::models::AssetCategory nCategory)
+    {
+        auto vmAchievement = std::make_unique<ra::data::models::AchievementModel>();
+
+        if (nCategory == ra::data::models::AssetCategory::Local)
+        {
+            vmAchievement->CreateServerCheckpoint();
+            vmAchievement->SetID(pAssets.GetNextLocalId());
+        }
+        else
+        {
+            vmAchievement->SetID(gsl::narrow_cast<uint32_t>(pAssets.Count() + 1));
+        }
+
+        vmAchievement->SetCategory(nCategory);
+        vmAchievement->SetName(L"AchievementTitle");
+        vmAchievement->SetDescription(L"AchievementDescription");
+        vmAchievement->SetBadge(L"12345");
+        vmAchievement->SetPoints(5);
+        vmAchievement->SetState(ra::data::models::AssetState::Active);
+        vmAchievement->SetTrigger("1=1");
+
+        if (nCategory != ra::data::models::AssetCategory::Local)
+            vmAchievement->CreateServerCheckpoint();
+
+        vmAchievement->CreateLocalCheckpoint();
+        return dynamic_cast<ra::data::models::AchievementModel&>(pAssets.Append(std::move(vmAchievement)));
+    }
+
+    /// <summary>
+    /// Creates a new AchievementModel for a promoted achievement.
+    /// </summary>
+    ra::data::models::AchievementModel& MockAchievement()
+    {
+        return MockAchievement(Assets(), ra::data::models::AssetCategory::Core);
+    }
+
+    /// <summary>
+    /// Creates a new AchievementModel for an unpromoted achievement.
+    /// </summary>
+    ra::data::models::AchievementModel& MockUnofficialAchievement()
+    {
+        return MockAchievement(Assets(), ra::data::models::AssetCategory::Unofficial);
+    }
+
+    /// <summary>
+    /// Creates a new AchievementModel for a promoted achievement.
+    /// </summary>
+    ra::data::models::AchievementModel& MockLocalAchievement()
+    {
+        return MockAchievement(Assets(), ra::data::models::AssetCategory::Local);
+    }
+
+    static ra::data::models::LeaderboardModel& MockLeaderboard(ra::data::models::GameAssets& pAssets, ra::data::models::AssetCategory nCategory)
+    {
+        auto vmLeaderboard = std::make_unique<ra::data::models::AchievementModel>();
+
+        if (nCategory == ra::data::models::AssetCategory::Local)
+        {
+            vmLeaderboard->CreateServerCheckpoint();
+            vmLeaderboard->SetID(pAssets.GetNextLocalId());
+        }
+        else
+        {
+            vmLeaderboard->SetID(gsl::narrow_cast<uint32_t>(pAssets.Count() + 1));
+        }
+
+        vmLeaderboard->SetName(L"LeaderboardTitle");
+        vmLeaderboard->SetDescription(L"LeaderboardDescription");
+
+        if (nCategory != ra::data::models::AssetCategory::Local)
+            vmLeaderboard->CreateServerCheckpoint();
+
+        vmLeaderboard->CreateLocalCheckpoint();
+        return dynamic_cast<ra::data::models::LeaderboardModel&>(pAssets.Append(std::move(vmLeaderboard)));
+    }
+
+    /// <summary>
+    /// Creates a new AchievementModel for a promoted achievement.
+    /// </summary>
+    ra::data::models::LeaderboardModel& MockLeaderboard()
+    {
+        return MockLeaderboard(Assets(), ra::data::models::AssetCategory::Core);
+    }
 
 private:
     class MockMemoryNotesModel : public ra::data::models::MemoryNotesModel

--- a/tests/services/AchievementRuntime_Tests.cpp
+++ b/tests/services/AchievementRuntime_Tests.cpp
@@ -3312,7 +3312,7 @@ public:
     TEST_METHOD(TestRichPresenceOverrideInspectingMemoryCompatibilityMode)
     {
         AchievementRuntimeHarness runtime;
-        runtime.mockGameContext.Assets().NewAchievement().SetCategory(ra::data::models::AssetCategory::Core);
+        runtime.mockGameContext.MockAchievement();
         runtime.mockGameContext.SetMode(ra::data::context::GameContext::Mode::CompatibilityTest);
         runtime.MockInspectingMemory(true);
         Assert::AreEqual(std::string("Testing Compatibility"), runtime.GetRichPresenceOverride());
@@ -3338,7 +3338,7 @@ public:
     {
         AchievementRuntimeHarness runtime;
         runtime.MockInspectingMemory(true);
-        runtime.mockGameContext.Assets().NewAchievement().SetCategory(ra::data::models::AssetCategory::Core);
+        runtime.mockGameContext.MockAchievement();
         runtime.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, true);
         Assert::AreEqual(std::string("Inspecting Memory in Hardcore mode"), runtime.GetRichPresenceOverride());
     }
@@ -3347,8 +3347,7 @@ public:
     {
         AchievementRuntimeHarness runtime;
         runtime.MockInspectingMemory(true);
-        auto& pAch = runtime.mockGameContext.Assets().NewAchievement();
-        pAch.SetCategory(ra::data::models::AssetCategory::Core);
+        auto& pAch = runtime.mockGameContext.MockAchievement();
         pAch.SetName(L"Modified");
         Assert::AreEqual(pAch.GetChanges(), ra::data::models::AssetChanges::Modified);
         runtime.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, true);
@@ -3359,9 +3358,7 @@ public:
     {
         AchievementRuntimeHarness runtime;
         runtime.MockInspectingMemory(true);
-        auto& pAch = runtime.mockGameContext.Assets().NewAchievement();
-        pAch.SetCategory(ra::data::models::AssetCategory::Core);
-        pAch.UpdateServerCheckpoint();
+        auto& pAch = runtime.mockGameContext.MockAchievement();
         Assert::AreEqual(pAch.GetChanges(), ra::data::models::AssetChanges::None);
         runtime.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, false);
         Assert::AreEqual(std::string("Inspecting Memory"), runtime.GetRichPresenceOverride());
@@ -3371,9 +3368,7 @@ public:
     {
         AchievementRuntimeHarness runtime;
         runtime.MockInspectingMemory(true);
-        auto& pAch = runtime.mockGameContext.Assets().NewAchievement();
-        pAch.SetCategory(ra::data::models::AssetCategory::Core);
-        pAch.SetID(1);
+        auto& pAch = runtime.mockGameContext.MockAchievement();
         pAch.SetName(L"Modified");
         Assert::AreEqual(pAch.GetChanges(), ra::data::models::AssetChanges::Modified);
         runtime.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, false);
@@ -3384,9 +3379,7 @@ public:
     {
         AchievementRuntimeHarness runtime;
         runtime.MockInspectingMemory(true);
-        auto& pAch = runtime.mockGameContext.Assets().NewAchievement();
-        pAch.SetCategory(ra::data::models::AssetCategory::Core);
-        pAch.SetID(1);
+        auto& pAch = runtime.mockGameContext.MockAchievement();
         pAch.SetName(L"Modified");
         pAch.UpdateLocalCheckpoint();
         Assert::AreEqual(pAch.GetChanges(), ra::data::models::AssetChanges::Unpublished);
@@ -3398,10 +3391,7 @@ public:
     {
         AchievementRuntimeHarness runtime;
         runtime.MockInspectingMemory(true);
-        auto& pAch = runtime.mockGameContext.Assets().NewAchievement();
-        pAch.SetCategory(ra::data::models::AssetCategory::Unofficial);
-        pAch.SetID(1);
-        pAch.UpdateServerCheckpoint();
+        auto& pAch = runtime.mockGameContext.MockUnofficialAchievement();
         Assert::AreEqual(pAch.GetChanges(), ra::data::models::AssetChanges::None);
         runtime.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, false);
         Assert::AreEqual(std::string("Inspecting Memory"), runtime.GetRichPresenceOverride());
@@ -3411,9 +3401,7 @@ public:
     {
         AchievementRuntimeHarness runtime;
         runtime.MockInspectingMemory(true);
-        auto& pAch = runtime.mockGameContext.Assets().NewAchievement();
-        pAch.SetCategory(ra::data::models::AssetCategory::Unofficial);
-        pAch.SetID(1);
+        auto& pAch = runtime.mockGameContext.MockUnofficialAchievement();
         pAch.SetName(L"Modified");
         Assert::AreEqual(pAch.GetChanges(), ra::data::models::AssetChanges::Modified);
         runtime.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, false);
@@ -3424,7 +3412,7 @@ public:
     {
         AchievementRuntimeHarness runtime;
         runtime.MockInspectingMemory(true);
-        runtime.mockGameContext.Assets().NewAchievement().SetCategory(ra::data::models::AssetCategory::Local);
+        runtime.mockGameContext.MockLocalAchievement();
         runtime.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, false);
         Assert::AreEqual(std::string("Developing Achievements"), runtime.GetRichPresenceOverride());
     }
@@ -3433,10 +3421,8 @@ public:
     {
         AchievementRuntimeHarness runtime;
         runtime.MockInspectingMemory(true);
-        runtime.mockGameContext.Assets().NewAchievement().SetCategory(ra::data::models::AssetCategory::Local);
-        auto& pAch = runtime.mockGameContext.Assets().NewAchievement();
-        pAch.SetCategory(ra::data::models::AssetCategory::Core);
-        pAch.UpdateServerCheckpoint();
+        runtime.mockGameContext.MockLocalAchievement();
+        auto& pAch = runtime.mockGameContext.MockAchievement();
         Assert::AreEqual(pAch.GetChanges(), ra::data::models::AssetChanges::None);
         runtime.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, false);
         Assert::AreEqual(std::string("Developing Achievements"), runtime.GetRichPresenceOverride());
@@ -3446,9 +3432,8 @@ public:
     {
         AchievementRuntimeHarness runtime;
         runtime.MockInspectingMemory(true);
-        runtime.mockGameContext.Assets().NewAchievement().SetCategory(ra::data::models::AssetCategory::Local);
-        auto& pAch = runtime.mockGameContext.Assets().NewAchievement();
-        pAch.SetCategory(ra::data::models::AssetCategory::Core);
+        runtime.mockGameContext.MockLocalAchievement();;
+        auto& pAch = runtime.mockGameContext.MockAchievement();
         pAch.SetName(L"Modified");
         Assert::AreEqual(pAch.GetChanges(), ra::data::models::AssetChanges::Modified);
         runtime.mockConfiguration.SetFeatureEnabled(ra::services::Feature::Hardcore, false);

--- a/tests/ui/viewmodels/AssetListViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/AssetListViewModel_Tests.cpp
@@ -505,7 +505,7 @@ private:
             AddAchievement(AssetCategory::Core, 15, L"Ach3");
         }
 
-        void AddLeaderboard(AssetCategory nCategory, const std::wstring& sTitle)
+        ra::data::models::LeaderboardModel& AddLeaderboard(AssetCategory nCategory, const std::wstring& sTitle)
         {
             auto vmLeaderboard = std::make_unique<ra::data::models::LeaderboardModel>();
             vmLeaderboard->SetID(gsl::narrow_cast<unsigned int>(mockGameContext.Assets().Count() + 1));
@@ -514,9 +514,11 @@ private:
             vmLeaderboard->CreateServerCheckpoint();
             vmLeaderboard->CreateLocalCheckpoint();
             vmLeaderboard->SetSubsetID(mockGameContext.ActiveGameId());
-            mockGameContext.Assets().Append(std::move(vmLeaderboard));
+            auto& vmAsset = mockGameContext.Assets().Append(std::move(vmLeaderboard));
 
             EnsureCoreSubset();
+
+            return dynamic_cast<ra::data::models::LeaderboardModel&>(vmAsset);
         }
 
         void AddLeaderboard()
@@ -4472,22 +4474,21 @@ public:
         vmAssetList.mockUserContext.Initialize("Username", "DisplayName", "ApiToken");
         vmAssetList.SetGameId(22U);
         vmAssetList.mockGameContext.SetActiveGameId(22U);
+        vmAssetList.mockGameContext.SetNote(0x1234, L"First note");
+        vmAssetList.mockGameContext.SetNote(0x5555, L"Second note");
         vmAssetList.SetSubsetFilter(22U);
         vmAssetList.SetAssetTypeFilter(ra::data::models::AssetType::Leaderboard);
-        vmAssetList.AddLeaderboard(ra::data::models::AssetCategory::Core, L"Leaderboard1");
-        auto* vmLeaderboard = dynamic_cast<ra::data::models::LeaderboardModel*>(vmAssetList.mockGameContext.Assets().GetItemAt(0));
-        Assert::IsNotNull(vmLeaderboard);
-        Ensures(vmLeaderboard != nullptr);
-        vmLeaderboard->SetDescription(L"Desc1");
-        vmLeaderboard->SetStartTrigger("0=1");
-        vmLeaderboard->SetSubmitTrigger("0xH1234=1");
-        vmLeaderboard->SetCancelTrigger("0xH1234=2");
-        vmLeaderboard->SetValueDefinition("0xH5555*2");
-        vmLeaderboard->SetValueFormat(ra::data::Value::Format::Score);
-        vmLeaderboard->SetLowerIsBetter(true);
-        vmLeaderboard->SetAuthor(L"OriginalAuthor");
+        auto& vmLeaderboard = vmAssetList.AddLeaderboard(ra::data::models::AssetCategory::Core, L"Leaderboard1");
+        vmLeaderboard.SetDescription(L"Desc1");
+        vmLeaderboard.SetStartTrigger("0=1");
+        vmLeaderboard.SetSubmitTrigger("0xH1234=1");
+        vmLeaderboard.SetCancelTrigger("0xH1234=2");
+        vmLeaderboard.SetValueDefinition("0xH5555*2");
+        vmLeaderboard.SetValueFormat(ra::data::Value::Format::Score);
+        vmLeaderboard.SetLowerIsBetter(true);
+        vmLeaderboard.SetAuthor(L"OriginalAuthor");
 
-        Assert::AreEqual({ 1U }, vmAssetList.mockGameContext.Assets().Count());
+        Assert::AreEqual({ 2U }, vmAssetList.mockGameContext.Assets().Count()); // leaderboard + notes
         Assert::AreEqual({ 1U }, vmAssetList.FilteredAssets().Count());
         Assert::AreEqual(AssetListViewModel::CategoryFilter::Core, vmAssetList.GetCategoryFilter());
 
@@ -4504,7 +4505,7 @@ public:
         vmAssetList.CloneSelected();
 
         // new Local leaderboard should be created and focused
-        Assert::AreEqual({ 2U }, vmAssetList.mockGameContext.Assets().Count());
+        Assert::AreEqual({ 3U }, vmAssetList.mockGameContext.Assets().Count());
         Assert::AreEqual({ 1U }, vmAssetList.FilteredAssets().Count());
         Assert::AreEqual(AssetListViewModel::CategoryFilter::Local, vmAssetList.GetCategoryFilter());
 
@@ -4527,6 +4528,7 @@ public:
         Assert::AreEqual(ra::data::Value::Format::Score, pLeaderboard->GetValueFormat());
         Assert::IsTrue(pLeaderboard->IsLowerBetter());
         Assert::AreEqual(std::wstring(L"DisplayName"), pLeaderboard->GetAuthor());
+        Assert::AreEqual(std::wstring(L""), pLeaderboard->GetValidationError());
 
         // and loaded in the editor, which should be shown (local achievement will always have ID 0)
         Assert::AreEqual({ 0U }, vmAssetList.mockWindowManager.AssetEditor.GetID());

--- a/tests/ui/viewmodels/AssetListViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/AssetListViewModel_Tests.cpp
@@ -451,7 +451,7 @@ private:
             EnsureCoreSubset();
         }
 
-        void AddAchievement(AssetCategory nCategory, unsigned nPoints, const std::wstring& sTitle,
+        ra::data::models::AchievementModel& AddAchievement(AssetCategory nCategory, unsigned nPoints, const std::wstring& sTitle,
             const std::wstring& sDescription, const std::wstring& sBadge, const std::string& sTrigger)
         {
             auto vmAchievement = std::make_unique<MockAchievementModel>();
@@ -469,9 +469,11 @@ private:
             vmAchievement->SetLocalAchievementInfo(*vmAchievement->m_pInfo);
             vmAchievement->SyncToLocalAchievementInfo();
             vmAchievement->EndUpdate();
-            mockGameContext.Assets().Append(std::move(vmAchievement));
+            auto& pAsset = mockGameContext.Assets().Append(std::move(vmAchievement));
 
             EnsureCoreSubset();
+
+            return dynamic_cast<ra::data::models::AchievementModel&>(pAsset);
         }
 
         void AddNewAchievement(unsigned nPoints, const std::wstring& sTitle,
@@ -3833,13 +3835,14 @@ public:
         vmAssetList.mockUserContext.Initialize("Username", "DisplayName", "ApiToken");
         vmAssetList.SetGameId(22U);
         vmAssetList.mockGameContext.SetActiveGameId(22U);
+        vmAssetList.mockGameContext.SetNote(0x1111, L"First Note");
         vmAssetList.SetSubsetFilter(22U);
         vmAssetList.AddAchievement(AssetCategory::Core, 5, L"Test1", L"Desc1", L"12345", "0xH1234=1");
-        vmAssetList.AddAchievement(AssetCategory::Core, 7, L"Test2", L"Desc2", L"11111", "0xH1111=1");
-        vmAssetList.mockGameContext.Assets().FindAchievement(2)->SetAuthor(L"OriginalAuthor");
-        vmAssetList.mockGameContext.Assets().FindAchievement(2)->SetAchievementType(ra::data::models::AchievementType::Progression);
+        auto& pAch2 = vmAssetList.AddAchievement(AssetCategory::Core, 10, L"Test2", L"Desc2", L"11111", "0xH1111=1");
+        pAch2.SetAuthor(L"OriginalAuthor");
+        pAch2.SetAchievementType(ra::data::models::AchievementType::Progression);
 
-        Assert::AreEqual({ 2U }, vmAssetList.mockGameContext.Assets().Count());
+        Assert::AreEqual({ 3U }, vmAssetList.mockGameContext.Assets().Count()); // two achievements + notes
         Assert::AreEqual({ 2U }, vmAssetList.FilteredAssets().Count());
         Assert::AreEqual(AssetListViewModel::CategoryFilter::Core, vmAssetList.GetCategoryFilter());
 
@@ -3856,7 +3859,7 @@ public:
         vmAssetList.CloneSelected();
 
         // new Local achievement should be created and focused
-        Assert::AreEqual({ 3U }, vmAssetList.mockGameContext.Assets().Count());
+        Assert::AreEqual({ 4U }, vmAssetList.mockGameContext.Assets().Count());
         Assert::AreEqual({ 1U }, vmAssetList.FilteredAssets().Count());
         Assert::AreEqual(AssetListViewModel::CategoryFilter::Local, vmAssetList.GetCategoryFilter());
 
@@ -3868,7 +3871,7 @@ public:
         Assert::AreEqual(AssetState::Inactive, pAsset->GetState());
         Assert::AreEqual(AssetChanges::New, pAsset->GetChanges());
         Assert::AreEqual({ 111000001U }, pAsset->GetId());
-        Assert::AreEqual(7, pAsset->GetPoints());
+        Assert::AreEqual(10, pAsset->GetPoints());
 
         const auto* pAchievement = vmAssetList.mockGameContext.Assets().FindAchievement(pAsset->GetId());
         Expects(pAchievement != nullptr);
@@ -3878,6 +3881,7 @@ public:
         Assert::AreEqual(std::string("0xH1111=1"), pAchievement->GetTrigger());
         Assert::AreEqual(std::wstring(L"DisplayName"), pAchievement->GetAuthor());
         Assert::AreEqual(ra::data::models::AchievementType::Progression, pAchievement->GetAchievementType());
+        Assert::AreEqual(std::wstring(L""), pAchievement->GetValidationError());
 
         // and loaded in the editor, which should be shown (local achievement will always have ID 0)
         Assert::AreEqual({ 0U }, vmAssetList.mockWindowManager.AssetEditor.GetID());
@@ -3887,7 +3891,7 @@ public:
 
         // copying the copy should create another copy, deselecting the first
         vmAssetList.CloneSelected();
-        Assert::AreEqual({ 4U }, vmAssetList.mockGameContext.Assets().Count());
+        Assert::AreEqual({ 5U }, vmAssetList.mockGameContext.Assets().Count());
         Assert::AreEqual({ 2U }, vmAssetList.FilteredAssets().Count());
         Assert::AreEqual(AssetListViewModel::CategoryFilter::Local, vmAssetList.GetCategoryFilter());
 

--- a/tests/ui/viewmodels/BrokenAchievementsViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/BrokenAchievementsViewModel_Tests.cpp
@@ -42,34 +42,22 @@ private:
             mockGameContext.SetGameTitle(L"GAME");
             mockGameContext.SetGameHash("HASH");
 
-            auto& ach1 = mockGameContext.Assets().NewAchievement();
-            ach1.SetCategory(ra::data::models::AssetCategory::Core);
-            ach1.SetID(1U);
+            auto& ach1 = mockGameContext.MockAchievement();
             ach1.SetName(L"Title1");
             ach1.SetState(ra::data::models::AssetState::Inactive);
-            auto& ach2 = mockGameContext.Assets().NewAchievement();
-            ach2.SetCategory(ra::data::models::AssetCategory::Core);
-            ach2.SetID(2U);
+            auto& ach2 = mockGameContext.MockAchievement();
             ach2.SetName(L"Title2");
             ach2.SetState(ra::data::models::AssetState::Active);
-            auto& ach3 = mockGameContext.Assets().NewAchievement();
-            ach3.SetCategory(ra::data::models::AssetCategory::Core);
-            ach3.SetID(3U);
+            auto& ach3 = mockGameContext.MockAchievement();
             ach3.SetName(L"Title3");
             ach3.SetState(ra::data::models::AssetState::Inactive);
-            auto& ach4 = mockGameContext.Assets().NewAchievement();
-            ach4.SetCategory(ra::data::models::AssetCategory::Core);
-            ach4.SetID(4U);
+            auto& ach4 = mockGameContext.MockAchievement();
             ach4.SetName(L"Title4");
             ach4.SetState(ra::data::models::AssetState::Active);
-            auto& ach5 = mockGameContext.Assets().NewAchievement();
-            ach5.SetCategory(ra::data::models::AssetCategory::Core);
-            ach5.SetID(5U);
+            auto& ach5 = mockGameContext.MockAchievement();
             ach5.SetName(L"Title5");
             ach5.SetState(ra::data::models::AssetState::Active);
-            auto& ach6 = mockGameContext.Assets().NewAchievement();
-            ach6.SetCategory(ra::data::models::AssetCategory::Core);
-            ach6.SetID(6U);
+            auto& ach6 = mockGameContext.MockAchievement();
             ach6.SetName(L"Title6");
             ach6.SetState(ra::data::models::AssetState::Active);
 
@@ -106,7 +94,7 @@ public:
     {
         BrokenAchievementsViewModelHarness vmBrokenAchievements;
         vmBrokenAchievements.mockGameContext.SetGameId(1U);
-        vmBrokenAchievements.mockGameContext.Assets().NewAchievement().SetCategory(ra::data::models::AssetCategory::Local);
+        vmBrokenAchievements.mockGameContext.MockLocalAchievement();
         vmBrokenAchievements.mockWindowManager.AssetList.SetCategoryFilter(AssetListViewModel::CategoryFilter::Local);
 
         bool bDialogSeen = false;

--- a/tests/ui/viewmodels/IntegrationMenuViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/IntegrationMenuViewModel_Tests.cpp
@@ -804,9 +804,7 @@ public:
         // at least one core achievement must exist in the filtered assets list
         // for the dialog to be shown.
         menu.mockGameContext.SetGameId(1234);
-        auto& pAch = menu.mockGameContext.Assets().NewAchievement();
-        pAch.SetCategory(ra::data::models::AssetCategory::Core);
-        pAch.SetID(1);
+        menu.mockGameContext.MockAchievement();
         menu.mockWindowManager.AssetList.SetCategoryFilter(ra::ui::viewmodels::AssetListViewModel::CategoryFilter::All);
 
         menu.AssertShowWindow<ra::ui::viewmodels::BrokenAchievementsViewModel>(IDM_RA_REPORTBROKENACHIEVEMENTS, false, "", DialogResult::None);

--- a/tests/ui/viewmodels/OverlayAchievementsPageViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/OverlayAchievementsPageViewModel_Tests.cpp
@@ -72,19 +72,12 @@ private:
             return nullptr;
         }
 
-        ra::data::models::AchievementModel& NewAchievement(AssetCategory nCategory)
-        {
-            auto& pAchievement = mockGameContext.Assets().NewAchievement();
-            pAchievement.SetCategory(nCategory);
-            return pAchievement;
-        }
-
         void SetProgress(ra::AchievementID nId, int nValue, int nMax)
         {
             auto* pAchievement = mockGameContext.Assets().FindAchievement(nId);
             if (!pAchievement)
             {
-                pAchievement = &mockGameContext.Assets().NewAchievement();
+                pAchievement = &mockGameContext.MockAchievement();
                 pAchievement->SetID(nId);
                 pAchievement->SetTrigger("0=1");
             }
@@ -536,7 +529,7 @@ public:
         snprintf(pAch3->public_.badge_name, sizeof(pAch3->public_.badge_name), "L000003");
         pAch3->public_.state = RC_CLIENT_ACHIEVEMENT_STATE_ACTIVE;
         // L000003 badge points at VM for full local badge path
-        auto& vmAch3 = achievementsPage.mockGameContext.Assets().NewAchievement();
+        auto& vmAch3 = achievementsPage.mockGameContext.MockAchievement();
         vmAch3.SetID(3);
         vmAch3.SetBadge(L"local\\1-abcdef0123456789.png");
 


### PR DESCRIPTION
Primarily used by the unit tests. Added `MockAchievement` and `MockLeaderboard` functions to `MockGameContext` as better alternatives.

Also fixes an issue where cloned leaderboards report a "no start condition" warning.