### PR TITLE
ensure condset is reconstructed for tooltip

### DIFF
--- a/src/ui/viewmodels/TriggerConditionViewModel.cpp
+++ b/src/ui/viewmodels/TriggerConditionViewModel.cpp
@@ -7,7 +7,6 @@
 #include "data\util\IndirectNoteResolver.hh"
 
 #include "services\AchievementLogicSerializer.hh"
-#include "services\AchievementRuntime.hh"
 #include "services\IConfiguration.hh"
 #include "services\ServiceLocator.hh"
 
@@ -637,8 +636,9 @@ const rc_condition_t* TriggerConditionViewModel::GetFirstCondition() const
     }
     else
     {
-        Expects(pGroup->m_pConditionSet != nullptr);
-        pFirstCondition = pGroup->m_pConditionSet->conditions;
+        auto* pCondSet = pGroup->GetConditionSet(pTriggerViewModel->IsValue());
+        Expects(pCondSet != nullptr);
+        pFirstCondition = pCondSet->conditions;
     }
 
     return pFirstCondition;
@@ -688,7 +688,7 @@ ra::data::ByteAddress TriggerConditionViewModel::GetIndirectAddress(ra::data::By
     if (pCondition)
     {
         auto& pCodeNotes = ra::services::ServiceLocator::Get<ra::context::IGameContext>().MemoryNotes();
-        ra::data::util::IndirectNoteResolver pIndirectNoteResolver(pCodeNotes);
+        const ra::data::util::IndirectNoteResolver pIndirectNoteResolver(pCodeNotes);
         std::vector<ra::data::util::IndirectNoteResolver::Node> vParentChain;
 
         const auto* pOperand1 = rc_condition_get_real_operand1(pCondition);

--- a/tests/ui/viewmodels/AssetEditorViewModel_Tests.cpp
+++ b/tests/ui/viewmodels/AssetEditorViewModel_Tests.cpp
@@ -2495,6 +2495,36 @@ public:
         editor.SetSelectedLeaderboardPart(AssetEditorViewModel::LeaderboardPart::Submit);
         Assert::AreEqual({ 0 }, editor.Trigger().Conditions().Count());
     }
+
+    TEST_METHOD(TestPasteAndModifyIncompleteComparison)
+    {
+        AssetEditorViewModelHarness editor;
+
+        // create an achievement and hook it up to a runtime structure that will hold the trigger definition
+        struct rc_client_achievement_info_t achievement_info;
+        memset(&achievement_info, 0, sizeof(achievement_info));
+        AchievementModel achievement;
+        achievement.CreateServerCheckpoint();
+        achievement.CreateLocalCheckpoint();
+        achievement.SetLocalAchievementInfo(achievement_info);
+        editor.LoadAsset(&achievement);
+
+        // paste an invalid trigger definition so that runtime structure has a null pointer
+        ra::services::mocks::MockClipboard mockClipboard;
+        mockClipboard.SetText(L"I:0xX0004_M:0xX0008");
+        editor.Trigger().PasteFromClipboard();
+
+        Assert::IsTrue(editor.HasAssetValidationError());
+        Assert::AreEqual(std::wstring(L"Invalid operator"), editor.GetAssetValidationError());
+
+        // modify the condition so the serialized trigger changes and the condset gets discarded
+        editor.Trigger().Conditions().GetItemAt(0)->SetSourceValue(0x000045);
+
+        // make sure the condset gets rebuilt by the tooltip code
+        const auto* pCondition = editor.Trigger().Conditions().GetItemAt(1);
+        Assert::AreEqual(std::wstring(L"0x0008 (indirect $0x0045+0x08)\r\n[No memory note]"),
+            pCondition->GetTooltip(TriggerConditionViewModel::SourceValueProperty));
+    }
 };
 
 } // namespace tests


### PR DESCRIPTION
https://discord.com/channels/310192285306454017/310195377993416714/1542992048020258889

Modifying a broken achievement caused the underlying data to be cleared out, so the attempt to build the tooltip caused a null reference error.